### PR TITLE
Fixing elapsed timer not zeroing upon GUI launch

### DIFF
--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -46,6 +46,7 @@ DissolveWindow::DissolveWindow(Dissolve &dissolve)
     refreshing_ = false;
     modified_ = false;
     dissolveIterating_ = false;
+    elapsedTimer_.zero();
 
     // Create statusbar widgets
     addStatusBarIcon(":/general/icons/step.svg")->setToolTip("Current step / iteration number");


### PR DESCRIPTION
![image](https://github.com/disorderedmaterials/dissolve/assets/101950441/388f8651-1da4-4763-8fed-7c590d2f801b)
Timer was not set to zero at start, so it passed this condition: https://github.com/disorderedmaterials/dissolve/blob/b8d634e6d808a0ed5b23ec261c318928f8660f7b/src/gui/guiFuncs.cpp#L316

This PR fixes that so the timer text is set to 'Idle' when the program launches.