### PR TITLE
Bugfix 15/10/21 Model Editability

### DIFF
--- a/src/gui/models/speciesIsoModel.cpp
+++ b/src/gui/models/speciesIsoModel.cpp
@@ -3,9 +3,6 @@
 #include "gui/delegates/isotopecombo.hui"
 #include "templates/variantpointer.h"
 
-Q_DECLARE_METATYPE(Sears91::Isotope)
-Q_DECLARE_METATYPE(std::shared_ptr<AtomType>)
-
 SpeciesIsoModel::SpeciesIsoModel(Species &species) : species_(species) {}
 
 int SpeciesIsoModel::rowCount(const QModelIndex &parent) const
@@ -130,12 +127,9 @@ bool SpeciesIsoModel::setData(const QModelIndex &index, const QVariant &value, i
 {
     if (!index.parent().isValid())
     {
-        if (index.row() != 0)
-            return false;
-        if (index.row() > species_.isotopologues().size())
-            return false;
         auto iso = species_.isotopologue(index.row());
         iso->setName(value.toString().toStdString());
+        emit(dataChanged(index, index));
         return true;
     }
 
@@ -143,12 +137,13 @@ bool SpeciesIsoModel::setData(const QModelIndex &index, const QVariant &value, i
         return false;
     if (index.column() != 2)
         return false;
-    auto isotopologue = species_.isotopologue(index.parent().row());
+    auto *isotopologue = species_.isotopologue(index.parent().row());
     auto [atomType, isotope] = isotopologue->isotopes()[index.row()];
     auto newIso = value.value<Sears91::Isotope>();
     if (Sears91::Z(isotope) != Sears91::Z(newIso))
         return false;
     isotopologue->setAtomTypeIsotope(atomType, newIso);
+    emit(dataChanged(index, index));
     return true;
 }
 

--- a/src/gui/models/speciesSiteModel.cpp
+++ b/src/gui/models/speciesSiteModel.cpp
@@ -52,7 +52,7 @@ int SpeciesSiteModel::rowCount(const QModelIndex &parent) const
 
 QVariant SpeciesSiteModel::data(const QModelIndex &index, int role) const
 {
-    if (role == Qt::DisplayRole)
+    if (role == Qt::DisplayRole || role == Qt::EditRole)
         return QString::fromStdString(std::string(rawData(index)->name()));
     else if (role == Qt::CheckStateRole && checkedItems_)
         return std::find(checkedItems_->get().begin(), checkedItems_->get().end(), rawData(index)) == checkedItems_->get().end()
@@ -66,7 +66,15 @@ QVariant SpeciesSiteModel::data(const QModelIndex &index, int role) const
 
 bool SpeciesSiteModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    if (role == Qt::CheckStateRole && checkedItems_)
+    if (role == Qt::EditRole)
+    {
+        rawData(index)->setName(value.toString().toStdString());
+
+        emit dataChanged(index, index);
+
+        return true;
+    }
+    else if (role == Qt::CheckStateRole && checkedItems_)
     {
         auto &xitems = checkedItems_->get();
         if (value.value<Qt::CheckState>() == Qt::Checked)
@@ -88,7 +96,7 @@ bool SpeciesSiteModel::setData(const QModelIndex &index, const QVariant &value, 
 Qt::ItemFlags SpeciesSiteModel::flags(const QModelIndex &index) const
 {
     return checkedItems_ ? Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsUserCheckable
-                         : Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+                         : Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable;
 }
 
 QVariant SpeciesSiteModel::headerData(int section, Qt::Orientation orientation, int role) const

--- a/src/gui/speciestab_funcs.cpp
+++ b/src/gui/speciestab_funcs.cpp
@@ -50,6 +50,8 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
                dissolve.masterImpropers()));
     // -- Isotopologues Tree
     ui_.IsotopologuesTree->setModel(&isos_);
+    connect(&isos_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), dissolveWindow,
+            SLOT(setModified()));
     ui_.IsotopologuesTree->setItemDelegateForColumn(1, new NullDelegate(this));
     ui_.IsotopologuesTree->setItemDelegateForColumn(2, new IsotopeComboDelegate(this));
 
@@ -74,6 +76,8 @@ SpeciesTab::SpeciesTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainT
 
     // Set sites model and connect signals
     ui_.SiteList->setModel(&sites_);
+    connect(&sites_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), dissolveWindow,
+            SLOT(setModified()));
     connect(ui_.SiteList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
             SLOT(siteSelectionChanged(const QItemSelection &, const QItemSelection &)));
 


### PR DESCRIPTION
Quick PR to address some editability issues with species isotopologue and site models, where the names of the objects could not (all) be changed. It also addresses signalling of general edits so that the GUI is aware of state change.

Changes here will also form part of patch release 0.8.4.