### PR TITLE
1543 Keyword Section Header Styling

### DIFF
--- a/src/gui/keywordWidgets/sectionHeader.ui
+++ b/src/gui/keywordWidgets/sectionHeader.ui
@@ -42,7 +42,10 @@
      <property name="font">
       <font>
        <pointsize>11</pointsize>
+       <italic>false</italic>
        <bold>false</bold>
+       <stylestrategy>PreferDefault</stylestrategy>
+       <kerning>true</kerning>
       </font>
      </property>
      <property name="text">

--- a/src/gui/keywordWidgets/sectionHeader.ui
+++ b/src/gui/keywordWidgets/sectionHeader.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>892</width>
-    <height>23</height>
+    <height>25</height>
    </rect>
   </property>
   <property name="font">
@@ -37,7 +37,7 @@
    <item>
     <widget class="QLabel" name="SectionLabel">
      <property name="enabled">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="font">
       <font>

--- a/src/gui/keywordWidgets/widgetFuncs.cpp
+++ b/src/gui/keywordWidgets/widgetFuncs.cpp
@@ -44,6 +44,7 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
         if (!sectionName.empty())
         {
             auto *sectionLabel = new SectionHeaderWidget(QString::fromStdString(std::string(sectionName)));
+            sectionLabel->setContentsMargins(0, 15, 0, 0);
             groupLayout->addWidget(sectionLabel, row++, 0, 1, 2);
         }
 

--- a/src/gui/keywordWidgets/widgetFuncs.cpp
+++ b/src/gui/keywordWidgets/widgetFuncs.cpp
@@ -44,7 +44,6 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
         if (!sectionName.empty())
         {
             auto *sectionLabel = new SectionHeaderWidget(QString::fromStdString(std::string(sectionName)));
-            sectionLabel->setContentsMargins(0, 15, 0, 0);
             groupLayout->addWidget(sectionLabel, row++, 0, 1, 2);
         }
 

--- a/src/gui/keywordWidgets/widgetFuncs.cpp
+++ b/src/gui/keywordWidgets/widgetFuncs.cpp
@@ -69,6 +69,7 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
             // Create a label and add it and the widget to our layout
             auto *nameLabel = new QLabel(QString::fromStdString(std::string(keyword->name())));
             nameLabel->setToolTip(QString::fromStdString(std::string(keyword->description())));
+            nameLabel->setContentsMargins(10, 0, 0, 0);
             groupLayout->addWidget(nameLabel, row, 0);
             groupLayout->addLayout(w, row++, 1);
 

--- a/src/gui/keywordWidgets/widgetFuncs.cpp
+++ b/src/gui/keywordWidgets/widgetFuncs.cpp
@@ -44,6 +44,8 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
         if (!sectionName.empty())
         {
             auto *sectionLabel = new SectionHeaderWidget(QString::fromStdString(std::string(sectionName)));
+            if (row != 0)
+                sectionLabel->setContentsMargins(0, 15, 0, 0);
             groupLayout->addWidget(sectionLabel, row++, 0, 1, 2);
         }
 


### PR DESCRIPTION
This PR slightly adjusts the styling of our keyword widgets, making the header easier to read, and indenting keyword names to differentiate between sections more clearly by putting emphasis on the section headers.

![image](https://github.com/disorderedmaterials/dissolve/assets/11457350/6f7f8be3-e31b-49cc-9fa1-f87026ec2ab3)
