### PR TITLE
EPSR - ignore unused AtomType pairs

### DIFF
--- a/src/classes/scatteringmatrix.cpp
+++ b/src/classes/scatteringmatrix.cpp
@@ -11,17 +11,39 @@
 #include <algorithm>
 #include <utility>
 
-ScatteringMatrix::ScatteringMatrix() = default;
-
 /*
  * Data
  */
+
+// Return number of AtomTypes involved
+int ScatteringMatrix::nAtomTypes() const { return atomTypes_.size(); }
+
+// Return atom types
+const std::vector<std::shared_ptr<AtomType>> &ScatteringMatrix::atomTypes() const { return atomTypes_; }
+
+// Return atom type at index specified
+std::shared_ptr<AtomType> ScatteringMatrix::atomType(int index) const { return atomTypes_[index]; }
+
+// Return index of atomtype in our local vector
+int ScatteringMatrix::indexOf(const std::shared_ptr<AtomType> &typeI) const
+{
+    auto it = std::find(atomTypes_.begin(), atomTypes_.end(), typeI);
+    assert(it != atomTypes_.end());
+    return it - atomTypes_.begin();
+}
+
+// Return index pair of atomtypes in our local vector
+std::tuple<int, int> ScatteringMatrix::pairIndexOf(const std::shared_ptr<AtomType> &typeI,
+                                                   const std::shared_ptr<AtomType> &typeJ) const
+{
+    return {indexOf(typeI), indexOf(typeJ)};
+}
 
 // Return number of reference AtomType pairs
 int ScatteringMatrix::nPairs() const { return typePairs_.size(); }
 
 // Return index of specified AtomType pair
-int ScatteringMatrix::pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
+int ScatteringMatrix::columnIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
 {
     auto index = 0;
     for (auto [i, j] : typePairs_)
@@ -45,7 +67,7 @@ double ScatteringMatrix::pairWeightInverse(double q, std::shared_ptr<AtomType> t
      * The required column of the inverse matrix is the original (row) index of the supplied data.
      */
 
-    auto index = pairIndex(std::move(typeI), std::move(typeJ));
+    auto index = columnIndex(std::move(typeI), std::move(typeJ));
     return inverse(q)[{index, dataIndex}];
 }
 
@@ -294,7 +316,6 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
                                               inverseA[{partialIndex, refDataIndex}]);
         }
     }
-
     return true;
 }
 
@@ -309,19 +330,22 @@ Array2D<double> ScatteringMatrix::matrixProduct(double q) const { return inverse
  */
 
 // Initialise from supplied list of AtomTypes
-void ScatteringMatrix::initialise(const std::vector<std::shared_ptr<AtomType>> &types, Array2D<Data1D> &estimatedSQ)
+void ScatteringMatrix::initialise(const AtomTypeMix &types, Array2D<Data1D> &estimatedSQ)
 {
     // Clear coefficients matrix and its inverse_, and empty our typePairs_ and data_ lists
     A_.clear();
     data_.clear();
+    atomTypes_.clear();
     typePairs_.clear();
 
     // Copy atom types
-    dissolve::for_each_pair(ParallelPolicies::seq, types.begin(), types.end(),
-                            [this](int i, auto at1, int j, auto at2) { typePairs_.emplace_back(at1, at2); });
+    atomTypes_.resize(types.nItems());
+    std::transform(types.begin(), types.end(), atomTypes_.begin(), [](const auto &atd) { return atd.atomType(); });
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_.begin(), atomTypes_.end(),
+                            [this](int i, auto &at1, int j, auto &at2) { typePairs_.emplace_back(at1, at2); });
 
     // Create partials array
-    estimatedSQ.initialise(types.size(), types.size(), true);
+    estimatedSQ.initialise(atomTypes_.size(), atomTypes_.size(), true);
     auto index = 0;
     for (auto [i, j] : typePairs_)
         estimatedSQ[index++].setTag(fmt::format("{}-{}", i->name(), j->name()));
@@ -345,7 +369,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const Neutro
     {
         for (auto m = n; m < nUsedTypes; ++m)
         {
-            auto colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
+            auto colIndex = columnIndex(usedTypes.atomType(n), usedTypes.atomType(m));
             if (colIndex == -1)
                 return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
                                         "('{}' and/or '{}').\n",
@@ -383,7 +407,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
     {
         for (int m = n; m < nUsedTypes; ++m)
         {
-            auto colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
+            auto colIndex = columnIndex(usedTypes.atomType(n), usedTypes.atomType(m));
             if (colIndex == -1)
                 return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
                                         "('{}' and/or '{}').\n",
@@ -412,7 +436,7 @@ bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::
     A_.addRow(typePairs_.size());
     const auto rowIndex = A_.nRows() - 1;
 
-    auto colIndex = pairIndex(at1, at2);
+    auto colIndex = columnIndex(at1, at2);
     if (colIndex == -1)
         return Messenger::error(
             "Weights associated to reference data contain one or more unknown AtomTypes ('{}' and/or '{}').\n", at1->name(),

--- a/src/classes/scatteringmatrix.h
+++ b/src/classes/scatteringmatrix.h
@@ -13,15 +13,13 @@
 
 // Forward Declarations
 class AtomType;
+class AtomTypeMix;
 class NeutronWeights;
 class XRayWeights;
 
 // Scattering Matrix Container
 class ScatteringMatrix
 {
-    public:
-    ScatteringMatrix();
-
     /*
      * Data
      *
@@ -32,6 +30,8 @@ class ScatteringMatrix
      * 	[  n,1     n,n ] [ xn ]   [ Bn ]
      */
     private:
+    // Source AtomType involved (with order defining pair order)
+    std::vector<std::shared_ptr<AtomType>> atomTypes_;
     // Reference pairs of AtomTypes
     std::vector<std::tuple<std::shared_ptr<AtomType>, std::shared_ptr<AtomType>>> typePairs_;
     // Coefficients matrix (A) (ci * cj * bi * bj * (typei == typej ? 1 : 2)) (n * n)
@@ -42,10 +42,20 @@ class ScatteringMatrix
     std::vector<std::tuple<bool, std::optional<XRayWeights>, StructureFactors::NormalisationType>> xRayData_;
 
     public:
+    // Return number of AtomTypes involved
+    int nAtomTypes() const;
+    // Return atom types
+    const std::vector<std::shared_ptr<AtomType>> &atomTypes() const;
+    // Return atom type at index specified
+    std::shared_ptr<AtomType> atomType(int index) const;
+    // Return index of atomtype in our local vector
+    int indexOf(const std::shared_ptr<AtomType> &typeI) const;
+    // Return index pair of atomtypes in our local vector
+    std::tuple<int, int> pairIndexOf(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Return number of reference AtomType pairs
     int nPairs() const;
-    // Return index of specified AtomType pair
-    int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
+    // Return column index of specified AtomType pair
+    int columnIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Return weight of the specified AtomType pair in the inverse matrix
     double pairWeightInverse(double q, std::shared_ptr<AtomType> typeI, std::shared_ptr<AtomType> typeJ, int dataIndex) const;
     // Calculate and return the scattering matrix at the specified Q value
@@ -68,7 +78,7 @@ class ScatteringMatrix
      */
     public:
     // Initialise from supplied list of AtomTypes
-    void initialise(const std::vector<std::shared_ptr<AtomType>> &types, Array2D<Data1D> &estimatedSQ);
+    void initialise(const AtomTypeMix &types, Array2D<Data1D> &estimatedSQ);
     // Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
     bool addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor = 1.0);
     // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -13,6 +13,7 @@
 // Forward Declarations
 class AtomType;
 class PartialSet;
+class ScatteringMatrix;
 
 // EPSR Module
 class EPSRModule : public Module
@@ -115,16 +116,19 @@ class EPSRModule : public Module
                        OptionalReferenceWrapper<const Array2D<Data1D>> optEstimatedSQ = std::nullopt);
 
     public:
+    // Return target Configuration (determined from target modules)
+    const Configuration *targetConfiguration() const;
     // Create / retrieve arrays for storage of empirical potential coefficients
-    Array2D<std::vector<double>> &potentialCoefficients(Dissolve &dissolve, const int nAtomTypes,
+    Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
                                                         std::optional<int> ncoeffp = std::nullopt);
     // Generate empirical potentials from current coefficients
-    bool generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::ExpansionFunctionType functionType, double rho,
-                                     std::optional<int> ncoeffp, double rminpt, double rmaxpt, double sigma1, double sigma2);
+    bool generateEmpiricalPotentials(Dissolve &dissolve, const std::vector<std::shared_ptr<AtomType>> &atomTypes,
+                                     EPSRModule::ExpansionFunctionType functionType, double rho, std::optional<int> ncoeffp,
+                                     double rminpt, double rmaxpt, double sigma1, double sigma2);
     // Generate and return single empirical potential function
     Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n);
     // Calculate absolute energy of empirical potentials
-    double absEnergyEP(Dissolve &dissolve);
+    double absEnergyEP(GenericList &moduleData, const ScatteringMatrix &matrix);
     // Test absolute energy of empirical potentials
     bool testAbsEnergyEP(Dissolve &dissolve);
     // Truncate the supplied data

--- a/src/modules/epsr/gui/epsrwidget_funcs.cpp
+++ b/src/modules/epsr/gui/epsrwidget_funcs.cpp
@@ -105,23 +105,27 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         else if (ui_.EstimatedSQButton->isChecked())
         {
             // Add experimentally-determined partial S(Q)
-            for (auto [first, second] : PairIterator(dissolve_.atomTypes().size()))
+            if (module_->targetConfiguration())
             {
-                auto &at1 = dissolve_.atomTypes()[first];
-                auto &at2 = dissolve_.atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+                auto &types = module_->targetConfiguration()->atomTypes();
+                for (auto [first, second] : PairIterator(types.nItems()))
+                {
+                    auto &atd1 = types[first];
+                    auto &atd2 = types[second];
+                    const std::string id = fmt::format("{}-{}", atd1.atomTypeName(), atd2.atomTypeName());
 
-                // Unweighted estimated partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->uniqueName(), id),
-                                                           fmt::format("{} (Estimated)", id), "Estimated");
+                    // Unweighted estimated partial
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->uniqueName(), id),
+                                                               fmt::format("{} (Estimated)", id), "Estimated");
 
-                // Calculated / summed partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->uniqueName(), id),
-                                                           fmt::format("{} (Calc)", id), "Calc");
+                    // Calculated / summed partial
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->uniqueName(), id),
+                                                               fmt::format("{} (Calc)", id), "Calc");
 
-                // Deltas
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->uniqueName(), id),
-                                                           fmt::format("{} (Delta)", id), "Delta");
+                    // Deltas
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->uniqueName(), id),
+                                                               fmt::format("{} (Delta)", id), "Delta");
+                }
             }
         }
         else if (ui_.EstimatedGRButton->isChecked())
@@ -149,12 +153,12 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             }
 
             // Add experimentally-determined partial g(r)
-            PairIterator pairs(dissolve_.atomTypes().size());
-            for (auto [first, second] : pairs)
+            auto &types = module_->targetConfiguration()->atomTypes();
+            for (auto [first, second] : PairIterator(types.nItems()))
             {
-                auto &at1 = dissolve_.atomTypes()[first];
-                auto &at2 = dissolve_.atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+                auto &atd1 = types[first];
+                auto &atd2 = types[second];
+                const std::string id = fmt::format("{}-{}", atd1.atomTypeName(), atd2.atomTypeName());
 
                 // Experimentally-determined unweighted partial
                 graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedGR//{}", module_->uniqueName(), id),
@@ -182,14 +186,15 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         else if (ui_.PotentialsButton->isChecked())
         {
             // Add on additional potentials
-            PairIterator pairs(dissolve_.atomTypes().size());
-            for (auto [first, second] : pairs)
+            auto &types = module_->targetConfiguration()->atomTypes();
+            for (auto [first, second] : PairIterator(types.nItems()))
             {
-                auto &at1 = dissolve_.atomTypes()[first];
-                auto &at2 = dissolve_.atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+                auto &atd1 = types[first];
+                auto &atd2 = types[second];
+                const std::string id = fmt::format("{}-{}", atd1.atomTypeName(), atd2.atomTypeName());
 
-                graph_->createRenderable<RenderableData1D, Data1D>(dissolve_.pairPotential(at1, at2)->uAdditional(), id, "Phi");
+                graph_->createRenderable<RenderableData1D, Data1D>(
+                    dissolve_.pairPotential(atd1.atomType(), atd2.atomType())->uAdditional(), id, "Phi");
             }
         }
         else if (ui_.RFactorButton->isChecked())


### PR DESCRIPTION
This PR modifies the EPSR module to ignore unused `AtomType` pairs / potentials (i.e. those not used in the target `Configuration`) in both the main algorithm and the GUI widget.