### PR TITLE
Filter Node Tree

### DIFF
--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -16,6 +16,7 @@ set(models_MOC_HDRS
     masterTorsionModel.h
     moduleLayerModel.h
     moduleModel.h
+    nodePaletteFilterProxy.h
     modulePaletteModel.h
     nodePaletteModel.h
     pairPotentialModel.h
@@ -66,6 +67,7 @@ set(models_SRCS
     masterTorsionModel.cpp
     moduleLayerModel.cpp
     moduleModel.cpp
+    nodePaletteFilterProxy.cpp
     modulePaletteModel.cpp
     nodePaletteModel.cpp
     pairPotentialModel.cpp

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -5,7 +5,7 @@
 #include "procedure/nodes/registry.h"
 
 // Set allowed categories
-void NodePaletteFilterProxy::setContext(const ProcedureNode::NodeContext context)
+void NodePaletteFilterProxy::setContext(ProcedureNode::NodeContext context)
 {
     context_ = context;
     invalidateFilter();

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "gui/models/nodePaletteFilterProxy.h"
+#include "procedure/nodes/registry.h"
+
+NodePaletteFilterProxy::NodePaletteFilterProxy(const std::vector<std::string>& categories) : categories_(categories) {}
+
+// Set allowed categories
+void NodePaletteFilterProxy::setCategories(const std::vector<std::string>& categories)
+{
+    categories_ = categories;
+    invalidateFilter();
+}
+
+/*
+ * QSortFilterProxyModel overrides
+ */
+
+bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
+{
+    auto category =
+        std::next(ProcedureNodeRegistry::categoryMap().begin(), sourceModel()->parent(sourceModel()->index(row, 0)).row())->first;
+    return std::find(categories_.begin(), categories_.end(), category) != categories_.end();
+}
+

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -17,7 +17,6 @@ void NodePaletteFilterProxy::setContext(const ProcedureNode::NodeContext context
 
 bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
-
     if (context_ == ProcedureNode::NodeContext::AnyContext)
         return true;
 
@@ -30,7 +29,7 @@ bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent
          {"Calculate", "Data", "General", "Operate", "Pick", "Potentials", "Sites"}},
     };
 
-    auto category = std::next(ProcedureNodeRegistry::categoryMap().begin(), parent.isValid() ? parent.row() : row)->first;
     const auto &contextCategoryList = contextCategories.at(context_);
+    auto category = std::next(ProcedureNodeRegistry::categoryMap().begin(), parent.isValid() ? parent.row() : row)->first;
     return std::find(contextCategoryList.begin(), contextCategoryList.end(), category) != contextCategoryList.end();
 }

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -4,7 +4,7 @@
 #include "gui/models/nodePaletteFilterProxy.h"
 #include "procedure/nodes/registry.h"
 
-// Set allowed categories
+// Set current context
 void NodePaletteFilterProxy::setContext(ProcedureNode::NodeContext context)
 {
     context_ = context;

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -20,16 +20,21 @@ bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent
     if (context_ == ProcedureNode::NodeContext::AnyContext)
         return true;
 
-    static const std::map<ProcedureNode::NodeContext, std::vector<std::string>> contextCategories = {
-        {ProcedureNode::NodeContext::NoContext, {}},
-        {ProcedureNode::NodeContext::AnalysisContext, {"Data"}},
-        {ProcedureNode::NodeContext::GenerationContext,
-         {"Calculate", "Build", "Calculate", "Data", "General", "Operate", "Pick", "Potentials", "Sites"}},
-        {ProcedureNode::NodeContext::OperateContext,
-         {"Calculate", "Data", "General", "Operate", "Pick", "Potentials", "Sites"}},
-    };
-
-    const auto &contextCategoryList = contextCategories.at(context_);
     auto category = std::next(ProcedureNodeRegistry::categoryMap().begin(), parent.isValid() ? parent.row() : row)->first;
-    return std::find(contextCategoryList.begin(), contextCategoryList.end(), category) != contextCategoryList.end();
+    
+    switch (context_)
+    {
+        case (ProcedureNode::NodeContext::AnyContext):
+            return true;
+        case (ProcedureNode::NodeContext::NoContext):
+            return false;
+        case (ProcedureNode::NodeContext::OperateContext):
+            return category == "Operate";
+        case (ProcedureNode::NodeContext::GenerateContext):
+            return category != "Operate";
+        case (ProcedureNode::NodeContext::AnalysisContext):
+            return category != "Build" && category != "Potentials" && category != "Operate";
+        default:
+            throw(.....);
+    }
 }

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -30,7 +30,7 @@ bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent
         case (ProcedureNode::NodeContext::GenerationContext):
             return category != "Operate";
         case (ProcedureNode::NodeContext::AnalysisContext):
-            return category != "Build" && category != "Potentials" && category != "Operate";
+            return category != "Build" && category != "Potentials" && category != "Operate" && category != "Sites";
         default:
             throw("Context '{}' is not handled in the Node Palette.", ProcedureNode::nodeContexts().keyword(context_));
     }

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -20,7 +20,7 @@ bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent
     if (context_ == ProcedureNode::NodeContext::AnyContext)
         return true;
 
-    static std::map<ProcedureNode::NodeContext, std::vector<std::string>> contextCategories = {
+    static const std::map<ProcedureNode::NodeContext, std::vector<std::string>> contextCategories = {
         {ProcedureNode::NodeContext::NoContext, {}},
         {ProcedureNode::NodeContext::AnalysisContext, {"Data"}},
         {ProcedureNode::NodeContext::GenerationContext,

--- a/src/gui/models/nodePaletteFilterProxy.cpp
+++ b/src/gui/models/nodePaletteFilterProxy.cpp
@@ -17,11 +17,8 @@ void NodePaletteFilterProxy::setContext(ProcedureNode::NodeContext context)
 
 bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent) const
 {
-    if (context_ == ProcedureNode::NodeContext::AnyContext)
-        return true;
-
     auto category = std::next(ProcedureNodeRegistry::categoryMap().begin(), parent.isValid() ? parent.row() : row)->first;
-    
+
     switch (context_)
     {
         case (ProcedureNode::NodeContext::AnyContext):
@@ -30,11 +27,11 @@ bool NodePaletteFilterProxy::filterAcceptsRow(int row, const QModelIndex &parent
             return false;
         case (ProcedureNode::NodeContext::OperateContext):
             return category == "Operate";
-        case (ProcedureNode::NodeContext::GenerateContext):
+        case (ProcedureNode::NodeContext::GenerationContext):
             return category != "Operate";
         case (ProcedureNode::NodeContext::AnalysisContext):
             return category != "Build" && category != "Potentials" && category != "Operate";
         default:
-            throw(.....);
+            throw("Context '{}' is not handled in the Node Palette.", ProcedureNode::nodeContexts().keyword(context_));
     }
 }

--- a/src/gui/models/nodePaletteFilterProxy.h
+++ b/src/gui/models/nodePaletteFilterProxy.h
@@ -11,7 +11,7 @@ class NodePaletteFilterProxy : public QSortFilterProxyModel
     Q_OBJECT
 
     private:
-    // Currently context
+    // Current context
     ProcedureNode::NodeContext context_{ProcedureNode::NodeContext::NoContext};
 
     public:

--- a/src/gui/models/nodePaletteFilterProxy.h
+++ b/src/gui/models/nodePaletteFilterProxy.h
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "templates/flags.h"
+#include <QSortFilterProxyModel>
+
+class NodePaletteFilterProxy : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+    public:
+    NodePaletteFilterProxy(const std::vector<std::string>& categories = {});
+
+    private:
+    // Currently allowed categories
+    std::vector<std::string> categories_;
+
+    public:
+    // Set allowed categories
+    void setCategories(const std::vector<std::string>& categories);
+
+    /*
+     * QSortFilterProxyModel overrides
+     */
+    private:
+    bool filterAcceptsRow(int row, const QModelIndex &parent) const;
+};

--- a/src/gui/models/nodePaletteFilterProxy.h
+++ b/src/gui/models/nodePaletteFilterProxy.h
@@ -3,23 +3,20 @@
 
 #pragma once
 
-#include "templates/flags.h"
+#include "procedure/nodes/node.h"
 #include <QSortFilterProxyModel>
 
 class NodePaletteFilterProxy : public QSortFilterProxyModel
 {
     Q_OBJECT
 
-    public:
-    NodePaletteFilterProxy(const std::vector<std::string>& categories = {});
-
     private:
-    // Currently allowed categories
-    std::vector<std::string> categories_;
+    // Currently context
+    ProcedureNode::NodeContext context_{ProcedureNode::NodeContext::NoContext};
 
     public:
-    // Set allowed categories
-    void setCategories(const std::vector<std::string>& categories);
+    // Set current context
+    void setContext(const ProcedureNode::NodeContext context);
 
     /*
      * QSortFilterProxyModel overrides

--- a/src/gui/procedureWidget.h
+++ b/src/gui/procedureWidget.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "gui/models/nodePaletteFilterProxy.h"
 #include "gui/models/nodePaletteModel.h"
 #include "gui/models/procedureModel.h"
 #include "gui/ui_procedureWidget.h"
@@ -33,6 +34,8 @@ class ProcedureWidget : public QWidget
     OptionalReferenceWrapper<Procedure> procedure_;
     // Model for procedure
     ProcedureModel procedureModel_;
+    // Filter proxy for node palette
+    NodePaletteFilterProxy nodePaletteFilterProxy_;
     // Model for node palette
     NodePaletteModel nodePaletteModel_;
 

--- a/src/gui/procedureWidgetFuncs.cpp
+++ b/src/gui/procedureWidgetFuncs.cpp
@@ -19,7 +19,8 @@ ProcedureWidget::ProcedureWidget(QWidget *parent) : QWidget(parent)
     connect(&procedureModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(procedureDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
     // Set up the available nodes tree
-    ui_.AvailableNodesTree->setModel(&nodePaletteModel_);
+    nodePaletteFilterProxy_.setSourceModel(&nodePaletteModel_);
+    ui_.AvailableNodesTree->setModel(&nodePaletteFilterProxy_);
     ui_.AvailableNodesTree->expandAll();
     ui_.AvailableNodesTree->setVisible(false);
 }
@@ -29,6 +30,8 @@ void ProcedureWidget::setUp(DissolveWindow *dissolveWindow, Procedure &proc)
 {
     dissolveWindow_ = dissolveWindow;
     procedure_ = proc;
+    nodePaletteFilterProxy_.setContext(proc.context());
+    ui_.AvailableNodesTree->expandAll();
     procedureModel_.setData(proc);
     ui_.NodesTree->expandAll();
     ui_.NodesTree->resizeColumnToContents(0);

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -81,7 +81,7 @@ EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
                                                                    {ProcedureNode::AnalysisContext, "Analysis"},
                                                                    {ProcedureNode::GenerationContext, "Generation"},
                                                                    {ProcedureNode::OperateContext, "Operate"},
-                                                                   {ProcedureNode::OperateContext, "Any"},
+                                                                   {ProcedureNode::AnyContext, "Any"},
                                                                    {ProcedureNode::ParentProcedureContext, "ParentProcedure"}});
 }
 

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -21,6 +21,9 @@ Procedure::~Procedure() = default;
 // Clear all data
 void Procedure::clear() { rootSequence_.clear(); }
 
+// Return context for the main Procedure
+ProcedureNode::NodeContext Procedure::context() { return context_; }
+
 // Return root sequence
 ProcedureNodeSequence &Procedure::rootSequence() { return rootSequence_; }
 

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -35,6 +35,8 @@ class Procedure : public Serialisable<const CoreData &>
     {
         return rootSequence_.create<N>(name, args...);
     }
+    // Return context for the main Procedure
+    ProcedureNode::NodeContext context();
     // Return root sequence
     ProcedureNodeSequence &rootSequence();
     // Return named node if present (and matches the type / class given)


### PR DESCRIPTION
This PR implements the ability to filter Node trees using the parents context. The filtering is done by maintaining a vector of categories for each context - I'm not at all sure about these categories, so these likely need to be modified before merging this in.

Closes #1424.