### PR TITLE
Add Qt Designer to DevShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -230,11 +230,11 @@
         "nixpkgs": "nixpkgs_6"
       },
       "locked": {
-        "lastModified": 1680528871,
-        "narHash": "sha256-DPb7Z638N94c/4/cXzSx8BdxnxTPFj+QxA7tWIVaBZ4=",
+        "lastModified": 1686232008,
+        "narHash": "sha256-Z//2vkJYSU1/iCTnAnBeg4tOXWtsx5tsEnnS3y/qSM0=",
         "owner": "disorderedmaterials",
         "repo": "qt-idaaas",
-        "rev": "3fb484d010b4efa7aa591e914cb990ba8704ba46",
+        "rev": "99e40b7906cc1944d222a7f81c93280a4beb499d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,7 @@
               gdb
               gtk3
               openmpi
+              qt-idaaas.packages.${system}.qttools
               tbb
               valgrind
               ((import ./nix/weggli.nix) {


### PR DESCRIPTION
The qt-idaaas repo already had support for `qttools`, but we never updated the dependency in Dissolve because, well, we didn't need it.  We need it now, so I've updated the lock file to point to the latest version.

I've also gone ahead and put qttools in the dev shell, so Qt Designer will be available jsut just running `designer`

Closes #1643.