### PR TITLE
Enforce ordering of modules in TOML

### DIFF
--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -210,12 +210,11 @@ void ModuleLayer::deserialise(const SerialisedValue &node, const CoreData &coreD
         runControlFlags_.setFlag(ModuleLayer::RunControlFlag::EnergyStability);
     if (toml::find_or<bool>(node, "requireSizeFactors", false))
         runControlFlags_.setFlag(ModuleLayer::RunControlFlag::SizeFactors);
-    Serialisable::toVector(
-        node, "modules",
-        [&coreData, this](const SerialisedValue &data)
-        {
-            auto *module =
-                append(*ModuleTypes::moduleType(std::string(toml::find<std::string>(data, "type"), {})), {});
-            module->deserialise(data, coreData);
-        });
+    Serialisable::toVector(node, "modules",
+                           [&coreData, this](const SerialisedValue &data)
+                           {
+                               auto *module =
+                                   append(*ModuleTypes::moduleType(std::string(toml::find<std::string>(data, "type"), {})), {});
+                               module->deserialise(data, coreData);
+                           });
 }

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -215,7 +215,7 @@ void ModuleLayer::deserialise(const SerialisedValue &node, const CoreData &coreD
         [&coreData, this](const SerialisedValue &data)
         {
             auto *module =
-                append(*ModuleTypes::moduleType(std::string_view(std::string(toml::find<std::string>(data, "type"), {}))), {});
+                append(*ModuleTypes::moduleType(std::string(toml::find<std::string>(data, "type"), {})), {});
             module->deserialise(data, coreData);
         });
 }

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -196,7 +196,7 @@ SerialisedValue ModuleLayer::serialise() const
         result["requireEnergyStability"] = true;
     if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::SizeFactors))
         result["requireSizeFactors"] = true;
-    Serialisable::fromVectorToTable(modules_, "modules", result);
+    Serialisable::fromVector(modules_, "modules", result);
     return result;
 }
 
@@ -210,13 +210,12 @@ void ModuleLayer::deserialise(const SerialisedValue &node, const CoreData &coreD
         runControlFlags_.setFlag(ModuleLayer::RunControlFlag::EnergyStability);
     if (toml::find_or<bool>(node, "requireSizeFactors", false))
         runControlFlags_.setFlag(ModuleLayer::RunControlFlag::SizeFactors);
-    Serialisable::toMap(
+    Serialisable::toVector(
         node, "modules",
-        [&coreData, this](const auto &key, const SerialisedValue &data)
+        [&coreData, this](const SerialisedValue &data)
         {
             auto *module =
                 append(*ModuleTypes::moduleType(std::string_view(std::string(toml::find<std::string>(data, "type"), {}))), {});
-            module->setName(key);
             module->deserialise(data, coreData);
         });
 }


### PR DESCRIPTION
Just as with the nodes, the modules must be kept in an array, instead of a table, because the table will *not* maintain ordering.  This cleans up a couple of failing tests where data was referenced before it was loaded.