### PR TITLE
Fix GUI Module Contexts

### DIFF
--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -40,7 +40,7 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
     module = ModuleRegistry::create(ModuleTypes::Energy, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -73,7 +73,7 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
     module = ModuleRegistry::create(ModuleTypes::Energy, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -106,7 +106,7 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
     module = ModuleRegistry::create(ModuleTypes::Energy, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -137,7 +137,7 @@ void DissolveWindow::on_LayerCreateEvolveMDAction_triggered(bool checked)
     module = ModuleRegistry::create(ModuleTypes::Energy, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -169,7 +169,7 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
     module = ModuleRegistry::create(ModuleTypes::Energy, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -194,7 +194,7 @@ void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
     // Set any suitable module targets
     epsr->keywords().set("Target", Module::allOfType(ModuleTypes::NeutronSQ));
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -215,7 +215,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
     // Add the GR module
     newLayer->append(ModuleTypes::GR, dissolve_.coreData().configurations());
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -239,7 +239,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
     // Add a plain structure factor module
     newLayer->append(ModuleTypes::SQ, dissolve_.coreData().configurations());
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -266,7 +266,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
     // Add a NeutronSQ module
     newLayer->append(ModuleTypes::NeutronSQ, dissolve_.coreData().configurations());
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -293,7 +293,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFXRayAction_triggered(bool chec
     // Add an XRaySQ module
     newLayer->append(ModuleTypes::XRaySQ, dissolve_.coreData().configurations());
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -323,7 +323,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
     // Add an XRaySQ module
     newLayer->append(ModuleTypes::XRaySQ, dissolve_.coreData().configurations());
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -347,7 +347,7 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
     auto *calcRDFModule = ModuleRegistry::create(ModuleTypes::SiteRDF, newLayer);
     calcRDFModule->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);
@@ -375,7 +375,7 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
     module = ModuleRegistry::create(ModuleTypes::SDF, newLayer);
     module->keywords().set("Configuration", firstCfg);
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Run set-up stages for modules
     newLayer->setUpAll(context);

--- a/src/gui/moduleControlWidgetFuncs.cpp
+++ b/src/gui/moduleControlWidgetFuncs.cpp
@@ -213,7 +213,7 @@ void ModuleControlWidget::localKeywordChanged(int signalMask)
         keywordSignals -= KeywordBase::KeywordSignal::ClearModuleData;
     }
 
-    ModuleContext context(dissolve_.worldPool());
+    ModuleContext context(dissolve_.worldPool(), dissolve_);
 
     // Call the module's setUp() function if any other flags are still set
     if (keywordSignals.anySet())


### PR DESCRIPTION
This urgent PR fixes a bunch of instances where a reference to `Dissolve` was not passed to a `ModuleContext`, where it definitely should've been - this meant that the GUI crashes if you add a new "template" Layer, or modify a local keyword in a Module through the GUI...