### PR TITLE
Fix Custom Region Generation

### DIFF
--- a/src/classes/region.h
+++ b/src/classes/region.h
@@ -51,7 +51,7 @@ class Region
         // Setup iterator for voxel map
         // Iterate voxels in parallel
         dissolve::for_each_triplet(
-            ParallelPolicies::par, voxelMap_.beginIndices(), voxelMap_.endIndices(),
+            ParallelPolicies::seq, voxelMap_.beginIndices(), voxelMap_.endIndices(),
             [&](auto triplet, auto x, auto y, auto z)
             {
                 voxelMap_[triplet] = {
@@ -59,6 +59,7 @@ class Region
                     voxelCheckFunction(cfg, box_->getReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
                                                            (z + 0.5) * voxelSizeFrac_.z}))};
             });
+
         // Create linear vector of all available voxels
         auto nFreeVoxels = std::count_if(voxelMap_.begin(), voxelMap_.end(), [](const auto &voxel) { return voxel.second; });
         freeVoxels_.clear();


### PR DESCRIPTION
This PR regresses the parallel loop for custom region generation back to a sequential one, since with parallel operation we  encounter a race condition where the threads are setting and using our local expression variables at the same time, with unpredictable results.  The screenshot below clearly illustrates the errors when using even a simple condition of accepting all voxels with a `yFrac` value less than 0.5:
![image](https://github.com/disorderedmaterials/dissolve/assets/11457350/ccf143d0-f445-4372-9dfe-7bc28c51f188)
