### PR TITLE
1617 Parallel Region Generation

### DIFF
--- a/benchmark/region/region_benchmark.cpp
+++ b/benchmark/region/region_benchmark.cpp
@@ -7,6 +7,13 @@
 #include "common/problems.h"
 #include <cmath>
 
+class RandomVoxelKernel : public VoxelKernel
+{
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override { return DissolveMath::random() > 0.5; }
+};
+
 template <ProblemType problem, Population population> static void BM_Region_Generate(benchmark::State &state)
 {
     Problem<problem, population> problemDef;
@@ -14,7 +21,7 @@ template <ProblemType problem, Population population> static void BM_Region_Gene
     for (auto _ : state)
     {
         Region region;
-        region.generate(cfg, 1.0, [&](const Configuration *cfg, Vec3<double> r) { return DissolveMath::random() > 0.5; });
+        region.generate(cfg, 1.0, []() { return std::make_shared<RandomVoxelKernel>(); });
     }
 }
 

--- a/src/classes/region.cpp
+++ b/src/classes/region.cpp
@@ -7,6 +7,42 @@
 
 Region::Region() : box_(nullptr) {}
 
+// Generate region information
+bool Region::generate(const Configuration *cfg, double voxelSize, std::function<std::unique_ptr<VoxelKernel>()> kernelGenerator)
+{
+    box_ = cfg->box();
+
+    // Set fractional voxel sizes
+    for (auto n = 0; n < 3; ++n)
+        nVoxels_.set(n, std::max(int(box_->axisLength(n) / voxelSize), 1));
+    voxelSizeFrac_.set(1.0 / nVoxels_.x, 1.0 / nVoxels_.y, 1.0 / nVoxels_.z);
+
+    // Initialise 3D map and determine valid voxels
+    voxelMap_.initialise(nVoxels_.x, nVoxels_.y, nVoxels_.z);
+
+    // Create a voxel check kernel
+    auto voxelKernel = kernelGenerator();
+
+    // Setup iterator for voxel map
+    // Iterate voxels in parallel
+    dissolve::for_each_triplet(
+        ParallelPolicies::seq, voxelMap_.beginIndices(), voxelMap_.endIndices(),
+        [&](auto triplet, auto x, auto y, auto z)
+        {
+            voxelMap_[triplet] = {
+                Vec3<int>(x, y, z),
+                voxelKernel->isVoxelValid(cfg, box_->getReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
+                                                              (z + 0.5) * voxelSizeFrac_.z}))};
+        });
+    // Create linear vector of all available voxels
+    auto nFreeVoxels = std::count_if(voxelMap_.begin(), voxelMap_.end(), [](const auto &voxel) { return voxel.second; });
+    freeVoxels_.clear();
+    freeVoxels_.resize(nFreeVoxels);
+    std::copy_if(voxelMap_.begin(), voxelMap_.end(), freeVoxels_.begin(), [](const auto &voxel) { return voxel.second; });
+
+    return nFreeVoxels > 0;
+}
+
 // Return whether the region is valid
 bool Region::isValid() const { return !voxelMap_.empty() && !freeVoxels_.empty(); }
 

--- a/src/classes/region.h
+++ b/src/classes/region.h
@@ -10,10 +10,19 @@
 #include "templates/array3D.h"
 #include "templates/parallelDefs.h"
 #include "templates/vector3.h"
+#include <functional>
 #include <vector>
 
 // Forward Declarations
 class Configuration;
+
+// Voxel Kernel
+class VoxelKernel
+{
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    virtual bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const = 0;
+};
 
 // Region Data
 class Region
@@ -36,38 +45,8 @@ class Region
 
     public:
     // Generate region information
-    template <class Lam> bool generate(const Configuration *cfg, double voxelSize, Lam voxelCheckFunction)
-    {
-        box_ = cfg->box();
-
-        // Set fractional voxel sizes
-        for (auto n = 0; n < 3; ++n)
-            nVoxels_.set(n, std::max(int(box_->axisLength(n) / voxelSize), 1));
-        voxelSizeFrac_.set(1.0 / nVoxels_.x, 1.0 / nVoxels_.y, 1.0 / nVoxels_.z);
-
-        // Initialise 3D map and determine valid voxels
-        voxelMap_.initialise(nVoxels_.x, nVoxels_.y, nVoxels_.z);
-
-        // Setup iterator for voxel map
-        // Iterate voxels in parallel
-        dissolve::for_each_triplet(
-            ParallelPolicies::seq, voxelMap_.beginIndices(), voxelMap_.endIndices(),
-            [&](auto triplet, auto x, auto y, auto z)
-            {
-                voxelMap_[triplet] = {
-                    Vec3<int>(x, y, z),
-                    voxelCheckFunction(cfg, box_->getReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
-                                                           (z + 0.5) * voxelSizeFrac_.z}))};
-            });
-
-        // Create linear vector of all available voxels
-        auto nFreeVoxels = std::count_if(voxelMap_.begin(), voxelMap_.end(), [](const auto &voxel) { return voxel.second; });
-        freeVoxels_.clear();
-        freeVoxels_.resize(nFreeVoxels);
-        std::copy_if(voxelMap_.begin(), voxelMap_.end(), freeVoxels_.begin(), [](const auto &voxel) { return voxel.second; });
-
-        return nFreeVoxels > 0;
-    }
+    bool generate(const Configuration *cfg, double voxelSize,
+                  std::function<std::unique_ptr<VoxelKernel>(void)> kernelGenerator);
     // Return whether the region is valid
     bool isValid() const;
     // Return the fraction free voxels in the region

--- a/src/classes/region.h
+++ b/src/classes/region.h
@@ -8,6 +8,7 @@
 #include "classes/configuration.h"
 #include "templates/algorithms.h"
 #include "templates/array3D.h"
+#include "templates/combinable.h"
 #include "templates/parallelDefs.h"
 #include "templates/vector3.h"
 #include <functional>
@@ -43,10 +44,18 @@ class Region
     // Lower-left corner voxel indices of free regions
     std::vector<std::pair<Vec3<int>, bool>> freeVoxels_;
 
+    private:
+    // Generate voxel combinable
+    static dissolve::CombinableFunctor<std::shared_ptr<VoxelKernel>>
+    createCombinableVoxelKernel(std::function<std::shared_ptr<VoxelKernel>(void)> kernelGenerator)
+    {
+        return kernelGenerator;
+    }
+
     public:
     // Generate region information
     bool generate(const Configuration *cfg, double voxelSize,
-                  std::function<std::unique_ptr<VoxelKernel>(void)> kernelGenerator);
+                  const std::function<std::shared_ptr<VoxelKernel>(void)> &kernelGenerator);
     // Return whether the region is valid
     bool isValid() const;
     // Return the fraction free voxels in the region

--- a/src/procedure/nodes/customRegion.cpp
+++ b/src/procedure/nodes/customRegion.cpp
@@ -70,25 +70,3 @@ std::shared_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()
 {
     return std::make_shared<CustomRegionVoxelKernel>(expression_.asString(), minimumValue_, maximumValue_);
 }
-
-/*
- * Region Data
- */
-
-// Return whether voxel centred at supplied real coordinates is valid
-bool CustomRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
-{
-    // Poke values into our variables
-    x_->setValue(r.x);
-    y_->setValue(r.y);
-    z_->setValue(r.z);
-    auto rFrac = cfg->box()->getFractional(r);
-    xFrac_->setValue(rFrac.x);
-    yFrac_->setValue(rFrac.y);
-    zFrac_->setValue(rFrac.z);
-
-    // Assess expression
-    auto x = expression_.asDouble();
-
-    return (x >= minimumValue_ && x <= maximumValue_);
-}

--- a/src/procedure/nodes/customRegion.cpp
+++ b/src/procedure/nodes/customRegion.cpp
@@ -59,9 +59,9 @@ CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase
     zFrac_ = expression_.addLocalVariable("zFrac");
 }
 
-std::unique_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()
+std::shared_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()
 {
-    auto kernel = std::make_unique<CustomRegionVoxelKernel>();
+    auto kernel = std::make_shared<CustomRegionVoxelKernel>();
 
     kernel->initialise(expression_.asString(), minimumValue_, maximumValue_);
 

--- a/src/procedure/nodes/customRegion.cpp
+++ b/src/procedure/nodes/customRegion.cpp
@@ -7,8 +7,11 @@
 #include "keywords/double.h"
 #include "keywords/nodeValue.h"
 
-// Set up any necessary data for the kernel
-void CustomRegionVoxelKernel::initialise(std::string_view expressionString, double minimumValue, double maximumValue)
+/*
+ * Custom Region Voxel Kernel
+ */
+
+CustomRegionVoxelKernel::CustomRegionVoxelKernel(std::string_view expressionString, double minimumValue, double maximumValue)
 {
     // Create our local variables
     x_ = expression_.addLocalVariable("x");
@@ -44,6 +47,10 @@ bool CustomRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3<
     return (x >= minimumValue_ && x <= maximumValue_);
 }
 
+/*
+ * Custom Region
+ */
+
 CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::CustomRegion)
 {
     keywords_.setOrganisation("Options", "Definition");
@@ -61,11 +68,7 @@ CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase
 
 std::shared_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()
 {
-    auto kernel = std::make_shared<CustomRegionVoxelKernel>();
-
-    kernel->initialise(expression_.asString(), minimumValue_, maximumValue_);
-
-    return kernel;
+    return std::make_shared<CustomRegionVoxelKernel>(expression_.asString(), minimumValue_, maximumValue_);
 }
 
 /*

--- a/src/procedure/nodes/customRegion.cpp
+++ b/src/procedure/nodes/customRegion.cpp
@@ -11,7 +11,9 @@
  * Custom Region Voxel Kernel
  */
 
-CustomRegionVoxelKernel::CustomRegionVoxelKernel(std::string_view expressionString, double minimumValue, double maximumValue)
+CustomRegionVoxelKernel::CustomRegionVoxelKernel(std::string_view expressionString,
+                                                 std::vector<std::shared_ptr<ExpressionVariable>> parameters,
+                                                 double minimumValue, double maximumValue)
 {
     // Create our local variables
     x_ = expression_.addLocalVariable("x");
@@ -22,7 +24,7 @@ CustomRegionVoxelKernel::CustomRegionVoxelKernel(std::string_view expressionStri
     zFrac_ = expression_.addLocalVariable("zFrac");
 
     // Set the expression
-    expression_.set(expressionString);
+    expression_.set(expressionString, std::move(parameters));
 
     // Set limits
     minimumValue_ = minimumValue;
@@ -61,5 +63,5 @@ CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase
 
 std::shared_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()
 {
-    return std::make_shared<CustomRegionVoxelKernel>(expression_.asString(), minimumValue_, maximumValue_);
+    return std::make_shared<CustomRegionVoxelKernel>(expression_.asString(), getParameters(), minimumValue_, maximumValue_);
 }

--- a/src/procedure/nodes/customRegion.cpp
+++ b/src/procedure/nodes/customRegion.cpp
@@ -57,13 +57,6 @@ CustomRegionProcedureNode::CustomRegionProcedureNode() : RegionProcedureNodeBase
     keywords_.add<NodeValueKeyword>("Expression", "Expression describing region", expression_, this);
     keywords_.add<DoubleKeyword>("Minimum", "Minimum value for descriptive function defining region", minimumValue_);
     keywords_.add<DoubleKeyword>("Maximum", "Maximum value for descriptive function defining region", maximumValue_);
-
-    x_ = expression_.addLocalVariable("x");
-    y_ = expression_.addLocalVariable("y");
-    z_ = expression_.addLocalVariable("z");
-    xFrac_ = expression_.addLocalVariable("xFrac");
-    yFrac_ = expression_.addLocalVariable("yFrac");
-    zFrac_ = expression_.addLocalVariable("zFrac");
 }
 
 std::shared_ptr<VoxelKernel> CustomRegionProcedureNode::createVoxelKernel()

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -10,7 +10,8 @@
 class CustomRegionVoxelKernel : public VoxelKernel
 {
     public:
-    explicit CustomRegionVoxelKernel(std::string_view expressionString = "", double minimumValue = 0.0,
+    explicit CustomRegionVoxelKernel(std::string_view expressionString = "",
+                                     std::vector<std::shared_ptr<ExpressionVariable>> = {}, double minimumValue = 0.0,
                                      double maximumValue = 1.0);
 
     protected:

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -10,9 +10,9 @@
 class CustomRegionVoxelKernel : public VoxelKernel
 {
     public:
-    CustomRegionVoxelKernel(std::string_view expressionString, double minimumValue, double maximumValue);
+    explicit CustomRegionVoxelKernel(std::string_view expressionString = "", double minimumValue = 0.0, double maximumValue = 1.0);
 
-    private:
+    protected:
     // Local variables, set when checking voxels
     std::shared_ptr<ExpressionVariable> x_, y_, z_, xFrac_, yFrac_, zFrac_;
     // Expression describing region
@@ -28,24 +28,11 @@ class CustomRegionVoxelKernel : public VoxelKernel
 };
 
 // Custom Region
-class CustomRegionProcedureNode : public RegionProcedureNodeBase
+class CustomRegionProcedureNode : public RegionProcedureNodeBase, CustomRegionVoxelKernel
 {
     public:
     CustomRegionProcedureNode();
     ~CustomRegionProcedureNode() override = default;
-
-    /*
-     * Control
-     */
-    private:
-    // Local variables, set when checking voxels
-    std::shared_ptr<ExpressionVariable> x_, y_, z_, xFrac_, yFrac_, zFrac_;
-    // Expression describing region
-    NodeValue expression_;
-    // Minimum threshold value for function
-    double minimumValue_{0.0};
-    // Maximum threshold value for function
-    double maximumValue_{1.0};
 
     /*
      * Region Data

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -9,6 +9,9 @@
 // Custom Region Voxel Kernel
 class CustomRegionVoxelKernel : public VoxelKernel
 {
+    public:
+    CustomRegionVoxelKernel(std::string_view expressionString, double minimumValue, double maximumValue);
+
     private:
     // Local variables, set when checking voxels
     std::shared_ptr<ExpressionVariable> x_, y_, z_, xFrac_, yFrac_, zFrac_;
@@ -20,8 +23,6 @@ class CustomRegionVoxelKernel : public VoxelKernel
     double maximumValue_{1.0};
 
     public:
-    // Set up necessary data for the kernel
-    void initialise(std::string_view expressionString, double minimumValue, double maximumValue);
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
 };

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -6,6 +6,26 @@
 #include "procedure/nodeValue.h"
 #include "procedure/nodes/regionBase.h"
 
+// Custom Region Voxel Kernel
+class CustomRegionVoxelKernel : public VoxelKernel
+{
+    private:
+    // Local variables, set when checking voxels
+    std::shared_ptr<ExpressionVariable> x_, y_, z_, xFrac_, yFrac_, zFrac_;
+    // Expression describing region
+    NodeValue expression_;
+    // Minimum threshold value for function
+    double minimumValue_{0.0};
+    // Maximum threshold value for function
+    double maximumValue_{1.0};
+
+    public:
+    // Set up necessary data for the kernel
+    void initialise(std::string_view expressionString, double minimumValue, double maximumValue);
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
+};
+
 // Custom Region
 class CustomRegionProcedureNode : public RegionProcedureNodeBase
 {
@@ -29,6 +49,10 @@ class CustomRegionProcedureNode : public RegionProcedureNodeBase
     /*
      * Region Data
      */
+    protected:
+    // Return a new voxel check kernel
+    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+
     public:
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -51,7 +51,7 @@ class CustomRegionProcedureNode : public RegionProcedureNodeBase
      */
     protected:
     // Return a new voxel check kernel
-    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+    std::shared_ptr<VoxelKernel> createVoxelKernel() override;
 
     public:
     // Return whether voxel centred at supplied real coordinates is valid

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -10,7 +10,8 @@
 class CustomRegionVoxelKernel : public VoxelKernel
 {
     public:
-    explicit CustomRegionVoxelKernel(std::string_view expressionString = "", double minimumValue = 0.0, double maximumValue = 1.0);
+    explicit CustomRegionVoxelKernel(std::string_view expressionString = "", double minimumValue = 0.0,
+                                     double maximumValue = 1.0);
 
     protected:
     // Local variables, set when checking voxels

--- a/src/procedure/nodes/customRegion.h
+++ b/src/procedure/nodes/customRegion.h
@@ -53,8 +53,4 @@ class CustomRegionProcedureNode : public RegionProcedureNodeBase
     protected:
     // Return a new voxel check kernel
     std::shared_ptr<VoxelKernel> createVoxelKernel() override;
-
-    public:
-    // Return whether voxel centred at supplied real coordinates is valid
-    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
 };

--- a/src/procedure/nodes/cylindricalRegion.cpp
+++ b/src/procedure/nodes/cylindricalRegion.cpp
@@ -6,11 +6,33 @@
 #include "keywords/double.h"
 #include "keywords/vec3Double.h"
 
+/*
+ * Cylindrical Region Voxel Kernel
+ */
+
+CylindricalRegionVoxelKernel::CylindricalRegionVoxelKernel(Vec3<double> originFrac, double radius, Vec3<double> vector)
+    : originFrac_(std::move(originFrac)), radius_(radius), vector_(std::move(vector))
+{
+}
+
 // Return whether voxel centred at supplied real coordinates is valid
 bool CylindricalRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
 {
-    // TODO
+    auto l0 = originFrac_;
+    cfg->box()->toReal(l0);
+    const auto l1 = l0 + vector_;
+    const auto denominator = (l1 - l0).magnitude();
+
+    auto p0 = cfg->box()->minimumImage(r, l0);
+    auto num = ((p0 - l0) * (p0 - l1)).magnitude();
+
+    // Check distance vs cylinder radius
+    return (num / denominator) <= radius_;
 }
+
+/*
+ * Cylindrical Region
+ */
 
 CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
     : RegionProcedureNodeBase(ProcedureNode::NodeType::CylindricalRegion)
@@ -29,7 +51,7 @@ CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
 // Return a new voxel check kernel
 std::shared_ptr<VoxelKernel> CylindricalRegionProcedureNode::createVoxelKernel()
 {
-    return std::make_shared<CylindricalRegionVoxelKernel>();
+    return std::make_shared<CylindricalRegionVoxelKernel>(originFrac_, radius_, vector_);
 }
 
 // Return whether voxel centred at supplied real coordinates is valid

--- a/src/procedure/nodes/cylindricalRegion.cpp
+++ b/src/procedure/nodes/cylindricalRegion.cpp
@@ -6,6 +6,12 @@
 #include "keywords/double.h"
 #include "keywords/vec3Double.h"
 
+// Return whether voxel centred at supplied real coordinates is valid
+bool CylindricalRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
+{
+    // TODO
+}
+
 CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
     : RegionProcedureNodeBase(ProcedureNode::NodeType::CylindricalRegion)
 {
@@ -19,6 +25,9 @@ CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
 /*
  * Region Data
  */
+
+// Return a new voxel check kernel
+std::unique_ptr<VoxelKernel> CylindricalRegionProcedureNode::createVoxelKernel() { return std::make_unique<CylindricalRegionVoxelKernel>(); }
 
 // Return whether voxel centred at supplied real coordinates is valid
 bool CylindricalRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const

--- a/src/procedure/nodes/cylindricalRegion.cpp
+++ b/src/procedure/nodes/cylindricalRegion.cpp
@@ -44,27 +44,8 @@ CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
     keywords_.add<Vec3DoubleKeyword>("Vector", "Cylinder vector", vector_, Vec3Labels::XYZLabels);
 }
 
-/*
- * Region Data
- */
-
 // Return a new voxel check kernel
 std::shared_ptr<VoxelKernel> CylindricalRegionProcedureNode::createVoxelKernel()
 {
     return std::make_shared<CylindricalRegionVoxelKernel>(originFrac_, radius_, vector_);
-}
-
-// Return whether voxel centred at supplied real coordinates is valid
-bool CylindricalRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
-{
-    auto l0 = originFrac_;
-    cfg->box()->toReal(l0);
-    const auto l1 = l0 + vector_;
-    const auto denominator = (l1 - l0).magnitude();
-
-    auto p0 = cfg->box()->minimumImage(r, l0);
-    auto num = ((p0 - l0) * (p0 - l1)).magnitude();
-
-    // Check distance vs cylinder radius
-    return (num / denominator) <= radius_;
 }

--- a/src/procedure/nodes/cylindricalRegion.cpp
+++ b/src/procedure/nodes/cylindricalRegion.cpp
@@ -27,7 +27,10 @@ CylindricalRegionProcedureNode::CylindricalRegionProcedureNode()
  */
 
 // Return a new voxel check kernel
-std::unique_ptr<VoxelKernel> CylindricalRegionProcedureNode::createVoxelKernel() { return std::make_unique<CylindricalRegionVoxelKernel>(); }
+std::shared_ptr<VoxelKernel> CylindricalRegionProcedureNode::createVoxelKernel()
+{
+    return std::make_shared<CylindricalRegionVoxelKernel>();
+}
 
 // Return whether voxel centred at supplied real coordinates is valid
 bool CylindricalRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const

--- a/src/procedure/nodes/cylindricalRegion.h
+++ b/src/procedure/nodes/cylindricalRegion.h
@@ -48,8 +48,4 @@ class CylindricalRegionProcedureNode : public RegionProcedureNodeBase
     protected:
     // Return a new voxel check kernel
     std::shared_ptr<VoxelKernel> createVoxelKernel() override;
-
-    public:
-    // Return whether voxel centred at supplied real coordinates is valid
-    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
 };

--- a/src/procedure/nodes/cylindricalRegion.h
+++ b/src/procedure/nodes/cylindricalRegion.h
@@ -36,7 +36,7 @@ class CylindricalRegionProcedureNode : public RegionProcedureNodeBase
      */
     protected:
     // Return a new voxel check kernel
-    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+    std::shared_ptr<VoxelKernel> createVoxelKernel() override;
 
     public:
     // Return whether voxel centred at supplied real coordinates is valid

--- a/src/procedure/nodes/cylindricalRegion.h
+++ b/src/procedure/nodes/cylindricalRegion.h
@@ -9,9 +9,10 @@
 class CylindricalRegionVoxelKernel : public VoxelKernel
 {
     public:
-    CylindricalRegionVoxelKernel(Vec3<double> originFrac, double radius, Vec3<double> vector);
+    explicit CylindricalRegionVoxelKernel(Vec3<double> originFrac = {0.0, 0.0, 0.0}, double radius = 5.0,
+                                          Vec3<double> vector = {0.0, 0.0, 1.0});
 
-    private:
+    protected:
     // Origin of vector in fractional coordinates
     Vec3<double> originFrac_{0.0, 0.0, 0.0};
     // Radius of cylindrical region
@@ -25,22 +26,11 @@ class CylindricalRegionVoxelKernel : public VoxelKernel
 };
 
 // Cylindrical Region
-class CylindricalRegionProcedureNode : public RegionProcedureNodeBase
+class CylindricalRegionProcedureNode : public RegionProcedureNodeBase, CylindricalRegionVoxelKernel
 {
     public:
     CylindricalRegionProcedureNode();
     ~CylindricalRegionProcedureNode() override = default;
-
-    /*
-     * Control
-     */
-    private:
-    // Origin of vector in fractional coordinates
-    Vec3<double> originFrac_{0.0, 0.0, 0.0};
-    // Radius of cylindrical region
-    double radius_{5.0};
-    // Cylinder vector
-    Vec3<double> vector_{0.0, 0.0, 1.0};
 
     /*
      * Region Data

--- a/src/procedure/nodes/cylindricalRegion.h
+++ b/src/procedure/nodes/cylindricalRegion.h
@@ -9,6 +9,17 @@
 class CylindricalRegionVoxelKernel : public VoxelKernel
 {
     public:
+    CylindricalRegionVoxelKernel(Vec3<double> originFrac, double radius, Vec3<double> vector);
+
+    private:
+    // Origin of vector in fractional coordinates
+    Vec3<double> originFrac_{0.0, 0.0, 0.0};
+    // Radius of cylindrical region
+    double radius_{5.0};
+    // Cylinder vector
+    Vec3<double> vector_{0.0, 0.0, 1.0};
+
+    public:
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
 };

--- a/src/procedure/nodes/cylindricalRegion.h
+++ b/src/procedure/nodes/cylindricalRegion.h
@@ -5,6 +5,14 @@
 
 #include "procedure/nodes/regionBase.h"
 
+// Custom Region Voxel Kernel
+class CylindricalRegionVoxelKernel : public VoxelKernel
+{
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
+};
+
 // Cylindrical Region
 class CylindricalRegionProcedureNode : public RegionProcedureNodeBase
 {
@@ -26,6 +34,10 @@ class CylindricalRegionProcedureNode : public RegionProcedureNodeBase
     /*
      * Region Data
      */
+    protected:
+    // Return a new voxel check kernel
+    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+
     public:
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;

--- a/src/procedure/nodes/generalRegion.cpp
+++ b/src/procedure/nodes/generalRegion.cpp
@@ -5,6 +5,13 @@
 #include "classes/configuration.h"
 #include "keywords/double.h"
 
+// Return whether voxel centred at supplied real coordinates is valid
+bool GeneralRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
+{
+    // TODO
+}
+
+
 GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::GeneralRegion)
 {
     keywords_.setOrganisation("Options", "Definition");
@@ -15,6 +22,9 @@ GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBa
 /*
  * Region Data
  */
+
+// Return a new voxel check kernel
+std::unique_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel() { return std::make_unique<GeneralRegionVoxelKernel>(); }
 
 // Return whether voxel centred at supplied real coordinates is valid
 bool GeneralRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const

--- a/src/procedure/nodes/generalRegion.cpp
+++ b/src/procedure/nodes/generalRegion.cpp
@@ -30,32 +30,15 @@ GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBa
                                  0.1);
 }
 
-/*
- * Region Data
- */
-
 // Return a new voxel check kernel
 std::shared_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel()
 {
     return std::make_shared<GeneralRegionVoxelKernel>(toleranceSquared_);
 }
 
-// Return whether voxel centred at supplied real coordinates is valid
-bool GeneralRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
-{
-    // If any atom in the Configuration is less than some tolerance value to this coordinate, invalidate the voxel
-    return !std::any_of(cfg->atoms().begin(), cfg->atoms().end(),
-                        [&](const auto &i) { return cfg->box()->minimumDistanceSquared(i.r(), r) <= toleranceSquared_; });
-}
-
-/*
- * Execute
- */
-
 // Prepare any necessary data, ready for execution
 bool GeneralRegionProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
-    // Retrieve keyword values
     toleranceSquared_ = tolerance_ * tolerance_;
 
     return true;

--- a/src/procedure/nodes/generalRegion.cpp
+++ b/src/procedure/nodes/generalRegion.cpp
@@ -33,13 +33,5 @@ GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBa
 // Return a new voxel check kernel
 std::shared_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel()
 {
-    return std::make_shared<GeneralRegionVoxelKernel>(toleranceSquared_);
-}
-
-// Prepare any necessary data, ready for execution
-bool GeneralRegionProcedureNode::prepare(const ProcedureContext &procedureContext)
-{
-    toleranceSquared_ = tolerance_ * tolerance_;
-
-    return true;
+    return std::make_shared<GeneralRegionVoxelKernel>(tolerance_ * tolerance_);
 }

--- a/src/procedure/nodes/generalRegion.cpp
+++ b/src/procedure/nodes/generalRegion.cpp
@@ -5,11 +5,23 @@
 #include "classes/configuration.h"
 #include "keywords/double.h"
 
+/*
+ * General Region Voxel Kernel
+ */
+
+GeneralRegionVoxelKernel::GeneralRegionVoxelKernel(double toleranceSquared) : toleranceSquared_(toleranceSquared) {}
+
 // Return whether voxel centred at supplied real coordinates is valid
 bool GeneralRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const
 {
-    // TODO
+    // If any atom in the Configuration is less than some tolerance value to this coordinate, invalidate the voxel
+    return !std::any_of(cfg->atoms().begin(), cfg->atoms().end(),
+                        [&](const auto &i) { return cfg->box()->minimumDistanceSquared(i.r(), r) <= toleranceSquared_; });
 }
+
+/*
+ * General Region
+ */
 
 GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::GeneralRegion)
 {
@@ -25,7 +37,7 @@ GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBa
 // Return a new voxel check kernel
 std::shared_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel()
 {
-    return std::make_shared<GeneralRegionVoxelKernel>();
+    return std::make_shared<GeneralRegionVoxelKernel>(toleranceSquared_);
 }
 
 // Return whether voxel centred at supplied real coordinates is valid

--- a/src/procedure/nodes/generalRegion.cpp
+++ b/src/procedure/nodes/generalRegion.cpp
@@ -11,7 +11,6 @@ bool GeneralRegionVoxelKernel::isVoxelValid(const Configuration *cfg, const Vec3
     // TODO
 }
 
-
 GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBase(ProcedureNode::NodeType::GeneralRegion)
 {
     keywords_.setOrganisation("Options", "Definition");
@@ -24,7 +23,10 @@ GeneralRegionProcedureNode::GeneralRegionProcedureNode() : RegionProcedureNodeBa
  */
 
 // Return a new voxel check kernel
-std::unique_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel() { return std::make_unique<GeneralRegionVoxelKernel>(); }
+std::shared_ptr<VoxelKernel> GeneralRegionProcedureNode::createVoxelKernel()
+{
+    return std::make_shared<GeneralRegionVoxelKernel>();
+}
 
 // Return whether voxel centred at supplied real coordinates is valid
 bool GeneralRegionProcedureNode::isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -40,11 +40,4 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase, GeneralRegion
     protected:
     // Return a new voxel check kernel
     std::shared_ptr<VoxelKernel> createVoxelKernel() override;
-
-    /*
-     * Execute
-     */
-    public:
-    // Prepare any necessary data, ready for execution
-    bool prepare(const ProcedureContext &procedureContext) override;
 };

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -43,10 +43,6 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
     // Return a new voxel check kernel
     std::shared_ptr<VoxelKernel> createVoxelKernel() override;
 
-    public:
-    // Return whether voxel centred at supplied real coordinates is valid
-    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
-
     /*
      * Execute
      */

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -9,6 +9,13 @@
 class GeneralRegionVoxelKernel : public VoxelKernel
 {
     public:
+    GeneralRegionVoxelKernel(double toleranceSquared);
+
+    private:
+    // Squared tolerance
+    double toleranceSquared_;
+
+    public:
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
 };
@@ -25,9 +32,9 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
      */
     private:
     // Distance tolerance (threshold) for avoiding existing atoms
-    double tolerance_;
+    double tolerance_{1.0};
     // Squared tolerance
-    double toleranceSquared_;
+    double toleranceSquared_{1.0};
 
     /*
      * Region Data

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -34,7 +34,7 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
      */
     protected:
     // Return a new voxel check kernel
-    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+    std::shared_ptr<VoxelKernel> createVoxelKernel() override;
 
     public:
     // Return whether voxel centred at supplied real coordinates is valid

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -5,6 +5,14 @@
 
 #include "procedure/nodes/regionBase.h"
 
+// General Region Voxel Kernel
+class GeneralRegionVoxelKernel : public VoxelKernel
+{
+    public:
+    // Return whether voxel centred at supplied real coordinates is valid
+    bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;
+};
+
 // General Region
 class GeneralRegionProcedureNode : public RegionProcedureNodeBase
 {
@@ -24,6 +32,10 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
     /*
      * Region Data
      */
+    protected:
+    // Return a new voxel check kernel
+    std::unique_ptr<VoxelKernel> createVoxelKernel() override;
+
     public:
     // Return whether voxel centred at supplied real coordinates is valid
     bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const override;

--- a/src/procedure/nodes/generalRegion.h
+++ b/src/procedure/nodes/generalRegion.h
@@ -9,11 +9,11 @@
 class GeneralRegionVoxelKernel : public VoxelKernel
 {
     public:
-    GeneralRegionVoxelKernel(double toleranceSquared);
+    explicit GeneralRegionVoxelKernel(double toleranceSquared = 1.0);
 
-    private:
+    protected:
     // Squared tolerance
-    double toleranceSquared_;
+    double toleranceSquared_{1.0};
 
     public:
     // Return whether voxel centred at supplied real coordinates is valid
@@ -21,7 +21,7 @@ class GeneralRegionVoxelKernel : public VoxelKernel
 };
 
 // General Region
-class GeneralRegionProcedureNode : public RegionProcedureNodeBase
+class GeneralRegionProcedureNode : public RegionProcedureNodeBase, GeneralRegionVoxelKernel
 {
     public:
     GeneralRegionProcedureNode();
@@ -33,8 +33,6 @@ class GeneralRegionProcedureNode : public RegionProcedureNodeBase
     private:
     // Distance tolerance (threshold) for avoiding existing atoms
     double tolerance_{1.0};
-    // Squared tolerance
-    double toleranceSquared_{1.0};
 
     /*
      * Region Data

--- a/src/procedure/nodes/regionBase.cpp
+++ b/src/procedure/nodes/regionBase.cpp
@@ -35,6 +35,5 @@ const Region &RegionProcedureNodeBase::region() const { return region_; }
 // Execute node
 bool RegionProcedureNodeBase::execute(const ProcedureContext &procedureContext)
 {
-    return region_.generate(procedureContext.configuration(), voxelSize_, [&](){ return createVoxelKernel(); });
-//                            [&](const Configuration *cfg, Vec3<double> r) { return isVoxelValid(cfg, r) != invert_; });
+    return region_.generate(procedureContext.configuration(), voxelSize_, [&]() { return createVoxelKernel(); });
 }

--- a/src/procedure/nodes/regionBase.cpp
+++ b/src/procedure/nodes/regionBase.cpp
@@ -35,6 +35,6 @@ const Region &RegionProcedureNodeBase::region() const { return region_; }
 // Execute node
 bool RegionProcedureNodeBase::execute(const ProcedureContext &procedureContext)
 {
-    return region_.generate(procedureContext.configuration(), voxelSize_,
-                            [&](const Configuration *cfg, Vec3<double> r) { return isVoxelValid(cfg, r) != invert_; });
+    return region_.generate(procedureContext.configuration(), voxelSize_, [&](){ return createVoxelKernel(); });
+//                            [&](const Configuration *cfg, Vec3<double> r) { return isVoxelValid(cfg, r) != invert_; });
 }

--- a/src/procedure/nodes/regionBase.h
+++ b/src/procedure/nodes/regionBase.h
@@ -41,6 +41,8 @@ class RegionProcedureNodeBase : public ProcedureNode
     protected:
     // Return whether voxel centred at supplied real coordinates is valid
     virtual bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const = 0;
+    // Return a new voxel check kernel
+    virtual std::unique_ptr<VoxelKernel> createVoxelKernel() = 0;
 
     public:
     // Return current region data

--- a/src/procedure/nodes/regionBase.h
+++ b/src/procedure/nodes/regionBase.h
@@ -39,8 +39,6 @@ class RegionProcedureNodeBase : public ProcedureNode
     double voxelSize_{1.0};
 
     protected:
-    // Return whether voxel centred at supplied real coordinates is valid
-    virtual bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const = 0;
     // Return a new voxel check kernel
     virtual std::shared_ptr<VoxelKernel> createVoxelKernel() = 0;
 

--- a/src/procedure/nodes/regionBase.h
+++ b/src/procedure/nodes/regionBase.h
@@ -42,7 +42,7 @@ class RegionProcedureNodeBase : public ProcedureNode
     // Return whether voxel centred at supplied real coordinates is valid
     virtual bool isVoxelValid(const Configuration *cfg, const Vec3<double> &r) const = 0;
     // Return a new voxel check kernel
-    virtual std::unique_ptr<VoxelKernel> createVoxelKernel() = 0;
+    virtual std::shared_ptr<VoxelKernel> createVoxelKernel() = 0;
 
     public:
     // Return current region data

--- a/src/templates/combinable.h
+++ b/src/templates/combinable.h
@@ -6,7 +6,7 @@
 namespace dissolve
 {
 // A combinable container used in multithreading operations
-// The local method retrives a thread local object during the multithreading computations
+// The local method retrieves a thread local object during the multithreading computations
 // We then use finalize to combine each thread local storage instance into the parent container
 // using std::transform
 
@@ -36,8 +36,9 @@ template <class Container> class CombinableContainer
     Container &parent_;
     dissolve::combinable<Container> combinable_;
 };
+
 // A combinable value used in multithreading operations
-// The local method retrives a thread local object during the multithreading computations
+// The local method retrieves a thread local object during the multithreading computations
 // We then use finalize to combine each thread local storage instance into a final value
 // using the std::plus operator
 
@@ -49,7 +50,6 @@ template <class Container> class CombinableContainer
 // - After the parallel operation call finalize to retrieve the final accumulated value.
 template <class ValueType> class CombinableValue
 {
-
     public:
     template <typename Lambda> CombinableValue(Lambda initializer) : combinable_(initializer) {}
     ValueType finalize() { return combinable_.combine(std::plus<ValueType>()); }
@@ -57,6 +57,25 @@ template <class ValueType> class CombinableValue
 
     private:
     dissolve::combinable<ValueType> combinable_;
+};
+
+// A combinable functor used in multithreading operations
+// The local method retrieves a thread local object during the multithreading computations
+
+// Usage:
+// - Create an instance by passing in a lambda initializer which specifies how to create local
+// instances of the value type
+// - Capture the combinable by reference in the lambda operator of the parallel operation
+// - Within the lambda operator call local() to access a thread local version of the container
+template <class ClassType> class CombinableFunctor
+{
+
+    public:
+    template <typename Lambda> CombinableFunctor(Lambda initializer) : combinable_(initializer) {}
+    ClassType &local() { return combinable_.local(); }
+
+    private:
+    dissolve::combinable<ClassType> combinable_;
 };
 
 } // namespace dissolve


### PR DESCRIPTION
This PR enables region generation to be performed in parallel. The idea of a `VoxelKernel` is introduced - a small class which encapsulates the necessary objects and/or mathematics to be able to check voxel validity.  Essentially this just means farming out the existing member variables of the region procedure nodes, and moving the virtual `isVoxelValid()` function.

I have to say I quite enjoyed this one!  I would appreciate any and all comments on the methodology, the naming of the classes, and the introduction of a new combinable class, `CombinableFunctor` - since we don't sum or `finalise()` any data in this workflow, a new class seemed appropriate.

Closes #1617.