### PR TITLE
Species Viewer Context Menu

### DIFF
--- a/src/gui/importLigParGenDialogFuncs.cpp
+++ b/src/gui/importLigParGenDialogFuncs.cpp
@@ -23,6 +23,9 @@ ImportLigParGenDialog::ImportLigParGenDialog(QWidget *parent, Dissolve &dissolve
     // Set model for the atom type list
     ui_.AtomTypeList->setModel(&atomTypeModel_);
 
+    // Hide site actions in the SpeciesViewer
+    ui_.SpeciesView->setSiteActionsVisible(false);
+
     // Register pages with the wizard
     registerPage(ImportLigParGenDialog::SelectFilesPage, "Choose XML and/or XYZ Files");
     registerPage(ImportLigParGenDialog::PreviewSpeciesPage, "Imported Coordinates");

--- a/src/gui/speciesViewer.hui
+++ b/src/gui/speciesViewer.hui
@@ -112,6 +112,8 @@ class SpeciesViewer : public BaseViewer
     SpeciesSite *site_;
     // Sites are visible
     bool sitesVisible_;
+    // Site management menu actions are visible in the context menu
+    bool siteActionsVisible_{true};
 
     public:
     // Set target Species
@@ -124,6 +126,8 @@ class SpeciesViewer : public BaseViewer
     SpeciesSite *speciesSite() const;
     // Toggle site visibility
     void setSiteVisible(bool visible);
+    // Toggle visibility of site management menu actions in the context menu
+    void setSiteActionsVisible(bool visible);
 
     /*
      * Renderable

--- a/src/gui/speciesViewer_input.cpp
+++ b/src/gui/speciesViewer_input.cpp
@@ -106,6 +106,9 @@ void SpeciesViewer::mouseMoved(int dx, int dy)
         postRedisplay();
 }
 
+// Toggle visibility of site management menu actions in the context menu
+void SpeciesViewer::setSiteActionsVisible(bool visible) { siteActionsVisible_ = visible; }
+
 // Context menu requested
 void SpeciesViewer::contextMenuRequested(QPoint pos)
 {
@@ -145,6 +148,7 @@ void SpeciesViewer::contextMenuRequested(QPoint pos)
         actionMap[createSiteMenu->addAction("Atom Types")] = "CreateDynamicAtomTypes";
         actionMap[createSiteMenu->addAction("Empty Fragment String")] = "CreateFragment";
         createSiteMenu->setEnabled(nSelected > 0);
+        createSiteMenu->menuAction()->setVisible(siteActionsVisible_);
 
         auto *modifySiteMenu = menu.addMenu("Modify current site...");
         modifySiteMenu->setFont(font());
@@ -165,6 +169,7 @@ void SpeciesViewer::contextMenuRequested(QPoint pos)
                 modifySiteMenu->setEnabled(false);
         }
         modifySiteMenu->setEnabled(sitesVisible_);
+        modifySiteMenu->menuAction()->setVisible(siteActionsVisible_);
 
         // Set menu (only if DissolveWindow is set)
         if (dissolveWindow_)

--- a/src/modules/avgMol/gui/avgMolWidgetFuncs.cpp
+++ b/src/modules/avgMol/gui/avgMolWidgetFuncs.cpp
@@ -15,5 +15,8 @@ AvgMolModuleWidget::AvgMolModuleWidget(QWidget *parent, AvgMolModule *module, Di
 
     ui_.SpeciesView->setSpecies(&module_->averageSpecies());
 
+    // Hide site actions in the SpeciesViewer
+    ui_.SpeciesView->setSiteActionsVisible(false);
+
     refreshing_ = false;
 }


### PR DESCRIPTION
Small PR that updates the `SpeciesViewer` to toggle visibility of site-related actions in its context menu. These actions are then hidden in the `SpeciesViewers` associated with the `AvgMol` module widget and the `ImportLigParGenDialog` respectively.

Closes #1641.