### PR TITLE
Fixup Web CI

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -23,8 +23,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-    - name: Acquire Code Version
-      uses: "./.github/workflows/get-version"
+    - name: Setup
+      uses: "./.github/workflows/setup"
     - name: Build Website
       uses: "./.github/workflows/website"
       with:


### PR DESCRIPTION
Tiny PR to fix our `web.yml` workflow, which a careless developer forgot to change over to the new `setup` action following #1361.