### PR TITLE
917 fixing module timing

### DIFF
--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -407,7 +407,7 @@ void DissolveWindow::updateWhileRunning(int iterationsRemaining)
     iterationLabel_->setText(QStringLiteral("%1").arg(dissolve_.iteration(), 6, 10, QLatin1Char('0')));
 
     // Set ETA text if we can
-    if (iterationsRemaining == -1)
+    if (iterationsRemaining == -1 || iterationsRemaining == 0) 
         etaLabel_->setText("--:--:--");
     else
     {

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -407,7 +407,7 @@ void DissolveWindow::updateWhileRunning(int iterationsRemaining)
     iterationLabel_->setText(QStringLiteral("%1").arg(dissolve_.iteration(), 6, 10, QLatin1Char('0')));
 
     // Set ETA text if we can
-    if (iterationsRemaining == -1 || iterationsRemaining == 0) 
+    if (iterationsRemaining == -1 || iterationsRemaining == 0)
         etaLabel_->setText("--:--:--");
     else
     {

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,7 +304,7 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (!module->executeProcessing(*this, worldPool()))
+                if (module->executeProcessing(*this, worldPool()) == failed)
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,9 +304,9 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (module->executeProcessing(*this, worldPool()))
-                    if(module->executeProcessing(*this, worldPool()) == 2) Messenger::print("aaa");
+                if (!module->executeProcessing(*this, worldPool()))
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
+
             }
         }
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,7 +304,7 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (!module->executeProcessing(*this, worldPool()))
+                if (module->executeProcessing(*this, worldPool()) == ExecutionResult::Failed)
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -305,7 +305,7 @@ bool Dissolve::iterate(int nIterations)
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
                 if (module->executeProcessing(*this, worldPool()))
-                    Messenger::print(module->executeProcessing(*this, worldPool()));
+                    if(module->executeProcessing(*this, worldPool()) == 2) Messenger::print("aaa");
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -306,7 +306,6 @@ bool Dissolve::iterate(int nIterations)
 
                 if (!module->executeProcessing(*this, worldPool()))
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
-
             }
         }
 

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,7 +304,7 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (static_cast<int>(module->executeProcessing(*this, worldPool())) == 0)
+                if (module->executeProcessing(*this, worldPool()) == Module::ExecutionResult::Failed)
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,7 +304,8 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (module->executeProcessing(*this, worldPool()) == failed)
+                if (module->executeProcessing(*this, worldPool()))
+                    Messenger::print(module->executeProcessing(*this, worldPool()));
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -304,7 +304,7 @@ bool Dissolve::iterate(int nIterations)
 
                 Messenger::heading("{} ({})", ModuleTypes::moduleType(module->type()), module->name());
 
-                if (module->executeProcessing(*this, worldPool()) == ExecutionResult::Failed)
+                if (static_cast<int>(module->executeProcessing(*this, worldPool())) == 0)
                     return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
             }
         }

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -180,7 +180,7 @@ bool Module::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Keywor
 }
 
 // Run main processing stage
-enum executeProcessing Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Begin timer
     Timer timer;

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -191,10 +191,16 @@ enum Module::executionResult Module::executeProcessing(Dissolve &dissolve, const
 
     // Accumulate timing information
     timer.stop();
+
     if (result == success)
     {
         processTimes_ += timer.secondsElapsed();
-    } 
+    }
+    else
+    {
+        // If process is not run, do not add to the timing
+        processTimes_ += 0;
+    }
 
     return result;
 }

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -151,7 +151,7 @@ bool Module::isDisabled() const { return !enabled_; }
  */
 
 // Run main processing
-enum Module::executionResult Module::process(Dissolve &dissolve, const ProcessPool &procPool) { return failed; }
+Module::ExecutionResult Module::process(Dissolve &dissolve, const ProcessPool &procPool) { return ExecutionResult::Failed; }
 
 // Set target data
 void Module::setTargets(const std::vector<std::unique_ptr<Configuration>> &configurations,
@@ -180,7 +180,7 @@ bool Module::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Keywor
 }
 
 // Run main processing stage
-enum Module::executionResult Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Begin timer
     Timer timer;
@@ -192,7 +192,7 @@ enum Module::executionResult Module::executeProcessing(Dissolve &dissolve, const
     // Accumulate timing information
     timer.stop();
 
-    if (result == success)
+    if (result == ExecutionResult::Success)
     {
         processTimes_ += timer.secondsElapsed();
     }

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -180,7 +180,7 @@ bool Module::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Keywor
 }
 
 // Run main processing stage
-bool Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
+enum executeProcessing Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Begin timer
     Timer timer;
@@ -191,7 +191,10 @@ bool Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Accumulate timing information
     timer.stop();
-    processTimes_ += timer.secondsElapsed();
+    if (result == success)
+    {
+        processTimes_ += timer.secondsElapsed();
+    } 
 
     return result;
 }

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -151,7 +151,7 @@ bool Module::isDisabled() const { return !enabled_; }
  */
 
 // Run main processing
-bool Module::process(Dissolve &dissolve, const ProcessPool &procPool) { return false; }
+enum Module::executionResult Module::process(Dissolve &dissolve, const ProcessPool &procPool) { return failed; }
 
 // Set target data
 void Module::setTargets(const std::vector<std::unique_ptr<Configuration>> &configurations,
@@ -180,7 +180,7 @@ bool Module::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Keywor
 }
 
 // Run main processing stage
-enum executionResult Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult Module::executeProcessing(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Begin timer
     Timer timer;

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -193,14 +193,7 @@ Module::ExecutionResult Module::executeProcessing(Dissolve &dissolve, const Proc
     timer.stop();
 
     if (result == ExecutionResult::Success)
-    {
         processTimes_ += timer.secondsElapsed();
-    }
-    else
-    {
-        // If process is not run, do not add to the timing
-        processTimes_ += 0;
-    }
 
     return result;
 }

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -108,11 +108,11 @@ class Module : public Serialisable<const CoreData &>
     // Whether the Module is enabled
     bool enabled_;
     // Process exit information
-    enum executionResult
+    enum class ExecutionResult
     {
-        failed,
-        success,
-        notExecuted
+        Failed,
+        Success,
+        NotExecuted
     };
 
     public:
@@ -136,7 +136,7 @@ class Module : public Serialisable<const CoreData &>
      */
     private:
     // Run main processing
-    virtual enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
+    virtual Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
 
     public:
     // Set target data
@@ -145,7 +145,7 @@ class Module : public Serialisable<const CoreData &>
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {});
     // Run main processing stage
-    enum Module::executionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
+    Module::ExecutionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
 
     /*
      * Timing

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -108,7 +108,7 @@ class Module : public Serialisable<const CoreData &>
     // Whether the Module is enabled
     bool enabled_;
     // Process exit information
-    enum processExecuted
+    enum executionResult
     {
         failed,
         success,

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -107,6 +107,13 @@ class Module : public Serialisable<const CoreData &>
     int frequency_;
     // Whether the Module is enabled
     bool enabled_;
+    // Process exit information
+    enum processExecuted
+    {
+        failed,
+        success,
+        notExecuted
+    };
 
     public:
     // Set frequency at which to run Module (relative to layer execution count)
@@ -138,7 +145,7 @@ class Module : public Serialisable<const CoreData &>
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {});
     // Run main processing stage
-    bool executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
+    enum executeProcessing executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
 
     /*
      * Timing

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -136,7 +136,7 @@ class Module : public Serialisable<const CoreData &>
      */
     private:
     // Run main processing
-    virtual Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
+    virtual ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
 
     public:
     // Set target data
@@ -145,7 +145,7 @@ class Module : public Serialisable<const CoreData &>
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {});
     // Run main processing stage
-    Module::ExecutionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
+    ExecutionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
 
     /*
      * Timing

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -136,7 +136,7 @@ class Module : public Serialisable<const CoreData &>
      */
     private:
     // Run main processing
-    virtual bool process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
+    virtual enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) = 0;
 
     public:
     // Set target data
@@ -145,7 +145,7 @@ class Module : public Serialisable<const CoreData &>
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {});
     // Run main processing stage
-    enum executionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
+    enum Module::executionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
 
     /*
      * Timing

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -107,6 +107,8 @@ class Module : public Serialisable<const CoreData &>
     int frequency_;
     // Whether the Module is enabled
     bool enabled_;
+
+    public:
     // Process exit information
     enum class ExecutionResult
     {
@@ -114,8 +116,6 @@ class Module : public Serialisable<const CoreData &>
         Success,
         NotExecuted
     };
-
-    public:
     // Set frequency at which to run Module (relative to layer execution count)
     void setFrequency(int freq);
     // Return frequency at which to run Module (relative to layer execution count)

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -109,7 +109,7 @@ class Module : public Serialisable<const CoreData &>
     bool enabled_;
 
     public:
-    // Process exit information
+    // Module execution result
     enum class ExecutionResult
     {
         Failed,

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -145,7 +145,7 @@ class Module : public Serialisable<const CoreData &>
     // Run set-up stage
     virtual bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals = {});
     // Run main processing stage
-    enum executeProcessing executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
+    enum executionResult executeProcessing(Dissolve &dissolve, const ProcessPool &procPool);
 
     /*
      * Timing

--- a/src/modules/accumulate/accumulate.h
+++ b/src/modules/accumulate/accumulate.h
@@ -39,5 +39,5 @@ class AccumulateModule : public Module
      */
     public:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/accumulate/accumulate.h
+++ b/src/modules/accumulate/accumulate.h
@@ -39,5 +39,5 @@ class AccumulateModule : public Module
      */
     public:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/accumulate/accumulate.h
+++ b/src/modules/accumulate/accumulate.h
@@ -39,5 +39,5 @@ class AccumulateModule : public Module
      */
     public:
     // Run main processing
-    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/accumulate/accumulate.h
+++ b/src/modules/accumulate/accumulate.h
@@ -39,5 +39,5 @@ class AccumulateModule : public Module
      */
     public:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -26,8 +26,10 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
 {
     // Get the modules and decide on the PartialSet data name we're looking for
     if (targetModules_.empty())
+    {
         Messenger::error("No target modules set.");
         return failed;
+    }
 
     Messenger::print("Accumulate: Target data to accumulate is '{}'.\n", targetPartialSet().keyword(targetPartialSet_));
     Messenger::print("Accumulate: Save data is {}.\n", DissolveSys::onOff(save_));
@@ -42,16 +44,20 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
         auto targetDataIt = std::find_if(validTargets.begin(), validTargets.end(),
                                          [targetModule](const auto &target) { return target.first == targetModule->type(); });
         if (targetDataIt == validTargets.end())
+        {
             Messenger::error("Module of type '{}' is not a valid target.\n",
-                                    ModuleTypes::moduleType(targetModule->type()));
+                        ModuleTypes::moduleType(targetModule->type()));
             return failed;
+        }
 
         auto dataName = targetDataIt->second[targetPartialSet_];
         if (dataName.empty())
+        {
             Messenger::error("This data type ('{}') is not valid for a module of type '{}'.\n",
                                     targetPartialSet().keyword(targetPartialSet_),
                                     ModuleTypes::moduleType(targetModule->type()));
             return failed;
+        }
 
         // Find the target data
         auto targetSet = dissolve.processingModuleData().valueIf<PartialSet>(dataName, targetModule->name());

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -22,7 +22,7 @@ EnumOptions<AccumulateModule::TargetPartialSet> AccumulateModule::targetPartialS
 }
 
 // Run main processing
-enum processExecuted AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Get the modules and decide on the PartialSet data name we're looking for
     if (targetModules_.empty())

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -45,8 +45,7 @@ Module::ExecutionResult AccumulateModule::process(Dissolve &dissolve, const Proc
                                          [targetModule](const auto &target) { return target.first == targetModule->type(); });
         if (targetDataIt == validTargets.end())
         {
-            Messenger::error("Module of type '{}' is not a valid target.\n",
-                        ModuleTypes::moduleType(targetModule->type()));
+            Messenger::error("Module of type '{}' is not a valid target.\n", ModuleTypes::moduleType(targetModule->type()));
             return ExecutionResult::Failed;
         }
 
@@ -54,8 +53,7 @@ Module::ExecutionResult AccumulateModule::process(Dissolve &dissolve, const Proc
         if (dataName.empty())
         {
             Messenger::error("This data type ('{}') is not valid for a module of type '{}'.\n",
-                                    targetPartialSet().keyword(targetPartialSet_),
-                                    ModuleTypes::moduleType(targetModule->type()));
+                             targetPartialSet().keyword(targetPartialSet_), ModuleTypes::moduleType(targetModule->type()));
             return ExecutionResult::Failed;
         }
 

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -22,7 +22,7 @@ EnumOptions<AccumulateModule::TargetPartialSet> AccumulateModule::targetPartialS
 }
 
 // Run main processing
-enum executeProcessing AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum processExecuted AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Get the modules and decide on the PartialSet data name we're looking for
     if (targetModules_.empty())

--- a/src/modules/accumulate/process.cpp
+++ b/src/modules/accumulate/process.cpp
@@ -22,13 +22,13 @@ EnumOptions<AccumulateModule::TargetPartialSet> AccumulateModule::targetPartialS
 }
 
 // Run main processing
-enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AccumulateModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Get the modules and decide on the PartialSet data name we're looking for
     if (targetModules_.empty())
     {
         Messenger::error("No target modules set.");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     Messenger::print("Accumulate: Target data to accumulate is '{}'.\n", targetPartialSet().keyword(targetPartialSet_));
@@ -47,7 +47,7 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
         {
             Messenger::error("Module of type '{}' is not a valid target.\n",
                         ModuleTypes::moduleType(targetModule->type()));
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         auto dataName = targetDataIt->second[targetPartialSet_];
@@ -56,7 +56,7 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
             Messenger::error("This data type ('{}') is not valid for a module of type '{}'.\n",
                                     targetPartialSet().keyword(targetPartialSet_),
                                     ModuleTypes::moduleType(targetModule->type()));
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         // Find the target data
@@ -65,7 +65,7 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
         {
             Messenger::print("Target PartialSet data '{}' in module '{}' does not yet exist.\n",
                              targetPartialSet().keyword(targetPartialSet_), targetModule->name());
-            return notExecuted;
+            return ExecutionResult::NotExecuted;
         }
 
         // Realise the accumulated partial set
@@ -81,8 +81,8 @@ enum Module::executionResult AccumulateModule::process(Dissolve &dissolve, const
         std::vector<std::string> units = {"r, Angstroms", "Q, Angstroms**-1", "r, Angstroms"};
         if (save_ && !(MPIRunMaster(procPool, accumulated.save(fmt::format("{}-{}", name(), targetModule->name()), dataName,
                                                                suffixes[targetPartialSet_], units[targetPartialSet_]))))
-            return failed;
+            return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/analyse/analyse.h
+++ b/src/modules/analyse/analyse.h
@@ -31,5 +31,5 @@ class AnalyseModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/analyse/analyse.h
+++ b/src/modules/analyse/analyse.h
@@ -31,5 +31,5 @@ class AnalyseModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -6,13 +6,13 @@
 #include "modules/analyse/analyse.h"
 
 // Run main processing
-enum Module::executionResult AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Execute the analysis
@@ -20,9 +20,9 @@ enum Module::executionResult AnalyseModule::process(Dissolve &dissolve, const Pr
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
     {
-        Messenger::error("Analysis failed.\n");
-        return failed;
+        Messenger::error("Analysis ExecutionResult::Failed.\n");
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -6,7 +6,7 @@
 #include "modules/analyse/analyse.h"
 
 // Run main processing
-enum executionResult AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -6,17 +6,19 @@
 #include "modules/analyse/analyse.h"
 
 // Run main processing
-bool AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult AnalyseModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("Analysis failed.\n");
+        Messenger::error("Analysis failed.\n");
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -10,15 +10,19 @@ enum Module::executionResult AnalyseModule::process(Dissolve &dissolve, const Pr
 {
     // Check for Configuration target
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Execute the analysis
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
+    {
         Messenger::error("Analysis failed.\n");
         return failed;
+    }
 
     return success;
 }

--- a/src/modules/angle/angle.h
+++ b/src/modules/angle/angle.h
@@ -87,5 +87,5 @@ class AngleModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/angle/angle.h
+++ b/src/modules/angle/angle.h
@@ -87,5 +87,5 @@ class AngleModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/angle/angle.h
+++ b/src/modules/angle/angle.h
@@ -87,5 +87,5 @@ class AngleModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -12,13 +12,13 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum Module::executionResult AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -60,8 +60,8 @@ enum Module::executionResult AngleModule::process(Dissolve &dissolve, const Proc
     if (!analyser_.execute(context))
     {
         Messenger::error("Angle experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -16,8 +16,10 @@ enum Module::executionResult AngleModule::process(Dissolve &dissolve, const Proc
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     selectB_->setDistanceReferenceSite(selectA_);
@@ -56,8 +58,10 @@ enum Module::executionResult AngleModule::process(Dissolve &dissolve, const Proc
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
+    {
         Messenger::error("Angle experienced problems with its analysis.\n");
         return failed;
+    }
 
     return success;
 }

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum executionResult AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -12,11 +12,12 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-bool AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Ensure any parameters in our nodes are set correctly
     selectB_->setDistanceReferenceSite(selectA_);
@@ -55,7 +56,8 @@ bool AngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("Angle experienced problems with its analysis.\n");
+        Messenger::error("Angle experienced problems with its analysis.\n");
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/atomShake/atomShake.h
+++ b/src/modules/atomShake/atomShake.h
@@ -36,5 +36,5 @@ class AtomShakeModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/atomShake/atomShake.h
+++ b/src/modules/atomShake/atomShake.h
@@ -36,5 +36,5 @@ class AtomShakeModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/atomShake/atomShake.h
+++ b/src/modules/atomShake/atomShake.h
@@ -36,5 +36,5 @@ class AtomShakeModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -12,7 +12,7 @@
 #include "modules/atomShake/atomShake.h"
 
 // Run main processing
-enum executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -12,11 +12,12 @@
 #include "modules/atomShake/atomShake.h"
 
 // Run main processing
-bool AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Retrieve control parameters from Configuration
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -16,8 +16,10 @@ enum Module::executionResult AtomShakeModule::process(Dissolve &dissolve, const 
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Retrieve control parameters from Configuration
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -152,11 +152,11 @@ enum executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessP
 
     // Collect statistics across all processes
     if (!procPool.allSum(&nAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return false;
+        return failed;
 
     Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
 
@@ -181,5 +181,5 @@ enum executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessP
     if (nAccepted > 0)
         targetConfiguration_->incrementContentsVersion();
 
-    return true;
+    return success;
 }

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -12,13 +12,13 @@
 #include "modules/atomShake/atomShake.h"
 
 // Run main processing
-enum Module::executionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AtomShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Retrieve control parameters from Configuration
@@ -154,11 +154,11 @@ enum Module::executionResult AtomShakeModule::process(Dissolve &dissolve, const 
 
     // Collect statistics across all processes
     if (!procPool.allSum(&nAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
 
     Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
 
@@ -183,5 +183,5 @@ enum Module::executionResult AtomShakeModule::process(Dissolve &dissolve, const 
     if (nAccepted > 0)
         targetConfiguration_->incrementContentsVersion();
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/avgMol/avgMol.h
+++ b/src/modules/avgMol/avgMol.h
@@ -52,5 +52,5 @@ class AvgMolModule : public Module
     // Run set-up stage
     bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals) override;
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/avgMol/avgMol.h
+++ b/src/modules/avgMol/avgMol.h
@@ -52,5 +52,5 @@ class AvgMolModule : public Module
     // Run set-up stage
     bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals) override;
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/avgMol/avgMol.h
+++ b/src/modules/avgMol/avgMol.h
@@ -52,5 +52,5 @@ class AvgMolModule : public Module
     // Run set-up stage
     bool setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<KeywordBase::KeywordSignal> actionSignals) override;
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/avgMol/process.cpp
+++ b/src/modules/avgMol/process.cpp
@@ -50,23 +50,26 @@ bool AvgMolModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-bool AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Grab Box pointer
     const auto *box = targetConfiguration_->box();
 
     // Get the target site
     if (!targetSite_)
-        return Messenger::error("No target site defined.\n");
+        Messenger::error("No target site defined.\n");
+        return failed;
 
     // Get site parent species
     auto *sp = targetSite_->parent();
     if (sp != targetSpecies_)
-        return Messenger::error("Internal error - target site parent is not the same as the target species.\n");
+        Messenger::error("Internal error - target site parent is not the same as the target species.\n");
+        return failed;
 
     Messenger::print("AvgMol: Target site (species) is {} ({}).\n", targetSite_->name(), targetSpecies_->name());
     if (exportFileAndFormat_.hasFilename())
@@ -119,8 +122,8 @@ bool AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if (exportFileAndFormat_.hasFilename())
     {
         if (!exportFileAndFormat_.exportData(&averageSpecies_))
-            return false;
+            return failed;
     }
 
-    return true;
+    return success;
 }

--- a/src/modules/avgMol/process.cpp
+++ b/src/modules/avgMol/process.cpp
@@ -50,7 +50,7 @@ bool AvgMolModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum executionResult AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/avgMol/process.cpp
+++ b/src/modules/avgMol/process.cpp
@@ -49,13 +49,13 @@ bool AvgMolModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AvgMolModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Grab Box pointer
@@ -65,7 +65,7 @@ enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const Pro
     if (!targetSite_)
     {
         Messenger::error("No target site defined.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Get site parent species
@@ -73,7 +73,7 @@ enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const Pro
     if (sp != targetSpecies_)
     {
         Messenger::error("Internal error - target site parent is not the same as the target species.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     Messenger::print("AvgMol: Target site (species) is {} ({}).\n", targetSite_->name(), targetSpecies_->name());
@@ -127,8 +127,8 @@ enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const Pro
     if (exportFileAndFormat_.hasFilename())
     {
         if (!exportFileAndFormat_.exportData(&averageSpecies_))
-            return failed;
+            return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/avgMol/process.cpp
+++ b/src/modules/avgMol/process.cpp
@@ -20,7 +20,6 @@ bool AvgMolModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
         if (targetSite_->parent() == nullptr)
         {
             targetSpecies_ = nullptr;
-
             return Messenger::error("Target site has no parent species.\n");
         }
         else if (targetSite_->parent() != targetSpecies_)
@@ -54,22 +53,28 @@ enum Module::executionResult AvgMolModule::process(Dissolve &dissolve, const Pro
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Grab Box pointer
     const auto *box = targetConfiguration_->box();
 
     // Get the target site
     if (!targetSite_)
+    {
         Messenger::error("No target site defined.\n");
         return failed;
+    }
 
     // Get site parent species
     auto *sp = targetSite_->parent();
     if (sp != targetSpecies_)
+    {
         Messenger::error("Internal error - target site parent is not the same as the target species.\n");
         return failed;
+    }
 
     Messenger::print("AvgMol: Target site (species) is {} ({}).\n", targetSite_->name(), targetSpecies_->name());
     if (exportFileAndFormat_.hasFilename())

--- a/src/modules/axisAngle/axisAngle.h
+++ b/src/modules/axisAngle/axisAngle.h
@@ -65,5 +65,5 @@ class AxisAngleModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/axisAngle/axisAngle.h
+++ b/src/modules/axisAngle/axisAngle.h
@@ -65,5 +65,5 @@ class AxisAngleModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/axisAngle/axisAngle.h
+++ b/src/modules/axisAngle/axisAngle.h
@@ -65,5 +65,5 @@ class AxisAngleModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -11,7 +11,7 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum executionResult AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -15,8 +15,10 @@ enum Module::executionResult AxisAngleModule::process(Dissolve &dissolve, const 
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
@@ -35,8 +37,10 @@ enum Module::executionResult AxisAngleModule::process(Dissolve &dissolve, const 
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
+    {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");
         return failed;
+    }
 
     return success;
 }

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -11,13 +11,13 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum Module::executionResult AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -39,8 +39,8 @@ enum Module::executionResult AxisAngleModule::process(Dissolve &dissolve, const 
     if (!analyser_.execute(context))
     {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -11,11 +11,12 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-bool AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Ensure any parameters in our nodes are set correctly
     calculateAxisAngle_->keywords().set("Symmetric", symmetric_);
@@ -34,7 +35,8 @@ bool AxisAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("AxisAngle experienced problems with its analysis.\n");
+        Messenger::error("AxisAngle experienced problems with its analysis.\n");
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -48,5 +48,5 @@ class BenchmarkModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -48,5 +48,5 @@ class BenchmarkModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/benchmark/benchmark.h
+++ b/src/modules/benchmark/benchmark.h
@@ -48,5 +48,5 @@ class BenchmarkModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -16,8 +16,10 @@ enum Module::executionResult BenchmarkModule::process(Dissolve &dissolve, const 
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Get options
     Messenger::print("Benchmark: Test timings will be averaged over {} {}.\n", nRepeats_, nRepeats_ == 1 ? "run" : "runs");

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -12,7 +12,7 @@
 #include "modules/gr/gr.h"
 
 // Run main processing
-enum executionResult BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -12,13 +12,13 @@
 #include "modules/gr/gr.h"
 
 // Run main processing
-enum Module::executionResult BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Get options
@@ -170,7 +170,7 @@ enum Module::executionResult BenchmarkModule::process(Dissolve &dissolve, const 
                           "Distributor (regional)", timing, save_);
     }
 
-    return success;
+    return ExecutionResult::Success;
 }
 
 // Print timing information, assessing it against last value in existing timings (if found)

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -12,11 +12,12 @@
 #include "modules/gr/gr.h"
 
 // Run main processing
-bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Get options
     Messenger::print("Benchmark: Test timings will be averaged over {} {}.\n", nRepeats_, nRepeats_ == 1 ? "run" : "runs");
@@ -167,7 +168,7 @@ bool BenchmarkModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                           "Distributor (regional)", timing, save_);
     }
 
-    return true;
+    return success;
 }
 
 // Print timing information, assessing it against last value in existing timings (if found)

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -56,5 +56,5 @@ class BraggModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -56,5 +56,5 @@ class BraggModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/bragg/bragg.h
+++ b/src/modules/bragg/bragg.h
@@ -56,5 +56,5 @@ class BraggModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -163,11 +163,11 @@ Module::ExecutionResult BraggModule::process(Dissolve &dissolve, const ProcessPo
             {
                 LineParser intensityParser(&procPool);
                 if (!intensityParser.openOutput(fmt::format("{}-{}-{}.txt", name_, atd1.atomTypeName(), atd2.atomTypeName())))
-                    return ExecutionResult::Failed;
+                    return false;
                 intensityParser.writeLineF("#     Q      Intensity({},{})\n", atd1.atomTypeName(), atd2.atomTypeName());
                 for (const auto &reflxn : braggReflections)
                     if (!intensityParser.writeLineF("{:10.6f}  {:10.6e}\n", reflxn.q(), reflxn.intensity(i, j)))
-                        return ExecutionResult::Failed;
+                        return false;
                 intensityParser.closeFiles();
 
                 return EarlyReturn<bool>::Continue;

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -9,7 +9,7 @@
 #include "templates/algorithms.h"
 
 // Run main processing
-executionResult BraggModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult BraggModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate Bragg contributions.
@@ -20,8 +20,10 @@ executionResult BraggModule::process(Dissolve &dissolve, const ProcessPool &proc
 
     // Check for Configuration target
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return executionResult;
+        return failed;
+    }
 
     // Print argument/parameter summary
     Messenger::print("Bragg: Calculating Bragg S(Q) over {} < Q < {} Angstroms**-1 using bin size of {} Angstroms**-1.\n",

--- a/src/modules/bragg/process.cpp
+++ b/src/modules/bragg/process.cpp
@@ -128,8 +128,10 @@ enum Module::executionResult BraggModule::process(Dissolve &dissolve, const Proc
         if (nErrors == 0)
             Messenger::print("All data match.\n");
         else
+        {
             Messenger::error("Calculated and reference data are inconsistent.\n");
             return failed;
+        }
     }
 
     // Save reflection data?

--- a/src/modules/checkSpecies/checkSpecies.h
+++ b/src/modules/checkSpecies/checkSpecies.h
@@ -92,5 +92,5 @@ class CheckSpeciesModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checkSpecies/checkSpecies.h
+++ b/src/modules/checkSpecies/checkSpecies.h
@@ -92,5 +92,5 @@ class CheckSpeciesModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checkSpecies/checkSpecies.h
+++ b/src/modules/checkSpecies/checkSpecies.h
@@ -92,5 +92,5 @@ class CheckSpeciesModule : public Module
      */
     private:
     // Run main processing
-    executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checkSpecies/checkSpecies.h
+++ b/src/modules/checkSpecies/checkSpecies.h
@@ -92,5 +92,5 @@ class CheckSpeciesModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -11,13 +11,13 @@
 #include <numeric>
 
 // Run main processing
-enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Retrieve necessary keyword values
     if (!targetSpecies_)
     {
         Messenger::error("No target species provided.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     Messenger::print("CheckSpecies: Target species is '{}'.\n", targetSpecies_->name());
@@ -37,7 +37,7 @@ enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, con
             if (i - 1 >= targetSpecies_->nAtoms())
             {
                 Messenger::error("Atom index {} is out of range ({} atoms in species).\n", i, targetSpecies_->nAtoms());
-                return failed;
+                return ExecutionResult::Failed;
             }
 
             auto &spAtom = targetSpecies_->atom(i - 1);
@@ -146,5 +146,5 @@ enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, con
                             });
     }
 
-    return (((nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0) ? success : failed);
+    return (((nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0) ? ExecutionResult::Success : ExecutionResult::Failed);
 }

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -146,5 +146,7 @@ Module::ExecutionResult CheckSpeciesModule::process(Dissolve &dissolve, const Pr
                             });
     }
 
-    return (((nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0) ? ExecutionResult::Success : ExecutionResult::Failed);
+    return (((nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0)
+                ? ExecutionResult::Success
+                : ExecutionResult::Failed);
 }

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -11,11 +11,12 @@
 #include <numeric>
 
 // Run main processing
-bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Retrieve necessary keyword values
     if (!targetSpecies_)
-        return Messenger::error("No target species provided.\n");
+        Messenger::error("No target species provided.\n");
+        return failed;
 
     Messenger::print("CheckSpecies: Target species is '{}'.\n", targetSpecies_->name());
     Messenger::print("CheckSpecies: Tolerance for parameter checks is {:.5e}.", tolerance_);
@@ -32,7 +33,8 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
             // Get specified atom - tuple contains 'human-readable' indices from 1 - N...
             auto i = std::get<0>(indexName).at(0);
             if (i - 1 >= targetSpecies_->nAtoms())
-                return Messenger::error("Atom index {} is out of range ({} atoms in species).\n", i, targetSpecies_->nAtoms());
+                Messenger::error("Atom index {} is out of range ({} atoms in species).\n", i, targetSpecies_->nAtoms());
+                return failed;
 
             auto &spAtom = targetSpecies_->atom(i - 1);
             auto at = spAtom.atomType();
@@ -140,5 +142,5 @@ bool CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool
                             });
     }
 
-    return (nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0;
+    return (nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == failed;
 }

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -15,8 +15,10 @@ enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, con
 {
     // Retrieve necessary keyword values
     if (!targetSpecies_)
+    {
         Messenger::error("No target species provided.\n");
         return failed;
+    }
 
     Messenger::print("CheckSpecies: Target species is '{}'.\n", targetSpecies_->name());
     Messenger::print("CheckSpecies: Tolerance for parameter checks is {:.5e}.", tolerance_);
@@ -33,8 +35,10 @@ enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, con
             // Get specified atom - tuple contains 'human-readable' indices from 1 - N...
             auto i = std::get<0>(indexName).at(0);
             if (i - 1 >= targetSpecies_->nAtoms())
+            {
                 Messenger::error("Atom index {} is out of range ({} atoms in species).\n", i, targetSpecies_->nAtoms());
                 return failed;
+            }
 
             auto &spAtom = targetSpecies_->atom(i - 1);
             auto at = spAtom.atomType();

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -142,5 +142,5 @@ enum executionResult CheckSpeciesModule::process(Dissolve &dissolve, const Proce
                             });
     }
 
-    return (nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == failed;
+    return (((nAtomTypesFailed + nChargesFailed + nBondsFailed + nAnglesFailed + nTorsionsFailed + nImpropersFailed) == 0) ? success : failed);
 }

--- a/src/modules/checkSpecies/process.cpp
+++ b/src/modules/checkSpecies/process.cpp
@@ -11,7 +11,7 @@
 #include <numeric>
 
 // Run main processing
-enum executionResult CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult CheckSpeciesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Retrieve necessary keyword values
     if (!targetSpecies_)

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -33,5 +33,5 @@ class ChecksModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -33,5 +33,5 @@ class ChecksModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checks/checks.h
+++ b/src/modules/checks/checks.h
@@ -33,5 +33,5 @@ class ChecksModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -17,8 +17,10 @@ enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const Pro
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
     Messenger::print("Checks: Threshold for angle checks is {} degrees\n", angleThreshold_);

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -7,7 +7,7 @@
 #include "modules/checks/checks.h"
 
 // Run main processing
-bool ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Perform simple checks for the target Configuration(s)
@@ -17,7 +17,8 @@ bool ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
     Messenger::print("Checks: Threshold for angle checks is {} degrees\n", angleThreshold_);
@@ -44,7 +45,7 @@ bool ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         if (!procPool.allTrue(ok))
         {
             Messenger::error("Failed consistency check between processes.\n");
-            return false;
+            return failed;
         }
     }
 
@@ -67,9 +68,9 @@ bool ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         if (!procPool.allTrue(ok))
         {
             Messenger::error("Failed consistency check between processes.\n");
-            return false;
+            return failed;
         }
     }
 
-    return true;
+    return success;
 }

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -7,7 +7,7 @@
 #include "modules/checks/checks.h"
 
 // Run main processing
-enum executionResult ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Perform simple checks for the target Configuration(s)

--- a/src/modules/checks/process.cpp
+++ b/src/modules/checks/process.cpp
@@ -7,7 +7,7 @@
 #include "modules/checks/checks.h"
 
 // Run main processing
-enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult ChecksModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Perform simple checks for the target Configuration(s)
@@ -19,7 +19,7 @@ enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const Pro
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     Messenger::print("Checks: Threshold for distance checks is {} Angstroms\n", distanceThreshold_);
@@ -47,7 +47,7 @@ enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const Pro
         if (!procPool.allTrue(ok))
         {
             Messenger::error("Failed consistency check between processes.\n");
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -70,9 +70,9 @@ enum Module::executionResult ChecksModule::process(Dissolve &dissolve, const Pro
         if (!procPool.allTrue(ok))
         {
             Messenger::error("Failed consistency check between processes.\n");
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/dAngle/dAngle.h
+++ b/src/modules/dAngle/dAngle.h
@@ -67,5 +67,5 @@ class DAngleModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dAngle/dAngle.h
+++ b/src/modules/dAngle/dAngle.h
@@ -67,5 +67,5 @@ class DAngleModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dAngle/dAngle.h
+++ b/src/modules/dAngle/dAngle.h
@@ -67,5 +67,5 @@ class DAngleModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -15,8 +15,10 @@ enum Module::executionResult DAngleModule::process(Dissolve &dissolve, const Pro
 {
     // Check for Configuration target
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     calculateAngle_->keywords().set("Symmetric", symmetric_);
@@ -35,8 +37,10 @@ enum Module::executionResult DAngleModule::process(Dissolve &dissolve, const Pro
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
+    {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
         return failed;
+    }
 
     return success;
 }

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -11,13 +11,13 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum Module::executionResult DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -39,8 +39,8 @@ enum Module::executionResult DAngleModule::process(Dissolve &dissolve, const Pro
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -11,7 +11,7 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum executionResult DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -11,11 +11,12 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-bool DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
 
     // Ensure any parameters in our nodes are set correctly
     calculateAngle_->keywords().set("Symmetric", symmetric_);
@@ -34,7 +35,8 @@ bool DAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
+        Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/dataTest/dataTest.h
+++ b/src/modules/dataTest/dataTest.h
@@ -45,5 +45,5 @@ class DataTestModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dataTest/dataTest.h
+++ b/src/modules/dataTest/dataTest.h
@@ -45,5 +45,5 @@ class DataTestModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dataTest/dataTest.h
+++ b/src/modules/dataTest/dataTest.h
@@ -45,5 +45,5 @@ class DataTestModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/dataTest/process.cpp
+++ b/src/modules/dataTest/process.cpp
@@ -10,7 +10,7 @@
 #include "modules/dataTest/dataTest.h"
 
 // Run main processing
-enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * This is a serial routine.
@@ -30,7 +30,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData)
         {
             Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
-            return failed;
+            return ExecutionResult::Failed;
         }
         const Data1D &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
@@ -42,7 +42,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
                          referenceData.tag(), error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -54,7 +54,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData1)
         {
             Messenger::error("No data with tag '{}' exists.\n", tag1);
-            return failed;
+            return ExecutionResult::Failed;
         }
         const Data1D data1 = optData1->get();
         Messenger::print("Located reference data '{}'.\n", tag1);
@@ -62,7 +62,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData2)
         {    
             Messenger::error("No data with tag '{}' exists.\n", tag2);
-            return failed;
+            return ExecutionResult::Failed;
         }
         const Data1D data2 = optData2->get();
         Messenger::print("Located reference data '{}'.\n", tag2);
@@ -74,7 +74,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
                          error, tag2, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
         {    
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -87,7 +87,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData)
         {
             Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
-            return failed;
+            return ExecutionResult::Failed;
         }
         const Data2D &data = *optData;
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
@@ -99,7 +99,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         // if (isnan(error) || error > threshold_) return false;
 
         Messenger::error("Error calculation between 2D datasets is not yet implemented.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Loop over reference three-dimensional data supplied
@@ -111,7 +111,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData)
         {
             Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
-            return failed;
+            return ExecutionResult::Failed;
         }
         const Data3D &data = *optData;
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
@@ -123,7 +123,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
                          referenceData.tag(), error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -135,7 +135,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData)
         {
             Messenger::error("No data with tag '{}' exists.\n", tag);
-            return failed;
+            return ExecutionResult::Failed;
         }
         const SampledDouble &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", tag);
@@ -147,7 +147,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
                          error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -159,7 +159,7 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
         if (!optData)
         {
             Messenger::error("No data with tag '{}' exists.\n", tag);
-            return failed;
+            return ExecutionResult::Failed;
         }
         const SampledVector &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", tag);
@@ -171,9 +171,9 @@ enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const P
                          error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/dataTest/process.cpp
+++ b/src/modules/dataTest/process.cpp
@@ -60,7 +60,7 @@ Module::ExecutionResult DataTestModule::process(Dissolve &dissolve, const Proces
         Messenger::print("Located reference data '{}'.\n", tag1);
         auto optData2 = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(tag2);
         if (!optData2)
-        {    
+        {
             Messenger::error("No data with tag '{}' exists.\n", tag2);
             return ExecutionResult::Failed;
         }
@@ -73,7 +73,7 @@ Module::ExecutionResult DataTestModule::process(Dissolve &dissolve, const Proces
         Messenger::print("Internal data '{}' has error of {:7.3e} with data '{}' and is {} (threshold is {:6.3e})\n\n", tag1,
                          error, tag2, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-        {    
+        {
             return ExecutionResult::Failed;
         }
     }

--- a/src/modules/dataTest/process.cpp
+++ b/src/modules/dataTest/process.cpp
@@ -10,7 +10,7 @@
 #include "modules/dataTest/dataTest.h"
 
 // Run main processing
-enum executionResult DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * This is a serial routine.

--- a/src/modules/dataTest/process.cpp
+++ b/src/modules/dataTest/process.cpp
@@ -10,7 +10,7 @@
 #include "modules/dataTest/dataTest.h"
 
 // Run main processing
-bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * This is a serial routine.
@@ -28,7 +28,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference data
         auto optData = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(referenceData.tag());
         if (!optData)
-            return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+        {
+            Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+            return failed;
+        }
         const Data1D &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
 
@@ -38,7 +41,9 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Target data '{}' has error of {:7.3e} with reference data and is {} (threshold is {:6.3e})\n\n",
                          referenceData.tag(), error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-            return false;
+        {
+            return failed;
+        }
     }
 
     // Loop over internal one-dimensional data tests
@@ -47,12 +52,18 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference datasets
         auto optData1 = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(tag1);
         if (!optData1)
-            return Messenger::error("No data with tag '{}' exists.\n", tag1);
+        {
+            Messenger::error("No data with tag '{}' exists.\n", tag1);
+            return failed;
+        }
         const Data1D data1 = optData1->get();
         Messenger::print("Located reference data '{}'.\n", tag1);
         auto optData2 = dissolve.processingModuleData().searchBase<Data1DBase, Data1D, SampledData1D>(tag2);
         if (!optData2)
-            return Messenger::error("No data with tag '{}' exists.\n", tag2);
+        {    
+            Messenger::error("No data with tag '{}' exists.\n", tag2);
+            return failed;
+        }
         const Data1D data2 = optData2->get();
         Messenger::print("Located reference data '{}'.\n", tag2);
 
@@ -62,7 +73,9 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Internal data '{}' has error of {:7.3e} with data '{}' and is {} (threshold is {:6.3e})\n\n", tag1,
                          error, tag2, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-            return false;
+        {    
+            return failed;
+        }
     }
 
     // Loop over reference two-dimensional data supplied
@@ -72,7 +85,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference data
         auto optData = dissolve.processingModuleData().search<const Data2D>(referenceData.tag());
         if (!optData)
-            return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+        {
+            Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+            return failed;
+        }
         const Data2D &data = *optData;
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
 
@@ -82,7 +98,8 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // is {:6.3e})\n\n", testData2D->name(), error, isnan(error) || error > threshold_ ? "NOT OK" : "OK", threshold_);
         // if (isnan(error) || error > threshold_) return false;
 
-        return Messenger::error("Error calculation between 2D datasets is not yet implemented.\n");
+        Messenger::error("Error calculation between 2D datasets is not yet implemented.\n");
+        return failed;
     }
 
     // Loop over reference three-dimensional data supplied
@@ -92,7 +109,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference data
         auto optData = dissolve.processingModuleData().search<const Data3D>(referenceData.tag());
         if (!optData)
-            return Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+        {
+            Messenger::error("No data with tag '{}' exists.\n", referenceData.tag());
+            return failed;
+        }
         const Data3D &data = *optData;
         Messenger::print("Located reference data '{}'.\n", referenceData.tag());
 
@@ -102,7 +122,9 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Target data '{}' has error of {:7.3f} with calculated data and is {} (threshold is {:6.3e})\n\n",
                          referenceData.tag(), error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-            return false;
+        {
+            return failed;
+        }
     }
 
     // Loop over reference values supplied for SampledDouble objects
@@ -111,7 +133,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference data
         auto optData = dissolve.processingModuleData().search<const SampledDouble>(tag);
         if (!optData)
-            return Messenger::error("No data with tag '{}' exists.\n", tag);
+        {
+            Messenger::error("No data with tag '{}' exists.\n", tag);
+            return failed;
+        }
         const SampledDouble &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", tag);
 
@@ -121,7 +146,9 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Target data '{}' has error of {:7.3e} with reference data and is {} (threshold is {:6.3e})\n\n", tag,
                          error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-            return false;
+        {
+            return failed;
+        }
     }
 
     // Loop over reference values supplied for SampledVector objects
@@ -130,7 +157,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // Locate the target reference data
         auto optData = dissolve.processingModuleData().search<const SampledVector>(tag);
         if (!optData)
-            return Messenger::error("No data with tag '{}' exists.\n", tag);
+        {
+            Messenger::error("No data with tag '{}' exists.\n", tag);
+            return failed;
+        }
         const SampledVector &data = optData->get();
         Messenger::print("Located reference data '{}'.\n", tag);
 
@@ -140,8 +170,10 @@ bool DataTestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         Messenger::print("Target data '{}' has error of {:7.3e} with reference data and is {} (threshold is {:6.3e})\n\n", tag,
                          error, notOK ? "NOT OK" : "OK", threshold_);
         if (notOK)
-            return false;
+        {
+            return failed;
+        }
     }
 
-    return true;
+    return success;
 }

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -80,7 +80,7 @@ class EnergyModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -80,7 +80,7 @@ class EnergyModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -80,7 +80,7 @@ class EnergyModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -333,7 +333,7 @@ EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processi
     return EnergyModule::EnergyStable;
 }
 
-// Check energy stability of specified Configurations, returning the number that failed
+// Check energy stability of specified Configurations, returning the number that ExecutionResult::Failed
 int EnergyModule::nUnstable(GenericList &processingData, const std::vector<Configuration *> &configurations)
 {
     auto nFailed = 0;

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -23,7 +23,7 @@ bool EnergyModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate Energy for the target Configuration(s)
@@ -35,7 +35,7 @@ enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const Pro
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     auto strategy = procPool.bestStrategy();
@@ -252,14 +252,14 @@ enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const Pro
                              "is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return failed;
+                return ExecutionResult::Failed;
 
             delta = testReferenceInter_.value() - interEnergy;
             Messenger::print("Reference interatomic energy delta with production value is {:15.9e} kJ/mol "
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return failed;
+                return ExecutionResult::Failed;
         }
         if (testReferenceIntra_)
         {
@@ -268,14 +268,14 @@ enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const Pro
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return failed;
+                return ExecutionResult::Failed;
 
             delta = testReferenceIntra_.value() - intraEnergy;
             Messenger::print("Reference intramolecular energy delta with production value is {:15.9e} kJ/mol "
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return failed;
+                return ExecutionResult::Failed;
         }
 
         // Compare production vs 'correct' values
@@ -293,7 +293,7 @@ enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const Pro
         // All OK?
         if (!procPool.allTrue((fabs(interDelta) < testThreshold_) && (fabs(intraDelta) < testThreshold_) &&
                               (fabs(moleculeDelta) < testThreshold_)))
-            return failed;
+            return ExecutionResult::Failed;
     }
     else
     {
@@ -398,5 +398,5 @@ enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const Pro
 
     Messenger::print("\n");
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -23,7 +23,7 @@ bool EnergyModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum executionResult EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate Energy for the target Configuration(s)

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -23,7 +23,7 @@ bool EnergyModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate Energy for the target Configuration(s)
@@ -33,7 +33,10 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     auto strategy = procPool.bestStrategy();
 
@@ -249,14 +252,14 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                              "is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return false;
+                return failed;
 
             delta = testReferenceInter_.value() - interEnergy;
             Messenger::print("Reference interatomic energy delta with production value is {:15.9e} kJ/mol "
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return false;
+                return failed;
         }
         if (testReferenceIntra_)
         {
@@ -265,14 +268,14 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return false;
+                return failed;
 
             delta = testReferenceIntra_.value() - intraEnergy;
             Messenger::print("Reference intramolecular energy delta with production value is {:15.9e} kJ/mol "
                              "and is {} (threshold is {:10.3e} kJ/mol)\n",
                              delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
             if (!procPool.allTrue(fabs(delta) < testThreshold_))
-                return false;
+                return failed;
         }
 
         // Compare production vs 'correct' values
@@ -290,7 +293,7 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
         // All OK?
         if (!procPool.allTrue((fabs(interDelta) < testThreshold_) && (fabs(intraDelta) < testThreshold_) &&
                               (fabs(moleculeDelta) < testThreshold_)))
-            return false;
+            return failed;
     }
     else
     {
@@ -395,5 +398,5 @@ bool EnergyModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 
     Messenger::print("\n");
 
-    return true;
+    return success;
 }

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -175,7 +175,7 @@ class EPSRModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -175,7 +175,7 @@ class EPSRModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -175,7 +175,7 @@ class EPSRModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -553,7 +553,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve, const ProcessPoo
                                       : !scatteringMatrix_.addPartialReferenceData(data, at1, at2, 1.0, (1.0 - feedback_)))
             {
                 Messenger::error("EPSR: Failed to augment scattering matrix with partial {}-{}.\n", at1->name(), at2->name());
-                return ExecutionResult::Failed;
+                return false;
             }
 
             return EarlyReturn<bool>::Continue;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -556,7 +556,7 @@ enum Module::executionResult EPSRModule::process(Dissolve &dissolve, const Proce
                                 {
                                     Messenger::error("EPSR: Failed to augment scattering matrix with partial {}-{}.\n",
                                                     at1->name(), at2->name());
-                                    return failed
+                                    return failed;
                                 }
 
                                 return EarlyReturn<bool>::Continue;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -122,7 +122,7 @@ bool EPSRModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<Ke
 }
 
 // Run main processing
-enum executionResult EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult EPSRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     std::string testDataName;
 
@@ -473,7 +473,7 @@ enum executionResult EPSRModule::process(Dissolve &dissolve, const ProcessPool &
             {
                 Data1DExportFileFormat exportFormat(fmt::format("{}-Diff.q", module->name()));
                 if (exportFormat.exportData(differenceData))
-                    { procPool.decideTrue() };
+                    procPool.decideTrue();
                 else
                     return (procPool.decideFalse() ? success : failed);
             }

--- a/src/modules/exportCoordinates/exportCoordinates.h
+++ b/src/modules/exportCoordinates/exportCoordinates.h
@@ -29,5 +29,5 @@ class ExportCoordinatesModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportCoordinates/exportCoordinates.h
+++ b/src/modules/exportCoordinates/exportCoordinates.h
@@ -29,5 +29,5 @@ class ExportCoordinatesModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportCoordinates/exportCoordinates.h
+++ b/src/modules/exportCoordinates/exportCoordinates.h
@@ -29,5 +29,5 @@ class ExportCoordinatesModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportCoordinates/process.cpp
+++ b/src/modules/exportCoordinates/process.cpp
@@ -8,10 +8,13 @@
 #include "modules/exportCoordinates/exportCoordinates.h"
 
 // Run main processing
-bool ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!coordinatesFormat_.hasFilename())
+    {
         Messenger::error("No valid file/format set for coordinate export.\n");
+        return failed;
+    }
 
     std::string originalFilename{coordinatesFormat_.filename()};
     if (tagWithIteration_)
@@ -19,7 +22,10 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &pro
 
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Only the pool master saves the data
     if (procPool.isMaster())
@@ -31,16 +37,16 @@ bool ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &pro
         {
             Messenger::print("Export: Failed to export coordinates file '{}'.\n", coordinatesFormat_.filename());
             procPool.decideFalse();
-            return false;
+            return failed;
         }
 
         procPool.decideTrue();
     }
     else if (!procPool.decision())
-        return false;
+        return failed;
 
     // Reset filename
     coordinatesFormat_.setFilename(originalFilename);
 
-    return true;
+    return success;
 }

--- a/src/modules/exportCoordinates/process.cpp
+++ b/src/modules/exportCoordinates/process.cpp
@@ -8,12 +8,12 @@
 #include "modules/exportCoordinates/exportCoordinates.h"
 
 // Run main processing
-enum Module::executionResult ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!coordinatesFormat_.hasFilename())
     {
         Messenger::error("No valid file/format set for coordinate export.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     std::string originalFilename{coordinatesFormat_.filename()};
@@ -24,7 +24,7 @@ enum Module::executionResult ExportCoordinatesModule::process(Dissolve &dissolve
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Only the pool master saves the data
@@ -37,16 +37,16 @@ enum Module::executionResult ExportCoordinatesModule::process(Dissolve &dissolve
         {
             Messenger::print("Export: Failed to export coordinates file '{}'.\n", coordinatesFormat_.filename());
             procPool.decideFalse();
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         procPool.decideTrue();
     }
     else if (!procPool.decision())
-        return failed;
+        return ExecutionResult::Failed;
 
     // Reset filename
     coordinatesFormat_.setFilename(originalFilename);
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/exportCoordinates/process.cpp
+++ b/src/modules/exportCoordinates/process.cpp
@@ -8,7 +8,7 @@
 #include "modules/exportCoordinates/exportCoordinates.h"
 
 // Run main processing
-enum executionResult ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ExportCoordinatesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!coordinatesFormat_.hasFilename())
     {

--- a/src/modules/exportPairPotentials/exportPairPotentials.h
+++ b/src/modules/exportPairPotentials/exportPairPotentials.h
@@ -25,5 +25,5 @@ class ExportPairPotentialsModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportPairPotentials/exportPairPotentials.h
+++ b/src/modules/exportPairPotentials/exportPairPotentials.h
@@ -25,5 +25,5 @@ class ExportPairPotentialsModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportPairPotentials/exportPairPotentials.h
+++ b/src/modules/exportPairPotentials/exportPairPotentials.h
@@ -25,5 +25,5 @@ class ExportPairPotentialsModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportPairPotentials/process.cpp
+++ b/src/modules/exportPairPotentials/process.cpp
@@ -15,7 +15,7 @@ enum Module::executionResult ExportPairPotentialsModule::process(Dissolve &disso
     if (!pairPotentialFormat_.hasFilename())
     {
         Messenger::error("No valid file/format set for pair potential export.\n");
-        return failed
+        return failed;
     }
 
     // Only the pool master saves the data

--- a/src/modules/exportPairPotentials/process.cpp
+++ b/src/modules/exportPairPotentials/process.cpp
@@ -13,7 +13,10 @@
 bool ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!pairPotentialFormat_.hasFilename())
-        return Messenger::error("No valid file/format set for pair potential export.\n");
+    {
+        Messenger::error("No valid file/format set for pair potential export.\n");
+        return failed
+    }
 
     // Only the pool master saves the data
     if (procPool.isMaster())
@@ -35,7 +38,7 @@ bool ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &
                 Messenger::print("Export: Failed to export pair potential file '{}'.\n", pairPotentialFormat_.filename());
                 pairPotentialFormat_.setFilename(rootPPName);
                 procPool.decideFalse();
-                return false;
+                return failed;
             }
 
             procPool.decideTrue();
@@ -45,7 +48,7 @@ bool ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &
         pairPotentialFormat_.setFilename(rootPPName);
     }
     else if (!procPool.decision())
-        return false;
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/exportPairPotentials/process.cpp
+++ b/src/modules/exportPairPotentials/process.cpp
@@ -10,7 +10,7 @@
 #include "modules/exportPairPotentials/exportPairPotentials.h"
 
 // Run main processing
-bool ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!pairPotentialFormat_.hasFilename())
     {

--- a/src/modules/exportPairPotentials/process.cpp
+++ b/src/modules/exportPairPotentials/process.cpp
@@ -10,12 +10,12 @@
 #include "modules/exportPairPotentials/exportPairPotentials.h"
 
 // Run main processing
-enum Module::executionResult ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult ExportPairPotentialsModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!pairPotentialFormat_.hasFilename())
     {
         Messenger::error("No valid file/format set for pair potential export.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Only the pool master saves the data
@@ -38,7 +38,7 @@ enum Module::executionResult ExportPairPotentialsModule::process(Dissolve &disso
                 Messenger::print("Export: Failed to export pair potential file '{}'.\n", pairPotentialFormat_.filename());
                 pairPotentialFormat_.setFilename(rootPPName);
                 procPool.decideFalse();
-                return failed;
+                return ExecutionResult::Failed;
             }
 
             procPool.decideTrue();
@@ -48,7 +48,7 @@ enum Module::executionResult ExportPairPotentialsModule::process(Dissolve &disso
         pairPotentialFormat_.setFilename(rootPPName);
     }
     else if (!procPool.decision())
-        return failed;
+        return ExecutionResult::Failed;
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/exportTrajectory/exportTrajectory.h
+++ b/src/modules/exportTrajectory/exportTrajectory.h
@@ -27,5 +27,5 @@ class ExportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportTrajectory/exportTrajectory.h
+++ b/src/modules/exportTrajectory/exportTrajectory.h
@@ -27,5 +27,5 @@ class ExportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportTrajectory/exportTrajectory.h
+++ b/src/modules/exportTrajectory/exportTrajectory.h
@@ -27,5 +27,5 @@ class ExportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/exportTrajectory/process.cpp
+++ b/src/modules/exportTrajectory/process.cpp
@@ -10,7 +10,7 @@
 #include "modules/exportTrajectory/exportTrajectory.h"
 
 // Run main processing
-enum executionResult ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!trajectoryFormat_.hasFilename())
     {

--- a/src/modules/exportTrajectory/process.cpp
+++ b/src/modules/exportTrajectory/process.cpp
@@ -10,14 +10,20 @@
 #include "modules/exportTrajectory/exportTrajectory.h"
 
 // Run main processing
-bool ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!trajectoryFormat_.hasFilename())
+    {
         Messenger::error("No valid file/format set for trajectory export.\n");
+        return failed;
+    }
 
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Only the pool master saves the data
     if (procPool.isMaster())
@@ -29,13 +35,13 @@ bool ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
         {
             Messenger::print("Export: Failed to append trajectory file '{}'.\n", trajectoryFormat_.filename());
             procPool.decideFalse();
-            return false;
+            return failed;
         }
 
         procPool.decideTrue();
     }
     else if (!procPool.decision())
-        return false;
+        return failed;
 
-    return true;
+    return success;
 }

--- a/src/modules/exportTrajectory/process.cpp
+++ b/src/modules/exportTrajectory/process.cpp
@@ -10,19 +10,19 @@
 #include "modules/exportTrajectory/exportTrajectory.h"
 
 // Run main processing
-enum Module::executionResult ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult ExportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     if (!trajectoryFormat_.hasFilename())
     {
         Messenger::error("No valid file/format set for trajectory export.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Check for Configuration target
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Only the pool master saves the data
@@ -35,13 +35,13 @@ enum Module::executionResult ExportTrajectoryModule::process(Dissolve &dissolve,
         {
             Messenger::print("Export: Failed to append trajectory file '{}'.\n", trajectoryFormat_.filename());
             procPool.decideFalse();
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         procPool.decideTrue();
     }
     else if (!procPool.decision())
-        return failed;
+        return ExecutionResult::Failed;
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -45,7 +45,7 @@ class ForcesModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -45,7 +45,7 @@ class ForcesModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/forces/forces.h
+++ b/src/modules/forces/forces.h
@@ -45,7 +45,7 @@ class ForcesModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Run set-up stage

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -408,10 +408,13 @@ enum Module::executionResult ForcesModule::process(Dissolve &dissolve, const Pro
             // Grab reference force array and check size
             const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", name());
             if (fRef.size() != targetConfiguration_->nAtoms())
-                return Messenger::error("Number of force components in ReferenceForces is {}, but the "
-                                        "Configuration '{}' contains {} atoms.\n",
-                                        fRef.size(), targetConfiguration_->name(), targetConfiguration_->nAtoms());
-
+            {
+               Messenger::error("Number of force components in ReferenceForces is {}, but the "
+                                "Configuration '{}' contains {} atoms.\n",
+                                fRef.size(), targetConfiguration_->name(), targetConfiguration_->nAtoms());
+                return failed;
+            }
+ 
             Messenger::print("\nTesting reference forces against calculated 'correct' forces - "
                              "atoms with erroneous forces will be output...\n");
             sumError = 0.0;
@@ -493,7 +496,7 @@ enum Module::executionResult ForcesModule::process(Dissolve &dissolve, const Pro
         }
 
         if (!procPool.allTrue((nFailed1 + nFailed2 + nFailed3) == 0))
-            return false;
+            return failed;
     }
     else
     {

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -29,7 +29,7 @@ bool ForcesModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum executeProcessing ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ForcesModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -395,7 +395,8 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve, const ProcessP
             }
         }
 
-        Messenger::print("Number of atoms with ExecutionResult::Failed force components = {} = {}\n", nFailed1, nFailed1 == 0 ? "OK" : "NOT OK");
+        Messenger::print("Number of atoms with ExecutionResult::Failed force components = {} = {}\n", nFailed1,
+                         nFailed1 == 0 ? "OK" : "NOT OK");
         Messenger::print("Average error in force components was {}%.\n", sumError / (targetConfiguration_->nAtoms() * 6));
 
         // Test reference forces against production (if reference forces present)
@@ -409,12 +410,12 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve, const ProcessP
             const auto &fRef = processingData.value<std::vector<Vec3<double>>>("ReferenceForces", name());
             if (fRef.size() != targetConfiguration_->nAtoms())
             {
-               Messenger::error("Number of force components in ReferenceForces is {}, but the "
-                                "Configuration '{}' contains {} atoms.\n",
-                                fRef.size(), targetConfiguration_->name(), targetConfiguration_->nAtoms());
+                Messenger::error("Number of force components in ReferenceForces is {}, but the "
+                                 "Configuration '{}' contains {} atoms.\n",
+                                 fRef.size(), targetConfiguration_->name(), targetConfiguration_->nAtoms());
                 return ExecutionResult::Failed;
             }
- 
+
             Messenger::print("\nTesting reference forces against calculated 'correct' forces - "
                              "atoms with erroneous forces will be output...\n");
             sumError = 0.0;
@@ -515,10 +516,10 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve, const ProcessP
 
         // If writing to a file, append it here
         if (saveData && !exportedForces_.exportData(f))
-            {
-                Messenger::error("Failed to save forces.\n");
-                return ExecutionResult::Failed;
-            }
+        {
+            Messenger::error("Failed to save forces.\n");
+            return ExecutionResult::Failed;
+        }
     }
 
     return ExecutionResult::Success;

--- a/src/modules/geomOpt/geomOpt.h
+++ b/src/modules/geomOpt/geomOpt.h
@@ -268,5 +268,5 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/geomOpt/geomOpt.h
+++ b/src/modules/geomOpt/geomOpt.h
@@ -268,5 +268,5 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/geomOpt/geomOpt.h
+++ b/src/modules/geomOpt/geomOpt.h
@@ -268,5 +268,5 @@ class GeometryOptimisationModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/geomOpt/process.cpp
+++ b/src/modules/geomOpt/process.cpp
@@ -6,7 +6,7 @@
 #include "modules/geomOpt/geomOpt.h"
 
 // Run main processing
-enum executionResult GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Print argument/parameter summary
     Messenger::print("Optimise: Maximum number of cycles is {}.\n", maxCycles_);

--- a/src/modules/geomOpt/process.cpp
+++ b/src/modules/geomOpt/process.cpp
@@ -6,7 +6,7 @@
 #include "modules/geomOpt/geomOpt.h"
 
 // Run main processing
-bool GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Print argument/parameter summary
     Messenger::print("Optimise: Maximum number of cycles is {}.\n", maxCycles_);
@@ -16,7 +16,10 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &
 
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Initialise working arrays for coordinates and forces
     rRef_.resize(targetConfiguration_->nAtoms(), Vec3<double>());
@@ -25,5 +28,5 @@ bool GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &
 
     optimise<Configuration>(dissolve.potentialMap(), procPool, targetConfiguration_);
 
-    return true;
+    return success;
 }

--- a/src/modules/geomOpt/process.cpp
+++ b/src/modules/geomOpt/process.cpp
@@ -6,7 +6,7 @@
 #include "modules/geomOpt/geomOpt.h"
 
 // Run main processing
-enum Module::executionResult GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult GeometryOptimisationModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Print argument/parameter summary
     Messenger::print("Optimise: Maximum number of cycles is {}.\n", maxCycles_);
@@ -18,7 +18,7 @@ enum Module::executionResult GeometryOptimisationModule::process(Dissolve &disso
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Initialise working arrays for coordinates and forces
@@ -28,5 +28,5 @@ enum Module::executionResult GeometryOptimisationModule::process(Dissolve &disso
 
     optimise<Configuration>(dissolve.potentialMap(), procPool, targetConfiguration_);
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -105,5 +105,5 @@ class GRModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -105,5 +105,5 @@ class GRModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -105,5 +105,5 @@ class GRModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -64,11 +64,11 @@ Module::ExecutionResult GRModule::process(Dissolve &dissolve, const ProcessPool 
             if (requestedRange_.value_or(0.0) > rdfRange)
             {
                 Messenger::error("Specified RDF range of {} Angstroms is out of range for Configuration "
-                                        "'{}' (max = {} Angstroms).\n",
-                                        requestedRange_.value(), cfg->niceName(), rdfRange);
+                                 "'{}' (max = {} Angstroms).\n",
+                                 requestedRange_.value(), cfg->niceName(), rdfRange);
                 return ExecutionResult::Failed;
             }
-                 
+
             rdfRange = requestedRange_.value();
             Messenger::print("Cutoff for Configuration '{}' is {} Angstroms.\n", cfg->niceName(), rdfRange);
         }

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -8,7 +8,7 @@
 #include "modules/gr/gr.h"
 
 // Run main processing
-enum executionResult GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult GRModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate standard partial g(r)

--- a/src/modules/histogramCN/histogramCN.h
+++ b/src/modules/histogramCN/histogramCN.h
@@ -46,5 +46,5 @@ class HistogramCNModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/histogramCN/histogramCN.h
+++ b/src/modules/histogramCN/histogramCN.h
@@ -46,5 +46,5 @@ class HistogramCNModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/histogramCN/histogramCN.h
+++ b/src/modules/histogramCN/histogramCN.h
@@ -46,5 +46,5 @@ class HistogramCNModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -35,7 +35,7 @@ Module::ExecutionResult HistogramCNModule::process(Dissolve &dissolve, const Pro
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");
         return ExecutionResult::Failed;
-    } 
+    }
 
     return ExecutionResult::Success;
 }

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -16,7 +16,10 @@ enum Module::executionResult HistogramCNModule::process(Dissolve &dissolve, cons
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     if (excludeSameMolecule_)

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -12,13 +12,13 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum Module::executionResult HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -34,8 +34,8 @@ enum Module::executionResult HistogramCNModule::process(Dissolve &dissolve, cons
     if (!analyser_.execute(context))
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     } 
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-bool HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
@@ -29,7 +29,10 @@ bool HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("HistogramCN experienced problems with its analysis.\n");
+    {
+        Messenger::error("HistogramCN experienced problems with its analysis.\n");
+        return failed;
+    } 
 
-    return true;
+    return success;
 }

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum executionResult HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult HistogramCNModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/importTrajectory/importTrajectory.h
+++ b/src/modules/importTrajectory/importTrajectory.h
@@ -27,5 +27,5 @@ class ImportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/importTrajectory/importTrajectory.h
+++ b/src/modules/importTrajectory/importTrajectory.h
@@ -27,5 +27,5 @@ class ImportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/importTrajectory/importTrajectory.h
+++ b/src/modules/importTrajectory/importTrajectory.h
@@ -27,5 +27,5 @@ class ImportTrajectoryModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/importTrajectory/process.cpp
+++ b/src/modules/importTrajectory/process.cpp
@@ -8,7 +8,7 @@
 #include "modules/importTrajectory/importTrajectory.h"
 
 // Run main processing
-enum executionResult ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)

--- a/src/modules/importTrajectory/process.cpp
+++ b/src/modules/importTrajectory/process.cpp
@@ -8,11 +8,14 @@
 #include "modules/importTrajectory/importTrajectory.h"
 
 // Run main processing
-bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     Messenger::print("Import: Reading trajectory file frame from '{}' into Configuration '{}'...\n",
                      trajectoryFormat_.filename(), targetConfiguration_->name());
@@ -20,7 +23,10 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
     // Open the file
     LineParser parser(&procPool);
     if ((!parser.openInput(trajectoryFormat_.filename())) || (!parser.isFileGoodForReading()))
-        return Messenger::error("Couldn't open trajectory file '{}'.\n", trajectoryFormat_.filename());
+    {
+        Messenger::error("Couldn't open trajectory file '{}'.\n", trajectoryFormat_.filename());
+        return failed;
+    }
 
     // Does a seek position exist in the processing module info?
     std::string streamPosName = fmt::format("TrajectoryPosition_{}", targetConfiguration_->niceName());
@@ -34,7 +40,11 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
     // Read the frame
     std::optional<Matrix3> unitCell;
     if (!trajectoryFormat_.importData(parser, targetConfiguration_, unitCell))
-        return Messenger::error("Failed to read trajectory frame data.\n");
+    {
+        Messenger::error("Failed to read trajectory frame data.\n");
+        return failed;
+    }
+ 
     targetConfiguration_->incrementContentsVersion();
 
     // Set the trajectory file position in the restart file
@@ -58,5 +68,5 @@ bool ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &proc
     // Make sure that the configuration contents are up-to-date w.r.t. cell locations etc.
     targetConfiguration_->updateAtomLocations(clearExistingLocations);
 
-    return true;
+    return success;
 }

--- a/src/modules/importTrajectory/process.cpp
+++ b/src/modules/importTrajectory/process.cpp
@@ -8,13 +8,13 @@
 #include "modules/importTrajectory/importTrajectory.h"
 
 // Run main processing
-enum Module::executionResult ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult ImportTrajectoryModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     Messenger::print("Import: Reading trajectory file frame from '{}' into Configuration '{}'...\n",
@@ -25,7 +25,7 @@ enum Module::executionResult ImportTrajectoryModule::process(Dissolve &dissolve,
     if ((!parser.openInput(trajectoryFormat_.filename())) || (!parser.isFileGoodForReading()))
     {
         Messenger::error("Couldn't open trajectory file '{}'.\n", trajectoryFormat_.filename());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Does a seek position exist in the processing module info?
@@ -42,7 +42,7 @@ enum Module::executionResult ImportTrajectoryModule::process(Dissolve &dissolve,
     if (!trajectoryFormat_.importData(parser, targetConfiguration_, unitCell))
     {
         Messenger::error("Failed to read trajectory frame data.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
  
     targetConfiguration_->incrementContentsVersion();
@@ -68,5 +68,5 @@ enum Module::executionResult ImportTrajectoryModule::process(Dissolve &dissolve,
     // Make sure that the configuration contents are up-to-date w.r.t. cell locations etc.
     targetConfiguration_->updateAtomLocations(clearExistingLocations);
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/importTrajectory/process.cpp
+++ b/src/modules/importTrajectory/process.cpp
@@ -44,7 +44,7 @@ Module::ExecutionResult ImportTrajectoryModule::process(Dissolve &dissolve, cons
         Messenger::error("Failed to read trajectory frame data.\n");
         return ExecutionResult::Failed;
     }
- 
+
     targetConfiguration_->incrementContentsVersion();
 
     // Set the trajectory file position in the restart file

--- a/src/modules/intraAngle/intraAngle.h
+++ b/src/modules/intraAngle/intraAngle.h
@@ -55,5 +55,5 @@ class IntraAngleModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraAngle/intraAngle.h
+++ b/src/modules/intraAngle/intraAngle.h
@@ -55,5 +55,5 @@ class IntraAngleModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraAngle/intraAngle.h
+++ b/src/modules/intraAngle/intraAngle.h
@@ -55,5 +55,5 @@ class IntraAngleModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -10,13 +10,13 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum Module::executionResult IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -33,8 +33,8 @@ enum Module::executionResult IntraAngleModule::process(Dissolve &dissolve, const
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateAngle experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -10,7 +10,7 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-enum executionResult IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -10,11 +10,14 @@
 #include "procedure/nodes/select.h"
 
 // Run main processing
-bool IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     selectB_->setDistanceReferenceSite(selectA_);
@@ -28,7 +31,10 @@ bool IntraAngleModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateAngle experienced problems with its analysis.\n");
+    {
+        Messenger::error("CalculateAngle experienced problems with its analysis.\n");
+        return failed;
+    }
 
-    return true;
+    return success;
 }

--- a/src/modules/intraDistance/intraDistance.h
+++ b/src/modules/intraDistance/intraDistance.h
@@ -45,5 +45,5 @@ class IntraDistanceModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraDistance/intraDistance.h
+++ b/src/modules/intraDistance/intraDistance.h
@@ -45,5 +45,5 @@ class IntraDistanceModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraDistance/intraDistance.h
+++ b/src/modules/intraDistance/intraDistance.h
@@ -45,5 +45,5 @@ class IntraDistanceModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -14,8 +14,11 @@ bool IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPoo
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
-
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
+    
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);
 
@@ -23,7 +26,10 @@ bool IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPoo
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateRDF experienced problems with its analysis.\n");
+    {
+        Messenger::error("CalculateRDF experienced problems with its analysis.\n");
+        return failed;
+    }
 
-    return true;
+    return success;
 }

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -10,7 +10,7 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum executionResult IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -10,13 +10,13 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum Module::executionResult IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -28,8 +28,8 @@ enum Module::executionResult IntraDistanceModule::process(Dissolve &dissolve, co
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -10,7 +10,7 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-bool IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
@@ -18,7 +18,7 @@ bool IntraDistanceModule::process(Dissolve &dissolve, const ProcessPool &procPoo
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
     }
-    
+
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);
 

--- a/src/modules/intraShake/intraShake.h
+++ b/src/modules/intraShake/intraShake.h
@@ -58,5 +58,5 @@ class IntraShakeModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraShake/intraShake.h
+++ b/src/modules/intraShake/intraShake.h
@@ -58,5 +58,5 @@ class IntraShakeModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraShake/intraShake.h
+++ b/src/modules/intraShake/intraShake.h
@@ -58,5 +58,5 @@ class IntraShakeModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -15,13 +15,13 @@
 #include "modules/intraShake/intraShake.h"
 
 // Run main processing
-enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Retrieve control parameters
@@ -86,7 +86,7 @@ enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const
         if (!spPop.first->attachedAtomListsGenerated())
         {
             Messenger::error("Species '{}' has no attached atom lists, so module can't proceed.\n", spPop.first->name());
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -318,19 +318,19 @@ enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const
 
     // Collect statistics across all processes
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nBondAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nBondAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nAngleAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nAngleAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nTorsionAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nTorsionAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
 
     Messenger::print("IntraShake: Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
     Messenger::print("IntraShake: Total number of attempted moves was {} ({} work, {} comms).\n",
@@ -391,5 +391,5 @@ enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const
     if ((nBondAccepted > 0) || (nAngleAccepted > 0) || (nTorsionAccepted > 0))
         targetConfiguration_->incrementContentsVersion();
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -15,7 +15,7 @@
 #include "modules/intraShake/intraShake.h"
 
 // Run main processing
-enum executionResult IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -318,19 +318,19 @@ enum Module::executionResult IntraShakeModule::process(Dissolve &dissolve, const
 
     // Collect statistics across all processes
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nBondAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nBondAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nAngleAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nAngleAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nTorsionAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nTorsionAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
 
     Messenger::print("IntraShake: Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
     Messenger::print("IntraShake: Total number of attempted moves was {} ({} work, {} comms).\n",

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -83,5 +83,5 @@ class MDModule : public Module
      */
     private:
     // Run main processing
-    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -83,5 +83,5 @@ class MDModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -83,5 +83,5 @@ class MDModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/md/md.h
+++ b/src/modules/md/md.h
@@ -83,5 +83,5 @@ class MDModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -11,7 +11,7 @@
 #include "modules/md/md.h"
 
 // Run main processing
-enum executionResult MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -11,13 +11,13 @@
 #include "modules/md/md.h"
 
 // Run main processing
-enum Module::executionResult MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Get control parameters
@@ -59,12 +59,12 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
         auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), targetConfiguration_);
         if (stabilityResult == EnergyModule::NotAssessable)
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
         else if (stabilityResult == EnergyModule::EnergyUnstable)
         {
             Messenger::print("Skipping MD for Configuration '{}'.\n", targetConfiguration_->niceName());
-            return notExecuted;
+            return ExecutionResult::NotExecuted;
         }
     }
 
@@ -187,13 +187,13 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
             {
                 Messenger::error("Failed to open MD trajectory output file '{}'.\n", trajectoryFile);
                 procPool.decideFalse();
-                return failed;
+                return ExecutionResult::Failed;
             }
             procPool.decideTrue();
         }
         else if (!procPool.decision())
         {
-            return failed;
+            return ExecutionResult::Failed;
         }
     }
 
@@ -234,7 +234,7 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
         if (!determineTimeStep(timestepType_, fixedTimestep_, fUnbound, fBound))
         {
             Messenger::print("Forces are currently too high for MD to proceed. Skipping this run.\n");
-            return notExecuted;
+            return ExecutionResult::NotExecuted;
         }
     }
 
@@ -348,7 +348,7 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
                 if (!trajParser.writeLine(header))
                 {
                     procPool.decideFalse();
-                    return failed;
+                    return ExecutionResult::Failed;
                 }
 
                 // Write Atoms
@@ -358,7 +358,7 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
                                                i.r().x, i.r().y, i.r().z))
                     {
                         procPool.decideFalse();
-                        return failed;
+                        return ExecutionResult::Failed;
                     }
                 }
 
@@ -366,7 +366,7 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
             }
             else if (!procPool.decision())
             {
-                return failed;
+                return ExecutionResult::Failed;
             }
         }
     }
@@ -390,5 +390,5 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
      * Calculation End
      */
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -15,8 +15,10 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
+    {
         Messenger::error("No configuration target set for module '{}'.\n", name());
         return failed;
+    }
 
     // Get control parameters
     const auto maxForce = capForcesAt_ * 100.0; // To convert from kJ/mol to 10 J/mol
@@ -56,7 +58,9 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
     {
         auto stabilityResult = EnergyModule::checkStability(dissolve.processingModuleData(), targetConfiguration_);
         if (stabilityResult == EnergyModule::NotAssessable)
+        {
             return failed;
+        }
         else if (stabilityResult == EnergyModule::EnergyUnstable)
         {
             Messenger::print("Skipping MD for Configuration '{}'.\n", targetConfiguration_->niceName());
@@ -81,7 +85,9 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
     std::vector<const Molecule *> targetMolecules;
     std::vector<int> free(targetConfiguration_->nAtoms(), 0);
     if (restrictToSpecies_.empty())
+    {
         std::fill(free.begin(), free.end(), 1);
+    }
     else
         for (const auto &mol : targetConfiguration_->molecules())
             if (std::find(restrictToSpecies_.begin(), restrictToSpecies_.end(), mol->species()) != restrictToSpecies_.end())
@@ -128,7 +134,10 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
         std::fill(velocities.begin(), velocities.end(), Vec3<double>());
     }
     else
+    {
         Messenger::print("Existing velocities will be used.\n");
+    }
+        
     Messenger::print("\n");
 
     // Store atomic masses for future use
@@ -183,7 +192,9 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
             procPool.decideTrue();
         }
         else if (!procPool.decision())
+        {
             return failed;
+        }
     }
 
     // Write header
@@ -354,7 +365,9 @@ enum Module::executionResult MDModule::process(Dissolve &dissolve, const Process
                 procPool.decideTrue();
             }
             else if (!procPool.decision())
+            {
                 return failed;
+            }
         }
     }
     timer.stop();

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -11,7 +11,7 @@
 #include "modules/md/md.h"
 
 // Run main processing
-enum executeProcessing MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult MDModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -137,7 +137,7 @@ Module::ExecutionResult MDModule::process(Dissolve &dissolve, const ProcessPool 
     {
         Messenger::print("Existing velocities will be used.\n");
     }
-        
+
     Messenger::print("\n");
 
     // Store atomic masses for future use

--- a/src/modules/molShake/molShake.h
+++ b/src/modules/molShake/molShake.h
@@ -44,5 +44,5 @@ class MolShakeModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/molShake/molShake.h
+++ b/src/modules/molShake/molShake.h
@@ -44,5 +44,5 @@ class MolShakeModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/molShake/molShake.h
+++ b/src/modules/molShake/molShake.h
@@ -44,5 +44,5 @@ class MolShakeModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/molShake/process.cpp
+++ b/src/modules/molShake/process.cpp
@@ -12,7 +12,7 @@
 #include "modules/molShake/molShake.h"
 
 // Run main processing
-enum executionResult MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/molShake/process.cpp
+++ b/src/modules/molShake/process.cpp
@@ -12,13 +12,13 @@
 #include "modules/molShake/molShake.h"
 
 // Run main processing
-enum Module::executionResult MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Retrieve control parameters from Configuration
@@ -219,17 +219,17 @@ enum Module::executionResult MolShakeModule::process(Dissolve &dissolve, const P
 
     // Collect statistics across all processes
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nGeneralAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nTranslationAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nTranslationsAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nRotationAttempts, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
     if (!procPool.allSum(&nRotationsAccepted, 1, strategy, commsTimer))
-        return failed;
+        return ExecutionResult::Failed;
 
     Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
 
@@ -267,5 +267,5 @@ enum Module::executionResult MolShakeModule::process(Dissolve &dissolve, const P
     if ((nRotationsAccepted > 0) || (nTranslationsAccepted > 0))
         targetConfiguration_->incrementContentsVersion();
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/molShake/process.cpp
+++ b/src/modules/molShake/process.cpp
@@ -219,17 +219,17 @@ enum Module::executionResult MolShakeModule::process(Dissolve &dissolve, const P
 
     // Collect statistics across all processes
     if (!procPool.allSum(&totalDelta, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nGeneralAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nTranslationAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nTranslationsAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nRotationAttempts, 1, strategy, commsTimer))
-        return false;
+        return failed;
     if (!procPool.allSum(&nRotationsAccepted, 1, strategy, commsTimer))
-        return false;
+        return failed;
 
     Messenger::print("Total energy delta was {:10.4e} kJ/mol.\n", totalDelta);
 

--- a/src/modules/molShake/process.cpp
+++ b/src/modules/molShake/process.cpp
@@ -12,11 +12,14 @@
 #include "modules/molShake/molShake.h"
 
 // Run main processing
-bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Retrieve control parameters from Configuration
     auto rCut = cutoffDistance_.value_or(dissolve.pairPotentialRange());
@@ -264,5 +267,5 @@ bool MolShakeModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     if ((nRotationsAccepted > 0) || (nTranslationsAccepted > 0))
         targetConfiguration_->incrementContentsVersion();
 
-    return true;
+    return success;
 }

--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -80,7 +80,7 @@ class NeutronSQModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -80,7 +80,7 @@ class NeutronSQModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -80,7 +80,7 @@ class NeutronSQModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/neutronSQ/process.cpp
+++ b/src/modules/neutronSQ/process.cpp
@@ -133,7 +133,7 @@ bool NeutronSQModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Fla
 }
 
 // Run main processing
-enum executionResult NeutronSQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult NeutronSQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate neutron structure factors from existing S(Q) data

--- a/src/modules/neutronSQ/process.cpp
+++ b/src/modules/neutronSQ/process.cpp
@@ -153,7 +153,6 @@ Module::ExecutionResult NeutronSQModule::process(Dissolve &dissolve, const Proce
     {
         Messenger::error("A source GR module (in the SQ module) must be provided.\n");
         return ExecutionResult::Failed;
-
     }
 
     // Print argument/parameter summary

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -10,7 +10,7 @@
 #include "procedure/nodes/sequence.h"
 
 // Run main processing
-enum executionResult SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -10,13 +10,13 @@
 #include "procedure/nodes/sequence.h"
 
 // Run main processing
-enum Module::executionResult SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -34,7 +34,7 @@ enum Module::executionResult SDFModule::process(Dissolve &dissolve, const Proces
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Save data?
@@ -47,12 +47,12 @@ enum Module::executionResult SDFModule::process(Dissolve &dissolve, const Proces
             else
             {
                 procPool.decideFalse();
-                return failed;
+                return ExecutionResult::Failed;
             }
         }
         else if (!procPool.decision())
-            return failed;
+            return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -10,11 +10,14 @@
 #include "procedure/nodes/sequence.h"
 
 // Run main processing
-bool SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for Configuration target
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     collectVector_->keywords().set("RangeX", rangeX_);
@@ -29,7 +32,10 @@ bool SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateSDF experienced problems with its analysis.\n");
+    {
+        Messenger::error("CalculateSDF experienced problems with its analysis.\n");
+        return failed;
+    }
 
     // Save data?
     if (sdfFileAndFormat_.hasFilename())
@@ -41,12 +47,12 @@ bool SDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             else
             {
                 procPool.decideFalse();
-                return false;
+                return failed;
             }
         }
         else if (!procPool.decision())
-            return false;
+            return failed;
     }
 
-    return true;
+    return success;
 }

--- a/src/modules/sdf/sdf.h
+++ b/src/modules/sdf/sdf.h
@@ -52,5 +52,5 @@ class SDFModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/sdf/sdf.h
+++ b/src/modules/sdf/sdf.h
@@ -52,5 +52,5 @@ class SDFModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/sdf/sdf.h
+++ b/src/modules/sdf/sdf.h
@@ -52,5 +52,5 @@ class SDFModule : public Module
      */
     private:
     // Run main processing
-    enum executeProcessing process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -12,13 +12,13 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Ensure any parameters in our nodes are set correctly
@@ -35,7 +35,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // Accumulate instantaneous coordination number data
@@ -51,7 +51,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                 if (!exportFormat.exportData(sumA))
                 {
                     Messenger::error("Failed to write instantaneous coordination number data for range A.\n");
-                    return failed;
+                    return ExecutionResult::Failed;
                 }
             }
         }
@@ -65,7 +65,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                 if (!exportFormat.exportData(sumB))
                 {
                     Messenger::error("Failed to write instantaneous coordination number data for range B.\n");
-                    return failed;
+                    return ExecutionResult::Failed;
                 }
             }
         }
@@ -79,7 +79,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                 if (!exportFormat.exportData(sumC))
                 {
                     Messenger::error("Failed to write instantaneous coordination number data for range C.\n");
-                    return failed;
+                    return ExecutionResult::Failed;
                 }
             }
         }
@@ -93,7 +93,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
         {
             Messenger::error("Test coordination number for range B supplied, but calculation for that range "
                             "is not active.\n");
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         const auto delta = testRangeA_.value() - sumCN_->sum(0);
@@ -102,7 +102,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return failed;
+            return ExecutionResult::Failed;
     }
     if (testRangeB_)
     {
@@ -111,7 +111,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
         {
             Messenger::error("Test coordination number for range B supplied, but calculation for that range "
                                     "is not active.\n");
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         const auto delta = testRangeB_.value() - sumCN_->sum(1);
@@ -120,7 +120,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return failed;
+            return ExecutionResult::Failed;
     }
     if (testRangeC_)
     {
@@ -129,7 +129,7 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
         {
             Messenger::error("Test coordination number for range C supplied, but calculation for that range "
                             "is not active.\n");
-            return failed;
+            return ExecutionResult::Failed;
         }
 
         const auto delta = testRangeC_.value() - sumCN_->sum(2);
@@ -138,8 +138,8 @@ enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const Pr
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return failed;
+            return ExecutionResult::Failed;
     }
 
-    return success;
+    return ExecutionResult::Success;
 }

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -90,8 +90,11 @@ enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPoo
     {
         // Is range A enabled?
         if (!isRangeEnabled(0))
-            return Messenger::error("Test coordination number for range B supplied, but calculation for that range "
-                                    "is not active.\n");
+        {
+            Messenger::error("Test coordination number for range B supplied, but calculation for that range "
+                            "is not active.\n");
+            return failed;
+        }
 
         const auto delta = testRangeA_.value() - sumCN_->sum(0);
 
@@ -99,14 +102,17 @@ enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPoo
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return false;
+            return failed;
     }
     if (testRangeB_)
     {
         // Is range B enabled?
         if (!isRangeEnabled(1))
-            return Messenger::error("Test coordination number for range B supplied, but calculation for that range "
+        {
+            Messenger::error("Test coordination number for range B supplied, but calculation for that range "
                                     "is not active.\n");
+            return failed;
+        }
 
         const auto delta = testRangeB_.value() - sumCN_->sum(1);
 
@@ -114,14 +120,17 @@ enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPoo
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return false;
+            return failed;
     }
     if (testRangeC_)
     {
         // Is range B enabled?
         if (!isRangeEnabled(2))
-            return Messenger::error("Test coordination number for range C supplied, but calculation for that range "
-                                    "is not active.\n");
+        {
+            Messenger::error("Test coordination number for range C supplied, but calculation for that range "
+                            "is not active.\n");
+            return failed;
+        }
 
         const auto delta = testRangeC_.value() - sumCN_->sum(2);
 
@@ -129,8 +138,8 @@ enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPoo
                          "(threshold is {:10.3e})\n",
                          delta, fabs(delta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         if (!procPool.allTrue(fabs(delta) < testThreshold_))
-            return false;
+            return failed;
     }
 
-    return true;
+    return success;
 }

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -12,11 +12,14 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-bool SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // Ensure any parameters in our nodes are set correctly
     collectDistance_->keywords().set("RangeX", distanceRange_);
@@ -30,7 +33,10 @@ bool SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
     ProcedureContext context(procPool, targetConfiguration_);
     context.setDataListAndPrefix(dissolve.processingModuleData(), name());
     if (!analyser_.execute(context))
-        return Messenger::error("CalculateRDF experienced problems with its analysis.\n");
+    {
+        Messenger::error("CalculateRDF experienced problems with its analysis.\n");
+        return failed;
+    }
 
     // Accumulate instantaneous coordination number data
     if (instantaneous_)
@@ -43,7 +49,10 @@ bool SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             {
                 Data1DExportFileFormat exportFormat(fmt::format("{}_SumA.txt", name()));
                 if (!exportFormat.exportData(sumA))
-                    return Messenger::error("Failed to write instantaneous coordination number data for range A.\n");
+                {
+                    Messenger::error("Failed to write instantaneous coordination number data for range A.\n");
+                    return failed;
+                }
             }
         }
         if (isRangeEnabled(1))
@@ -54,7 +63,10 @@ bool SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             {
                 Data1DExportFileFormat exportFormat(fmt::format("{}_SumB.txt", name()));
                 if (!exportFormat.exportData(sumB))
-                    return Messenger::error("Failed to write instantaneous coordination number data for range B.\n");
+                {
+                    Messenger::error("Failed to write instantaneous coordination number data for range B.\n");
+                    return failed;
+                }
             }
         }
         if (isRangeEnabled(2))
@@ -65,7 +77,10 @@ bool SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
             {
                 Data1DExportFileFormat exportFormat(fmt::format("{}_SumC.txt", name()));
                 if (!exportFormat.exportData(sumC))
-                    return Messenger::error("Failed to write instantaneous coordination number data for range C.\n");
+                {
+                    Messenger::error("Failed to write instantaneous coordination number data for range C.\n");
+                    return failed;
+                }
             }
         }
     }

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -12,7 +12,7 @@
 #include "procedure/nodes/sum1D.h"
 
 // Run main processing
-enum executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult SiteRDFModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -92,7 +92,7 @@ Module::ExecutionResult SiteRDFModule::process(Dissolve &dissolve, const Process
         if (!isRangeEnabled(0))
         {
             Messenger::error("Test coordination number for range B supplied, but calculation for that range "
-                            "is not active.\n");
+                             "is not active.\n");
             return ExecutionResult::Failed;
         }
 
@@ -110,7 +110,7 @@ Module::ExecutionResult SiteRDFModule::process(Dissolve &dissolve, const Process
         if (!isRangeEnabled(1))
         {
             Messenger::error("Test coordination number for range B supplied, but calculation for that range "
-                                    "is not active.\n");
+                             "is not active.\n");
             return ExecutionResult::Failed;
         }
 
@@ -128,7 +128,7 @@ Module::ExecutionResult SiteRDFModule::process(Dissolve &dissolve, const Process
         if (!isRangeEnabled(2))
         {
             Messenger::error("Test coordination number for range C supplied, but calculation for that range "
-                            "is not active.\n");
+                             "is not active.\n");
             return ExecutionResult::Failed;
         }
 

--- a/src/modules/siteRDF/siteRDF.h
+++ b/src/modules/siteRDF/siteRDF.h
@@ -75,5 +75,5 @@ class SiteRDFModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/siteRDF/siteRDF.h
+++ b/src/modules/siteRDF/siteRDF.h
@@ -75,5 +75,5 @@ class SiteRDFModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/siteRDF/siteRDF.h
+++ b/src/modules/siteRDF/siteRDF.h
@@ -75,5 +75,5 @@ class SiteRDFModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -6,16 +6,16 @@
 #include "modules/skeleton/skeleton.h"
 
 // Run main processing
-enum Module::executionResult SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // MODULE CODE
 
-    return failed;
+    return ExecutionResult::Failed;
 }

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -6,13 +6,16 @@
 #include "modules/skeleton/skeleton.h"
 
 // Run main processing
-bool SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // MODULE CODE
 
-    return false;
+    return failed;
 }

--- a/src/modules/skeleton/process.cpp
+++ b/src/modules/skeleton/process.cpp
@@ -6,7 +6,7 @@
 #include "modules/skeleton/skeleton.h"
 
 // Run main processing
-enum executionResult SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult SkeletonModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -24,5 +24,5 @@ class SkeletonModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -24,5 +24,5 @@ class SkeletonModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/skeleton/skeleton.h
+++ b/src/modules/skeleton/skeleton.h
@@ -24,5 +24,5 @@ class SkeletonModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -132,7 +132,7 @@ Module::ExecutionResult SQModule::process(Dissolve &dissolve, const ProcessPool 
             partial.initialise(unweightedsq.partial(0, 0));
 
         // For each partial in our S(Q) array, calculate the broadened Bragg function and blend it
-        auto result = for_each_pair_early(
+        auto success = for_each_pair_early(
             unweightedsq.atomTypeMix().begin(), unweightedsq.atomTypeMix().end(),
             [&](auto i, auto &at1, auto j, auto &at2) -> EarlyReturn<bool>
             {
@@ -143,7 +143,7 @@ Module::ExecutionResult SQModule::process(Dissolve &dissolve, const ProcessPool 
                     Messenger::error(
                         "SQ data has a partial between {} and {}, but no such intensities exist in the reflection data.\n",
                         at1.atomTypeName(), at2.atomTypeName());
-                    return ExecutionResult::Failed;
+                    return false;
                 }
 
                 // Grab relevant partial and oop over reflections
@@ -158,7 +158,7 @@ Module::ExecutionResult SQModule::process(Dissolve &dissolve, const ProcessPool 
 
                 return EarlyReturn<bool>::Continue;
             });
-        if (result && !result.value())
+        if (success && !success.value())
             return ExecutionResult::Failed;
 
         // Finalise partials

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -20,7 +20,7 @@ void SQModule::setTargets(const std::vector<std::unique_ptr<Configuration>> &con
 }
 
 // Run main processing
-enum executionResult SQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult SQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate S(Q) from Configuration's g(r).

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -107,9 +107,13 @@ enum Module::executionResult SQModule::process(Dissolve &dissolve, const Process
     {
         // Check if reflection data is present
         if (!dissolve.processingModuleData().contains("Reflections", sourceBragg_->name()))
-            return Messenger::error("Bragg scattering requested to be included, but reflections from the module '{}' "
-                                    "could not be located.\n",
-                                    sourceBragg_->name());
+        {
+            Messenger::error("Bragg scattering requested to be included, but reflections from the module '{}' "
+                            "could not be located.\n",
+                            sourceBragg_->name());
+            return failed;
+        }
+
         const auto &braggReflections =
             dissolve.processingModuleData().value<std::vector<BraggReflection>>("Reflections", sourceBragg_->name());
         const auto nReflections = braggReflections.size();

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -109,8 +109,8 @@ Module::ExecutionResult SQModule::process(Dissolve &dissolve, const ProcessPool 
         if (!dissolve.processingModuleData().contains("Reflections", sourceBragg_->name()))
         {
             Messenger::error("Bragg scattering requested to be included, but reflections from the module '{}' "
-                            "could not be located.\n",
-                            sourceBragg_->name());
+                             "could not be located.\n",
+                             sourceBragg_->name());
             return ExecutionResult::Failed;
         }
 

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -69,7 +69,7 @@ class SQModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -69,7 +69,7 @@ class SQModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -69,7 +69,7 @@ class SQModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -5,16 +5,16 @@
 #include "modules/test/test.h"
 
 // Run main processing
-enum Module::executionResult TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+Module::ExecutionResult TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
     {
         Messenger::error("No configuration target set for module '{}'.\n", name());
-        return failed;
+        return ExecutionResult::Failed;
     }
 
     // MODULE CODE
 
-    return failed;
+    return ExecutionResult::Failed;
 }

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -5,13 +5,16 @@
 #include "modules/test/test.h"
 
 // Run main processing
-bool TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum executionResult TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)
-        return Messenger::error("No configuration target set for module '{}'.\n", name());
+    {
+        Messenger::error("No configuration target set for module '{}'.\n", name());
+        return failed;
+    }
 
     // MODULE CODE
 
-    return false;
+    return failed;
 }

--- a/src/modules/test/process.cpp
+++ b/src/modules/test/process.cpp
@@ -5,7 +5,7 @@
 #include "modules/test/test.h"
 
 // Run main processing
-enum executionResult TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult TestModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     // Check for zero Configuration targets
     if (!targetConfiguration_)

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -24,5 +24,5 @@ class TestModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -24,5 +24,5 @@ class TestModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/test/test.h
+++ b/src/modules/test/test.h
@@ -24,5 +24,5 @@ class TestModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 };

--- a/src/modules/xRaySQ/process.cpp
+++ b/src/modules/xRaySQ/process.cpp
@@ -304,7 +304,10 @@ enum Module::executionResult XRaySQModule::process(Dissolve &dissolve, const Pro
     auto rMax = weightedGR.total().xAxis().back();
     auto rho = grModule->effectiveDensity();
     if (!rho)
-        return Messenger::error("No effective density available from RDF module '{}'\n", grModule->name());
+    {
+        Messenger::error("No effective density available from RDF module '{}'\n", grModule->name());
+        return failed;
+    }
     Fourier::sineFT(repGR, 1.0 / (2.0 * PI * PI * *rho), rMin, 0.05, rMax, WindowFunction(referenceWindowFunction_));
 
     // Save data if requested

--- a/src/modules/xRaySQ/process.cpp
+++ b/src/modules/xRaySQ/process.cpp
@@ -34,10 +34,7 @@ bool XRaySQModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
         // Load the data
         Data1D referenceData;
         if (!referenceFQ_.importData(referenceData, &procPool))
-        {
-            Messenger::error("[SETUP {}] Failed to load reference data '{}'.\n", name_, referenceFQ_.filename());
-            return false;
-        }
+            return Messenger::error("[SETUP {}] Failed to load reference data '{}'.\n", name_, referenceFQ_.filename());
 
         // Get dependent modules
         if (!sourceSQ_)

--- a/src/modules/xRaySQ/process.cpp
+++ b/src/modules/xRaySQ/process.cpp
@@ -143,7 +143,7 @@ bool XRaySQModule::setUp(Dissolve &dissolve, const ProcessPool &procPool, Flags<
 }
 
 // Run main processing
-enum executionResult XRaySQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
+enum Module::executionResult XRaySQModule::process(Dissolve &dissolve, const ProcessPool &procPool)
 {
     /*
      * Calculate x-ray structure factors from existing g(r) data

--- a/src/modules/xRaySQ/xRaySQ.h
+++ b/src/modules/xRaySQ/xRaySQ.h
@@ -82,7 +82,7 @@ class XRaySQModule : public Module
      */
     private:
     // Run main processing
-    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    Module::ExecutionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/xRaySQ/xRaySQ.h
+++ b/src/modules/xRaySQ/xRaySQ.h
@@ -82,7 +82,7 @@ class XRaySQModule : public Module
      */
     private:
     // Run main processing
-    bool process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data

--- a/src/modules/xRaySQ/xRaySQ.h
+++ b/src/modules/xRaySQ/xRaySQ.h
@@ -82,7 +82,7 @@ class XRaySQModule : public Module
      */
     private:
     // Run main processing
-    enum executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
+    enum Module::executionResult process(Dissolve &dissolve, const ProcessPool &procPool) override;
 
     public:
     // Set target data


### PR DESCRIPTION
## Changes made:
- Module `process()` functions return an enum instead of a bool
    - Enum has three types: `failed`, `success` and `notExecuted`
    - `notExecuted` is returned when the process legitimately fails (e.g process is not needed)
- Process time is only added to if `success` is returned
- Fixed small issue: when Simulation > Step is used, after running the step the ETA is set to `??:??:??`, now it goes back to `--:--:--`