### PR TITLE
Fixup HistogramCN

### DIFF
--- a/src/math/integerHistogram1D.cpp
+++ b/src/math/integerHistogram1D.cpp
@@ -48,40 +48,26 @@ void IntegerHistogram1D::updateAccumulatedData()
     }
 }
 
-// Create dsiplay data object covering extents of current bins
+// Create display data object covering extents of current bins
 const std::pair<Data1D, int> IntegerHistogram1D::createDisplayData()
 {
+    // If we haven't binned anything yet, return now
+    if (raw_.empty())
+        return std::make_pair(Data1D(), 0);
 
     // Get limiting key values
-    std::optional<int> expectedMinimum = raw_.empty() ? std::nullopt : std::optional<int>(raw_.begin()->first);
-    if (minimum_)
-        expectedMinimum = expectedMinimum ? std::min(*minimum_, *expectedMinimum) : *minimum_;
-
-    std::optional<int> expectedMaximum = raw_.empty() ? std::nullopt : std::optional<int>(std::prev(raw_.end())->first);
-    if (maximum_)
-        expectedMaximum = expectedMaximum ? std::max(*maximum_, *expectedMaximum) : *maximum_;
-
-    // Need to check on null values - set to zeroes if both null, or if one is null set it to match the other
-    if (!expectedMinimum && !expectedMaximum)
-    {
-        expectedMinimum = 0;
-        expectedMaximum = 0;
-    }
-    else if (!expectedMinimum)
-        expectedMinimum = expectedMaximum;
-    else if (!expectedMaximum)
-        expectedMaximum = expectedMinimum;
-
-    auto expectedNBins = (*expectedMaximum - *expectedMinimum) + 1;
+    auto expectedMinimum = minimum_ ? std::min(*minimum_, raw_.begin()->first) : raw_.begin()->first;
+    auto expectedMaximum = maximum_ ? std::max(*maximum_, std::prev(raw_.end())->first) : std::prev(raw_.end())->first;
+    auto expectedNBins = (expectedMaximum - expectedMinimum) + 1;
 
     // Set up data
     Data1D data;
     data.initialise(expectedNBins, true);
-    auto x = *expectedMinimum;
+    auto x = expectedMinimum;
     for (auto n = 0; n < expectedNBins; ++n)
         data.xAxis(n) = x++;
 
-    return std::make_pair(data, expectedMinimum.value());
+    return std::make_pair(data, expectedMinimum);
 }
 
 // Initialise with specified bin range

--- a/src/math/integerHistogram1D.cpp
+++ b/src/math/integerHistogram1D.cpp
@@ -200,18 +200,18 @@ bool IntegerHistogram1D::serialise(LineParser &parser) const
                            DissolveSys::btoa(maximum_.has_value()), maximum_.value_or(0)))
         return false;
 
-    if (!parser.writeLineF("{}  {} \n", nBinned_, nMissed_))
+    if (!parser.writeLineF("{}  {}\n", nBinned_, nMissed_))
         return false;
 
     if (!zeroCounter_.serialise(parser))
         return false;
 
-    if (!parser.writeLineF("{} \n", raw_.size()))
+    if (!parser.writeLineF("{}\n", raw_.size()))
         return false;
 
     for (auto &[key, value] : raw_)
     {
-        if (!parser.writeLineF("{} {} \n", key, value))
+        if (!parser.writeLineF("{} {}\n", key, value))
             return false;
         if (!averages_.at(key).serialise(parser))
             return false;

--- a/src/modules/histogramCN/histogramCN.cpp
+++ b/src/modules/histogramCN/histogramCN.cpp
@@ -30,8 +30,7 @@ HistogramCNModule::HistogramCNModule() : Module(ModuleTypes::HistogramCN), analy
     auto calcExpression_ = forEachA.create<CalculateExpressionProcedureNode>({});
     calcExpression_->setExpression("B.nSelected");
 
-    auto collectCN_ =
-        forEachA.create<IntegerCollect1DProcedureNode>("Bins", calcExpression_, ProcedureNode::AnalysisContext, 0, 10);
+    auto collectCN_ = forEachA.create<IntegerCollect1DProcedureNode>("Bins", calcExpression_, ProcedureNode::AnalysisContext);
 
     auto process1D = analyser_.createRootNode<Process1DProcedureNode>("Histogram", collectCN_);
     auto &normalisation = process1D->branch()->get();

--- a/src/modules/histogramCN/histogramCN.cpp
+++ b/src/modules/histogramCN/histogramCN.cpp
@@ -4,6 +4,7 @@
 #include "modules/histogramCN/histogramCN.h"
 #include "keywords/bool.h"
 #include "keywords/configuration.h"
+#include "keywords/fileAndFormat.h"
 #include "keywords/range.h"
 #include "keywords/speciesSiteVector.h"
 #include "keywords/vec3Double.h"
@@ -32,8 +33,8 @@ HistogramCNModule::HistogramCNModule() : Module(ModuleTypes::HistogramCN), analy
 
     auto collectCN_ = forEachA.create<IntegerCollect1DProcedureNode>("Bins", calcExpression_, ProcedureNode::AnalysisContext);
 
-    auto process1D = analyser_.createRootNode<Process1DProcedureNode>("Histogram", collectCN_);
-    auto &normalisation = process1D->branch()->get();
+    auto process1D_ = analyser_.createRootNode<Process1DProcedureNode>("Histogram", collectCN_);
+    auto &normalisation = process1D_->branch()->get();
     auto norm = normalisation.create<OperateNormaliseProcedureNode>({});
 
     /*
@@ -53,4 +54,7 @@ HistogramCNModule::HistogramCNModule() : Module(ModuleTypes::HistogramCN), analy
     keywords_.add<RangeKeyword>("DistanceRange",
                                 "Distance range (min, max) over which to calculate coordination number from central site",
                                 distanceRange_, 0.0, std::nullopt, Vec3Labels::MinMaxDeltaLabels);
+    keywords_.setOrganisation("Export");
+    keywords_.add<FileAndFormatKeyword>("Export", "File format and file name under which to save calculated HitogramCN data",
+                                        process1D_->exportFileAndFormat(), "EndExport");
 }

--- a/src/modules/histogramCN/histogramCN.cpp
+++ b/src/modules/histogramCN/histogramCN.cpp
@@ -31,10 +31,10 @@ HistogramCNModule::HistogramCNModule() : Module(ModuleTypes::HistogramCN), analy
     auto calcExpression_ = forEachA.create<CalculateExpressionProcedureNode>({});
     calcExpression_->setExpression("B.nSelected");
 
-    auto collectCN_ = forEachA.create<IntegerCollect1DProcedureNode>("Bins", calcExpression_, ProcedureNode::AnalysisContext);
+    auto collectCN = forEachA.create<IntegerCollect1DProcedureNode>("Bins", calcExpression_, ProcedureNode::AnalysisContext);
 
-    auto process1D_ = analyser_.createRootNode<Process1DProcedureNode>("Histogram", collectCN_);
-    auto &normalisation = process1D_->branch()->get();
+    auto process1D = analyser_.createRootNode<Process1DProcedureNode>("Histogram", collectCN);
+    auto &normalisation = process1D->branch()->get();
     auto norm = normalisation.create<OperateNormaliseProcedureNode>({});
 
     /*
@@ -56,5 +56,5 @@ HistogramCNModule::HistogramCNModule() : Module(ModuleTypes::HistogramCN), analy
                                 distanceRange_, 0.0, std::nullopt, Vec3Labels::MinMaxDeltaLabels);
     keywords_.setOrganisation("Export");
     keywords_.add<FileAndFormatKeyword>("Export", "File format and file name under which to save calculated HitogramCN data",
-                                        process1D_->exportFileAndFormat(), "EndExport");
+                                        process1D->exportFileAndFormat(), "EndExport");
 }

--- a/src/procedure/nodes/integerCollect1D.cpp
+++ b/src/procedure/nodes/integerCollect1D.cpp
@@ -13,9 +13,9 @@
 #include "procedure/nodes/sequence.h"
 
 IntegerCollect1DProcedureNode::IntegerCollect1DProcedureNode(std::shared_ptr<CalculateProcedureNodeBase> observable,
-                                                             ProcedureNode::NodeContext subCollectContext, int rMin, int rMax)
-    : ProcedureNode(ProcedureNode::NodeType::IntegerCollect1D, {ProcedureNode::AnalysisContext}),
-      xObservable_{observable, 0}, minimum_{rMin}, maximum_{rMax}, subCollectBranch_(subCollectContext, *this, "SubCollect")
+                                                             ProcedureNode::NodeContext subCollectContext)
+    : ProcedureNode(ProcedureNode::NodeType::IntegerCollect1D, {ProcedureNode::AnalysisContext}), xObservable_{observable, 0},
+      subCollectBranch_(subCollectContext, *this, "SubCollect")
 {
     keywords_.setOrganisation("Options", "Quantity / Range");
     keywords_.add<NodeAndIntegerKeyword<CalculateProcedureNodeBase>>(

--- a/src/procedure/nodes/integerCollect1D.cpp
+++ b/src/procedure/nodes/integerCollect1D.cpp
@@ -20,10 +20,10 @@ IntegerCollect1DProcedureNode::IntegerCollect1DProcedureNode(std::shared_ptr<Cal
     keywords_.setOrganisation("Options", "Quantity / Range");
     keywords_.add<NodeAndIntegerKeyword<CalculateProcedureNodeBase>>(
         "QuantityX", "Calculated observable to collect", xObservable_, this, ProcedureNode::NodeClass::Calculate, true);
-    keywords_.add<OptionalIntegerKeyword>("Minimum", "Minimum of the x-axis of the histogram", minimum_, 0, std::nullopt, 1,
-                                          "Use Minimum value");
-    keywords_.add<OptionalIntegerKeyword>("Maximum", "Maximum of the x-axis of the histogram", maximum_, 0, std::nullopt, 1,
-                                          "Use Maximum value");
+    keywords_.add<OptionalIntegerKeyword>("Minimum", "Minimum allowed bin value for the histogram", minimum_, 0, std::nullopt,
+                                          1, "No Limit");
+    keywords_.add<OptionalIntegerKeyword>("Maximum", "Maximum allowed bin value for the histogram", maximum_, 0, std::nullopt,
+                                          1, "No Limit");
     keywords_.addHidden<NodeBranchKeyword>("SubCollect", "Branch which runs if the target quantity was binned successfully",
                                            subCollectBranch_);
 }

--- a/src/procedure/nodes/integerCollect1D.h
+++ b/src/procedure/nodes/integerCollect1D.h
@@ -16,8 +16,7 @@ class IntegerCollect1DProcedureNode : public ProcedureNode
 {
     public:
     IntegerCollect1DProcedureNode(std::shared_ptr<CalculateProcedureNodeBase> observable = nullptr,
-                                  ProcedureNode::NodeContext subCollectContext = ProcedureNode::AnalysisContext, int rMin = 0,
-                                  int rMax = 10);
+                                  ProcedureNode::NodeContext subCollectContext = ProcedureNode::AnalysisContext);
     ~IntegerCollect1DProcedureNode() override = default;
 
     /*


### PR DESCRIPTION
This PR focused on addressing some reports of output from `HistogramCN` "not being visible", or "not working properly". The observed behaviour was that the output graph would be blank, with coordinates showing as `-nan,-nan`. Inspecting the restart file did indeed show the presence of `-nan`s in the generated `Data1D`.

The root cause of this seemed to be related to our limit determination for the `Data1D` which did not always result in an `averages_` `Data1D` consistent with the `raw_` vector.  Removing the "assumed" limits passed to the `IntegerCollect1D` node and tidying up our determination of the data limits seems to resolve these issues.