### PR TITLE
Smaller GUI

### DIFF
--- a/src/gui/dataWidget.h
+++ b/src/gui/dataWidget.h
@@ -33,8 +33,6 @@ class DataWidget : public QWidget
      * Tools
      */
     private slots:
-    // Interaction
-    void on_InteractionViewButton_clicked(bool checked);
     // Graph
     void on_GraphResetButton_clicked(bool checked);
     void on_GraphFollowAllButton_clicked(bool checked);

--- a/src/gui/dataWidget.ui
+++ b/src/gui/dataWidget.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>640</width>
-    <height>352</height>
+    <width>486</width>
+    <height>156</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -342,14 +342,14 @@
          <item>
           <widget class="ExponentialSpin" name="GraphFollowXLengthSpin">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
            <property name="minimumSize">
             <size>
-             <width>64</width>
+             <width>0</width>
              <height>0</height>
             </size>
            </property>
@@ -440,7 +440,7 @@
          <item>
           <widget class="QComboBox" name="ViewTypeCombo">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -605,7 +605,7 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>151</width>
+          <width>0</width>
           <height>20</height>
          </size>
         </property>
@@ -653,8 +653,8 @@
       <item>
        <widget class="QGroupBox" name="DataGroup">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-          <horstretch>0</horstretch>
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>1</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
@@ -680,7 +680,7 @@
          <item>
           <widget class="QTreeView" name="DataTree">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -720,6 +720,12 @@
    </item>
    <item>
     <widget class="QFrame" name="InfoFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="font">
       <font>
        <pointsize>10</pointsize>

--- a/src/gui/dataWidget.ui
+++ b/src/gui/dataWidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>486</width>
-    <height>156</height>
+    <width>386</width>
+    <height>262</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -43,7 +43,7 @@
    <item>
     <widget class="QFrame" name="ToolsFrame">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+      <sizepolicy hsizetype="Ignored" vsizetype="Minimum">
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
@@ -56,7 +56,7 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout_3">
       <property name="spacing">
-       <number>6</number>
+       <number>2</number>
       </property>
       <property name="leftMargin">
        <number>0</number>
@@ -70,113 +70,6 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item>
-       <widget class="QWidget" name="InteractionToolsWidget" native="true">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
-         <property name="spacing">
-          <number>0</number>
-         </property>
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="InteractionToolsLabel">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
-           <property name="text">
-            <string/>
-           </property>
-           <property name="pixmap">
-            <pixmap resource="main.qrc">:/viewer_toolbar/icons/viewer_toolbar_interaction.svg</pixmap>
-           </property>
-           <property name="scaledContents">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="InteractionViewButton">
-           <property name="minimumSize">
-            <size>
-             <width>32</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="maximumSize">
-            <size>
-             <width>32</width>
-             <height>32</height>
-            </size>
-           </property>
-           <property name="toolTip">
-            <string>View mode</string>
-           </property>
-           <property name="text">
-            <string>I</string>
-           </property>
-           <property name="icon">
-            <iconset resource="main.qrc">
-             <normaloff>:/viewer/icons/viewer_interact.svg</normaloff>
-             <normalon>:/viewer/icons/viewer_interact_on.svg</normalon>:/viewer/icons/viewer_interact.svg</iconset>
-           </property>
-           <property name="iconSize">
-            <size>
-             <width>24</width>
-             <height>24</height>
-            </size>
-           </property>
-           <property name="checkable">
-            <bool>true</bool>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="Line" name="line">
-        <property name="frameShadow">
-         <enum>QFrame::Sunken</enum>
-        </property>
-        <property name="lineWidth">
-         <number>2</number>
-        </property>
-        <property name="midLineWidth">
-         <number>1</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-       </widget>
-      </item>
       <item>
        <widget class="QWidget" name="GraphToolsWidget" native="true">
         <property name="sizePolicy">
@@ -209,10 +102,16 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>26</width>
+             <height>26</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="text">
@@ -230,14 +129,14 @@
           <widget class="QToolButton" name="GraphResetButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">
@@ -252,8 +151,8 @@
            </property>
            <property name="iconSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>22</width>
+             <height>22</height>
             </size>
            </property>
            <property name="checkable">
@@ -271,14 +170,14 @@
           <widget class="QToolButton" name="GraphFollowAllButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">
@@ -294,8 +193,8 @@
            </property>
            <property name="iconSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>22</width>
+             <height>22</height>
             </size>
            </property>
            <property name="checkable">
@@ -307,14 +206,14 @@
           <widget class="QToolButton" name="GraphFollowXButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">
@@ -330,8 +229,8 @@
            </property>
            <property name="iconSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>22</width>
+             <height>22</height>
             </size>
            </property>
            <property name="checkable">
@@ -342,7 +241,7 @@
          <item>
           <widget class="ExponentialSpin" name="GraphFollowXLengthSpin">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -420,10 +319,16 @@
              <verstretch>0</verstretch>
             </sizepolicy>
            </property>
+           <property name="minimumSize">
+            <size>
+             <width>26</width>
+             <height>26</height>
+            </size>
+           </property>
            <property name="maximumSize">
             <size>
-             <width>24</width>
-             <height>24</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="text">
@@ -440,7 +345,7 @@
          <item>
           <widget class="QComboBox" name="ViewTypeCombo">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
              <horstretch>0</horstretch>
              <verstretch>0</verstretch>
             </sizepolicy>
@@ -481,14 +386,14 @@
           <widget class="QToolButton" name="ViewToggleDataButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">
@@ -516,14 +421,14 @@
           <widget class="QToolButton" name="ViewAxesVisibleButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">
@@ -558,14 +463,14 @@
           <widget class="QToolButton" name="ViewCopyToClipboardButton">
            <property name="minimumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="maximumSize">
             <size>
-             <width>32</width>
-             <height>32</height>
+             <width>26</width>
+             <height>26</height>
             </size>
            </property>
            <property name="toolTip">

--- a/src/gui/dataWidgetFuncs.cpp
+++ b/src/gui/dataWidgetFuncs.cpp
@@ -11,10 +11,6 @@ DataWidget::DataWidget(QWidget *parent) : QWidget(parent)
     // Set up our UI
     ui_.setupUi(this);
 
-    // Create button group for interaction tools
-    QButtonGroup *interactionToolsGroup = new QButtonGroup;
-    interactionToolsGroup->addButton(ui_.InteractionViewButton);
-
     // Set data for group manager model
     renderableGroupManagerModel_.setSourceData(ui_.DataView->groupManager());
     ui_.DataTree->setModel(&renderableGroupManagerModel_);
@@ -44,12 +40,6 @@ DataViewer *DataWidget::dataViewer() { return ui_.DataView; }
 /*
  * Tools
  */
-
-// Interaction
-void DataWidget::on_InteractionViewButton_clicked(bool checked)
-{
-    dataViewer()->setInteractionMode(DataViewer::InteractionMode::Default);
-}
 
 // Graph
 void DataWidget::on_GraphResetButton_clicked(bool checked)
@@ -157,16 +147,6 @@ void DataWidget::clearRenderableData()
 void DataWidget::updateToolbar()
 {
     Locker refreshLock(refreshLock_);
-
-    // Set current interaction mode
-    switch (dataViewer()->interactionMode())
-    {
-        case (DataViewer::InteractionMode::Default):
-            ui_.InteractionViewButton->setChecked(true);
-            break;
-        default:
-            break;
-    }
 
     // Controls reflecting the state of options in the underlying DataViewer
     // -- Graph

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1146</width>
-    <height>846</height>
+    <width>819</width>
+    <height>743</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="font">
    <font>
@@ -23,6 +29,12 @@
     <normaloff>:/dissolve/icons/dissolve.png</normaloff>:/dissolve/icons/dissolve.png</iconset>
   </property>
   <widget class="QWidget" name="Centralwidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
    <layout class="QHBoxLayout" name="horizontalLayout">
     <property name="spacing">
      <number>4</number>
@@ -41,10 +53,28 @@
     </property>
     <item>
      <widget class="QStackedWidget" name="MainStack">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <widget class="QWidget" name="LogoPage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <widget class="QLabel" name="LogoLabel">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Ignored" vsizetype="Ignored">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string/>
           </property>
@@ -62,6 +92,12 @@
        </layout>
       </widget>
       <widget class="QWidget" name="MainPage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <property name="spacing">
          <number>0</number>
@@ -83,7 +119,7 @@
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
-            <verstretch>10</verstretch>
+            <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="currentIndex">
@@ -102,7 +138,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1146</width>
+     <width>819</width>
      <height>21</height>
     </rect>
    </property>

--- a/src/gui/keywordWidgets/sectionHeader.ui
+++ b/src/gui/keywordWidgets/sectionHeader.ui
@@ -6,9 +6,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>892</width>
-    <height>25</height>
+    <width>542</width>
+    <height>27</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="font">
    <font>
@@ -39,6 +45,12 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="font">
       <font>
        <pointsize>11</pointsize>
@@ -55,6 +67,12 @@
    </item>
    <item>
     <widget class="Line" name="line">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>

--- a/src/gui/keywordWidgets/widget.hui
+++ b/src/gui/keywordWidgets/widget.hui
@@ -5,14 +5,14 @@
 
 #include "gui/keywordWidgets/base.h"
 #include "keywords/store.h"
-#include <QTabWidget>
+#include <QScrollArea>
 
 // Forward Declarations
 class CoreData;
 class QPushButton;
 
 // Keywords Widget
-class KeywordsWidget : public QWidget
+class KeywordsWidget : public QScrollArea
 {
     Q_OBJECT
 

--- a/src/gui/keywordWidgets/widgetFuncs.cpp
+++ b/src/gui/keywordWidgets/widgetFuncs.cpp
@@ -12,10 +12,11 @@
 #include <QPushButton>
 #include <QSpacerItem>
 
-KeywordsWidget::KeywordsWidget(QWidget *parent) : QWidget(parent)
+KeywordsWidget::KeywordsWidget(QWidget *parent) : QScrollArea(parent)
 {
     refreshing_ = false;
-    setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Expanding);
+
+    setWidgetResizable(true);
 }
 
 /*
@@ -32,7 +33,7 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
     auto &groupMap = keywordMap.at(keywordIndexInfo.first);
 
     // Create a new QWidget and layout for the next group?
-    auto *groupWidget = new QWidget;
+    auto *groupWidget = new QWidget(parentWidget());
     auto *groupLayout = new QGridLayout(groupWidget);
     auto row = 0;
     for (auto sectionName : keywordIndexInfo.second)
@@ -44,6 +45,7 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
         if (!sectionName.empty())
         {
             auto *sectionLabel = new SectionHeaderWidget(QString::fromStdString(std::string(sectionName)));
+
             if (row != 0)
                 sectionLabel->setContentsMargins(0, 15, 0, 0);
             groupLayout->addWidget(sectionLabel, row++, 0, 1, 2);
@@ -82,7 +84,8 @@ void KeywordsWidget::setUp(KeywordStore::KeywordStoreIndexInfo keywordIndexInfo,
 
     // Add vertical spacer to the end of the group
     groupLayout->addItem(new QSpacerItem(0, 0, QSizePolicy::Minimum, QSizePolicy::Expanding), row, 0);
-    setLayout(groupLayout);
+    groupWidget->setLayout(groupLayout);
+    setWidget(groupWidget);
 }
 
 // Create a suitable button for the named group


### PR DESCRIPTION
This PR addresses the refusal of the main Dissolve window to go below a certain horizontal and vertical size. Principal culprits were the `QLabel` displaying our logo (which enforced a minimum size on the whole window), `KeywordWidget` which could have long lists of keywords, and the `DataWidget` which was just greedy.

Some judicious use of `QSizePolicy::Ignored` in places helps a great deal, and `KeywordWidget` now employs a `QScrollArea`. The `DataWidget` has had most work done beyond just adjusting size policies, with redundant toolbar buttons removed, and the rest made slightly smaller.

![image](https://github.com/disorderedmaterials/dissolve/assets/11457350/1e23dc8f-0973-4e3b-969a-57963ed2cdd0)

![image](https://github.com/disorderedmaterials/dissolve/assets/11457350/8c8862f7-7443-473a-b7bf-8eef3e81f820)
