### PR TITLE
Fix TOML testing framework

### DIFF
--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -42,16 +42,16 @@ void runParse(std::filesystem::path input, int steps = 1)
         input.remove_filename();
         std::filesystem::current_path(input);
 
-	SerialisedValue toml;
-	bool knownGood;
-	{
-	  CoreData coreData;
-	  Dissolve initial(coreData);
-	  initial.loadInput(std::string_view(std::string(filename)));
-	  toml = initial.serialise();
-	  initial.prepare();
-	  knownGood = initial.iterate(steps);
-	}
+        SerialisedValue toml;
+        bool knownGood;
+        {
+            CoreData coreData;
+            Dissolve initial(coreData);
+            initial.loadInput(std::string_view(std::string(filename)));
+            toml = initial.serialise();
+            initial.prepare();
+            knownGood = initial.iterate(steps);
+        }
 
         CoreData coreData2;
         Dissolve repeat(coreData2);

--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -42,13 +42,18 @@ void runParse(std::filesystem::path input, int steps = 1)
         input.remove_filename();
         std::filesystem::current_path(input);
 
-        CoreData coreData, coreData2;
-        Dissolve initial(coreData);
-        initial.loadInput(std::string_view(std::string(filename)));
-        auto toml = initial.serialise();
-        initial.prepare();
-        auto knownGood = initial.iterate(steps);
+	SerialisedValue toml;
+	bool knownGood;
+	{
+	  CoreData coreData;
+	  Dissolve initial(coreData);
+	  initial.loadInput(std::string_view(std::string(filename)));
+	  toml = initial.serialise();
+	  initial.prepare();
+	  knownGood = initial.iterate(steps);
+	}
 
+        CoreData coreData2;
         Dissolve repeat(coreData2);
         repeat.setInputFilename(std::string(filename));
         EXPECT_NO_THROW(repeat.deserialise(toml));

--- a/unit/io/toml.cpp
+++ b/unit/io/toml.cpp
@@ -52,7 +52,6 @@ void runParse(std::filesystem::path input, int steps = 1)
         Dissolve repeat(coreData2);
         repeat.setInputFilename(std::string(filename));
         EXPECT_NO_THROW(repeat.deserialise(toml));
-        repeat.deserialise(toml);
         auto toml2 = repeat.serialise();
 
         compare_toml("", toml, toml2);


### PR DESCRIPTION
Several of our failing TOML tests aren't problems with the TOML serialisation, but due to an issue with the testing framework.  We have to call into Dissolve twice and we've been having issues with cross talk between the two invocations.  The two objects are distinct, so there must be some static class member being set.  Either way, destroying the original CoreData and Dissolve causes clears these values out and allows the second pass to run properly.