### PR TITLE
Fix KeywordStore::get

### DIFF
--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -200,7 +200,7 @@ class KeywordStore
     int getInt(std::string_view name) const;
 
     // Get specified keyword data, casting as necessary
-    template <class D, class K> OptionalReferenceWrapper<const D> get(std::string_view name) const
+    template <class D, class K> std::optional<const D> get(std::string_view name) const
     {
         auto optKd = find(name);
         if (!optKd)
@@ -213,7 +213,7 @@ class KeywordStore
 
         return keyword->data();
     }
-    template <class D, class K> OptionalReferenceWrapper<D> get(std::string_view name)
+    template <class D, class K> std::optional<D> get(std::string_view name)
     {
         auto optKd = find(name);
         if (!optKd)

--- a/src/modules/epsr/gui/epsrWidgetFuncs.cpp
+++ b/src/modules/epsr/gui/epsrWidgetFuncs.cpp
@@ -138,10 +138,9 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
                 else
                 {
                     auto optRDFModule =
-                        optSQModule.value().get()->keywords().get<const GRModule *, ModuleKeyword<const GRModule>>(
-                            "SourceRDFs");
+                        optSQModule.value()->keywords().get<const GRModule *, ModuleKeyword<const GRModule>>("SourceRDFs");
                     if (optRDFModule)
-                        rdfModuleName = optRDFModule.value().get()->name();
+                        rdfModuleName = optRDFModule.value()->name();
                     else
                         rdfModuleName = "UNKNOWN_RDF_MODULE";
                 }

--- a/unit/procedure/procedure.cpp
+++ b/unit/procedure/procedure.cpp
@@ -76,8 +76,7 @@ TEST(ProcedureTest, Scope)
     // -- Confirm current keyword data
     auto keywordNode = selectC->keywords()
                            .get<std::shared_ptr<const SelectProcedureNode>, NodeKeyword<SelectProcedureNode>>("ReferenceSite")
-                           .value()
-                           .get();
+                           .value();
     EXPECT_EQ(keywordNode, selectA);
     // -- Move 'C' so it is before 'A'
     std::swap(procedure.rootSequence().sequence()[0], procedure.rootSequence().sequence()[1]);
@@ -85,8 +84,7 @@ TEST(ProcedureTest, Scope)
     procedure.rootSequence().validateNodeKeywords();
     keywordNode = selectC->keywords()
                       .get<std::shared_ptr<const SelectProcedureNode>, NodeKeyword<SelectProcedureNode>>("ReferenceSite")
-                      .value()
-                      .get();
+                      .value();
     EXPECT_EQ(keywordNode, nullptr);
 }
 


### PR DESCRIPTION
A very brief PR to fix an issue with the `get()` template functions in `KeywordStore`.  The return type was `OptionalReferenceWrapper<D>`, but this is a wholly unsuitable type to be returning, e.g. `double` data and many others.

The return type is modified to be a plain `std::optional`, and given the sparing use of the function in the code we don't need to modify the target data through its reference anyway.