### PR TITLE
Procedure Context Fold

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -68,14 +68,13 @@ bool Configuration::generate(const ProcedureContext &procedureContext)
 
     // Generate the contents
     Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", niceName());
-    ProcedureContext context(procedureContext, this);
-    auto result = generator_.execute(context);
+    auto result = generator_.execute({procedureContext, this});
     if (!result)
         return Messenger::error("Failed to generate Configuration '{}'.\n", niceName());
     Messenger::print("\n");
 
     // Set-up Cells for the Box
-    cells_.generate(box_.get(), requestedCellDivisionLength_, context.potentialMap().range());
+    cells_.generate(box_.get(), requestedCellDivisionLength_, procedureContext.potentialMap().range());
 
     // Make sure all objects know about each other
     updateObjectRelationships();

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -68,8 +68,7 @@ bool Configuration::generate(const ProcedureContext &procedureContext)
 
     // Generate the contents
     Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", niceName());
-    auto context = procedureContext;
-    context.setConfiguration(this);
+    ProcedureContext context(procedureContext, this);
     auto result = generator_.execute(context);
     if (!result)
         return Messenger::error("Failed to generate Configuration '{}'.\n", niceName());

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -17,9 +17,7 @@ Module::ExecutionResult AnalyseModule::process(ModuleContext &moduleContext)
     }
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Analysis ExecutionResult::Failed.\n");

--- a/src/modules/analyse/process.cpp
+++ b/src/modules/analyse/process.cpp
@@ -17,8 +17,7 @@ Module::ExecutionResult AnalyseModule::process(ModuleContext &moduleContext)
     }
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("Analysis ExecutionResult::Failed.\n");
         return ExecutionResult::Failed;

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -56,8 +56,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
         selectC_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("Angle experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -56,9 +56,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
         selectC_->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("Angle experienced problems with its analysis.\n");

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -35,9 +35,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -35,8 +35,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("AxisAngle experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -35,8 +35,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
         selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -35,9 +35,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
         selectC_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateDAngle experienced problems with its analysis.\n");

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -30,9 +30,7 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
     selectB_->keywords().set("InclusiveRange", distanceRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -30,8 +30,7 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
     selectB_->keywords().set("InclusiveRange", distanceRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("HistogramCN experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -29,8 +29,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     collectABC_->keywords().set("RangeX", angleRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateAngle experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -29,9 +29,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     collectABC_->keywords().set("RangeX", angleRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateAngle experienced problems with its analysis.\n");

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -24,9 +24,7 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
     collectDistance_->keywords().set("RangeX", distanceRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -24,8 +24,7 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
     collectDistance_->keywords().set("RangeX", distanceRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/orientedSDF/process.cpp
+++ b/src/modules/orientedSDF/process.cpp
@@ -33,10 +33,7 @@ Module::ExecutionResult OrientedSDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/qSpecies/process.cpp
+++ b/src/modules/qSpecies/process.cpp
@@ -25,11 +25,7 @@ Module::ExecutionResult QSpeciesModule::process(ModuleContext &moduleContext)
     selectNF_->keywords().set("InclusiveRange", distanceRange_);
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
-
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("Q Species experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -30,10 +30,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext TEST(moduleContext.dissolve(), moduleContext.processPool(), targetConfiguration_);
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -30,6 +30,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
+    ProcedureContext TEST(moduleContext.dissolve(), moduleContext.processPool(), targetConfiguration_);
     ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
     context.setDissolve(moduleContext.dissolve());
     context.setProcessingDataPrefix(name());

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -30,8 +30,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
         selectB_->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateSDF experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -31,9 +31,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     cnNormaliser_->keywords().set("Site", ConstNodeVector<SelectProcedureNode>{selectA_});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.processPool(), targetConfiguration_);
-    context.setDissolve(moduleContext.dissolve());
-    context.setProcessingDataPrefix(name());
+    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
     if (!analyser_.execute(context))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -31,8 +31,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     cnNormaliser_->keywords().set("Site", ConstNodeVector<SelectProcedureNode>{selectA_});
 
     // Execute the analysis
-    ProcedureContext context(moduleContext.dissolve(), targetConfiguration_, name());
-    if (!analyser_.execute(context))
+    if (!analyser_.execute({moduleContext.dissolve(), targetConfiguration_, name()}))
     {
         Messenger::error("CalculateRDF experienced problems with its analysis.\n");
         return ExecutionResult::Failed;

--- a/src/procedure/nodes/collect1D.cpp
+++ b/src/procedure/nodes/collect1D.cpp
@@ -64,8 +64,8 @@ bool Collect1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram1D>(
-        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.processingModuleData().realiseIf<Histogram1D>(
+        dataName, procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("One-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/collect2D.cpp
+++ b/src/procedure/nodes/collect2D.cpp
@@ -62,8 +62,8 @@ bool Collect2DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram2D>(
-        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.processingModuleData().realiseIf<Histogram2D>(
+        dataName, procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("Two-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/collect3D.cpp
+++ b/src/procedure/nodes/collect3D.cpp
@@ -98,8 +98,8 @@ bool Collect3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<Histogram3D>(
-        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.processingModuleData().realiseIf<Histogram3D>(
+        dataName, procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("Three-dimensional histogram data for '{}' was not in the target list, so it will now "

--- a/src/procedure/nodes/context.cpp
+++ b/src/procedure/nodes/context.cpp
@@ -5,55 +5,54 @@
 #include "main/dissolve.h"
 #include <stdexcept>
 
-ProcedureContext::ProcedureContext(const ProcessPool &procPool) : processPool_(procPool) {}
-
-ProcedureContext::ProcedureContext(const ProcessPool &procPool, Configuration *cfg)
-    : processPool_(procPool), configuration_(cfg)
+// Set reference to Dissolve
+void ProcedureContext::set(Dissolve &dissolve)
 {
+    dissolve_ = dissolve;
+    processPool_ = dissolve.worldPool();
 }
 
-ProcedureContext::ProcedureContext(const ProcessPool &procPool, Dissolve &dissolve)
-    : processPool_(procPool), dissolve_(dissolve)
-{
-}
+// Set available ProcessPool
+void ProcedureContext::set(const ProcessPool &procPool) { processPool_ = procPool; }
 
-// Return available process pool
-const ProcessPool &ProcedureContext::processPool() const { return processPool_; };
+// Set prefix for generated processing data
+void ProcedureContext::set(std::string_view prefix) { processingDataPrefix_ = prefix; }
 
 // Set target Configuration
-void ProcedureContext::setConfiguration(Configuration *cfg) { configuration_ = cfg; }
-
-// Return target Configuration
-Configuration *ProcedureContext::configuration() const
-{
-    if (!configuration_)
-        throw(std::runtime_error("No configuration set in this procedure's context.\n"));
-    return configuration_;
-}
-
-// Set reference to Dissolve
-void ProcedureContext::setDissolve(Dissolve &dissolve) { dissolve_ = dissolve; }
+void ProcedureContext::set(Configuration *cfg) { configuration_ = cfg; }
 
 // Return reference to Dissolve
 Dissolve &ProcedureContext::dissolve() const
 {
     if (!dissolve_)
-        throw(std::runtime_error("No reference to Dissolve is set in this procedure's context.\n"));
+        throw(std::runtime_error("No reference to Dissolve is set in this context.\n"));
     return dissolve_->get();
 }
 
-// Set target data list and prefix
-void ProcedureContext::setProcessingDataPrefix(std::string_view prefix) { processingDataPrefix_ = prefix; }
+// Return target Configuration
+Configuration *ProcedureContext::configuration() const
+{
+    if (!configuration_)
+        throw(std::runtime_error("No configuration set in this context.\n"));
+    return configuration_;
+}
 
-// Return prefix for generated data
-std::string_view ProcedureContext::processingDataPrefix() const { return processingDataPrefix_; }
+// Return available process pool
+const ProcessPool &ProcedureContext::processPool() const
+{
+    if (!processPool_)
+        throw(std::runtime_error("No reference to a ProcessPool is set in this context.\n"));
+    return processPool_->get();
+};
 
-// Return target list for generated data
-GenericList &ProcedureContext::dataList() const
+// Return prefix to use for processing data
+std::string_view ProcedureContext::processingModuleDataPrefix() const { return processingDataPrefix_; }
+
+// Return processing data list
+GenericList &ProcedureContext::processingModuleData() const
 {
     if (!dissolve_)
-        throw(std::runtime_error(
-            "No reference to Dissolve is set in this procedure's context, so cannot return processingModuleData.\n"));
+        throw(std::runtime_error("No reference to Dissolve is set in this context, so cannot return processingModuleData.\n"));
     return dissolve_->get().processingModuleData();
 }
 
@@ -61,7 +60,6 @@ GenericList &ProcedureContext::dataList() const
 const PotentialMap &ProcedureContext::potentialMap() const
 {
     if (!dissolve_)
-        throw(std::runtime_error(
-            "No reference to Dissolve is set in this procedure's context, so cannot return potentialMap.\n"));
+        throw(std::runtime_error("No reference to Dissolve is set in this context, so cannot return potentialMap.\n"));
     return dissolve_->get().potentialMap();
 }

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "templates/optionalRef.h"
+#include <fmt/format.h>
 #include <stdexcept>
 #include <string>
 
@@ -18,52 +19,53 @@ class ProcessPool;
 class ProcedureContext
 {
     public:
-    explicit ProcedureContext(const ProcessPool &procPool);
-    ProcedureContext(const ProcessPool &procPool, Configuration *cfg);
-    ProcedureContext(const ProcessPool &procPool, Dissolve &dissolve);
-    template <class... ContextObjects>
-    ProcedureContext(Dissolve &dissolve, const ProcessPool &procPool, ContextObjects &&...contextObjects)
-        : dissolve_(dissolve), processPool_(procPool)
+    template <class... ContextObjects> ProcedureContext(const ProcedureContext &other, ContextObjects &&...contextObjects)
     {
-        (
-            [&]
-            {
-                set(contextObjects);
-            }(),
-            ...);
+        *this = other;
+        ([&] { set(contextObjects); }(), ...);
+    }
+    template <class... ContextObjects> ProcedureContext(ContextObjects &&...contextObjects)
+    {
+        ([&] { set(contextObjects); }(), ...);
     }
 
     private:
+    // Reference to Dissolve
+    OptionalReferenceWrapper<Dissolve> dissolve_;
     // Available process pool
-    const ProcessPool &processPool_;
+    OptionalReferenceWrapper<const ProcessPool> processPool_;
     // Target Configuration
     Configuration *configuration_{nullptr};
     // Prefix for generated data
     std::string processingDataPrefix_;
-    // Dissolve
-    OptionalReferenceWrapper<Dissolve> dissolve_;
 
     private:
-    template <class T> void set(T) { throw(std::runtime_error("Invalid object type passed to ProcedureContext set().\n")); }
-    template <class T> void set(Configuration *cfg) { printf("It's a config!\n"); };
+    // Set reference to Dissolve
+    void set(Dissolve &dissolve);
+    // Set available ProcessPool
+    void set(const ProcessPool &procPool);
+    // Set prefix for generated processing data
+    void set(std::string_view prefix);
+    // Set target Configuration
+    void set(Configuration *cfg);
+    // Catch any unrecognised object type
+    template <class T> void set(T obj)
+    {
+        throw(std::runtime_error(
+            fmt::format("Invalid object type ({}) passed to ProcedureContext set().\n", typeid(obj).name())));
+    }
 
     public:
-    // Return available process pool
-    const ProcessPool &processPool() const;
-    // Set target Configuration
-    void setConfiguration(Configuration *cfg);
-    // Return target Configuration
-    Configuration *configuration() const;
-    // Set prefix for generated processing data
-    void setProcessingDataPrefix(std::string_view prefix);
-    // Return prefix for generated data
-    std::string_view processingDataPrefix() const;
-    // Return target list for generated data
-    GenericList &dataList() const;
-    // Set reference to Dissolve
-    void setDissolve(Dissolve &dissolve);
     // Return reference to Dissolve
     Dissolve &dissolve() const;
+    // Return available process pool
+    const ProcessPool &processPool() const;
+    // Return target Configuration
+    Configuration *configuration() const;
+    // Return prefix to use for processing data
+    std::string_view processingModuleDataPrefix() const;
+    // Return processing data list
+    GenericList &processingModuleData() const;
     // Return potential map
     const PotentialMap &potentialMap() const;
 };

--- a/src/procedure/nodes/context.h
+++ b/src/procedure/nodes/context.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "templates/optionalRef.h"
+#include <stdexcept>
 #include <string>
 
 // Forward Declarations
@@ -20,6 +21,17 @@ class ProcedureContext
     explicit ProcedureContext(const ProcessPool &procPool);
     ProcedureContext(const ProcessPool &procPool, Configuration *cfg);
     ProcedureContext(const ProcessPool &procPool, Dissolve &dissolve);
+    template <class... ContextObjects>
+    ProcedureContext(Dissolve &dissolve, const ProcessPool &procPool, ContextObjects &&...contextObjects)
+        : dissolve_(dissolve), processPool_(procPool)
+    {
+        (
+            [&]
+            {
+                set(contextObjects);
+            }(),
+            ...);
+    }
 
     private:
     // Available process pool
@@ -30,6 +42,10 @@ class ProcedureContext
     std::string processingDataPrefix_;
     // Dissolve
     OptionalReferenceWrapper<Dissolve> dissolve_;
+
+    private:
+    template <class T> void set(T) { throw(std::runtime_error("Invalid object type passed to ProcedureContext set().\n")); }
+    template <class T> void set(Configuration *cfg) { printf("It's a config!\n"); };
 
     public:
     // Return available process pool

--- a/src/procedure/nodes/integerCollect1D.cpp
+++ b/src/procedure/nodes/integerCollect1D.cpp
@@ -64,8 +64,8 @@ bool IntegerCollect1DProcedureNode::prepare(const ProcedureContext &procedureCon
 {
     // Construct our data name, and search for it in the supplied list
     std::string dataName = fmt::format("{}_{}_Bins", name(), procedureContext.configuration()->niceName());
-    auto [target, status] = procedureContext.dataList().realiseIf<IntegerHistogram1D>(
-        dataName, procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto [target, status] = procedureContext.processingModuleData().realiseIf<IntegerHistogram1D>(
+        dataName, procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     if (status == GenericItem::ItemStatus::Created)
     {
         Messenger::printVerbose("One-dimensional histogram data for '{}' was not in the target list, so it will now be "

--- a/src/procedure/nodes/iterateData1D.cpp
+++ b/src/procedure/nodes/iterateData1D.cpp
@@ -77,8 +77,9 @@ bool IterateData1DProcedureNode::execute(const ProcedureContext &procedureContex
     if (!forEachBranch_.empty())
     {
         // Retrieve / realise the normalised data from the supplied list
-        auto &data = procedureContext.dataList().realise<Data1D>(
-            fmt::format("Process1D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+        auto &data = procedureContext.processingModuleData().realise<Data1D>(fmt::format("Process1D//{}", name()),
+                                                                             procedureContext.processingModuleDataPrefix(),
+                                                                             GenericItem::InRestartFileFlag);
         data.setTag(name());
 
         // Copy the averaged data from the associated Process1D node

--- a/src/procedure/nodes/process1D.cpp
+++ b/src/procedure/nodes/process1D.cpp
@@ -116,8 +116,8 @@ bool Process1DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process1DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data1D>(
-        fmt::format("Process1D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.processingModuleData().realise<Data1D>(
+        fmt::format("Process1D//{}", name()), procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process2D.cpp
+++ b/src/procedure/nodes/process2D.cpp
@@ -90,8 +90,8 @@ bool Process2DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process2DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data2D>(
-        fmt::format("Process2D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.processingModuleData().realise<Data2D>(
+        fmt::format("Process2D//{}", name()), procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/process3D.cpp
+++ b/src/procedure/nodes/process3D.cpp
@@ -95,8 +95,8 @@ bool Process3DProcedureNode::prepare(const ProcedureContext &procedureContext)
 bool Process3DProcedureNode::finalise(const ProcedureContext &procedureContext)
 {
     // Retrieve / realise the normalised data from the supplied list
-    auto &data = procedureContext.dataList().realise<Data3D>(
-        fmt::format("Process3D//{}", name()), procedureContext.processingDataPrefix(), GenericItem::InRestartFileFlag);
+    auto &data = procedureContext.processingModuleData().realise<Data3D>(
+        fmt::format("Process3D//{}", name()), procedureContext.processingModuleDataPrefix(), GenericItem::InRestartFileFlag);
     processedData_ = &data;
     data.setTag(name());
 

--- a/src/procedure/nodes/runLayer.cpp
+++ b/src/procedure/nodes/runLayer.cpp
@@ -42,7 +42,7 @@ bool RunLayerNode::execute(const ProcedureContext &procedureContext)
     if (!layer_->runThisIteration(procedureContext.dissolve().iteration()))
         return true;
 
-    if (!layer_->canRun(procedureContext.dataList()))
+    if (!layer_->canRun(procedureContext.processingModuleData()))
         return true;
 
     ModuleContext moduleContext(procedureContext.processPool(), procedureContext.dissolve());

--- a/src/procedure/nodes/sum1D.cpp
+++ b/src/procedure/nodes/sum1D.cpp
@@ -75,8 +75,8 @@ bool Sum1DProcedureNode::finalise(const ProcedureContext &procedureContext)
         if (rangeEnabled_[i])
         {
             if (!sum_[i].has_value())
-                sum_[i] = procedureContext.dataList().realise<SampledDouble>(
-                    fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.processingDataPrefix(),
+                sum_[i] = procedureContext.processingModuleData().realise<SampledDouble>(
+                    fmt::format("Sum1D//{}//{}", name(), rangeNames[i]), procedureContext.processingModuleDataPrefix(),
                     GenericItem::InRestartFileFlag);
             if (instantaneous_)
                 sum_[i]->get() = Integrator::sum(sourceData_->processedData(), range_[i]);

--- a/tests/procedure/calculateExpression.cpp
+++ b/tests/procedure/calculateExpression.cpp
@@ -21,12 +21,12 @@ TEST(CalculateExpressionProcedureNodeTest, Basic)
 
     // Simple number
     expressionNode->keywords().set("Expression", NodeValueProxy(4));
-    expressionNode->execute(ProcedureContext(ProcessPool()));
+    expressionNode->execute({});
     EXPECT_DOUBLE_EQ(expressionNode->value(0), 4.0);
 
     // Expressions
     expressionNode->keywords().set("Expression", NodeValueProxy("3.8 * sin(1.2)"));
-    expressionNode->execute(ProcedureContext(ProcessPool()));
+    expressionNode->execute({});
     EXPECT_DOUBLE_EQ(expressionNode->value(0), 3.8 * sin(1.2));
 }
 

--- a/tests/procedure/select.cpp
+++ b/tests/procedure/select.cpp
@@ -86,8 +86,7 @@ TEST_F(SelectProcedureNodeTest, Simple)
     auto selectN = testProcedure.createRootNode<SelectProcedureNode>(
         "SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_}, ProcedureNode::NodeContext::AnalysisContext);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
 
     auto N = nType_ * 2;
     EXPECT_EQ(selectN->nSitesInStack(), N * 2);
@@ -113,8 +112,7 @@ TEST_F(SelectProcedureNodeTest, All)
     auto selectN = forEachAr.create<SelectProcedureNode>("SelectN", std::vector<const SpeciesSite *>{alphaSite_, betaSite_},
                                                          ProcedureNode::NodeContext::AnalysisContext);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
 
     EXPECT_EQ(selectAr->nSitesInStack(), 1);
     EXPECT_EQ(selectN->nSitesInStack(), nType_ * 2 * 2);
@@ -130,13 +128,11 @@ TEST_F(SelectProcedureNodeTest, Ranges)
                                                          ProcedureNode::NodeContext::AnalysisContext);
     selectN->setDistanceReferenceSite(selectAr);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-
     for (auto rangeInt = 1; rangeInt <= nType_; ++rangeInt)
     {
         selectN->setInclusiveDistanceRange({0.0, rangeInt * 1.0});
 
-        testProcedure.execute(context);
+        testProcedure.execute({dissolve_.worldPool(), configuration_});
 
         EXPECT_EQ(selectAr->nSitesInStack(), 1);
         EXPECT_EQ(selectN->nSitesInStack(), rangeInt * 2 * 2);
@@ -155,15 +151,13 @@ TEST_F(SelectProcedureNodeTest, Indices)
                                                          ProcedureNode::NodeContext::AnalysisContext);
     selectN->setDistanceReferenceSite(selectAr);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-
     auto N = nType_ * 2;
 
     for (auto rangeInt = 1; rangeInt <= nType_; ++rangeInt)
     {
         selectN->setInclusiveDistanceRange({0.0, rangeInt * 1.0});
 
-        testProcedure.execute(context);
+        testProcedure.execute({dissolve_.worldPool(), configuration_});
 
         EXPECT_EQ(selectAr->nSitesInStack(), 1);
         EXPECT_EQ(selectN->nSitesInStack(), rangeInt * 2 * 2);
@@ -193,10 +187,8 @@ TEST_F(SelectProcedureNodeTest, Exclusions1)
     auto selectN2 = forEachN1.create<SelectProcedureNode>("SelectN2", std::vector<const SpeciesSite *>{alphaSiteN_},
                                                           ProcedureNode::NodeContext::AnalysisContext);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-
     // No exclusions
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN1->nSitesInStack(), nType_);
     EXPECT_EQ(selectN2->nSitesInStack(), nType_);
     EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
@@ -205,7 +197,7 @@ TEST_F(SelectProcedureNodeTest, Exclusions1)
 
     // Exclude same site
     selectN2->keywords().set("ExcludeSameSite", ConstNodeVector<SelectProcedureNode>{selectN1});
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN1->nSitesInStack(), nType_);
     EXPECT_EQ(selectN2->nSitesInStack(), nType_ - 1);
     EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
@@ -214,7 +206,7 @@ TEST_F(SelectProcedureNodeTest, Exclusions1)
 
     // Exclude same molecule as well (no effect)
     selectN2->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectN1});
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN1->nSitesInStack(), nType_);
     EXPECT_EQ(selectN2->nSitesInStack(), nType_ - 1);
     EXPECT_DOUBLE_EQ(selectN1->nAvailableSitesAverage(), double(nType_));
@@ -230,10 +222,8 @@ TEST_F(SelectProcedureNodeTest, Exclusions2)
     auto selectO = forEachN.create<SelectProcedureNode>("SelectO", std::vector<const SpeciesSite *>{alphaSiteO_},
                                                         ProcedureNode::NodeContext::AnalysisContext);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-
     // No exclusions
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN->nSitesInStack(), nType_);
     EXPECT_EQ(selectO->nSitesInStack(), nType_);
     EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));
@@ -242,7 +232,7 @@ TEST_F(SelectProcedureNodeTest, Exclusions2)
 
     // Exclude same molecule
     selectO->keywords().set("ExcludeSameMolecule", ConstNodeVector<SelectProcedureNode>{selectN});
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN->nSitesInStack(), nType_);
     EXPECT_EQ(selectO->nSitesInStack(), nType_ - 1);
     EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));
@@ -258,11 +248,9 @@ TEST_F(SelectProcedureNodeTest, Inclusions)
     auto selectO = forEachN.create<SelectProcedureNode>("SelectO", std::vector<const SpeciesSite *>{alphaSiteO_},
                                                         ProcedureNode::NodeContext::AnalysisContext);
 
-    ProcedureContext context(dissolve_.worldPool(), configuration_);
-
     // Require same molecule as first site
     selectO->keywords().set("SameMoleculeAsSite", selectN);
-    testProcedure.execute(context);
+    testProcedure.execute({dissolve_.worldPool(), configuration_});
     EXPECT_EQ(selectN->nSitesInStack(), nType_);
     EXPECT_EQ(selectO->nSitesInStack(), 1);
     EXPECT_DOUBLE_EQ(selectN->nAvailableSitesAverage(), double(nType_));


### PR DESCRIPTION
Thoughts welcome on this PR - I've replaced the old `ProcedureContext` constructors with templated ones taking a parameter pack, and then uses a fold expression to iterate over the passed objects and set them in the class.

This allows code to be neatened considerably, as well as permitting some nice inline brace-initialisation of contexts. The drawback is that the intent behind some arguments is assumed based on type. Specifically I'm referring to the `std::string_view` type which is assumed to be the module data prefix. I think I can live with this, but of course open to your comments on the matter.

I've also taken the liberty of tidying a few function names etc.  If we agree this is all good and approved, I'll wait until other PRs involving new modules (~#1627~ and #1584) have been merged in so I can retrofit them here first.