### PR TITLE
1541 Unused Atom Types

### DIFF
--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -200,6 +200,9 @@ void DissolveWindow::on_SpeciesDeleteAction_triggered(bool checked)
     ui_.MainTabs->removeByPage(spTab->page());
     dissolve_.coreData().removeSpecies(spTab->species());
 
+    // May now have unused atomtypes...
+    dissolve_.coreData().removeUnusedAtomTypes();
+
     setModified({DissolveSignals::DataMutations::SpeciesMutated, DissolveSignals::DataMutations::IsotopologuesMutated});
     fullUpdate();
 }
@@ -217,6 +220,9 @@ void DissolveWindow::on_SpeciesAddForcefieldTermsAction_triggered(bool checked)
     {
         // Atom types will likely have changed, so make sure the Isotopologues in the species are up-to-date
         species->updateIsotopologues();
+
+        // May now have unused atomtypes...
+        dissolve_.coreData().removeUnusedAtomTypes();
 
         // Fully update GUI
         setModified();
@@ -252,6 +258,10 @@ void DissolveWindow::on_SpeciesSimplifyAtomTypesAction_triggered(bool checked)
     if (nModified > 0)
     {
         Messenger::print("{} atom types were modified.\n", nModified);
+
+        // May now have unused atomtypes...
+        dissolve_.coreData().removeUnusedAtomTypes();
+
         setModified();
         fullUpdate();
     }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -32,27 +32,7 @@ bool Dissolve::prepare()
     }
 
     // Remove unused atom types
-    AtomTypeMix usedAtomTypes;
-    for (const auto &sp : coreData_.species())
-        usedAtomTypes.add(sp->atomTypes());
-
-    coreData_.atomTypes().erase(std::remove_if(coreData_.atomTypes().begin(), coreData_.atomTypes().end(),
-                                               [&](const auto &at)
-                                               {
-                                                   if (usedAtomTypes.contains(at))
-                                                       return false;
-                                                   else
-                                                   {
-                                                       Messenger::warn("Pruning unused atom type '{}'...\n", at->name());
-                                                       return true;
-                                                   }
-                                               }),
-                                coreData_.atomTypes().end());
-
-    // Reassign AtomType indices (in case one or more have been added / removed)
-    auto count = 0;
-    for (const auto &at : coreData_.atomTypes())
-        at->setIndex(count++);
+    coreData_.removeUnusedAtomTypes();
 
     // Store / update last-used pair potential cutoff
     // If lastPairPotentialCutoff is nullopt, store the current value and move on leaving the cutoff to use as nullopt.


### PR DESCRIPTION
This PR performs a clean-up of unused atom types after "significant" operations involving `Species` (adding forcefield terms, deleting etc.) in order to prevent said unused atom types causing issues elsewhere (e.g. generating errors in pair potential generation since they have `None` form type).

Closes #1541.