### PR TITLE
IfValueInRange Node

### DIFF
--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -324,7 +324,7 @@ bool ProcedureModel::canDropMimeData(const QMimeData *data, Qt::DropAction actio
             return false;
 
         // Now check the suitability of the existing node in the target scope context.
-        if (!existingNode->isContextRelevant(scope->get().sequenceContext()))
+        if (!existingNode->isContextRelevant(scope->get().context()))
             return false;
 
         return true;
@@ -348,7 +348,7 @@ bool ProcedureModel::canDropMimeData(const QMimeData *data, Qt::DropAction actio
         auto newNode = mimeData->node();
         if (!newNode)
             return false;
-        if (!newNode->isContextRelevant(scope->get().sequenceContext()))
+        if (!newNode->isContextRelevant(scope->get().context()))
             return false;
 
         return true;

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   cylindricalRegion.cpp
   directionalGlobalPotential.cpp
   generalRegion.cpp
+  ifValueInRange.cpp
   importCoordinates.cpp
   integerCollect1D.cpp
   integrate1D.cpp
@@ -72,6 +73,7 @@ add_library(
   cylindricalRegion.h
   directionalGlobalPotential.h
   generalRegion.h
+  ifValueInRange.h
   importCoordinates.h
   integerCollect1D.h
   integrate1D.h

--- a/src/procedure/nodes/ifValueInRange.cpp
+++ b/src/procedure/nodes/ifValueInRange.cpp
@@ -12,7 +12,7 @@
 
 IfValueInRangeProcedureNode::IfValueInRangeProcedureNode()
     : ProcedureNode(ProcedureNode::NodeType::IfValueInRange, {NodeContext::AnyContext}),
-      thenBranch_(NodeContext::ParentProcedureContext, *this, "Then")
+      thenBranch_(NodeContext::InheritContext, *this, "Then")
 {
     keywords_.setOrganisation("Options", "Condition");
     keywords_.add<NodeValueKeyword>("Value", "Value expression to test", value_, this);

--- a/src/procedure/nodes/ifValueInRange.cpp
+++ b/src/procedure/nodes/ifValueInRange.cpp
@@ -72,8 +72,7 @@ bool IfValueInRangeProcedureNode::execute(const ProcedureContext &procedureConte
 {
     // Evaluate and check
     if (valueRange_.contains(value_.asDouble()))
-        if (!thenBranch_.execute(procedureContext))
-            return false;
+        return thenBranch_.execute(procedureContext);
 
     return true;
 }

--- a/src/procedure/nodes/ifValueInRange.cpp
+++ b/src/procedure/nodes/ifValueInRange.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/ifValueInRange.h"
+#include "expression/variable.h"
+#include "keywords/node.h"
+#include "keywords/nodeBranch.h"
+#include "keywords/nodeValue.h"
+#include "keywords/range.h"
+#include "procedure/nodes/sequence.h"
+#include <algorithm>
+
+IfValueInRangeProcedureNode::IfValueInRangeProcedureNode()
+    : ProcedureNode(ProcedureNode::NodeType::IfValueInRange, {NodeContext::AnyContext}),
+      thenBranch_(NodeContext::ParentProcedureContext, *this, "Then")
+{
+    keywords_.setOrganisation("Options", "Condition");
+    keywords_.add<NodeValueKeyword>("Value", "Value expression to test", value_, this);
+    keywords_.add<RangeKeyword>("ValidRange", "Valid acceptance range for value", valueRange_,
+                                Vec3Labels::MinMaxBinwidthlabels);
+
+    keywords_.addHidden<NodeBranchKeyword>("Then", "Branch to run on valid value", thenBranch_);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether a name for the node must be provided
+bool IfValueInRangeProcedureNode::mustBeNamed() const { return false; }
+
+/*
+ * Parameters
+ */
+
+// Return the named parameter (if it exists)
+std::shared_ptr<ExpressionVariable>
+IfValueInRangeProcedureNode::getParameter(std::string_view name, std::shared_ptr<ExpressionVariable> excludeParameter)
+{
+    for (auto var : parameters_)
+        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
+            return var;
+
+    return nullptr;
+}
+
+// Return vector of all parameters for this node
+OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> IfValueInRangeProcedureNode::parameters() const
+{
+    return parameters_;
+}
+
+/*
+ * Branch
+ */
+
+// Return the branch from this node (if it has one)
+OptionalReferenceWrapper<ProcedureNodeSequence> IfValueInRangeProcedureNode::branch() { return thenBranch_; }
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool IfValueInRangeProcedureNode::prepare(const ProcedureContext &procedureContext)
+{
+    return thenBranch_.prepare(procedureContext);
+}
+
+// Execute node
+bool IfValueInRangeProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    // Evaluate and check
+    if (valueRange_.contains(value_.asDouble()))
+        if (!thenBranch_.execute(procedureContext))
+            return false;
+
+    return true;
+}
+
+// Finalise any necessary data after execution
+bool IfValueInRangeProcedureNode::finalise(const ProcedureContext &procedureContext)
+{
+    return thenBranch_.finalise(procedureContext);
+}

--- a/src/procedure/nodes/ifValueInRange.h
+++ b/src/procedure/nodes/ifValueInRange.h
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "math/range.h"
+#include "procedure/nodes/node.h"
+#include "procedure/nodes/sequence.h"
+#include <memory>
+#include <set>
+
+// IfValueInRange Node
+class IfValueInRangeProcedureNode : public ProcedureNode
+{
+    public:
+    explicit IfValueInRangeProcedureNode();
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Parameters
+     */
+    private:
+    // Defined parameters
+    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
+    // Pointers to individual parameters
+    std::shared_ptr<ExpressionVariable> currentValueParameter_;
+
+    public:
+    // Add new parameter
+    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
+    // Return the named parameter (if it exists)
+    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
+                                                     std::shared_ptr<ExpressionVariable> excludeParameter) override;
+    // Return vector of all parameters for this node
+    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
+
+    /*
+     * Value & Acceptable Range
+     */
+    private:
+    // Value that we are testing
+    NodeValue value_;
+    // Range of acceptable values
+    Range valueRange_{0.0, 5.0};
+
+    /*
+     * Branch
+     */
+    private:
+    // Branch for Then
+    ProcedureNodeSequence thenBranch_;
+
+    public:
+    // Return the branch from this node (if it has one)
+    OptionalReferenceWrapper<ProcedureNodeSequence> branch() override;
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+    // Finalise any necessary data after execution
+    bool finalise(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -104,7 +104,7 @@ bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
 {
     // Check for spurious context checks
     if (targetContext == ProcedureNode::NodeContext::InheritContext)
-        throw(std::runtime_error(fmt::format("Attempted to context check node '{}' with an InheritedContext.\n")));
+        throw(std::runtime_error(fmt::format("Attempted to context check node '{}' with an InheritedContext.\n", name_)));
 
     // If the node is suitable in Any context, or if there is no context (None) return immediately
     if (targetContext == ProcedureNode::NodeContext::NoContext || targetContext == ProcedureNode::NodeContext::AnyContext ||

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -104,7 +104,8 @@ bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
 {
     // Check for spurious context checks
     if (targetContext == ProcedureNode::NodeContext::InheritContext)
-        throw(std::runtime_error(fmt::format("Attempted to context check node '{}' with an InheritedContext.\n", name_)));
+        throw(std::runtime_error(fmt::format("Attempted to context check node '{}' with an InheritedContext.\n",
+                                             name_.empty() ? nodeTypes().keyword(type_) : name_)));
 
     // If the node is suitable in Any context, or if there is no context (None) return immediately
     if (targetContext == ProcedureNode::NodeContext::NoContext || targetContext == ProcedureNode::NodeContext::AnyContext ||

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -102,9 +102,10 @@ ProcedureNode::NodeType ProcedureNode::type() const { return type_; }
 // Return whether the supplied context is relevant for the current node
 bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
 {
-    // If the node is suitable in Any context return immediately
-    if (std::find(relevantContexts_.begin(), relevantContexts_.end(), ProcedureNode::NodeContext::AnyContext) !=
-        relevantContexts_.end())
+    // If the node is suitable in Any context, or if there is no context (None) return immediately
+    if (targetContext == ProcedureNode::NodeContext::NoContext ||
+        std::find(relevantContexts_.begin(), relevantContexts_.end(), ProcedureNode::NodeContext::AnyContext) !=
+            relevantContexts_.end())
         return true;
 
     // If the node is relevant in the context, check that against the supplied one. Otherwise, search for it in our vector

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -46,6 +46,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::GeneralRegion, "GeneralRegion"},
                      {ProcedureNode::NodeType::ImportCoordinates, "ImportCoordinates"},
                      {ProcedureNode::NodeType::IntegerCollect1D, "IntegerCollect1D"},
+                     {ProcedureNode::NodeType::IfValueInRange, "IfValueInRange"},
                      {ProcedureNode::NodeType::Integrate1D, "Integrate1D"},
                      {ProcedureNode::NodeType::OperateDivide, "OperateDivide"},
                      {ProcedureNode::NodeType::OperateExpression, "OperateExpression"},

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -102,26 +102,17 @@ ProcedureNode::NodeType ProcedureNode::type() const { return type_; }
 // Return whether the supplied context is relevant for the current node
 bool ProcedureNode::isContextRelevant(NodeContext targetContext) const
 {
+    // Check for spurious context checks
+    if (targetContext == ProcedureNode::NodeContext::InheritContext)
+        throw(std::runtime_error(fmt::format("Attempted to context check node '{}' with an InheritedContext.\n")));
+
     // If the node is suitable in Any context, or if there is no context (None) return immediately
-    if (targetContext == ProcedureNode::NodeContext::NoContext ||
+    if (targetContext == ProcedureNode::NodeContext::NoContext || targetContext == ProcedureNode::NodeContext::AnyContext ||
         std::find(relevantContexts_.begin(), relevantContexts_.end(), ProcedureNode::NodeContext::AnyContext) !=
             relevantContexts_.end())
         return true;
 
-    // If the node is relevant in the context, check that against the supplied one. Otherwise, search for it in our vector
-    if (std::find(relevantContexts_.begin(), relevantContexts_.end(), ProcedureNode::NodeContext::ParentProcedureContext) !=
-        relevantContexts_.end())
-    {
-        if (!scope_)
-            throw(
-                std::runtime_error(fmt::format("Node type '{}' requires check for parent scope context, but it has no scope.\n",
-                                               ProcedureNode::nodeTypes().keyword(type_))));
-        auto &seq = *scope_;
-        return std::find(relevantContexts_.begin(), relevantContexts_.end(), seq.get().sequenceContext()) !=
-               relevantContexts_.end();
-    }
-    else
-        return std::find(relevantContexts_.begin(), relevantContexts_.end(), targetContext) != relevantContexts_.end();
+    return std::find(relevantContexts_.begin(), relevantContexts_.end(), targetContext) != relevantContexts_.end();
 }
 
 // Return whether the node is of the specified class

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -83,7 +83,7 @@ EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
                                                                    {ProcedureNode::GenerationContext, "Generation"},
                                                                    {ProcedureNode::OperateContext, "Operate"},
                                                                    {ProcedureNode::AnyContext, "Any"},
-                                                                   {ProcedureNode::ParentProcedureContext, "ParentProcedure"}});
+                                                                   {ProcedureNode::InheritContext, "Inherit"}});
 }
 
 ProcedureNode::ProcedureNode(ProcedureNode::NodeType nodeType, std::vector<NodeContext> relevantContexts,
@@ -166,7 +166,8 @@ ProcedureNode::NodeContext ProcedureNode::scopeContext() const
     if (!scope_)
         return ProcedureNode::NoContext;
 
-    return (*scope_).get().sequenceContext();
+    auto context = (*scope_).get().context();
+    return context == ProcedureNode::NodeContext::InheritContext ? parent()->scopeContext() : context;
 }
 
 // Return named node, optionally matching the type / class given, in or out of scope

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -58,6 +58,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         GeneralRegion,
         ImportCoordinates,
         IntegerCollect1D,
+        IfValueInRange,
         Integrate1D,
         OperateDivide,
         OperateExpression,

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -96,7 +96,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         GenerationContext = 2,
         OperateContext = 4,
         AnyContext = 8,
-        ParentProcedureContext = 16
+        InheritContext = 16
     };
     // Return enum option info for NodeContext
     static EnumOptions<NodeContext> nodeContexts();

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -18,6 +18,7 @@
 #include "procedure/nodes/cylindricalRegion.h"
 #include "procedure/nodes/directionalGlobalPotential.h"
 #include "procedure/nodes/generalRegion.h"
+#include "procedure/nodes/ifValueInRange.h"
 #include "procedure/nodes/importCoordinates.h"
 #include "procedure/nodes/integerCollect1D.h"
 #include "procedure/nodes/integrate1D.h"
@@ -76,6 +77,10 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
     registerProducer<CalculateVectorProcedureNode>(ProcedureNode::NodeType::CalculateVector,
                                                    "Calculate vector between two sites", "Calculate");
     registerProducer<SelectProcedureNode>(ProcedureNode::NodeType::Select, "Select sites for consideration", "Calculate");
+
+    // Control
+    registerProducer<IfValueInRangeProcedureNode>(ProcedureNode::NodeType::IfValueInRange,
+                                                  "Conditionally execute other nodes if a value is within range", "Control");
 
     // Data
     registerProducer<Collect1DProcedureNode>(ProcedureNode::NodeType::Collect1D, "Bin 1D quantity into a histogram", "Data");

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -36,7 +36,7 @@ void ProcedureNodeSequence::appendNode(NodeRef node, std::optional<int> insertAt
     node->setScope(*this);
 
     // Check context
-    if (!node->isContextRelevant(context_))
+    if (!node->isContextRelevant(context()))
         throw(std::runtime_error(fmt::format("Node '{}' (type = '{}') is not relevant to the '{}' context.\n", node->name(),
                                              ProcedureNode::nodeTypes().keyword(node->type()),
                                              ProcedureNode::nodeContexts().keyword(context_))));
@@ -400,7 +400,7 @@ bool ProcedureNodeSequence::check() const
                                     fmt::ptr(node->parent()), fmt::ptr(this));
 
         // Check context
-        if (!node->isContextRelevant(context_))
+        if (!node->isContextRelevant(context()))
             return Messenger::error("Node '{}' is not allowed in this context ({})\n", node->name(),
                                     ProcedureNode::nodeContexts().keyword(context_));
 

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -154,7 +154,10 @@ ProcedureNodeSequence::searchParameters(std::string_view name,
 OptionalReferenceWrapper<ProcedureNode> ProcedureNodeSequence::owner() const { return owner_; }
 
 // Return the context of the sequence
-ProcedureNode::NodeContext ProcedureNodeSequence::sequenceContext() const { return context_; }
+ProcedureNode::NodeContext ProcedureNodeSequence::context() const
+{
+    return context_ == ProcedureNode::NodeContext::InheritContext ? owner_->get().scopeContext() : context_;
+}
 
 // Return named node if present in this sequence, and which matches the (optional) type given
 ConstNodeRef ProcedureNodeSequence::node(std::string_view name, ConstNodeRef excludeNode,

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -88,7 +88,7 @@ class ProcedureNodeSequence : public Serialisable<const CoreData &>
     // Return this sequences owner
     OptionalReferenceWrapper<ProcedureNode> owner() const;
     // Return the context of the sequence
-    ProcedureNode::NodeContext sequenceContext() const;
+    ProcedureNode::NodeContext context() const;
     // Return named node if present (and matches the type / class given)
     ConstNodeRef node(std::string_view name, ConstNodeRef excludeNode = nullptr,
                       std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,

--- a/unit/procedure/procedure.cpp
+++ b/unit/procedure/procedure.cpp
@@ -5,6 +5,7 @@
 #include "keywords/node.h"
 #include "procedure/nodes/add.h"
 #include "procedure/nodes/box.h"
+#include "procedure/nodes/ifValueInRange.h"
 #include "procedure/nodes/parameters.h"
 #include "procedure/nodes/select.h"
 #include <gtest/gtest.h>
@@ -19,6 +20,12 @@ TEST(ProcedureTest, Context)
 
     // Select A
     auto selectA = procedure.createRootNode<SelectProcedureNode>("A");
+    // -- Select nodes are valid in most contexts except "Operate"
+    EXPECT_TRUE(selectA->isContextRelevant(ProcedureNode::NodeContext::AnyContext));
+    EXPECT_TRUE(selectA->isContextRelevant(ProcedureNode::NodeContext::NoContext));
+    EXPECT_TRUE(selectA->isContextRelevant(ProcedureNode::NodeContext::AnalysisContext));
+    EXPECT_TRUE(selectA->isContextRelevant(ProcedureNode::NodeContext::GenerationContext));
+    EXPECT_FALSE(selectA->isContextRelevant(ProcedureNode::NodeContext::OperateContext));
     auto &forEachA = selectA->branch()->get();
     EXPECT_TRUE(procedure.rootSequence().check());
 
@@ -37,6 +44,13 @@ TEST(ProcedureTest, Context)
 
     // Node with same name as an existing one
     EXPECT_THROW(procedure.createRootNode<BoxProcedureNode>("A"), std::runtime_error);
+
+    // Create a new node with an InheritContext type
+    auto ifValue = forEachB.create<IfValueInRangeProcedureNode>("IfValue");
+    auto &ifThen = ifValue->branch()->get();
+    EXPECT_TRUE(procedure.rootSequence().check());
+    EXPECT_EQ(ifThen.context(), ProcedureNode::NodeContext::AnalysisContext);
+    EXPECT_TRUE(ifValue->isContextRelevant(forEachB.context()));
 }
 
 TEST(ProcedureTest, Scope)


### PR DESCRIPTION
This PR introduces a new node in what is likely to become a series of useful "logic" additions to procedure writing in Dissolve.  The `IfValueInRange` node checks a given value (as a `NodeValue` expression) against a defined `Range`, only executing its "Then" branch if the value is within the specified limits.

Some other notable changes were made in order to allow this PR - principally, a sequence node can inherit the context from the encompassing (owning) parent sequence.  This is useful / necessary when introducing fully generic nodes like this one, and was technically already a feature in the code but it turned out to be horribly broken!