### PR TITLE
Fix Select Better Unit Test

### DIFF
--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -123,6 +123,7 @@ Configuration::addMolecule(const Species *sp, OptionalReferenceWrapper<const std
     adjustSpeciesPopulation(sp, 1);
 
     // Add Atoms from Species to the Molecule, using either species coordinates or those from the source CoordinateSet
+    auto previousNAtoms = atoms_.size();
     if (sourceCoordinates)
     {
         auto r = sourceCoordinates->get();
@@ -134,6 +135,9 @@ Configuration::addMolecule(const Species *sp, OptionalReferenceWrapper<const std
         for (auto n = 0; n < sp->nAtoms(); ++n)
             addAtom(&sp->atom(n), newMolecule, sp->atom(n).r());
     }
+
+    newMolecule->updateAtoms(atoms_, previousNAtoms);
+
     return newMolecule;
 }
 

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -114,7 +114,7 @@ std::shared_ptr<Molecule>
 Configuration::addMolecule(const Species *sp, OptionalReferenceWrapper<const std::vector<Vec3<double>>> sourceCoordinates)
 {
     // Create the new Molecule object and set its Species pointer
-    std::shared_ptr<Molecule> newMolecule = std::make_shared<Molecule>();
+    auto newMolecule = std::make_shared<Molecule>();
     newMolecule->setArrayIndex(molecules_.size());
     molecules_.push_back(newMolecule);
     newMolecule->setSpecies(sp);

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -4,7 +4,7 @@
 #include "classes/molecule.h"
 #include "classes/atom.h"
 #include "classes/box.h"
-#include "classes/speciesAtom.h"
+#include "classes/species.h"
 #include "classes/speciesBond.h"
 #include "templates/algorithms.h"
 
@@ -13,7 +13,11 @@
  */
 
 // Set Species that this Molecule represents
-void Molecule::setSpecies(const Species *sp) { species_ = sp; }
+void Molecule::setSpecies(const Species *sp)
+{
+    species_ = sp;
+    atoms_.reserve(sp->nAtoms());
+}
 
 // Return Species that this Molecule represents
 const Species *Molecule::species() const { return species_; }


### PR DESCRIPTION
This PR hopefully fixes the unit tests for the improvements to the `SelectProcedureNode`, following reports from various different people / CI workflows that the test would fail randomly, sometimes the indices test, sometimes the ranges test etc.

Here comes a lengthy explanation for what is a simple fix, but it's worth documenting...

The cause for this was likely my poor method to create the test `Configuration` in the first place - I created the molecules one-by-one, immediately calling the `setCentreOfGoemetry()` function to position it in the right place. However, good old `valgrind` revealed that this was generating a lot of invalid pointer accesses (but which didn't cause segfaults...). This was because the creation of the new `Atom`s invalidates the existing atoms since, without a pre-allocated `std::vector` to contain them, the call to `emplace_back` obviously invalidates the addresses of our objects. This is only half the problem, however! The above approach _should_ have been valid, but the actual atom offset in the new `Molecule` was not set in `Configuration::addMolecule()`, and so isn't valid until you call `Configuration::updateObjectRelationships()`. The fix for that is easy, and that's all I've done here, as well as reserving the `atoms_` vector in the `Molecule` (because we can, and we might as well).