### PR TITLE
Node Value Proxy

### DIFF
--- a/src/gui/importCIFDialogFuncs.cpp
+++ b/src/gui/importCIFDialogFuncs.cpp
@@ -260,7 +260,7 @@ void ImportCIFDialog::finalise()
 
             // Add
             auto addNode = generator.createRootNode<AddProcedureNode>(fmt::format("Add_{}", uniqueSuffix), coordsNode);
-            addNode->keywords().set("Population", NodeValue(int(cifSp->coordinates().size())));
+            addNode->keywords().set("Population", NodeValueProxy(int(cifSp->coordinates().size())));
             addNode->keywords().setEnumeration("Positioning", AddProcedureNode::PositioningType::Current);
             addNode->keywords().set("Rotate", false);
             addNode->keywords().setEnumeration("BoxAction", AddProcedureNode::BoxActionStyle::None);

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -236,7 +236,7 @@ bool KeywordStore::set(std::string_view name, const std::string value)
     getKeyword<StringKeyword>(keywords_, name)->data() = value;
     return true;
 }
-bool KeywordStore::set(std::string_view name, const NodeValue value)
+bool KeywordStore::set(std::string_view name, const NodeValueProxy value)
 {
     return getKeyword<NodeValueKeyword>(keywords_, name)->setData(value);
 }

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -146,7 +146,7 @@ class KeywordStore
     bool set(std::string_view name, const double value);
     bool set(std::string_view name, const int value);
     bool set(std::string_view name, const std::string value);
-    bool set(std::string_view name, const NodeValue value);
+    bool set(std::string_view name, const NodeValueProxy value);
     bool set(std::string_view name, const Vec3<double> value);
     bool set(std::string_view name, const Vec3<NodeValue> value);
     bool set(std::string_view name, const Range value);

--- a/src/procedure/nodeValue.cpp
+++ b/src/procedure/nodeValue.cpp
@@ -39,9 +39,6 @@ void NodeValue::operator=(const int value) { set(value); }
 // Assignment from integer
 void NodeValue::operator=(const double value) { set(value); }
 
-// Conversion (to double)
-NodeValue::operator double() { return asDouble(); }
-
 /*
  * Data
  */

--- a/src/procedure/nodeValue.cpp
+++ b/src/procedure/nodeValue.cpp
@@ -32,10 +32,18 @@ NodeValue::NodeValue(std::string_view expressionText,
 }
 
 // Assignment from integer
-void NodeValue::operator=(const int value) { set(value); }
+NodeValue &NodeValue::operator=(const int value)
+{
+    set(value);
+    return *this;
+}
 
 // Assignment from integer
-void NodeValue::operator=(const double value) { set(value); }
+NodeValue &NodeValue::operator=(const double value)
+{
+    set(value);
+    return *this;
+}
 
 /*
  * Data

--- a/src/procedure/nodeValue.cpp
+++ b/src/procedure/nodeValue.cpp
@@ -31,8 +31,6 @@ NodeValue::NodeValue(std::string_view expressionText,
     set(expressionText, parameters);
 }
 
-NodeValue::~NodeValue() = default;
-
 // Assignment from integer
 void NodeValue::operator=(const int value) { set(value); }
 

--- a/src/procedure/nodeValue.cpp
+++ b/src/procedure/nodeValue.cpp
@@ -5,30 +5,13 @@
 #include "base/sysFunc.h"
 #include <string>
 
-NodeValue::NodeValue()
-{
-    valueI_ = 0;
-    valueD_ = 0.0;
-    type_ = DoubleNodeValue;
-}
-NodeValue::NodeValue(const int i)
-{
-    valueI_ = i;
-    valueD_ = 0.0;
-    type_ = IntegerNodeValue;
-}
-NodeValue::NodeValue(const double d)
-{
-    valueI_ = 0;
-    valueD_ = d;
-    type_ = DoubleNodeValue;
-}
+NodeValue::NodeValue(const int i) : type_(NodeValue::IntegerNodeValue), valueI_(i) {}
+NodeValue::NodeValue(const double d) : valueD_(d) {}
 NodeValue::NodeValue(std::string_view expressionText,
                      std::optional<std::vector<std::shared_ptr<ExpressionVariable>>> parameters)
+    : type_(NodeValue::ExpressionNodeValue)
 {
-    valueI_ = 0;
-    valueD_ = 0.0;
-    set(expressionText, parameters);
+    set(expressionText, std::move(parameters));
 }
 
 // Assignment from integer

--- a/src/procedure/nodeValue.cpp
+++ b/src/procedure/nodeValue.cpp
@@ -195,3 +195,43 @@ bool NodeValue::operator==(const NodeValue &value) const
 }
 
 bool NodeValue::operator!=(const NodeValue &value) const { return !(*this == value); }
+
+/*
+ * Node Value Proxy
+ */
+
+NodeValueProxy::NodeValueProxy(const int i)
+{
+    valueI_ = i;
+    valueD_ = 0.0;
+    type_ = IntegerNodeValue;
+}
+NodeValueProxy::NodeValueProxy(const double d)
+{
+    valueI_ = 0;
+    valueD_ = d;
+    type_ = DoubleNodeValue;
+}
+NodeValueProxy::NodeValueProxy(std::string_view expressionText)
+{
+    valueI_ = 0;
+    valueD_ = 0.0;
+    type_ = ExpressionNodeValue;
+    expressionString_ = expressionText;
+}
+
+// Return value represented as a string
+std::string NodeValueProxy::asString(bool addQuotesIfRequired) const
+{
+    if (type_ == IntegerNodeValue)
+        return fmt::format("{}", valueI_);
+    else if (type_ == DoubleNodeValue)
+        return fmt::format("{}", valueD_);
+    else
+    {
+        if (addQuotesIfRequired)
+            return fmt::format("'{}'", expressionString_);
+        else
+            return fmt::format("{}", expressionString_);
+    }
+}

--- a/src/procedure/nodeValue.h
+++ b/src/procedure/nodeValue.h
@@ -26,7 +26,7 @@ class NodeValue : public Serialisable<>
     /*
      * Data
      */
-    private:
+    protected:
     // Value Types
     enum NodeValueType
     {
@@ -65,7 +65,7 @@ class NodeValue : public Serialisable<>
     // Return contained value as double
     double asDouble() const;
     // Return value represented as a string
-    std::string asString(bool addQuotesIfRequired = false) const;
+    virtual std::string asString(bool addQuotesIfRequired = false) const;
 
     /*
      * Serialisable
@@ -75,4 +75,24 @@ class NodeValue : public Serialisable<>
     SerialisedValue serialise() const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
+};
+
+// Node Value Proxy
+class NodeValueProxy : public NodeValue
+{
+    public:
+    NodeValueProxy(const int i);
+    NodeValueProxy(const double d);
+    NodeValueProxy(std::string_view expressionText);
+
+    private:
+    // String for expression
+    std::string expressionString_;
+
+    /*
+     * Value Retrieval
+     */
+    public:
+    // Return value represented as a string
+    std::string asString(bool addQuotesIfRequired = false) const override;
 };

--- a/src/procedure/nodeValue.h
+++ b/src/procedure/nodeValue.h
@@ -17,8 +17,8 @@ class NodeValue : public Serialisable<>
     NodeValue(std::string_view expressionText,
               std::optional<std::vector<std::shared_ptr<ExpressionVariable>>> parameters = std::nullopt);
     ~NodeValue() = default;
-    void operator=(const int value);
-    void operator=(const double value);
+    NodeValue &operator=(const int value);
+    NodeValue &operator=(const double value);
     bool operator==(const NodeValue &value) const;
     bool operator!=(const NodeValue &value) const;
 

--- a/src/procedure/nodeValue.h
+++ b/src/procedure/nodeValue.h
@@ -11,7 +11,7 @@
 class NodeValue : public Serialisable<>
 {
     public:
-    NodeValue();
+    NodeValue() = default;
     NodeValue(const int i);
     NodeValue(const double d);
     NodeValue(std::string_view expressionText,
@@ -34,11 +34,11 @@ class NodeValue : public Serialisable<>
         ExpressionNodeValue
     };
     // Type of contained data
-    NodeValueType type_;
+    NodeValueType type_{DoubleNodeValue};
     // Integer value, if defined
-    int valueI_;
+    int valueI_{0};
     // Double value, if defined
-    double valueD_;
+    double valueD_{0.0};
     // Expression, if defined
     Expression expression_;
 

--- a/src/procedure/nodeValue.h
+++ b/src/procedure/nodeValue.h
@@ -21,7 +21,6 @@ class NodeValue : public Serialisable<>
     void operator=(const double value);
     bool operator==(const NodeValue &value) const;
     bool operator!=(const NodeValue &value) const;
-    operator double();
 
     /*
      * Data

--- a/src/procedure/nodeValue.h
+++ b/src/procedure/nodeValue.h
@@ -16,7 +16,7 @@ class NodeValue : public Serialisable<>
     NodeValue(const double d);
     NodeValue(std::string_view expressionText,
               std::optional<std::vector<std::shared_ptr<ExpressionVariable>>> parameters = std::nullopt);
-    ~NodeValue();
+    ~NodeValue() = default;
     void operator=(const int value);
     void operator=(const double value);
     bool operator==(const NodeValue &value) const;

--- a/src/procedure/nodes/add.cpp
+++ b/src/procedure/nodes/add.cpp
@@ -140,7 +140,8 @@ bool AddProcedureNode::execute(const ProcedureContext &procedureContext)
 
     auto *cfg = procedureContext.configuration();
     const auto nAtomsToAdd = ipop * sp->nAtoms();
-    auto [rho, rhoUnits] = density_;
+    auto rho = std::get<0>(density_).asDouble();
+    auto rhoUnits = std::get<1>(density_);
 
     // If a density was not given, just add new molecules to the current box without adjusting its size
     Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
@@ -160,7 +161,7 @@ bool AddProcedureNode::execute(const ProcedureContext &procedureContext)
         else
             requiredVolume = ((sp->mass() * ipop) / AVOGADRO) / (rho / 1.0E24);
 
-        Messenger::print("[Add] Density for new species is {} {}.\n", rho.asDouble(), Units::densityUnits().keyword(rhoUnits));
+        Messenger::print("[Add] Density for new species is {} {}.\n", rho, Units::densityUnits().keyword(rhoUnits));
         Messenger::print("[Add] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
 
         // If the current box has no atoms in it, absorb the current volume rather than adding to it

--- a/src/procedure/nodes/addPair.cpp
+++ b/src/procedure/nodes/addPair.cpp
@@ -140,7 +140,8 @@ bool AddPairProcedureNode::execute(const ProcedureContext &procedureContext)
     auto *cfg = procedureContext.configuration();
 
     const auto nAtomsToAdd = ipop * (speciesA_->nAtoms() + speciesB_->nAtoms());
-    auto [rho, rhoUnits] = density_;
+    auto rho = std::get<0>(density_).asDouble();
+    auto rhoUnits = std::get<1>(density_);
 
     // If a density was not given, just add new molecules to the current box without adjusting its size
     Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
@@ -160,8 +161,7 @@ bool AddPairProcedureNode::execute(const ProcedureContext &procedureContext)
         else
             requiredVolume = (((speciesA_->mass() + speciesB_->mass()) * ipop) / AVOGADRO) / (rho / 1.0E24);
 
-        Messenger::print("[AddPair] Density for new species is {} {}.\n", rho.asDouble(),
-                         Units::densityUnits().keyword(rhoUnits));
+        Messenger::print("[AddPair] Density for new species is {} {}.\n", rho, Units::densityUnits().keyword(rhoUnits));
         Messenger::print("[AddPair] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
 
         // If the current box has no atoms in it, absorb the current volume rather than adding to it

--- a/src/procedure/nodes/rotateFragment.cpp
+++ b/src/procedure/nodes/rotateFragment.cpp
@@ -65,13 +65,13 @@ bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureConte
     switch (axis_)
     {
         case (OrientedSite::SiteAxis::XAxis):
-            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(0), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(0), rotation_.asDouble(), false);
             break;
         case (OrientedSite::SiteAxis::YAxis):
-            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(1), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(1), rotation_.asDouble(), false);
             break;
         case (OrientedSite::SiteAxis::ZAxis):
-            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(2), rotation_, false);
+            rotationMatrix.createRotationAxis(site.axes().columnAsVec3(2), rotation_.asDouble(), false);
             break;
     }
 

--- a/unit/procedure/calculateExpression.cpp
+++ b/unit/procedure/calculateExpression.cpp
@@ -20,12 +20,12 @@ TEST(CalculateExpressionTest, Basic)
     EXPECT_TRUE(procedure.rootSequence().check());
 
     // Simple number
-    expressionNode->keywords().set("Expression", NodeValue(4));
+    expressionNode->keywords().set("Expression", NodeValueProxy(4));
     expressionNode->execute(ProcedureContext(ProcessPool()));
     EXPECT_DOUBLE_EQ(expressionNode->value(0), 4.0);
 
     // Expressions
-    expressionNode->keywords().set("Expression", NodeValue("3.8 * sin(1.2)"));
+    expressionNode->keywords().set("Expression", NodeValueProxy("3.8 * sin(1.2)"));
     expressionNode->execute(ProcedureContext(ProcessPool()));
     EXPECT_DOUBLE_EQ(expressionNode->value(0), 3.8 * sin(1.2));
 }

--- a/unit/procedure/procedure.cpp
+++ b/unit/procedure/procedure.cpp
@@ -132,12 +132,10 @@ TEST(ProcedureTest, Parameters)
     auto bigVars = bigHole->getParameters();
     EXPECT_EQ(bigVars.size(), 6);
 
-    // Set an equation in A via a NodeValue
-    NodeValue simple("20.0");
-    NodeValue eggPinFromSmall("1 + Egg * Pin", smallVars), eggPinFromBig("1 + Egg * Pin", smallVars);
-    NodeValue eggBus("Egg / Bus", bigVars), busMeaning("Bus + MeaningOfLife", bigVars);
-    EXPECT_TRUE(simple.isValid() && eggPinFromSmall.isValid() && eggPinFromBig.isValid() && eggBus.isValid() &&
-                busMeaning.isValid());
+    // Set an equation in A via a NodeValueProxy
+    NodeValueProxy simple("20.0");
+    NodeValueProxy eggPinFromSmall("1 + Egg * Pin"), eggPinFromBig("1 + Egg * Pin");
+    NodeValueProxy eggBus("Egg / Bus"), busMeaning("Bus + MeaningOfLife");
     EXPECT_TRUE(smallHole->keywords().set("Population", simple));
     EXPECT_TRUE(smallHole->keywords().set("Population", eggPinFromSmall));
     EXPECT_TRUE(smallHole->keywords().set("Population", eggPinFromBig));

--- a/unit/procedure/rotateFragment.cpp
+++ b/unit/procedure/rotateFragment.cpp
@@ -48,7 +48,7 @@ TEST(RotateTest, Benzene)
     {
         auto molecules_before = cfg->molecules();
 
-        rotate->keywords().set("Rotation", NodeValue{x});
+        rotate->keywords().set("Rotation", NodeValueProxy(x));
         cfg->generate({ProcessPool(), dissolve});
 
         for (const auto &[mol1, mol2] : zip(molecules_before, cfg->molecules()))


### PR DESCRIPTION
This PR addresses an annoyance with the way `NodeValueKeyword`s are set programmatically in the code. For simple `int` or `double` constructions (i.e. `NodeValue(4)` or `NodeValue(2.2)`) everything is fine, but in several cases we need to set an expression-based value (e.g. `NodeValue("NF.nSelected")`).

This presents a problem, since the `NodeValue::NodeValue(std::string expression)` constructor tries to immediately parse and generate the expression, but has no `Procedure`/`ProcedureNode` context to work with and so fails, ultimately resulting in an empty string (from the empty `Expression` object) arriving at the target keyword.

Here we introduce a `NodeValueProxy` class which simply transfers the expression string to where it is needed without attempting to parse/generate the expression. The `KeywordStore::set` overload now takes `NodeValueProxy` instead of `NodeValue`.  Some other general tidying of the `NodeValue` class was also performed.