### PR TITLE
Space Separated Quoted Strings in CIFs

### DIFF
--- a/src/io/import/CIFImportLexer.g4
+++ b/src/io/import/CIFImportLexer.g4
@@ -71,6 +71,6 @@ UnsignedInteger:    DIGIT+;
 
 // Character Strings
 UnquotedString:     OrdinaryChar NonBlankChar*;
-SingleQuotedString: '\'' AnyPrintChar* '\'';
-DoubleQuotedString: '"' AnyPrintChar* '"';
+SingleQuotedString: '\'' AnyPrintChar*? '\'';
+DoubleQuotedString: '"' AnyPrintChar*? '"';
 SemiColonTextField: ';' EOL* (TextLeadChar AnyPrintChar* EOL*?)* ';';


### PR DESCRIPTION
Small PR to fix a bug where CIFs are not parsed when (single and double) quoted strings are space-separated on the same line. This bug is apparently due to the fact that the `*` operator is greedy, and meant that the closing `'`/`"` were included in the match, leading to: "'x' 'y'" being parsed as "x' 'y".

Closes #1551.