### PR TITLE
iterateSelection procedure node setup

### DIFF
--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -23,11 +23,8 @@ add_library(
   importCoordinates.cpp
   integerCollect1D.cpp
   integrate1D.cpp
-<<<<<<< HEAD
   iterateData1D.cpp
-=======
-  iterateSelection.cpp
->>>>>>> 73b74ead2 (iterateSelection setup)
+  iterateSelection.cppelection setup)
   node.cpp
   nodeReference.cpp
   operateBase.cpp

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -23,7 +23,11 @@ add_library(
   importCoordinates.cpp
   integerCollect1D.cpp
   integrate1D.cpp
+<<<<<<< HEAD
   iterateData1D.cpp
+=======
+  iterateSelection.cpp
+>>>>>>> 73b74ead2 (iterateSelection setup)
   node.cpp
   nodeReference.cpp
   operateBase.cpp
@@ -80,6 +84,7 @@ add_library(
   integerCollect1D.h
   integrate1D.h
   iterateData1D.h
+  iterateSelection.h
   node.h
   nodeReference.h
   operateBase.h

--- a/src/procedure/nodes/CMakeLists.txt
+++ b/src/procedure/nodes/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library(
   integerCollect1D.cpp
   integrate1D.cpp
   iterateData1D.cpp
-  iterateSelection.cppelection setup)
+  iterateSelection.cpp
   node.cpp
   nodeReference.cpp
   operateBase.cpp

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "procedure/nodes/iterateSelection.h"
+#include "classes/configuration.h"
+#include "classes/coreData.h"
+#include "classes/siteReference.h"
+#include "classes/species.h"
+#include "expression/variable.h"
+#include "keywords/node.h"
+#include "keywords/nodeBranch.h"
+#include "keywords/nodeVector.h"
+#include "keywords/range.h"
+#include "keywords/speciesSiteVector.h"
+#include "procedure/nodes/sequence.h"
+#include <algorithm>
+
+IterateSelectionProcedureNode::IterateSelectionProcedureNode(std::vector<const SpeciesSite *> sites,
+                                                             ProcedureNode::NodeContext forEachContext)
+    : ProcedureNode(ProcedureNode::NodeType::Select, {ProcedureNode::AnalysisContext, ProcedureNode::GenerationContext}),
+      speciesSites_(std::move(sites)))
+{
+    // Keywords
+}
+
+/*
+ * Selection Targets
+ */
+
+// Return vector of sites to select
+std::vector<const SpeciesSite *> &IterateSelectionProcedureNode::speciesSites() { return speciesSites_; }
+
+/*
+ * Selected Sites
+ */
+
+/*
+ * Branch
+ */
+
+// Return the branch from this node (if it has one)
+OptionalReferenceWrapper<ProcedureNodeSequence> IterateSelectionProcedureNode::branch() { return forEachBranch_; }
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureContext)
+{
+    // Check for at least one site being defined
+    if (speciesSites_.empty())
+        return Messenger::error("No sites are defined in the Select node '{}'.\n", name());
+
+    // If one exists, prepare the ForEach branch nodes
+    if (!forEachBranch_.prepare(procedureContext))
+        return false;
+
+    return true;
+}
+
+// Execute node
+bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureContext)
+{
+    // Create our site vector
+    sites_.clear();
+
+    return true;
+}

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -74,7 +74,24 @@ bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureCon
                 return false;
         }
     }
+    // Update parameters
+    nSelectedParameter_->setValue(int(sites.size()));
     return true;
 }
 
-bool IterateSelectionProcedureNode::finalise(const ProcedureContext &procedureContext) { return true; }
+bool IterateSelectionProcedureNode::finalise(const ProcedureContext &procedureContext)
+{
+    auto selectionSize = selection_->returnSites().size();
+    // If one exists, finalise the ForEach branch nodes
+    if (!forEachBranch_.finalise(procedureContext))
+        return false;
+
+    // Print out summary information
+    Messenger::print("Select - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(), nSelections_,
+                     selectionSize);
+    Messenger::print("Select - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
+                     nSelections_ == 0 ? 0 : double(nCumulativeSites_) / nSelections_);
+    Messenger::print("Select - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
+
+    return true;
+}

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -54,21 +54,26 @@ bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureCon
 // Execute node
 bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureContext)
 {
-    /*     auto sites = returnSite();
-        // Create our site vector
-        sites.clear();
-        // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
-        if (!forEachBranch_.empty())
+    // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
+    auto sites = selection_->returnSites();
+    currentSite_ = std::nullopt;
+    if (!forEachBranch_.empty())
+    {
+        auto index = 1;
+        for (const auto &siteInfo : sites)
         {
-            for (currentSiteIndex_ = 0; currentSiteIndex_ < sites.size(); ++currentSiteIndex_)
-            {
-                ++nCumulativeSites_;
+            currentSite_ = std::get<0>(siteInfo);
+            siteIndexParameter_->setValue(std::get<1>(siteInfo));
+            stackIndexParameter_->setValue(std::get<2>(siteInfo));
+            indexParameter_->setValue(index++);
 
-                // If the branch fails at any point, return failure here.  Otherwise, continue the loop
-                if (!forEachBranch_.execute(procedureContext))
-                    return false;
-            }
-        } */
+            ++nCumulativeSites_;
+
+            // If the branch fails at any point, return failure here.  Otherwise, continue the loop
+            if (!forEachBranch_.execute(procedureContext))
+                return false;
+        }
+    }
     return true;
 }
 

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -40,10 +40,6 @@ OptionalReferenceWrapper<ProcedureNodeSequence> IterateSelectionProcedureNode::b
 // Prepare any necessary data, ready for execution
 bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
-    // Check for at least one site being defined
-    if (speciesSites_.empty())
-        return Messenger::error("No sites are defined in the Select node '{}'.\n", name());
-
     // If one exists, prepare the ForEach branch nodes
     if (!forEachBranch_.prepare(procedureContext))
         return false;
@@ -55,7 +51,7 @@ bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureCon
 bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureContext)
 {
     // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
-    auto sites = selection_->returnSites();
+    const auto &sites = selection_->sites();
     currentSite_ = std::nullopt;
     if (!forEachBranch_.empty())
     {
@@ -74,24 +70,26 @@ bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureCon
                 return false;
         }
     }
+
     // Update parameters
     nSelectedParameter_->setValue(int(sites.size()));
+
     return true;
 }
 
 bool IterateSelectionProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
-    auto selectionSize = selection_->returnSites().size();
+    auto selectionSize = selection_->sites().size();
     // If one exists, finalise the ForEach branch nodes
     if (!forEachBranch_.finalise(procedureContext))
         return false;
 
     // Print out summary information
-    Messenger::print("Select - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(), nSelections_,
-                     selectionSize);
-    Messenger::print("Select - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
+    Messenger::print("[Iterate Selection] - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(),
+                     nSelections_, selectionSize);
+    Messenger::print("[Iterate Selection] - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
                      nSelections_ == 0 ? 0 : double(nCumulativeSites_) / nSelections_);
-    Messenger::print("Select - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
+    Messenger::print("[Iterate Selection] - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
 
     return true;
 }

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -62,10 +62,7 @@ OptionalReferenceWrapper<ProcedureNodeSequence> IterateSelectionProcedureNode::b
 bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // If one exists, prepare the ForEach branch nodes
-    if (!forEachBranch_.prepare(procedureContext))
-        return false;
-
-    return true;
+    return forEachBranch_.prepare(procedureContext);
 }
 
 // Execute node
@@ -106,11 +103,11 @@ bool IterateSelectionProcedureNode::finalise(const ProcedureContext &procedureCo
         return false;
 
     // Print out summary information
-    Messenger::print("[Iterate Selection] - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(),
+    Messenger::print("[IterateSelection] - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(),
                      nSelections_, selectionSize);
-    Messenger::print("[Iterate Selection] - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
+    Messenger::print("[IterateSelection] - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
                      nSelections_ == 0 ? 0 : double(nCumulativeSites_) / nSelections_);
-    Messenger::print("[Iterate Selection] - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
+    Messenger::print("[IterateSelection] - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
 
     return true;
 }

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -71,3 +71,5 @@ bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureCon
         } */
     return true;
 }
+
+bool IterateSelectionProcedureNode::finalise(const ProcedureContext &procedureContext) { return true; }

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "procedure/nodes/iterateSelection.h"
-#include "procedure/nodes/select.h"
 #include "classes/configuration.h"
 #include "classes/coreData.h"
 #include "classes/siteReference.h"
@@ -13,6 +12,7 @@
 #include "keywords/nodeVector.h"
 #include "keywords/range.h"
 #include "keywords/speciesSiteVector.h"
+#include "procedure/nodes/select.h"
 #include "procedure/nodes/sequence.h"
 #include <algorithm>
 
@@ -54,20 +54,20 @@ bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureCon
 // Execute node
 bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureContext)
 {
-/*     auto sites = returnSite();
-    // Create our site vector
-    sites.clear();
-    // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
-    if (!forEachBranch_.empty())
-    {
-        for (currentSiteIndex_ = 0; currentSiteIndex_ < sites.size(); ++currentSiteIndex_)
+    /*     auto sites = returnSite();
+        // Create our site vector
+        sites.clear();
+        // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
+        if (!forEachBranch_.empty())
         {
-            ++nCumulativeSites_;
+            for (currentSiteIndex_ = 0; currentSiteIndex_ < sites.size(); ++currentSiteIndex_)
+            {
+                ++nCumulativeSites_;
 
-            // If the branch fails at any point, return failure here.  Otherwise, continue the loop
-            if (!forEachBranch_.execute(procedureContext))
-                return false;
-        }
-    } */
+                // If the branch fails at any point, return failure here.  Otherwise, continue the loop
+                if (!forEachBranch_.execute(procedureContext))
+                    return false;
+            }
+        } */
     return true;
 }

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -24,6 +24,27 @@ IterateSelectionProcedureNode::IterateSelectionProcedureNode(ProcedureNode::Node
     // Keywords
     keywords_.add<NodeKeyword<SelectProcedureNode>>("Selection", "Target selection to iterate over", selection_, this,
                                                     ProcedureNode::NodeType::Select, true);
+
+    nSelectedParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("nSelected"));
+    siteIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("siteIndex"));
+    stackIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("stackIndex"));
+    indexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("index"));
+}
+
+/*
+ * Identity
+ */
+
+// Set node name
+void IterateSelectionProcedureNode::setName(std::string_view name)
+{
+    name_ = DissolveSys::niceName(name);
+
+    // Update parameter names to match
+    nSelectedParameter_->setName(fmt::format("{}.nSelected", name_));
+    siteIndexParameter_->setName(fmt::format("{}.siteIndex", name_));
+    stackIndexParameter_->setName(fmt::format("{}.stackIndex", name_));
+    indexParameter_->setName(fmt::format("{}.index", name_));
 }
 
 /*

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -15,12 +15,14 @@
 #include "procedure/nodes/sequence.h"
 #include <algorithm>
 
-IterateSelectionProcedureNode::IterateSelectionProcedureNode(std::vector<const SpeciesSite *> sites,
-                                                             ProcedureNode::NodeContext forEachContext)
-    : ProcedureNode(ProcedureNode::NodeType::Select, {ProcedureNode::AnalysisContext, ProcedureNode::GenerationContext}),
-      speciesSites_(std::move(sites)))
+IterateSelectionProcedureNode::IterateSelectionProcedureNode(ProcedureNode::NodeContext forEachContext)
+    : ProcedureNode(ProcedureNode::NodeType::IterateSelection,
+                    {ProcedureNode::AnalysisContext, ProcedureNode::GenerationContext}),
+      forEachBranch_(forEachContext, *this, "ForEach")
 {
     // Keywords
+    keywords_.add<NodeKeyword<SelectProcedureNode>>("Selection", "Target selection to iterate over", selection_, this,
+                                                    ProcedureNode::NodeType::Select, true);
 }
 
 /*
@@ -29,10 +31,6 @@ IterateSelectionProcedureNode::IterateSelectionProcedureNode(std::vector<const S
 
 // Return vector of sites to select
 std::vector<const SpeciesSite *> &IterateSelectionProcedureNode::speciesSites() { return speciesSites_; }
-
-/*
- * Selected Sites
- */
 
 /*
  * Branch

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "procedure/nodes/iterateSelection.h"
+#include "procedure/nodes/select.h"
 #include "classes/configuration.h"
 #include "classes/coreData.h"
 #include "classes/siteReference.h"
@@ -24,13 +25,6 @@ IterateSelectionProcedureNode::IterateSelectionProcedureNode(ProcedureNode::Node
     keywords_.add<NodeKeyword<SelectProcedureNode>>("Selection", "Target selection to iterate over", selection_, this,
                                                     ProcedureNode::NodeType::Select, true);
 }
-
-/*
- * Selection Targets
- */
-
-// Return vector of sites to select
-std::vector<const SpeciesSite *> &IterateSelectionProcedureNode::speciesSites() { return speciesSites_; }
 
 /*
  * Branch
@@ -60,8 +54,20 @@ bool IterateSelectionProcedureNode::prepare(const ProcedureContext &procedureCon
 // Execute node
 bool IterateSelectionProcedureNode::execute(const ProcedureContext &procedureContext)
 {
+/*     auto sites = returnSite();
     // Create our site vector
-    sites_.clear();
+    sites.clear();
+    // If a ForEach branch has been defined, process it for each of our sites in turn. Otherwise, we're done.
+    if (!forEachBranch_.empty())
+    {
+        for (currentSiteIndex_ = 0; currentSiteIndex_ < sites.size(); ++currentSiteIndex_)
+        {
+            ++nCumulativeSites_;
 
+            // If the branch fails at any point, return failure here.  Otherwise, continue the loop
+            if (!forEachBranch_.execute(procedureContext))
+                return false;
+        }
+    } */
     return true;
 }

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -21,8 +21,7 @@ class IterateSelectionProcedureNode : public ProcedureNode
 {
     public:
     explicit IterateSelectionProcedureNode(
-        std::vector<const SpeciesSite *> sites = {},
-        ProcedureNode::NodeContext forEachContext = ProcedureNode::NodeContext::AnalysisContext, bool axesRequired = false);
+        ProcedureNode::NodeContext forEachContext = ProcedureNode::NodeContext::AnalysisContext);
 
     /*
      * Parameters
@@ -32,6 +31,8 @@ class IterateSelectionProcedureNode : public ProcedureNode
     std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> nSelectedParameter_;
+    // Selection to iterate over
+    std::shared_ptr<const SelectProcedureNode> selection_{nullptr};
 
     /*
      * Selection Targets

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -7,7 +7,6 @@
 #include "procedure/nodes/node.h"
 #include "procedure/nodes/sequence.h"
 #include <memory>
-#include <set>
 
 // Forward Declarations
 class Element;

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -24,6 +24,13 @@ class IterateSelectionProcedureNode : public ProcedureNode
         ProcedureNode::NodeContext forEachContext = ProcedureNode::NodeContext::AnalysisContext);
 
     /*
+     * Identity
+     */
+    public:
+    // Set node name
+    void setName(std::string_view name) override;
+
+    /*
      * Parameters
      */
     private:

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -35,13 +35,6 @@ class IterateSelectionProcedureNode : public ProcedureNode
     std::shared_ptr<const SelectProcedureNode> selection_;
 
     /*
-     * Selection Targets
-     */
-    private:
-    // Vector of sites to select
-    std::vector<const SpeciesSite *> speciesSites_;
-
-    /*
      * Selected Sites
      */
     private:

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -32,7 +32,7 @@ class IterateSelectionProcedureNode : public ProcedureNode
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> nSelectedParameter_;
     // Selection to iterate over
-    std::shared_ptr<const SelectProcedureNode> selection_{nullptr};
+    std::shared_ptr<const SelectProcedureNode> selection_;
 
     /*
      * Selection Targets
@@ -41,16 +41,16 @@ class IterateSelectionProcedureNode : public ProcedureNode
     // Vector of sites to select
     std::vector<const SpeciesSite *> speciesSites_;
 
-    public:
-    // Return vector of sites to select
-    std::vector<const SpeciesSite *> &speciesSites();
-
     /*
      * Selected Sites
      */
     private:
-    // Vector of selected sites
-    std::vector<const Site *> sites_;
+    // Current Site index
+    int currentSiteIndex_;
+    // Number of selections made by the node
+    int nSelections_;
+    // Cumulative number of sites ever selected
+    unsigned long int nCumulativeSites_;
 
     /*
      * Branch

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "math/range.h"
+#include "procedure/nodes/node.h"
+#include "procedure/nodes/sequence.h"
+#include <memory>
+#include <set>
+
+// Forward Declarations
+class Element;
+class Molecule;
+class SiteStack;
+class Species;
+class SpeciesSite;
+
+// Iterate Selection Node
+class IterateSelectionProcedureNode : public ProcedureNode
+{
+    public:
+    explicit IterateSelectionProcedureNode(
+        std::vector<const SpeciesSite *> sites = {},
+        ProcedureNode::NodeContext forEachContext = ProcedureNode::NodeContext::AnalysisContext, bool axesRequired = false);
+
+    /*
+     * Parameters
+     */
+    private:
+    // Defined parameters
+    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
+    // Pointers to individual parameters
+    std::shared_ptr<ExpressionVariable> nSelectedParameter_;
+
+    /*
+     * Selection Targets
+     */
+    private:
+    // Vector of sites to select
+    std::vector<const SpeciesSite *> speciesSites_;
+
+    public:
+    // Return vector of sites to select
+    std::vector<const SpeciesSite *> &speciesSites();
+
+    /*
+     * Selected Sites
+     */
+    private:
+    // Vector of selected sites
+    std::vector<const Site *> sites_;
+
+    /*
+     * Branch
+     */
+    private:
+    // Branch for ForEach
+    ProcedureNodeSequence forEachBranch_;
+
+    public:
+    // Return the branch from this node (if it has one)
+    OptionalReferenceWrapper<ProcedureNodeSequence> branch() override;
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const ProcedureContext &procedureContext) override;
+    // Execute node
+    bool execute(const ProcedureContext &procedureContext) override;
+    // Finalise any necessary data after execution
+    bool finalise(const ProcedureContext &procedureContext) override;
+};

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -30,7 +30,7 @@ class IterateSelectionProcedureNode : public ProcedureNode
     // Defined parameters
     std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
-    std::shared_ptr<ExpressionVariable> nSelectedParameter_;
+    std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, stackIndexParameter_, indexParameter_;
     // Selection to iterate over
     std::shared_ptr<const SelectProcedureNode> selection_;
 
@@ -51,6 +51,8 @@ class IterateSelectionProcedureNode : public ProcedureNode
     int nSelections_;
     // Cumulative number of sites ever selected
     unsigned long int nCumulativeSites_;
+    // Current site
+    OptionalReferenceWrapper<const Site> currentSite_;
 
     /*
      * Branch

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -46,6 +46,7 @@ EnumOptions<ProcedureNode::NodeType> ProcedureNode::nodeTypes()
                      {ProcedureNode::NodeType::GeneralRegion, "GeneralRegion"},
                      {ProcedureNode::NodeType::ImportCoordinates, "ImportCoordinates"},
                      {ProcedureNode::NodeType::IntegerCollect1D, "IntegerCollect1D"},
+                     {ProcedureNode::NodeType::IterateSelection, "IterateSelection"},
                      {ProcedureNode::NodeType::IfValueInRange, "IfValueInRange"},
                      {ProcedureNode::NodeType::Integrate1D, "Integrate1D"},
                      {ProcedureNode::NodeType::IterateData1D, "IterateData1D"},

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -61,6 +61,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
         IfValueInRange,
         Integrate1D,
         IterateData1D,
+        IterateSelection,
         OperateDivide,
         OperateExpression,
         OperateGridNormalise,

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -178,7 +178,7 @@ double SelectProcedureNode::nAvailableSitesAverage() const { return double(nAvai
 OptionalReferenceWrapper<const Site> SelectProcedureNode::currentSite() const { return currentSite_; }
 
 // Return sites vector
-std::vector<std::tuple<const Site &, int, int>> SelectProcedureNode::returnSite() { return sites_; }
+std::vector<std::tuple<const Site &, int, int>> SelectProcedureNode::returnSites() const { return sites_; }
 
 /*
  * Branch

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -177,6 +177,9 @@ double SelectProcedureNode::nAvailableSitesAverage() const { return double(nAvai
 // Return current site
 OptionalReferenceWrapper<const Site> SelectProcedureNode::currentSite() const { return currentSite_; }
 
+// Return sites vector
+std::vector<const Site *> SelectProcedureNode::returnSite() { return sites_; }
+
 /*
  * Branch
  */

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -178,7 +178,7 @@ double SelectProcedureNode::nAvailableSitesAverage() const { return double(nAvai
 OptionalReferenceWrapper<const Site> SelectProcedureNode::currentSite() const { return currentSite_; }
 
 // Return sites vector
-std::vector<const Site *> SelectProcedureNode::returnSite() { return sites_; }
+std::vector<std::tuple<const Site &, int, int>> SelectProcedureNode::returnSite() { return sites_; }
 
 /*
  * Branch

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -177,9 +177,6 @@ double SelectProcedureNode::nAvailableSitesAverage() const { return double(nAvai
 // Return current site
 OptionalReferenceWrapper<const Site> SelectProcedureNode::currentSite() const { return currentSite_; }
 
-// Return sites vector
-std::vector<std::tuple<const Site &, int, int>> SelectProcedureNode::returnSites() const { return sites_; }
-
 /*
  * Branch
  */
@@ -314,14 +311,14 @@ bool SelectProcedureNode::finalise(const ProcedureContext &procedureContext)
         return false;
 
     // Print out summary information
-    Messenger::print("Select - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(), nSelections_,
+    Messenger::print("[Select] - Site '{}': Number of selections made = {} (last contained {} sites).\n", name(), nSelections_,
                      sites_.size());
-    Messenger::print("Select - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
+    Messenger::print("[Select] - Site '{}': Average number of sites selected per selection = {:.2f}.\n", name(),
                      nSelections_ == 0 ? 0 : double(nCumulativeSites_) / nSelections_);
-    Messenger::print("Select - Site '{}': Average number of sites available per selection = {:.2f}.\n", name(),
+    Messenger::print("[Select] - Site '{}': Average number of sites available per selection = {:.2f}.\n", name(),
                      nSelections_ == 0 ? 0 : double(nAvailableSites_) / nSelections_);
 
-    Messenger::print("Select - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
+    Messenger::print("[Select] - Site '{}': Cumulative number of sites selected = {}.\n", name(), nCumulativeSites_);
 
     return true;
 }

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -129,7 +129,13 @@ class SelectProcedureNode : public ProcedureNode
     // Return average number of sites available per selection, before any distance pruning
     double nAvailableSitesAverage() const;
     // Return current site
+<<<<<<< HEAD
     OptionalReferenceWrapper<const Site> currentSite() const;
+=======
+    const Site *currentSite() const;
+    //Return sites vector
+    std::vector<const Site *> returnSite();
+>>>>>>> a6e2574ba (add accessor to sites_ and correction)
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -131,7 +131,7 @@ class SelectProcedureNode : public ProcedureNode
     // Return current site
     OptionalReferenceWrapper<const Site> currentSite() const;
     // Return site vector
-    std::vector<std::tuple<const Site &, int, int>>  returnSites() const;
+    std::vector<std::tuple<const Site &, int, int>> returnSites() const;
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -130,8 +130,6 @@ class SelectProcedureNode : public ProcedureNode
     double nAvailableSitesAverage() const;
     // Return current site
     OptionalReferenceWrapper<const Site> currentSite() const;
-    // Return site vector
-    std::vector<std::tuple<const Site &, int, int>> returnSites() const;
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -129,13 +129,9 @@ class SelectProcedureNode : public ProcedureNode
     // Return average number of sites available per selection, before any distance pruning
     double nAvailableSitesAverage() const;
     // Return current site
-<<<<<<< HEAD
     OptionalReferenceWrapper<const Site> currentSite() const;
-=======
-    const Site *currentSite() const;
-    //Return sites vector
+    // Return site vector
     std::vector<const Site *> returnSite();
->>>>>>> a6e2574ba (add accessor to sites_ and correction)
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -131,7 +131,7 @@ class SelectProcedureNode : public ProcedureNode
     // Return current site
     OptionalReferenceWrapper<const Site> currentSite() const;
     // Return site vector
-    std::vector<std::tuple<const Site &, int, int>> returnSite();
+    std::vector<std::tuple<const Site &, int, int>>  returnSites() const;
 
     /*
      * Branch

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -131,7 +131,7 @@ class SelectProcedureNode : public ProcedureNode
     // Return current site
     OptionalReferenceWrapper<const Site> currentSite() const;
     // Return site vector
-    std::vector<const Site *> returnSite();
+    std::vector<std::tuple<const Site &, int, int>> returnSite();
 
     /*
      * Branch


### PR DESCRIPTION
closes #1610 In some use cases we wish to Select a bunch of sites, but check how many we actually selected before iterating over them. There is no control over when the ForEach branch runs, so an additional node - perhaps IterateSelection - which would allow iteration of the sites selected in the Select node would be useful.

This work will need to be done on top of work performed in https://github.com/disorderedmaterials/dissolve/pull/1608.