### PR TITLE
Select Better

### DIFF
--- a/src/procedure/nodes/calculateAngle.cpp
+++ b/src/procedure/nodes/calculateAngle.cpp
@@ -48,8 +48,9 @@ bool CalculateAngleProcedureNode::execute(const ProcedureContext &procedureConte
     assert(sites_[2] && sites_[2]->currentSite());
 
     // Determine the value of the observable
-    value_.x = procedureContext.configuration()->box()->angleInDegrees(
-        sites_[0]->currentSite()->origin(), sites_[1]->currentSite()->origin(), sites_[2]->currentSite()->origin());
+    value_.x = procedureContext.configuration()->box()->angleInDegrees(sites_[0]->currentSite()->get().origin(),
+                                                                       sites_[1]->currentSite()->get().origin(),
+                                                                       sites_[2]->currentSite()->get().origin());
 
     if (symmetric_ && value_.x > 90.0)
         value_.x = 180.0 - value_.x;

--- a/src/procedure/nodes/calculateAxisAngle.cpp
+++ b/src/procedure/nodes/calculateAxisAngle.cpp
@@ -73,8 +73,8 @@ bool CalculateAxisAngleProcedureNode::execute(const ProcedureContext &procedureC
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());
 
-    value_.x = Box::angleInDegrees(sites_[0]->currentSite()->axes().columnAsVec3(axes_[0]),
-                                   sites_[1]->currentSite()->axes().columnAsVec3(axes_[1]));
+    value_.x = Box::angleInDegrees(sites_[0]->currentSite()->get().axes().columnAsVec3(axes_[0]),
+                                   sites_[1]->currentSite()->get().axes().columnAsVec3(axes_[1]));
 
     if (symmetric_ && value_.x > 90.0)
         value_.x = 180.0 - value_.x;

--- a/src/procedure/nodes/calculateDistance.cpp
+++ b/src/procedure/nodes/calculateDistance.cpp
@@ -37,13 +37,12 @@ int CalculateDistanceProcedureNode::dimensionality() const { return 1; }
 // Execute node
 bool CalculateDistanceProcedureNode::execute(const ProcedureContext &procedureContext)
 {
-
     assert(sites_[0] && sites_[0]->currentSite());
     assert(sites_[1] && sites_[1]->currentSite());
 
     // Determine the value of the observable
-    value_.x = procedureContext.configuration()->box()->minimumDistance(sites_[0]->currentSite()->origin(),
-                                                                        sites_[1]->currentSite()->origin());
+    value_.x = procedureContext.configuration()->box()->minimumDistance(sites_[0]->currentSite()->get().origin(),
+                                                                        sites_[1]->currentSite()->get().origin());
 
     return true;
 }

--- a/src/procedure/nodes/calculateVector.cpp
+++ b/src/procedure/nodes/calculateVector.cpp
@@ -56,12 +56,12 @@ bool CalculateVectorProcedureNode::execute(const ProcedureContext &procedureCont
     assert(sites_[1] && sites_[1]->currentSite());
 
     // Determine the value of the observable
-    value_ = procedureContext.configuration()->box()->minimumVector(sites_[0]->currentSite()->origin(),
-                                                                    sites_[1]->currentSite()->origin());
+    value_ = procedureContext.configuration()->box()->minimumVector(sites_[0]->currentSite()->get().origin(),
+                                                                    sites_[1]->currentSite()->get().origin());
 
     // Rotate the vector into the local frame defined on the first site?
     if (rotateIntoFrame_)
-        value_ = sites_[0]->currentSite()->axes().transposeMultiply(value_);
+        value_ = sites_[0]->currentSite()->get().axes().transposeMultiply(value_);
 
     return true;
 }

--- a/src/procedure/nodes/operateNumberDensityNormalise.cpp
+++ b/src/procedure/nodes/operateNumberDensityNormalise.cpp
@@ -36,7 +36,7 @@ bool OperateNumberDensityNormaliseProcedureNode::operateData1D(const ProcessPool
         if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Average)
             (*targetData1D_) /= (node->nAverageSites() / cfg->box()->volume());
         else if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Available)
-            (*targetData1D_) /= (node->nAvailableSites() / cfg->box()->volume());
+            (*targetData1D_) /= (node->nAvailableSitesAverage() / cfg->box()->volume());
 
     return true;
 }
@@ -48,7 +48,7 @@ bool OperateNumberDensityNormaliseProcedureNode::operateData2D(const ProcessPool
         if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Average)
             (*targetData2D_) /= (node->nAverageSites() / cfg->box()->volume());
         else if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Available)
-            (*targetData2D_) /= (node->nAvailableSites() / cfg->box()->volume());
+            (*targetData2D_) /= (node->nAvailableSitesAverage() / cfg->box()->volume());
 
     return true;
 }
@@ -60,7 +60,7 @@ bool OperateNumberDensityNormaliseProcedureNode::operateData3D(const ProcessPool
         if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Average)
             (*targetData3D_) /= (node->nAverageSites() / cfg->box()->volume());
         else if (targetPopulation_ == SelectProcedureNode::SelectionPopulation::Available)
-            (*targetData3D_) /= (node->nAvailableSites() / cfg->box()->volume());
+            (*targetData3D_) /= (node->nAvailableSitesAverage() / cfg->box()->volume());
 
     return true;
 }

--- a/src/procedure/nodes/rotateFragment.cpp
+++ b/src/procedure/nodes/rotateFragment.cpp
@@ -39,21 +39,23 @@ bool RotateFragmentProcedureNode::mustBeNamed() const { return false; }
 
 bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureContext)
 {
-    auto site = site_->currentSite();
-    auto parent = site->parent();
-    auto molecule = site->molecule();
+    assert(site_->currentSite());
+
+    auto &site = site_->currentSite()->get();
+    auto parent = site.parent();
+    auto molecule = site.molecule();
     auto box = procedureContext.configuration()->box();
 
-    if (!site->uniqueSiteIndex().has_value())
+    if (!site.uniqueSiteIndex().has_value())
     {
         Messenger::warn("Parent index not set for for site generated from FragmentSite '{}', so cannot rotate.",
                         parent->name());
         return false;
     }
 
-    auto parentIndex = site->uniqueSiteIndex().value();
+    auto parentIndex = site.uniqueSiteIndex().value();
 
-    if (!site->hasAxes())
+    if (!site.hasAxes())
     {
         Messenger::warn("FragmentSite '{}' has no axes to rotate about.", parent->name());
         return false;
@@ -63,20 +65,20 @@ bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureConte
     switch (axis_)
     {
         case (OrientedSite::SiteAxis::XAxis):
-            rotationMatrix.createRotationAxis(site->axes().columnAsVec3(0), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(0), rotation_, false);
             break;
         case (OrientedSite::SiteAxis::YAxis):
-            rotationMatrix.createRotationAxis(site->axes().columnAsVec3(1), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(1), rotation_, false);
             break;
         case (OrientedSite::SiteAxis::ZAxis):
-            rotationMatrix.createRotationAxis(site->axes().columnAsVec3(2), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(2), rotation_, false);
             break;
     }
 
     for (auto index : parent->sitesAllAtomsIndices().at(parentIndex))
     {
         auto atom = molecule->atom(index);
-        atom->set(rotationMatrix.transform(box->minimumVector(site->origin(), atom->r())) + site->origin());
+        atom->set(rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin());
     }
 
     return true;

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -269,7 +269,7 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
                     continue;
             }
 
-            // All OK, so add site and index in its stack (1...N numbering)
+            // All OK, so add site, its global index among all site stacks, and index in its stack (1...N numbering)
             sites_.emplace_back(site, siteIndex, n + 1);
         }
     }
@@ -286,7 +286,7 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
         {
             currentSite_ = std::get<0>(siteInfo);
             siteIndexParameter_->setValue(std::get<1>(siteInfo));
-            stackIndexParameter_->setValue(std::get<1>(siteInfo));
+            stackIndexParameter_->setValue(std::get<2>(siteInfo));
             indexParameter_->setValue(index++);
 
             ++nCumulativeSites_;

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -159,6 +159,9 @@ EnumOptions<SelectProcedureNode::SelectionPopulation> SelectProcedureNode::selec
                                 {SelectProcedureNode::SelectionPopulation::Average, "Average"}});
 }
 
+// Return vector of selected sites
+const std::vector<std::tuple<const Site &, int, int>> &SelectProcedureNode::sites() const { return sites_; }
+
 // Return the number of available sites in the current stack, if any
 int SelectProcedureNode::nSitesInStack() const { return sites_.size(); }
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -228,7 +228,6 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
     /*
      * Add sites from specified Species/Sites
      */
-    double r;
     for (auto *spSite : speciesSites_)
     {
         const auto *siteStack = procedureContext.configuration()->siteStack(spSite);
@@ -257,8 +256,8 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
             // Check distance from reference site (if defined)
             if (distanceRef)
             {
-                r = procedureContext.configuration()->box()->minimumDistance(site.origin(), distanceRef->get().origin());
-                if (!inclusiveDistanceRange_.contains(r))
+                if (!inclusiveDistanceRange_.contains(
+                        procedureContext.configuration()->box()->minimumDistance(site.origin(), distanceRef->get().origin())))
                     continue;
             }
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -258,8 +258,8 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
                     continue;
             }
 
-            // All OK, so add site
-            sites_.emplace_back(site, n);
+            // All OK, so add site and index in its stack (1...N numbering)
+            sites_.emplace_back(site, n + 1);
         }
     }
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -266,7 +266,7 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
             }
 
             // All OK, so add site and index in its stack (1...N numbering)
-            sites_.emplace_back(site, siteIndex++, n+1);
+            sites_.emplace_back(site, siteIndex++, n + 1);
         }
     }
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -20,8 +20,6 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
     : ProcedureNode(ProcedureNode::NodeType::Select, {ProcedureNode::AnalysisContext, ProcedureNode::GenerationContext}),
       speciesSites_(std::move(sites)), axesRequired_(axesRequired), forEachBranch_(forEachContext, *this, "ForEach")
 {
-    inclusiveDistanceRange_.set(0.0, 5.0);
-
     keywords_.setOrganisation("Options", "Sites");
     keywords_.add<SpeciesSiteVectorKeyword>("Site", "Add target site(s) to the selection", speciesSites_, axesRequired_);
 
@@ -50,11 +48,6 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
     keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_);
 
     currentSiteIndex_ = -1;
-    nCumulativeSites_ = 0;
-    nSelections_ = 0;
-    nAvailableSites_ = 0;
-    sameMolecule_ = nullptr;
-    distanceReferenceSite_ = nullptr;
     nSelectedParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("nSelected"));
 }
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -168,8 +168,8 @@ double SelectProcedureNode::nAverageSites() const { return double(nCumulativeSit
 // Return the cumulative number of sites ever selected
 unsigned long int SelectProcedureNode::nCumulativeSites() const { return nCumulativeSites_; }
 
-// Return total number of sites available per selection
-unsigned long int SelectProcedureNode::nAvailableSites() const { return double(nAvailableSites_) / nSelections_; }
+// Return average number of sites available per selection, before any distance pruning
+double SelectProcedureNode::nAvailableSitesAverage() const { return double(nAvailableSites_) / nSelections_; }
 
 // Return current site
 OptionalReferenceWrapper<const Site> SelectProcedureNode::currentSite() const { return currentSite_; }
@@ -255,6 +255,7 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
             if (std::find(excludedSites_.begin(), excludedSites_.end(), &site) != excludedSites_.end())
                 continue;
 
+            // Increment available sites now, before distance pruning
             ++nAvailableSites_;
 
             // Check distance from reference site (if defined)

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -48,6 +48,8 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
     keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_);
 
     nSelectedParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("nSelected"));
+    siteIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("siteIndex"));
+    indexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("index"));
 }
 
 /*
@@ -61,6 +63,8 @@ void SelectProcedureNode::setName(std::string_view name)
 
     // Update parameter names to match
     nSelectedParameter_->setName(fmt::format("{}.nSelected", name_));
+    siteIndexParameter_->setName(fmt::format("{}.siteIndex", name_));
+    indexParameter_->setName(fmt::format("{}.index", name_));
 }
 
 /*
@@ -270,9 +274,12 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
     currentSite_ = std::nullopt;
     if (!forEachBranch_.empty())
     {
+        auto index = 1;
         for (const auto &siteInfo : sites_)
         {
             currentSite_ = siteInfo.first;
+            siteIndexParameter_->setValue(siteInfo.second);
+            indexParameter_->setValue(index++);
 
             ++nCumulativeSites_;
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -266,7 +266,7 @@ bool SelectProcedureNode::execute(const ProcedureContext &procedureContext)
             }
 
             // All OK, so add site and index in its stack (1...N numbering)
-            sites_.emplace_back(site, siteIndex++, n + 1);
+            sites_.emplace_back(site, siteIndex, n + 1);
         }
     }
 

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -102,9 +102,9 @@ class SelectProcedureNode : public ProcedureNode
      */
     private:
     // Vector of selected sites
-    std::vector<const Site *> sites_;
+    std::vector<std::pair<const Site &, int>> sites_;
     // Current site
-    const Site *currentSite_{nullptr};
+    OptionalReferenceWrapper<const Site> currentSite_;
     // Number of selections made by the node
     int nSelections_{0};
     // Cumulative number of sites ever selected
@@ -130,7 +130,7 @@ class SelectProcedureNode : public ProcedureNode
     // Return total number of sites available per selection
     unsigned long int nAvailableSites() const;
     // Return current site
-    const Site *currentSite() const;
+    OptionalReferenceWrapper<const Site> currentSite() const;
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -103,8 +103,8 @@ class SelectProcedureNode : public ProcedureNode
     private:
     // Vector of selected sites
     std::vector<const Site *> sites_;
-    // Current Site index
-    int currentSiteIndex_;
+    // Current site
+    const Site *currentSite_{nullptr};
     // Number of selections made by the node
     int nSelections_{0};
     // Cumulative number of sites ever selected

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -119,6 +119,8 @@ class SelectProcedureNode : public ProcedureNode
     };
     // Return EnumOptions for SelectionPopulation
     static EnumOptions<SelectionPopulation> selectionPopulations();
+    // Return vector of selected sites
+    const std::vector<std::tuple<const Site &, int, int>> &sites() const;
     // Return the number of available sites in the current stack, if any
     int nSitesInStack() const;
     // Return the average number of sites selected

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -38,7 +38,7 @@ class SelectProcedureNode : public ProcedureNode
     // Defined parameters
     std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
-    std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, indexParameter_;
+    std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, stackIndexParameter_, indexParameter_;
 
     public:
     // Return the named parameter (if it exists)
@@ -100,7 +100,7 @@ class SelectProcedureNode : public ProcedureNode
      */
     private:
     // Vector of selected sites
-    std::vector<std::pair<const Site &, int>> sites_;
+    std::vector<std::tuple<const Site &, int, int>> sites_;
     // Current site
     OptionalReferenceWrapper<const Site> currentSite_;
     // Number of selections made by the node

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -125,8 +125,8 @@ class SelectProcedureNode : public ProcedureNode
     double nAverageSites() const;
     // Return the cumulative number of sites ever selected
     unsigned long int nCumulativeSites() const;
-    // Return total number of sites available per selection
-    unsigned long int nAvailableSites() const;
+    // Return average number of sites available per selection, before any distance pruning
+    double nAvailableSitesAverage() const;
     // Return current site
     OptionalReferenceWrapper<const Site> currentSite() const;
 

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -81,7 +81,7 @@ class SelectProcedureNode : public ProcedureNode
     // Site to use for distance check
     std::shared_ptr<const SelectProcedureNode> distanceReferenceSite_;
     // Range of distance to allow from distance reference site (if limiting)
-    Range inclusiveDistanceRange_;
+    Range inclusiveDistanceRange_{0.0, 5.0};
 
     public:
     // Set other sites (nodes) which will exclude one of our sites if it has the same Molecule parent
@@ -106,11 +106,11 @@ class SelectProcedureNode : public ProcedureNode
     // Current Site index
     int currentSiteIndex_;
     // Number of selections made by the node
-    int nSelections_;
+    int nSelections_{0};
     // Cumulative number of sites ever selected
-    unsigned long int nCumulativeSites_;
+    unsigned long int nCumulativeSites_{0};
     // Total number of sites available per selection
-    unsigned long int nAvailableSites_;
+    unsigned long int nAvailableSites_{0};
 
     public:
     // Selection Populations

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -41,8 +41,6 @@ class SelectProcedureNode : public ProcedureNode
     std::shared_ptr<ExpressionVariable> nSelectedParameter_;
 
     public:
-    // Add new parameter
-    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
     // Return the named parameter (if it exists)
     std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                      std::shared_ptr<ExpressionVariable> excludeParameter) override;

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -38,7 +38,7 @@ class SelectProcedureNode : public ProcedureNode
     // Defined parameters
     std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
-    std::shared_ptr<ExpressionVariable> nSelectedParameter_;
+    std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, indexParameter_;
 
     public:
     // Return the named parameter (if it exists)

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -348,12 +348,9 @@ std::vector<std::shared_ptr<ExpressionVariable>> ProcedureNodeSequence::paramete
     // Recursively check our owner
     if (owner_)
     {
-        auto optOtherParams = owner_->get().parameters();
-        if (optOtherParams)
-        {
-            const std::vector<std::shared_ptr<ExpressionVariable>> otherParams = (*optOtherParams);
-            parameters.insert(parameters.end(), otherParams.begin(), otherParams.end());
-        }
+        auto otherParams = owner_->get().getParameters();
+
+        parameters.insert(parameters.end(), otherParams.begin(), otherParams.end());
     }
 
     return parameters;

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -349,7 +349,6 @@ std::vector<std::shared_ptr<ExpressionVariable>> ProcedureNodeSequence::paramete
     if (owner_)
     {
         auto otherParams = owner_->get().getParameters();
-
         parameters.insert(parameters.end(), otherParams.begin(), otherParams.end());
     }
 

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -335,7 +335,7 @@ std::vector<std::shared_ptr<ExpressionVariable>> ProcedureNodeSequence::paramete
     std::vector<std::shared_ptr<ExpressionVariable>> parameters;
 
     // Start from the target node and work backwards...
-    for (auto node : range)
+    for (const auto &node : range)
     {
         auto optOtherParams = node->parameters();
         if (optOtherParams)

--- a/unit/data/species.h
+++ b/unit/data/species.h
@@ -6,6 +6,34 @@
 
 namespace UnitTest
 {
+// Return argon test species
+const Species &argonSpecies()
+{
+    static Species argon_;
+    if (argon_.nAtoms() == 0)
+    {
+        argon_.setName("Argon");
+        argon_.addAtom(Elements::Ar, {0.000000, 0.000000, 0.000000});
+    }
+
+    return argon_;
+}
+
+// Return diatomic test species
+const Species &diatomicSpecies()
+{
+    static Species diatomic_;
+    if (diatomic_.nAtoms() == 0)
+    {
+        diatomic_.setName("Diatomic");
+        diatomic_.addAtom(Elements::N, {0.000000, 0.000000, 0.000000});
+        diatomic_.addAtom(Elements::O, {0.000000, 1.100000, 0.000000});
+        diatomic_.addMissingBonds();
+    }
+
+    return diatomic_;
+}
+
 // Return methane test species
 const Species &methaneSpecies()
 {

--- a/unit/procedure/CMakeLists.txt
+++ b/unit/procedure/CMakeLists.txt
@@ -1,3 +1,4 @@
 dissolve_unit_test(calculateExpression.cpp)
 dissolve_unit_test(procedure.cpp)
 dissolve_unit_test(rotateFragment.cpp)
+dissolve_unit_test(select.cpp)

--- a/unit/procedure/select.cpp
+++ b/unit/procedure/select.cpp
@@ -1,0 +1,271 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/select.h"
+#include "classes/configuration.h"
+#include "main/dissolve.h"
+#include "procedure/procedure.h"
+#include "unit/data/species.h"
+#include <gtest/gtest.h>
+#include <string>
+
+namespace UnitTest
+{
+class SelectTest : public ::testing::Test
+{
+    public:
+    SelectTest() : dissolve_(coreData_)
+    {
+        // Set up species
+        alphaSpecies_ = coreData_.copySpecies(&diatomicSpecies());
+        alphaSite_ = alphaSpecies_->addSite("NO");
+        alphaSite_->setType(SpeciesSite::SiteType::Dynamic);
+        alphaSite_->setDynamicElements({Elements::N, Elements::O});
+        alphaSiteN_ = alphaSpecies_->addSite("N");
+        alphaSiteN_->setType(SpeciesSite::SiteType::Dynamic);
+        alphaSiteN_->setDynamicElements({Elements::N});
+        alphaSiteO_ = alphaSpecies_->addSite("O");
+        alphaSiteO_->setType(SpeciesSite::SiteType::Dynamic);
+        alphaSiteO_->setDynamicElements({Elements::N});
+
+        betaSpecies_ = coreData_.copySpecies(&diatomicSpecies());
+        betaSite_ = betaSpecies_->addSite("N");
+        betaSite_->setType(SpeciesSite::SiteType::Dynamic);
+        betaSite_->setDynamicElements({Elements::N, Elements::O});
+
+        argonSpecies_ = coreData_.copySpecies(&argonSpecies());
+        argonSite_ = argonSpecies_->addSite("Ar");
+        argonSite_->setType(SpeciesSite::SiteType::Static);
+        argonSite_->setStaticOriginAtoms({&argonSpecies_->atom(0)});
+
+        /*
+         * Setup configuration
+         * Our configuration will comprise a contiguous row of N2 molecules of two different "types" along X,
+         * and a single argon at the centre of the two types
+         *
+         * For instance:
+         *                   N   N   N   N   N   N   N   N
+         *                   |   |   |   |Ar |   |   |   |
+         *                   O   O   O   O   O   O   O   O
+         *                  (a   a   a   a   b   b   b   b)
+         */
+
+        configuration_ = coreData_.addConfiguration();
+        configuration_->createBoxAndCells({nType_ * 4.0, 20, 20}, {90, 90, 90}, false, 10.0);
+        configuration_->updateCells(10.0);
+
+        // Add our molecules
+        for (auto pos = 0; pos < nType_ * 2; ++pos)
+        {
+            // Add the N2 molecule (alpha if less than nType, beta otherwise)
+            auto n2 = configuration_->addMolecule(pos < nType_ ? alphaSpecies_ : betaSpecies_);
+            n2->setCentreOfGeometry(configuration_->box(), {pos * 1.0, 0.0, 0.0});
+        }
+        auto argon = configuration_->addMolecule(argonSpecies_);
+        argon->setCentreOfGeometry(configuration_->box(), {nType_ - 0.5, 0.0, 0.0});
+
+        configuration_->updateObjectRelationships();
+        configuration_->updateAtomLocations(true);
+    };
+
+    protected:
+    CoreData coreData_;
+    Dissolve dissolve_;
+    Species *alphaSpecies_, *betaSpecies_, *argonSpecies_;
+    SpeciesSite *alphaSite_, *alphaSiteN_, *alphaSiteO_, *betaSite_, *argonSite_;
+    Configuration *configuration_;
+    const int nType_{10};
+
+    protected:
+    void SetUp() override {}
+};
+
+TEST_F(SelectTest, Simple)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectN = testProcedure.createRootNode<SelectProcedureNode>(
+        "SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_}, ProcedureNode::NodeContext::AnalysisContext);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+    testProcedure.execute(context);
+
+    auto N = nType_ * 2;
+    EXPECT_EQ(selectN->nSitesInStack(), N * 2);
+
+    auto &sites = selectN->sites();
+
+    // Check indices of selected sites
+    for (auto n = 0; n < sites.size(); ++n)
+    {
+        // Site index, running from 1...N+M
+        EXPECT_EQ(std::get<1>(sites[n]), n + 1);
+        // Stack index, running from 1...N (twice)
+        EXPECT_EQ(std::get<2>(sites[n]), (n % N) + 1);
+    }
+}
+
+TEST_F(SelectTest, All)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectAr = testProcedure.createRootNode<SelectProcedureNode>("SelectAr", std::vector<const SpeciesSite *>{argonSite_},
+                                                                      ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachAr = selectAr->branch()->get();
+    auto selectN = forEachAr.create<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_},
+                                                         ProcedureNode::NodeContext::AnalysisContext);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+    testProcedure.execute(context);
+
+    EXPECT_EQ(selectAr->nSitesInStack(), 1);
+    EXPECT_EQ(selectN->nSitesInStack(), nType_ * 2 * 2);
+}
+
+TEST_F(SelectTest, Ranges)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectAr = testProcedure.createRootNode<SelectProcedureNode>("SelectAr", std::vector<const SpeciesSite *>{argonSite_},
+                                                                      ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachAr = selectAr->branch()->get();
+    auto selectN = forEachAr.create<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_},
+                                                         ProcedureNode::NodeContext::AnalysisContext);
+    selectN->setDistanceReferenceSite(selectAr);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+
+    for (auto rangeInt = 1; rangeInt <= nType_; ++rangeInt)
+    {
+        selectN->setInclusiveDistanceRange({0.0, rangeInt * 1.0});
+
+        testProcedure.execute(context);
+
+        EXPECT_EQ(selectAr->nSitesInStack(), 1);
+        EXPECT_EQ(selectN->nSitesInStack(), rangeInt * 2 * 2);
+
+        configuration_->incrementContentsVersion();
+    }
+}
+
+TEST_F(SelectTest, Indices)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectAr = testProcedure.createRootNode<SelectProcedureNode>("SelectAr", std::vector<const SpeciesSite *>{argonSite_},
+                                                                      ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachAr = selectAr->branch()->get();
+    auto selectN = forEachAr.create<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_},
+                                                         ProcedureNode::NodeContext::AnalysisContext);
+    selectN->setDistanceReferenceSite(selectAr);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+
+    auto N = nType_ * 2;
+
+    for (auto rangeInt = 1; rangeInt <= nType_; ++rangeInt)
+    {
+        selectN->setInclusiveDistanceRange({0.0, rangeInt * 1.0});
+
+        testProcedure.execute(context);
+
+        EXPECT_EQ(selectAr->nSitesInStack(), 1);
+        EXPECT_EQ(selectN->nSitesInStack(), rangeInt * 2 * 2);
+
+        auto &sites = selectN->sites();
+
+        // Check global indices of selected sites
+        auto vectorIndex = 0;
+        for (auto siteIndex = nType_ * 2 - rangeInt * 2; siteIndex < nType_ * 2 + rangeInt * 2; ++siteIndex)
+        {
+            // Site index, running from 1...N+M
+            EXPECT_EQ(std::get<1>(sites[vectorIndex]), siteIndex + 1);
+            // Stack index, running from 1...N (twice)
+            EXPECT_EQ(std::get<2>(sites[vectorIndex++]), (siteIndex % N) + 1);
+        }
+
+        configuration_->incrementContentsVersion();
+    }
+}
+
+TEST_F(SelectTest, Exclusions1)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectN1 = testProcedure.createRootNode<SelectProcedureNode>("SelectN1", std::vector<const SpeciesSite *>{alphaSiteN_},
+                                                                      ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachN1 = selectN1->branch()->get();
+    auto selectN2 = forEachN1.create<SelectProcedureNode>("SelectN2", std::vector<const SpeciesSite *>{alphaSiteN_},
+                                                          ProcedureNode::NodeContext::AnalysisContext);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+
+    // No exclusions
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN1->nSitesInStack(), nType_);
+    EXPECT_EQ(selectN2->nSitesInStack(), nType_);
+    EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectN2->nAvailableSitesAverage(), double(nType_));
+    configuration_->incrementContentsVersion();
+
+    // Exclude same site
+    selectN2->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectN1});
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN1->nSitesInStack(), nType_);
+    EXPECT_EQ(selectN2->nSitesInStack(), nType_ - 1);
+    EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectN2->nAvailableSitesAverage(), double(nType_ - 1));
+    configuration_->incrementContentsVersion();
+
+    // Exclude same molecule as well (no effect)
+    selectN2->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectN1});
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN1->nSitesInStack(), nType_);
+    EXPECT_EQ(selectN2->nSitesInStack(), nType_ - 1);
+    EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectN2->nAvailableSitesAverage(), double(nType_ - 1));
+}
+
+TEST_F(SelectTest, Exclusions2)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectN = testProcedure.createRootNode<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSiteN_},
+                                                                     ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachN = selectN->branch()->get();
+    auto selectO = forEachN.create<SelectProcedureNode>("SelectO", std::vector<const SpeciesSite *>{alphaSiteO_},
+                                                        ProcedureNode::NodeContext::AnalysisContext);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+
+    // No exclusions
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN->nSitesInStack(), nType_);
+    EXPECT_EQ(selectO->nSitesInStack(), nType_);
+    EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectO->nAvailableSitesAverage(), double(nType_));
+    configuration_->incrementContentsVersion();
+
+    // Exclude same molecule
+    selectO->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectN});
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN->nSitesInStack(), nType_);
+    EXPECT_EQ(selectO->nSitesInStack(), nType_ - 1);
+    EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectO->nAvailableSitesAverage(), double(nType_ - 1));
+}
+
+TEST_F(SelectTest, Inclusions)
+{
+    Procedure testProcedure(ProcedureNode::NodeContext::AnalysisContext);
+    auto selectN = testProcedure.createRootNode<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSiteN_},
+                                                                     ProcedureNode::NodeContext::AnalysisContext);
+    auto &forEachN = selectN->branch()->get();
+    auto selectO = forEachN.create<SelectProcedureNode>("SelectO", std::vector<const SpeciesSite *>{alphaSiteO_},
+                                                        ProcedureNode::NodeContext::AnalysisContext);
+
+    ProcedureContext context(dissolve_.worldPool(), configuration_);
+
+    // Require same molecule as first site
+    selectO->keywords().set("SameMoleculeAsSite", selectN);
+    testProcedure.execute(context);
+    EXPECT_EQ(selectN->nSitesInStack(), nType_);
+    EXPECT_EQ(selectO->nSitesInStack(), 1);
+    EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));
+    EXPECT_DOUBLE_EQ(selectO->nAvailableSitesAverage(), 1.0);
+}
+} // namespace UnitTest

--- a/web/docs/userguide/procedures/nodes/selectnode.md
+++ b/web/docs/userguide/procedures/nodes/selectnode.md
@@ -33,6 +33,13 @@ The following parameters are exported by the node:
 |Parameter|Description|
 |:--------|-----------|
 |`nSelected`|The number of sites currently selected by the node|
+|`index`|The index of the current site in the ForEach loop. Note that this index is just the "local" index for the loop, and does not have any relation to the indices of the sites per se.| 
+|`stackIndex`|The "stack" index of the current site in the ForEach loop. This reflects the ordering of the sites as they are calculated from the configuration and so are tied to the atom indexing.|
+`siteIndex`|The "global stack" index of the current site over all possible sites targeted by the selection.|
+
+Thus, if there are _N_ sites of a given type, the `index` for a given site will change based on how many of the _N_ are selected according to other criteria (i.e. within a certain distance, not on the same molecule etc.) while a given site's `stackIndex` will remain the same regardless of how many are selected, provided _N_ does not change (i.e. the population of molecules in the `Configuration` is static).
+
+Similarly, the `siteIndex` remains constant for a given site regardless of how many species sites are requested for selection. So, if three sites are provided having _N_, _M_, and _O_ sites respectively, then the `siteIndex` number goes from `1...(N+M+O)`, with sites from _N_ always being numbered `1...N`, sites from _M_ being numbered `N+1...N+M`, and sites from _O_ being numbered `N+M+1...N+M+O`.
 
 ## Options
 


### PR DESCRIPTION
Here we focus primarily on the operation of the `SelectProcedureNode`, tidying a few things, using references where possible, and adding in some additional parameters. Those parameters are:

- `index` - the index of the site in the `ForEach` loop.
- `stackIndex` - the index of the current site in the original `SiteStack` from which it was selected.
- `siteIndex` - the index of the current site over all `SiteStack`s from all specified `SpeciesSite`s

Thus, if there are _N_ sites of a given type, the `index` for a given site will change based on how many of the _N_ are selected according to other criteria (i.e. within a certain distance, not on the same molecule etc.) while a given site's `stackIndex` will remain the same regardless of how many are selected, provided _N_ does not change (i.e. population of molecules in the `Configuration` is static).

Similarly, the `siteIndex` remains constant for a given site regardless of how many species sites are requested for selection. So, if three sites are provided having _N_, _M_, and _O_ sites respectively, then the `siteIndex` number goes from `1...(N+M+O)`, with sites from _N_ always being numbered `1...N`, sites from _M_ being numbered `N+1...N+M`, and sites from _O_ being numbered `N+M+1...N+M+O`.