### PR TITLE
Empty Expressions

### DIFF
--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -129,9 +129,6 @@ std::shared_ptr<ExpressionNode> Expression::rootNode() { return rootNode_; }
 // Execute expression
 std::optional<ExpressionValue> Expression::evaluate() const
 {
-    if (rootNode_)
-        return rootNode_->evaluate();
-
     // If there is no rootNode_ (i.e. expression) this is valid, and we just return an empty value
     if (!rootNode_)
         return ExpressionValue();

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -132,7 +132,11 @@ std::optional<ExpressionValue> Expression::evaluate() const
     if (rootNode_)
         return rootNode_->evaluate();
 
-    return ExpressionValue();
+    // If there is no rootNode_ (i.e. expression) this is valid, and we just return an empty value
+    if (!rootNode_)
+        return ExpressionValue();
+
+    return rootNode_->evaluate();
 }
 
 // Execute and return as integer

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -132,7 +132,7 @@ std::optional<ExpressionValue> Expression::evaluate() const
     if (rootNode_)
         return rootNode_->evaluate();
 
-    return std::nullopt;
+    return ExpressionValue();
 }
 
 // Execute and return as integer


### PR DESCRIPTION
This super simple PR modifies expression evaluation to return a default `ExpressionValue` (0) on an empty expression. This prevents crashes from occurring when calling `NodeValue::asInteger/asDouble` with empty expressions, which particularly occurs when not using a `Configuration` of fixed density. Closes #1638.