### PR TITLE
Run Layer Node

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -76,7 +76,7 @@ bool Configuration::generate(const ProcedureContext &procedureContext)
     Messenger::print("\n");
 
     // Set-up Cells for the Box
-    cells_.generate(box_.get(), requestedCellDivisionLength_, context.dissolve().potentialMap().range());
+    cells_.generate(box_.get(), requestedCellDivisionLength_, context.potentialMap().range());
 
     // Make sure all objects know about each other
     updateObjectRelationships();

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -10,6 +10,7 @@
 #include "classes/potentialMap.h"
 #include "classes/species.h"
 #include "modules/energy/energy.h"
+#include "main/dissolve.h"
 
 Configuration::Configuration() : generator_(ProcedureNode::GenerationContext, "Generator")
 {
@@ -75,7 +76,7 @@ bool Configuration::generate(const ProcedureContext &procedureContext)
     Messenger::print("\n");
 
     // Set-up Cells for the Box
-    cells_.generate(box_.get(), requestedCellDivisionLength_, context.potentialMap().range());
+    cells_.generate(box_.get(), requestedCellDivisionLength_, context.dissolve().potentialMap().range());
 
     // Make sure all objects know about each other
     updateObjectRelationships();

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -9,8 +9,8 @@
 #include "classes/cell.h"
 #include "classes/potentialMap.h"
 #include "classes/species.h"
-#include "modules/energy/energy.h"
 #include "main/dissolve.h"
+#include "modules/energy/energy.h"
 
 Configuration::Configuration() : generator_(ProcedureNode::GenerationContext, "Generator")
 {

--- a/src/gui/configurationTabFuncs.cpp
+++ b/src/gui/configurationTabFuncs.cpp
@@ -176,7 +176,7 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     dissolve_.regeneratePairPotentials();
 
     // Initialise the content
-    configuration_->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()});
+    configuration_->initialiseContent({dissolve_.worldPool(), dissolve_});
 
     // Update
     updateControls();

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -77,7 +77,7 @@ void DissolveWindow::on_ConfigurationCreateAction_triggered(bool checked)
         dissolve_.regeneratePairPotentials();
 
         // Initialise the content
-        newConfig->initialiseContent({dissolve_.worldPool(), dissolve_.potentialMap()});
+        newConfig->initialiseContent({dissolve_.worldPool(), dissolve_});
 
         // Fully update GUI
         setModified();

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -58,7 +58,7 @@ bool Dissolve::prepare()
         // If the configuration is empty, initialise it now
         if (cfg->nMolecules() == 0)
         {
-            if (!cfg->initialiseContent({worldPool_, potentialMap_}))
+            if (!cfg->initialiseContent({worldPool_, *this}))
                 return Messenger::error("Failed to initialise content for configuration '{}'.\n", cfg->name());
         }
         else if (newPairPotentialRange)

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -130,6 +130,7 @@ bool ModuleLayer::contains(Module *searchModule) const
 
 // Return vector of Modules
 std::vector<std::unique_ptr<Module>> &ModuleLayer::modules() { return modules_; }
+const std::vector<std::unique_ptr<Module>> &ModuleLayer::modules() const { return modules_; }
 
 // Return map of modules in the layer, optionally preceding the specified module
 std::map<ModuleTypes::ModuleType, std::vector<const Module *>> ModuleLayer::modulesAsMap(const Module *beforeThis) const

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -91,6 +91,7 @@ class ModuleLayer : public Serialisable<const CoreData &>
     bool contains(Module *searchModule) const;
     // Return vector of Modules
     std::vector<std::unique_ptr<Module>> &modules();
+    const std::vector<std::unique_ptr<Module>> &modules() const;
     // Return map of modules in the layer, optionally preceding the specified module
     std::map<ModuleTypes::ModuleType, std::vector<const Module *>> modulesAsMap(const Module *beforeThis = nullptr) const;
 

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -19,7 +19,7 @@ Module::ExecutionResult AnalyseModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Analysis ExecutionResult::Failed.\n");

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -18,7 +18,8 @@ Module::ExecutionResult AnalyseModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Analysis ExecutionResult::Failed.\n");

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -58,7 +58,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Angle experienced problems with its analysis.\n");

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -57,7 +57,8 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Angle experienced problems with its analysis.\n");

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -37,7 +37,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -36,7 +36,8 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -39,7 +39,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
         {
             Timer timer;
             Messenger::mute();
-            targetConfiguration_->generate({moduleContext.processPool(), moduleContext.dissolve().potentialMap()});
+            targetConfiguration_->generate({moduleContext.processPool(), moduleContext.dissolve()});
             Messenger::unMute();
             timing += timer.split();
         }

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -36,7 +36,8 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -37,7 +37,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -32,7 +32,7 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -31,7 +31,8 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -29,7 +29,6 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     collectABC_->keywords().set("RangeX", angleRange_);
 
     // Execute the analysis
-    // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
     context.setPrefix(name());

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -31,7 +31,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateAngle experienced problems with its analysis.\n");

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -29,8 +29,10 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     collectABC_->keywords().set("RangeX", angleRange_);
 
     // Execute the analysis
+    // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateAngle experienced problems with its analysis.\n");

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -25,7 +25,8 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -26,7 +26,7 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -30,8 +30,14 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
+<<<<<<< HEAD
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+=======
+    ProcedureContext context(procPool, targetConfiguration_);
+    context.setDissolve(dissolve);
+    context.setPrefix(name());
+>>>>>>> 94beb10c0 (ProcedureContext has a reference to Dissolve.)
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -32,7 +32,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -30,14 +30,9 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-<<<<<<< HEAD
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
-=======
-    ProcedureContext context(procPool, targetConfiguration_);
-    context.setDissolve(dissolve);
+    context.setDissolve(moduleContext.dissolve());
     context.setPrefix(name());
->>>>>>> 94beb10c0 (ProcedureContext has a reference to Dissolve.)
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -33,7 +33,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
-    context.setPrefix(name());
+    context.setProcessingDataPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -32,7 +32,8 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
 
     // Execute the analysis
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDataListAndPrefix(moduleContext.dissolve().processingModuleData(), name());
+    context.setDissolve(moduleContext.dissolve());
+    context.setPrefix(name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -44,8 +44,9 @@ add_library(
   regionBase.cpp
   registry.cpp
   remove.cpp
-  rotateFragment.cpp
   restraintPotential.cpp
+  rotateFragment.cpp
+  runLayer.cpp
   select.cpp
   sequence.cpp
   simpleGlobalPotential.cpp
@@ -97,8 +98,9 @@ add_library(
   regionBase.h
   registry.h
   remove.h
-  rotateFragment.h
   restraintPotential.h
+  rotateFragment.h
+  runLayer.h
   select.h
   sequence.h
   simpleGlobalPotential.h

--- a/src/procedure/nodes/collect1D.cpp
+++ b/src/procedure/nodes/collect1D.cpp
@@ -64,7 +64,7 @@ bool Collect1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram1D>(dataName, procedureContext.dataPrefix(),
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram1D>(dataName, procedureContext.processingDataPrefix(),
                                                                                GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {

--- a/src/procedure/nodes/collect1D.cpp
+++ b/src/procedure/nodes/collect1D.cpp
@@ -64,8 +64,8 @@ bool Collect1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram1D>(dataName, procedureContext.processingDataPrefix(),
-                                                                               GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram1D>(
+        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("One-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/collect2D.cpp
+++ b/src/procedure/nodes/collect2D.cpp
@@ -62,7 +62,7 @@ bool Collect2DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram2D>(dataName, procedureContext.dataPrefix(),
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram2D>(dataName, procedureContext.processingDataPrefix(),
                                                                                GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {

--- a/src/procedure/nodes/collect2D.cpp
+++ b/src/procedure/nodes/collect2D.cpp
@@ -62,8 +62,8 @@ bool Collect2DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram2D>(dataName, procedureContext.processingDataPrefix(),
-                                                                               GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram2D>(
+        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("Two-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/collect3D.cpp
+++ b/src/procedure/nodes/collect3D.cpp
@@ -99,8 +99,8 @@ bool Collect3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram3D>(dataName, procedureContext.processingDataPrefix(),
-                                                                               GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram3D>(
+        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("Three-dimensional histogram data for '{}' was not in the target list, so it will now "

--- a/src/procedure/nodes/collect3D.cpp
+++ b/src/procedure/nodes/collect3D.cpp
@@ -99,7 +99,7 @@ bool Collect3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram3D>(dataName, procedureContext.dataPrefix(),
+    auto [target, status] = procedureContext.dataList().realiseIf<Histogram3D>(dataName, procedureContext.processingDataPrefix(),
                                                                                GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -12,7 +12,7 @@ ProcedureContext::ProcedureContext(const ProcessPool &procPool, Configuration *c
 {
 }
 
-ProcedureContext::ProcedureContext(const ProcessPool &procPool, Dissolve& dissolve)
+ProcedureContext::ProcedureContext(const ProcessPool &procPool, Dissolve &dissolve)
     : processPool_(procPool), dissolve_(dissolve)
 {
 }
@@ -31,12 +31,9 @@ Configuration *ProcedureContext::configuration() const
     return configuration_;
 }
 
-void ProcedureContext::setDissolve(Dissolve &dissolve)
-{
-    dissolve_ = dissolve;
-}
+void ProcedureContext::setDissolve(Dissolve &dissolve) { dissolve_ = dissolve; }
 
-Dissolve& ProcedureContext::dissolve() const
+Dissolve &ProcedureContext::dissolve() const
 {
     if (!dissolve_)
         throw(std::runtime_error("No reference to Dissolve is set in this procedure's context.\n"));
@@ -52,13 +49,15 @@ std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
 GenericList &ProcedureContext::dataList() const
 {
     if (!dissolve_)
-        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context, so cannot return processingModuleData.\n"));
+        throw(std::runtime_error(
+            "No reference to Dissolve is set in this procedure's context, so cannot return processingModuleData.\n"));
     return dissolve_->get().processingModuleData();
 }
 
 const PotentialMap &ProcedureContext::potentialMap() const
 {
     if (!dissolve_)
-        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context, so cannot return potentialMap.\n"));
+        throw(std::runtime_error(
+            "No reference to Dissolve is set in this procedure's context, so cannot return potentialMap.\n"));
     return dissolve_->get().potentialMap();
 }

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -43,10 +43,10 @@ Dissolve &ProcedureContext::dissolve() const
 }
 
 // Set target data list and prefix
-void ProcedureContext::setPrefix(std::string_view prefix) { dataPrefix_ = prefix; }
+void ProcedureContext::setProcessingDataPrefix(std::string_view prefix) { processingDataPrefix_ = prefix; }
 
 // Return prefix for generated data
-std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
+std::string_view ProcedureContext::processingDataPrefix() const { return processingDataPrefix_; }
 
 // Return target list for generated data
 GenericList &ProcedureContext::dataList() const

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -31,8 +31,10 @@ Configuration *ProcedureContext::configuration() const
     return configuration_;
 }
 
+// Set reference to Dissolve
 void ProcedureContext::setDissolve(Dissolve &dissolve) { dissolve_ = dissolve; }
 
+// Return reference to Dissolve
 Dissolve &ProcedureContext::dissolve() const
 {
     if (!dissolve_)
@@ -46,6 +48,7 @@ void ProcedureContext::setPrefix(std::string_view prefix) { dataPrefix_ = prefix
 // Return prefix for generated data
 std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
 
+// Return target list for generated data
 GenericList &ProcedureContext::dataList() const
 {
     if (!dissolve_)
@@ -54,6 +57,7 @@ GenericList &ProcedureContext::dataList() const
     return dissolve_->get().processingModuleData();
 }
 
+// Return potential map
 const PotentialMap &ProcedureContext::potentialMap() const
 {
     if (!dissolve_)

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "procedure/nodes/context.h"
+#include "main/dissolve.h"
 #include <stdexcept>
 
 ProcedureContext::ProcedureContext(const ProcessPool &procPool) : processPool_(procPool) {}
@@ -11,8 +12,8 @@ ProcedureContext::ProcedureContext(const ProcessPool &procPool, Configuration *c
 {
 }
 
-ProcedureContext::ProcedureContext(const ProcessPool &procPool, const PotentialMap &potentialMap)
-    : processPool_(procPool), potentialMap_(potentialMap)
+ProcedureContext::ProcedureContext(const ProcessPool &procPool, Dissolve& dissolve)
+    : processPool_(procPool), dissolve_(dissolve)
 {
 }
 
@@ -30,31 +31,34 @@ Configuration *ProcedureContext::configuration() const
     return configuration_;
 }
 
-// Set target data list and prefix
-void ProcedureContext::setDataListAndPrefix(GenericList &list, std::string_view prefix)
+void ProcedureContext::setDissolve(Dissolve &dissolve)
 {
-    dataList_ = list;
-    dataPrefix_ = prefix;
+    dissolve_ = dissolve;
 }
+
+Dissolve& ProcedureContext::dissolve() const
+{
+    if (!dissolve_)
+        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context.\n"));
+    return dissolve_->get();
+}
+
+// Set target data list and prefix
+void ProcedureContext::setPrefix(std::string_view prefix) { dataPrefix_ = prefix; }
 
 // Return prefix for generated data
 std::string_view ProcedureContext::dataPrefix() const { return dataPrefix_; }
 
-// Return target list for generated data
 GenericList &ProcedureContext::dataList() const
 {
-    if (!dataList_)
-        throw(std::runtime_error("No data list set in this procedure's context.\n"));
-    return dataList_->get();
+    if (!dissolve_)
+        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context, so cannot return processingModuleData.\n"));
+    return dissolve_->get().processingModuleData();
 }
 
-// Set potential map
-void ProcedureContext::setPotentialMap(const PotentialMap &potentialMap) { potentialMap_ = potentialMap; }
-
-// Return potential map
 const PotentialMap &ProcedureContext::potentialMap() const
 {
-    if (!potentialMap_)
-        throw(std::runtime_error("No potential map was set in this procedure's context.\n"));
-    return potentialMap_->get();
+    if (!dissolve_)
+        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context, so cannot return potentialMap.\n"));
+    return dissolve_->get().potentialMap();
 }

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -8,6 +8,7 @@
 
 // Forward Declarations
 class Configuration;
+class Dissolve;
 class GenericList;
 class PotentialMap;
 class ProcessPool;
@@ -18,7 +19,7 @@ class ProcedureContext
     public:
     explicit ProcedureContext(const ProcessPool &procPool);
     ProcedureContext(const ProcessPool &procPool, Configuration *cfg);
-    ProcedureContext(const ProcessPool &procPool, const PotentialMap &potentialMap);
+    ProcedureContext(const ProcessPool &procPool, Dissolve &dissolve);
 
     private:
     // Available process pool
@@ -27,10 +28,8 @@ class ProcedureContext
     Configuration *configuration_{nullptr};
     // Prefix for generated data
     std::string dataPrefix_;
-    // Target list for generated data
-    OptionalReferenceWrapper<GenericList> dataList_;
-    // Potential map
-    OptionalReferenceWrapper<const PotentialMap> potentialMap_;
+    // Dissolve
+    OptionalReferenceWrapper<Dissolve> dissolve_;
 
     public:
     // Return available process pool
@@ -39,14 +38,16 @@ class ProcedureContext
     void setConfiguration(Configuration *cfg);
     // Return target Configuration
     Configuration *configuration() const;
-    // Set target data list and prefix
-    void setDataListAndPrefix(GenericList &list, std::string_view prefix);
+    // Set prefix
+    void setPrefix(std::string_view prefix);
     // Return prefix for generated data
     std::string_view dataPrefix() const;
     // Return target list for generated data
     GenericList &dataList() const;
-    // Set potential map
-    void setPotentialMap(const PotentialMap &potentialMap);
+    // Set dissolve
+    void setDissolve(Dissolve& dissolve);
+    // Return reference to dissolve
+    Dissolve& dissolve() const;
     // Return potential map
     const PotentialMap &potentialMap() const;
 };

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -44,9 +44,9 @@ class ProcedureContext
     std::string_view dataPrefix() const;
     // Return target list for generated data
     GenericList &dataList() const;
-    // Set dissolve
+    // Set reference to Dissolve
     void setDissolve(Dissolve &dissolve);
-    // Return reference to dissolve
+    // Return reference to Dissolve
     Dissolve &dissolve() const;
     // Return potential map
     const PotentialMap &potentialMap() const;

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -38,8 +38,8 @@ class ProcedureContext
     void setConfiguration(Configuration *cfg);
     // Return target Configuration
     Configuration *configuration() const;
-    // Set prefix
-    void setPrefix(std::string_view prefix);
+    // Set prefix for generated processing data
+    void setProcessingDataPrefix(std::string_view prefix);
     // Return prefix for generated data
     std::string_view dataPrefix() const;
     // Return target list for generated data

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -27,7 +27,7 @@ class ProcedureContext
     // Target Configuration
     Configuration *configuration_{nullptr};
     // Prefix for generated data
-    std::string dataPrefix_;
+    std::string processingDataPrefix_;
     // Dissolve
     OptionalReferenceWrapper<Dissolve> dissolve_;
 
@@ -41,7 +41,7 @@ class ProcedureContext
     // Set prefix for generated processing data
     void setProcessingDataPrefix(std::string_view prefix);
     // Return prefix for generated data
-    std::string_view dataPrefix() const;
+    std::string_view processingDataPrefix() const;
     // Return target list for generated data
     GenericList &dataList() const;
     // Set reference to Dissolve

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -45,9 +45,9 @@ class ProcedureContext
     // Return target list for generated data
     GenericList &dataList() const;
     // Set dissolve
-    void setDissolve(Dissolve& dissolve);
+    void setDissolve(Dissolve &dissolve);
     // Return reference to dissolve
-    Dissolve& dissolve() const;
+    Dissolve &dissolve() const;
     // Return potential map
     const PotentialMap &potentialMap() const;
 };

--- a/src/procedure/nodes/integerCollect1D.cpp
+++ b/src/procedure/nodes/integerCollect1D.cpp
@@ -64,7 +64,7 @@ bool IntegerCollect1DProcedureNode::prepare(const ProcedureContext &procedureCon
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<IntegerHistogram1D>(dataName, procedureContext.dataPrefix(),
+    auto [target, status] = procedureContext.dataList().realiseIf<IntegerHistogram1D>(dataName, procedureContext.processingDataPrefix(),
                                                                                       GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {

--- a/src/procedure/nodes/integerCollect1D.cpp
+++ b/src/procedure/nodes/integerCollect1D.cpp
@@ -64,8 +64,8 @@ bool IntegerCollect1DProcedureNode::prepare(const ProcedureContext &procedureCon
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<IntegerHistogram1D>(dataName, procedureContext.processingDataPrefix(),
-                                                                                      GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.dataList().realiseIf<IntegerHistogram1D>(
+        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("One-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -78,8 +78,8 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
 // Return enum option info for NodeContext
 EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
 {
-    return EnumOptions<ProcedureNode::NodeContext>("NodeContext", {
-                                                                   {ProcedureNode::NoContext, "None"}, {ProcedureNode::AnalysisContext, "Analysis"},
+    return EnumOptions<ProcedureNode::NodeContext>("NodeContext", {{ProcedureNode::NoContext, "None"},
+                                                                   {ProcedureNode::AnalysisContext, "Analysis"},
                                                                    {ProcedureNode::GenerationContext, "Generation"},
                                                                    {ProcedureNode::ControlContext, "Control"},
                                                                    {ProcedureNode::OperateContext, "Operate"},

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -65,6 +65,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::Remove, "Remove"},
                      {ProcedureNode::NodeType::RestraintPotential, "RestraintPotential"},
                      {ProcedureNode::NodeType::RotateFragment, "RotateFragment"},
+                     {ProcedureNode::NodeType::RunLayer, "RunLayer"},
                      {ProcedureNode::NodeType::Select, "Select"},
                      {ProcedureNode::NodeType::Sequence, "Sequence"},
                      {ProcedureNode::NodeType::SimpleGlobalPotential, "SimpleGlobalPotential"},
@@ -77,9 +78,10 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
 // Return enum option info for NodeContext
 EnumOptions<ProcedureNode::NodeContext> ProcedureNode::nodeContexts()
 {
-    return EnumOptions<ProcedureNode::NodeContext>("NodeContext", {{ProcedureNode::NoContext, "None"},
-                                                                   {ProcedureNode::AnalysisContext, "Analysis"},
+    return EnumOptions<ProcedureNode::NodeContext>("NodeContext", {
+                                                                   {ProcedureNode::NoContext, "None"}, {ProcedureNode::AnalysisContext, "Analysis"},
                                                                    {ProcedureNode::GenerationContext, "Generation"},
+                                                                   {ProcedureNode::ControlContext, "Control"},
                                                                    {ProcedureNode::OperateContext, "Operate"},
                                                                    {ProcedureNode::AnyContext, "Any"},
                                                                    {ProcedureNode::ParentProcedureContext, "ParentProcedure"}});

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -96,9 +96,9 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         AnalysisContext = 1,
         GenerationContext = 2,
         OperateContext = 4,
-        AnyContext = 8,
-        InheritContext = 16,
-        ControlContext = 32
+        ControlContext = 8,
+        AnyContext = 16,
+        InheritContext = 32,
     };
     // Return enum option info for NodeContext
     static EnumOptions<NodeContext> nodeContexts();

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -77,6 +77,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         Remove,
         RestraintPotential,
         RotateFragment,
+        RunLayer,
         Select,
         Sequence,
         SimpleGlobalPotential,
@@ -95,7 +96,8 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         GenerationContext = 2,
         OperateContext = 4,
         AnyContext = 8,
-        ParentProcedureContext = 16
+        ParentProcedureContext = 16,
+        ControlContext = 32
     };
     // Return enum option info for NodeContext
     static EnumOptions<NodeContext> nodeContexts();

--- a/src/procedure/nodes/process1D.cpp
+++ b/src/procedure/nodes/process1D.cpp
@@ -117,7 +117,7 @@ bool Process1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
     auto &data = procedureContext.dataList().realise<Data1D>(fmt::format("Process1D//{}", name()),
-                                                             procedureContext.dataPrefix(), GenericItem::InRestartFileFlag);
+                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process1D.cpp
+++ b/src/procedure/nodes/process1D.cpp
@@ -116,8 +116,8 @@ bool Process1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data1D>(fmt::format("Process1D//{}", name()),
-                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.dataList().realise<Data1D>(
+        fmt::format("Process1D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process2D.cpp
+++ b/src/procedure/nodes/process2D.cpp
@@ -91,7 +91,7 @@ bool Process2DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
     auto &data = procedureContext.dataList().realise<Data2D>(fmt::format("Process2D//{}", name()),
-                                                             procedureContext.dataPrefix(), GenericItem::InRestartFileFlag);
+                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process2D.cpp
+++ b/src/procedure/nodes/process2D.cpp
@@ -90,8 +90,8 @@ bool Process2DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process2DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data2D>(fmt::format("Process2D//{}", name()),
-                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.dataList().realise<Data2D>(
+        fmt::format("Process2D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process3D.cpp
+++ b/src/procedure/nodes/process3D.cpp
@@ -96,7 +96,7 @@ bool Process3DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
     auto &data = procedureContext.dataList().realise<Data3D>(fmt::format("Process3D//{}", name()),
-                                                             procedureContext.dataPrefix(), GenericItem::InRestartFileFlag);
+                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process3D.cpp
+++ b/src/procedure/nodes/process3D.cpp
@@ -95,8 +95,8 @@ bool Process3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process3DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data3D>(fmt::format("Process3D//{}", name()),
-                                                             procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.dataList().realise<Data3D>(
+        fmt::format("Process3D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/registry.cpp
+++ b/src/procedure/nodes/registry.cpp
@@ -39,6 +39,7 @@
 #include "procedure/nodes/remove.h"
 #include "procedure/nodes/restraintPotential.h"
 #include "procedure/nodes/rotateFragment.h"
+#include "procedure/nodes/runLayer.h"
 #include "procedure/nodes/select.h"
 #include "procedure/nodes/simpleGlobalPotential.h"
 #include "procedure/nodes/sizeFactor.h"
@@ -138,6 +139,9 @@ ProcedureNodeRegistry::ProcedureNodeRegistry()
 
     // Sites
     registerProducer<RotateFragmentProcedureNode>(ProcedureNode::NodeType::RotateFragment, "Rotate fragment sites", "Sites");
+
+    // Control
+    registerProducer<RunLayerNode>(ProcedureNode::NodeType::RunLayer, "Run layer", "Control");
 }
 
 /*

--- a/src/procedure/nodes/runLayer.cpp
+++ b/src/procedure/nodes/runLayer.cpp
@@ -4,6 +4,7 @@
 #include "procedure/nodes/runLayer.h"
 #include "keywords/layer.h"
 #include "main/dissolve.h"
+#include "module/context.h"
 #include "module/layer.h"
 #include "procedure/nodes/node.h"
 
@@ -44,14 +45,15 @@ bool RunLayerNode::execute(const ProcedureContext &procedureContext)
     if (!layer_->canRun(procedureContext.dataList()))
         return true;
 
+    ModuleContext moduleContext(procedureContext.processPool(), procedureContext.dissolve());
+
     // Run the modules
     for (auto &module : layer_->modules())
     {
         if (!module->runThisIteration(procedureContext.dissolve().iteration() / layer_->frequency()))
             continue;
 
-        if (module->executeProcessing(procedureContext.dissolve(), procedureContext.processPool()) ==
-            Module::ExecutionResult::Failed)
+        if (module->executeProcessing(moduleContext) == Module::ExecutionResult::Failed)
             return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
     }
 

--- a/src/procedure/nodes/runLayer.cpp
+++ b/src/procedure/nodes/runLayer.cpp
@@ -3,9 +3,9 @@
 
 #include "procedure/nodes/runLayer.h"
 #include "keywords/layer.h"
+#include "main/dissolve.h"
 #include "module/layer.h"
 #include "procedure/nodes/node.h"
-#include "main/dissolve.h"
 
 RunLayerNode::RunLayerNode(const ModuleLayer *layer)
     : ProcedureNode(ProcedureNode::NodeType::RunLayer, {ProcedureNode::ControlContext}), layer_(layer)
@@ -45,12 +45,13 @@ bool RunLayerNode::execute(const ProcedureContext &procedureContext)
         return true;
 
     // Run the modules
-    for (auto& module : layer_->modules())
+    for (auto &module : layer_->modules())
     {
         if (!module->runThisIteration(procedureContext.dissolve().iteration() / layer_->frequency()))
             continue;
 
-        if (module->executeProcessing(procedureContext.dissolve(), procedureContext.processPool()) == Module::ExecutionResult::Failed)
+        if (module->executeProcessing(procedureContext.dissolve(), procedureContext.processPool()) ==
+            Module::ExecutionResult::Failed)
             return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
     }
 

--- a/src/procedure/nodes/runLayer.cpp
+++ b/src/procedure/nodes/runLayer.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/runLayer.h"
+#include "keywords/layer.h"
+#include "module/layer.h"
+#include "procedure/nodes/node.h"
+#include "main/dissolve.h"
+
+RunLayerNode::RunLayerNode(const ModuleLayer *layer)
+    : ProcedureNode(ProcedureNode::NodeType::RunLayer, {ProcedureNode::ControlContext}), layer_(layer)
+{
+
+    keywords_.setOrganisation("Options", "Target");
+    keywords_.add<LayerKeyword>("Layer", "Target layer to run", layer_);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether a name for the node must be provided
+bool RunLayerNode::mustBeNamed() const { return false; }
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool RunLayerNode::prepare(const ProcedureContext &procedureContext) { return layer_ != nullptr; }
+
+// Execute node
+bool RunLayerNode::execute(const ProcedureContext &procedureContext)
+{
+    if (!layer_->isEnabled())
+    {
+        Messenger::warn("Layer {} is disabled, so it won't be run!", layer_->name());
+        return true;
+    }
+
+    if (!layer_->runThisIteration(procedureContext.dissolve().iteration()))
+        return true;
+
+    if (!layer_->canRun(procedureContext.dataList()))
+        return true;
+
+    // Run the modules
+    for (auto& module : layer_->modules())
+    {
+        if (!module->runThisIteration(procedureContext.dissolve().iteration() / layer_->frequency()))
+            continue;
+
+        if (module->executeProcessing(procedureContext.dissolve(), procedureContext.processPool()) == Module::ExecutionResult::Failed)
+            return Messenger::error("Module '{}' experienced problems. Exiting now.\n", module->name());
+    }
+
+    return true;
+}

--- a/src/procedure/nodes/runLayer.h
+++ b/src/procedure/nodes/runLayer.h
@@ -20,6 +20,7 @@ class RunLayerNode : public ProcedureNode
     bool mustBeNamed() const override;
 
     private:
+    // Target module layer to run
     const ModuleLayer *layer_{nullptr};
 
     /*

--- a/src/procedure/nodes/runLayer.h
+++ b/src/procedure/nodes/runLayer.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "procedure/nodes/node.h"
+class ModuleLayer;
+
+class RunLayerNode : public ProcedureNode
+{
+    public:
+    explicit RunLayerNode(const ModuleLayer *layer = nullptr);
+    ~RunLayerNode() override = default;
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    private:
+    const ModuleLayer *layer_{nullptr};
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/sum1D.cpp
+++ b/src/procedure/nodes/sum1D.cpp
@@ -76,7 +76,7 @@ bool Sum1DProcedureNode::finalise(const ProcedureContext &procedureContext)
         {
             if (!sum_[i].has_value())
                 sum_[i] = procedureContext.dataList().realise<SampledDouble>(
-                    fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.dataPrefix(),
+                    fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.processingDataPrefix(),
                     GenericItem::InRestartFileFlag);
             if (instantaneous_)
                 sum_[i]->get() = Integrator::sum(sourceData_->processedData(), range_[i]);

--- a/unit/procedure/rotateFragment.cpp
+++ b/unit/procedure/rotateFragment.cpp
@@ -49,7 +49,7 @@ TEST(RotateTest, Benzene)
         auto molecules_before = cfg->molecules();
 
         rotate->keywords().set("Rotation", NodeValue{x});
-        cfg->generate(ProcedureContext(ProcessPool(), dissolve.potentialMap()));
+        cfg->generate({ProcessPool(), dissolve});
 
         for (const auto &[mol1, mol2] : zip(molecules_before, cfg->molecules()))
         {


### PR DESCRIPTION
This PR achieves two things:
- A reference to `Dissolve` can be (optionally) added to a `ProcedureContext`.
- Implements a `RunLayer` node which is analogous to the "execution" part of the simulation hot-loop.