### PR TITLE
1505 Generalise Parameter Access

### DIFF
--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -154,7 +154,7 @@ antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext
     // Check local variables first
     const std::vector<std::shared_ptr<ExpressionVariable>> &localVars = *localVariables_;
     auto it = std::find_if(localVars.begin(), localVars.end(),
-                           [ctx](auto var) { return DissolveSys::sameString(var->name(), ctx->Name()->getText()); });
+                           [ctx](auto var) { return DissolveSys::sameString(var->baseName(), ctx->Name()->getText()); });
     if (it == localVars.end())
     {
         // Do we have any external variables available?
@@ -165,7 +165,7 @@ antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext
         // Does the named variable exist?
         const std::vector<std::shared_ptr<ExpressionVariable>> &extVars = *externalVariables_;
         it = std::find_if(extVars.begin(), extVars.end(),
-                          [ctx](auto var) { return DissolveSys::sameString(var->name(), ctx->Name()->getText()); });
+                          [ctx](auto var) { return DissolveSys::sameString(var->baseName(), ctx->Name()->getText()); });
         if (it == extVars.end())
             throw(ExpressionExceptions::ExpressionSemanticException(
                 fmt::format("Variable '{}' does not exist in this context.\n", ctx->Name()->getText())));

--- a/src/expression/ExpressionVisitor.cpp
+++ b/src/expression/ExpressionVisitor.cpp
@@ -165,7 +165,7 @@ antlrcpp::Any ExpressionVisitor::visitVariable(ExpressionParser::VariableContext
         // Does the named variable exist?
         const std::vector<std::shared_ptr<ExpressionVariable>> &extVars = *externalVariables_;
         it = std::find_if(extVars.begin(), extVars.end(),
-                          [ctx](auto var) { return DissolveSys::sameString(var->baseName(), ctx->Name()->getText()); });
+                          [ctx](auto var) { return DissolveSys::sameString(var->name(), ctx->Name()->getText()); });
         if (it == extVars.end())
             throw(ExpressionExceptions::ExpressionSemanticException(
                 fmt::format("Variable '{}' does not exist in this context.\n", ctx->Name()->getText())));

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -34,7 +34,8 @@ void Expression::operator=(const Expression &source)
 std::shared_ptr<ExpressionVariable> Expression::addLocalVariable(std::string_view name)
 {
     if (std::find_if(localVariables_.begin(), localVariables_.end(),
-                     [name](const auto &var) { return DissolveSys::sameString(name, var->name()); }) != localVariables_.end())
+                     [name](const auto &var)
+                     { return DissolveSys::sameString(name, var->baseName()); }) != localVariables_.end())
         throw(std::runtime_error(
             fmt::format("Tried to create local variable '{}' in Expression, but it already exists.\n", name)));
 

--- a/src/expression/reference.cpp
+++ b/src/expression/reference.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "expression/reference.h"
-
 #include "expression/variable.h"
 #include <utility>
 

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -9,16 +9,44 @@ ExpressionVariable::ExpressionVariable(const ExpressionValue &value)
 {
     // Private variables
     static int count = 0;
+    baseName_ = fmt::format("_ExpressionVariable{:02d}", count++);
     name_ = fmt::format("_ExpressionVariable{:02d}", count++);
     value_ = value;
 }
 
-ExpressionVariable::ExpressionVariable(std::string_view name, const ExpressionValue &value) : name_(name), value_(value) {}
+ExpressionVariable::ExpressionVariable(std::string_view name, const ExpressionValue &value)
+    : baseName_(name), name_(name), value_(value)
+{
+}
+
+// Update full name
+void ExpressionVariable::updateName()
+{
+    constexpr std::string_view separator = ".";
+    if (namePrefix_.empty())
+        name_ = baseName_;
+    else
+        name_ = fmt::format("{}{}{}", namePrefix_, separator, baseName_);
+}
 
 // Set name of variable
-void ExpressionVariable::setName(std::string_view s) { name_ = s; }
+void ExpressionVariable::setBaseName(std::string_view s)
+{
+    baseName_ = s;
+    updateName();
+}
 
-// Get name of variable
+// Return base name of the variable
+std::string_view ExpressionVariable::baseName() const { return baseName_; }
+
+// Set prefix to prepend to the base name
+void ExpressionVariable::setNamePrefix(std::string_view s)
+{
+    namePrefix_ = s;
+    updateName();
+}
+
+// Get full name of variable
 std::string_view ExpressionVariable::name() const { return name_; }
 
 // Set value
@@ -31,11 +59,11 @@ const ExpressionValue &ExpressionVariable::value() const { return value_; }
 ExpressionValue *ExpressionVariable::valuePointer() { return &value_; }
 
 // Express as a serialisable value
-SerialisedValue ExpressionVariable::serialise() const { return {{"name", name_}, {"value", value_}}; }
+SerialisedValue ExpressionVariable::serialise() const { return {{"name", baseName_}, {"value", value_}}; }
 
 // Read values from a serialisable value
 void ExpressionVariable::deserialise(const SerialisedValue &node)
 {
     value_ = toml::find<ExpressionValue>(node, "value");
-    setName(toml::find<std::string>(node, "name"));
+    setBaseName(toml::find<std::string>(node, "name"));
 }

--- a/src/expression/variable.h
+++ b/src/expression/variable.h
@@ -10,22 +10,34 @@ class ExpressionVariable : public Serialisable<>
 {
     public:
     ExpressionVariable(const ExpressionValue &value = ExpressionValue());
-    ExpressionVariable(std::string_view name, const ExpressionValue &value = ExpressionValue());
+    ExpressionVariable(std::string_view baseName, const ExpressionValue &value = ExpressionValue());
     ~ExpressionVariable() = default;
 
     /*
      * Variable Data
      */
+    private:
+    // Update full name
+    void updateName();
+
     protected:
-    // Name of the variable
+    // Base name of the variable (without any prefix)
+    std::string baseName_;
+    // Optional prefix to prepend to the base name in order to get the full variable name
+    std::string namePrefix_;
+    // Full name of the variable
     std::string name_;
     // Value of variable
     ExpressionValue value_;
 
     public:
-    // Set name of variable
-    void setName(std::string_view s);
-    // Get name of variable
+    // Set base name of the variable
+    void setBaseName(std::string_view s);
+    // Return base name of the variable
+    std::string_view baseName() const;
+    // Set prefix to prepend to the base name
+    void setNamePrefix(std::string_view s);
+    // Get full name of variable
     std::string_view name() const;
     // Set value
     void setValue(const ExpressionValue &value);

--- a/src/gui/models/expressionVariableVectorModel.cpp
+++ b/src/gui/models/expressionVariableVectorModel.cpp
@@ -76,7 +76,7 @@ QVariant ExpressionVariableVectorModel::data(const QModelIndex &index, int role)
     {
         // Name
         case 0:
-            return QString::fromStdString(std::string(var->name()));
+            return QString::fromStdString(std::string(var->baseName()));
         case 1:
             return var->value().type() == ExpressionValue::ValueType::Integer ? "Int" : "Real";
         case 2:
@@ -101,7 +101,7 @@ bool ExpressionVariableVectorModel::setData(const QModelIndex &index, const QVar
         auto p = parentNode_->getParameter(value.toString().toStdString(), true);
         if (p && p != var)
             return false;
-        var->setName(value.toString().toStdString());
+        var->setBaseName(value.toString().toStdString());
     }
     else if (index.column() == 2)
     {
@@ -117,7 +117,7 @@ bool ExpressionVariableVectorModel::setData(const QModelIndex &index, const QVar
         }
         else
             return Messenger::error("Value '{}' provided for variable '{}' doesn't appear to be a number.\n", varValue,
-                                    var->name());
+                                    var->baseName());
     }
 
     emit dataChanged(index, index);

--- a/src/procedure/nodes/calculateAxisAngle.cpp
+++ b/src/procedure/nodes/calculateAxisAngle.cpp
@@ -33,20 +33,7 @@ CalculateAxisAngleProcedureNode::CalculateAxisAngleProcedureNode(std::shared_ptr
         "Symmetric", "Whether to consider angles as symmetric about 90, mapping all angles to the range 0 - 90", symmetric_);
 
     // Create parameters
-    angleParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("theta"));
-}
-
-/*
- * Identity
- */
-
-// Set node name
-void CalculateAxisAngleProcedureNode::setName(std::string_view name)
-{
-    name_ = DissolveSys::niceName(name);
-
-    // Update parameter names to match
-    angleParameter_->setBaseName(fmt::format("{}.theta", name_));
+    angleParameter_ = addParameter("theta");
 }
 
 /*

--- a/src/procedure/nodes/calculateAxisAngle.cpp
+++ b/src/procedure/nodes/calculateAxisAngle.cpp
@@ -46,29 +46,7 @@ void CalculateAxisAngleProcedureNode::setName(std::string_view name)
     name_ = DissolveSys::niceName(name);
 
     // Update parameter names to match
-    angleParameter_->setName(fmt::format("{}.theta", name_));
-}
-
-/*
- * Parameters
- */
-
-// Return the named parameter (if it exists)
-std::shared_ptr<ExpressionVariable>
-CalculateAxisAngleProcedureNode::getParameter(std::string_view name, std::shared_ptr<ExpressionVariable> excludeParameter)
-{
-    for (auto var : parameters_)
-        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
-            return var;
-
-    return nullptr;
-}
-
-// Return vector of all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>>
-CalculateAxisAngleProcedureNode::parameters() const
-{
-    return parameters_;
+    angleParameter_->setBaseName(fmt::format("{}.theta", name_));
 }
 
 /*

--- a/src/procedure/nodes/calculateAxisAngle.h
+++ b/src/procedure/nodes/calculateAxisAngle.h
@@ -30,17 +30,8 @@ class CalculateAxisAngleProcedureNode : public CalculateProcedureNodeBase
      * Parameters
      */
     private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> angleParameter_;
-
-    public:
-    // Return the named parameter (if it exists)
-    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
-                                                     std::shared_ptr<ExpressionVariable> excludeParameter) override;
-    // Return vector of all parameters for this node
-    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
 
     /*
      * Data

--- a/src/procedure/nodes/calculateAxisAngle.h
+++ b/src/procedure/nodes/calculateAxisAngle.h
@@ -20,13 +20,6 @@ class CalculateAxisAngleProcedureNode : public CalculateProcedureNodeBase
     ~CalculateAxisAngleProcedureNode() override = default;
 
     /*
-     * Identity
-     */
-    public:
-    // Set node name
-    void setName(std::string_view name) override;
-
-    /*
      * Parameters
      */
     private:

--- a/src/procedure/nodes/ifValueInRange.cpp
+++ b/src/procedure/nodes/ifValueInRange.cpp
@@ -30,27 +30,6 @@ IfValueInRangeProcedureNode::IfValueInRangeProcedureNode()
 bool IfValueInRangeProcedureNode::mustBeNamed() const { return false; }
 
 /*
- * Parameters
- */
-
-// Return the named parameter (if it exists)
-std::shared_ptr<ExpressionVariable>
-IfValueInRangeProcedureNode::getParameter(std::string_view name, std::shared_ptr<ExpressionVariable> excludeParameter)
-{
-    for (auto var : parameters_)
-        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
-            return var;
-
-    return nullptr;
-}
-
-// Return vector of all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> IfValueInRangeProcedureNode::parameters() const
-{
-    return parameters_;
-}
-
-/*
  * Branch
  */
 

--- a/src/procedure/nodes/ifValueInRange.h
+++ b/src/procedure/nodes/ifValueInRange.h
@@ -30,8 +30,6 @@ class IfValueInRangeProcedureNode : public ProcedureNode
     std::shared_ptr<ExpressionVariable> currentValueParameter_;
 
     public:
-    // Add new parameter
-    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
     // Return the named parameter (if it exists)
     std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                      std::shared_ptr<ExpressionVariable> excludeParameter) override;

--- a/src/procedure/nodes/ifValueInRange.h
+++ b/src/procedure/nodes/ifValueInRange.h
@@ -26,8 +26,6 @@ class IfValueInRangeProcedureNode : public ProcedureNode
      * Parameters
      */
     private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> currentValueParameter_;
 

--- a/src/procedure/nodes/ifValueInRange.h
+++ b/src/procedure/nodes/ifValueInRange.h
@@ -29,13 +29,6 @@ class IfValueInRangeProcedureNode : public ProcedureNode
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> currentValueParameter_;
 
-    public:
-    // Return the named parameter (if it exists)
-    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
-                                                     std::shared_ptr<ExpressionVariable> excludeParameter) override;
-    // Return vector of all parameters for this node
-    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
-
     /*
      * Value & Acceptable Range
      */

--- a/src/procedure/nodes/iterateData1D.cpp
+++ b/src/procedure/nodes/iterateData1D.cpp
@@ -61,15 +61,6 @@ void IterateData1DProcedureNode::setName(std::string_view name)
 }
 
 /*
- *Parameters
- */
-// Return vector of all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> IterateData1DProcedureNode::parameters() const
-{
-    return parameters_;
-}
-
-/*
  * Branch
  */
 // Return the branch from this node (if it has one)

--- a/src/procedure/nodes/iterateData1D.cpp
+++ b/src/procedure/nodes/iterateData1D.cpp
@@ -42,22 +42,8 @@ void IterateData1DProcedureNode::setUpKeywords()
         ProcedureNode::NodeType::IntegerCollect1D, false);
     keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_);
 
-    xParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("x"));
-    valueParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("value"));
-}
-
-/*
- * Identity
- */
-
-// Set node name
-void IterateData1DProcedureNode::setName(std::string_view name)
-{
-    name_ = DissolveSys::niceName(name);
-
-    // Update parameter names to match
-    xParameter_->setBaseName(fmt::format("{}.x", name_));
-    valueParameter_->setBaseName(fmt::format("{}.value", name_));
+    xParameter_ = addParameter("x");
+    valueParameter_ = addParameter("value");
 }
 
 /*

--- a/src/procedure/nodes/iterateData1D.cpp
+++ b/src/procedure/nodes/iterateData1D.cpp
@@ -56,8 +56,8 @@ void IterateData1DProcedureNode::setName(std::string_view name)
     name_ = DissolveSys::niceName(name);
 
     // Update parameter names to match
-    xParameter_->setName(fmt::format("{}.x", name_));
-    valueParameter_->setName(fmt::format("{}.value", name_));
+    xParameter_->setBaseName(fmt::format("{}.x", name_));
+    valueParameter_->setBaseName(fmt::format("{}.value", name_));
 }
 
 /*

--- a/src/procedure/nodes/iterateData1D.h
+++ b/src/procedure/nodes/iterateData1D.h
@@ -28,13 +28,6 @@ class IterateData1DProcedureNode : public ProcedureNode
     void setUpKeywords();
 
     /*
-     * Identity
-     */
-    public:
-    // Set node name
-    void setName(std::string_view name) override;
-
-    /*
      * Data
      */
     private:

--- a/src/procedure/nodes/iterateData1D.h
+++ b/src/procedure/nodes/iterateData1D.h
@@ -47,8 +47,6 @@ class IterateData1DProcedureNode : public ProcedureNode
      * Parameters
      */
     private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> xParameter_, valueParameter_;
 

--- a/src/procedure/nodes/iterateData1D.h
+++ b/src/procedure/nodes/iterateData1D.h
@@ -50,10 +50,6 @@ class IterateData1DProcedureNode : public ProcedureNode
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> xParameter_, valueParameter_;
 
-    public:
-    // Return vector of all parameters for this node
-    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
-
     /*
      * Branch
      */

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -25,26 +25,10 @@ IterateSelectionProcedureNode::IterateSelectionProcedureNode(ProcedureNode::Node
     keywords_.add<NodeKeyword<SelectProcedureNode>>("Selection", "Target selection to iterate over", selection_, this,
                                                     ProcedureNode::NodeType::Select, true);
 
-    nSelectedParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("nSelected"));
-    siteIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("siteIndex"));
-    stackIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("stackIndex"));
-    indexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("index"));
-}
-
-/*
- * Identity
- */
-
-// Set node name
-void IterateSelectionProcedureNode::setName(std::string_view name)
-{
-    name_ = DissolveSys::niceName(name);
-
-    // Update parameter names to match
-    nSelectedParameter_->setBaseName(fmt::format("{}.nSelected", name_));
-    siteIndexParameter_->setBaseName(fmt::format("{}.siteIndex", name_));
-    stackIndexParameter_->setBaseName(fmt::format("{}.stackIndex", name_));
-    indexParameter_->setBaseName(fmt::format("{}.index", name_));
+    nSelectedParameter_ = addParameter("nSelected");
+    siteIndexParameter_ = addParameter("siteIndex");
+    stackIndexParameter_ = addParameter("stackIndex");
+    indexParameter_ = addParameter("index");
 }
 
 /*

--- a/src/procedure/nodes/iterateSelection.cpp
+++ b/src/procedure/nodes/iterateSelection.cpp
@@ -41,10 +41,10 @@ void IterateSelectionProcedureNode::setName(std::string_view name)
     name_ = DissolveSys::niceName(name);
 
     // Update parameter names to match
-    nSelectedParameter_->setName(fmt::format("{}.nSelected", name_));
-    siteIndexParameter_->setName(fmt::format("{}.siteIndex", name_));
-    stackIndexParameter_->setName(fmt::format("{}.stackIndex", name_));
-    indexParameter_->setName(fmt::format("{}.index", name_));
+    nSelectedParameter_->setBaseName(fmt::format("{}.nSelected", name_));
+    siteIndexParameter_->setBaseName(fmt::format("{}.siteIndex", name_));
+    stackIndexParameter_->setBaseName(fmt::format("{}.stackIndex", name_));
+    indexParameter_->setBaseName(fmt::format("{}.index", name_));
 }
 
 /*

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -33,8 +33,6 @@ class IterateSelectionProcedureNode : public ProcedureNode
      * Parameters
      */
     private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, stackIndexParameter_, indexParameter_;
     // Selection to iterate over

--- a/src/procedure/nodes/iterateSelection.h
+++ b/src/procedure/nodes/iterateSelection.h
@@ -23,13 +23,6 @@ class IterateSelectionProcedureNode : public ProcedureNode
         ProcedureNode::NodeContext forEachContext = ProcedureNode::NodeContext::AnalysisContext);
 
     /*
-     * Identity
-     */
-    public:
-    // Set node name
-    void setName(std::string_view name) override;
-
-    /*
      * Parameters
      */
     private:

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -237,6 +237,12 @@ OptionalReferenceWrapper<ProcedureNodeSequence> ProcedureNode::branch() { return
  * Parameters
  */
 
+// Add new parameter
+std::shared_ptr<ExpressionVariable> ProcedureNode::addParameter(std::string_view name, ExpressionValue initialValue)
+{
+    return parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
+}
+
 // Set named parameter in supplied vector
 bool ProcedureNode::setParameter(std::vector<std::shared_ptr<ExpressionVariable>> &parameters, std::string_view parameter,
                                  ExpressionValue value)
@@ -255,14 +261,15 @@ bool ProcedureNode::setParameter(std::vector<std::shared_ptr<ExpressionVariable>
 std::shared_ptr<ExpressionVariable> ProcedureNode::getParameter(std::string_view name,
                                                                 std::shared_ptr<ExpressionVariable> excludeParameter)
 {
+    for (auto var : parameters_)
+        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
+            return var;
+
     return nullptr;
 }
 
 // Return references to all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> ProcedureNode::parameters() const
-{
-    return std::nullopt;
-}
+const std::vector<std::shared_ptr<ExpressionVariable>> &ProcedureNode::parameters() const { return parameters_; }
 
 /*
  * Execution

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -135,7 +135,15 @@ ProcedureNode::NodeClass ProcedureNode::nodeClass() const { return class_; }
 bool ProcedureNode::mustBeNamed() const { return true; }
 
 // Set node name
-void ProcedureNode::setName(std::string_view name) { name_ = DissolveSys::niceName(name); }
+void ProcedureNode::setName(std::string_view name)
+{
+    name_ = DissolveSys::niceName(name);
+
+    // Re-set prefixes with the new node name, except if this is a Parameters-type node
+    if (type_ != ProcedureNode::NodeType::Parameters)
+        for (auto &par : parameters_)
+            par->setNamePrefix(name_);
+}
 
 // Return node name
 std::string_view ProcedureNode::name() const { return name_; }
@@ -240,7 +248,10 @@ OptionalReferenceWrapper<ProcedureNodeSequence> ProcedureNode::branch() { return
 // Add new parameter
 std::shared_ptr<ExpressionVariable> ProcedureNode::addParameter(std::string_view name, const ExpressionValue &initialValue)
 {
-    return parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
+    auto &newVar = parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
+    if (type_ != ProcedureNode::NodeType::Parameters)
+        newVar->setNamePrefix(name_);
+    return newVar;
 }
 
 // Set named parameter in supplied vector

--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -238,7 +238,7 @@ OptionalReferenceWrapper<ProcedureNodeSequence> ProcedureNode::branch() { return
  */
 
 // Add new parameter
-std::shared_ptr<ExpressionVariable> ProcedureNode::addParameter(std::string_view name, ExpressionValue initialValue)
+std::shared_ptr<ExpressionVariable> ProcedureNode::addParameter(std::string_view name, const ExpressionValue &initialValue)
 {
     return parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
 }

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -132,7 +132,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
     // Return whether a name for the node must be provided
     virtual bool mustBeNamed() const;
     // Set node name
-    virtual void setName(std::string_view name);
+    void setName(std::string_view name);
     // Return node name
     std::string_view name() const;
 

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -196,7 +196,7 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
 
     public:
     // Add new parameter
-    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
+    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, const ExpressionValue &initialValue = {});
     // Return the named parameter (if it exists)
     std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
                                                      std::shared_ptr<ExpressionVariable> excludeParameter = nullptr);

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -188,6 +188,8 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
      * Parameters
      */
     protected:
+    // Defined parameters
+    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Set named parameter in supplied vector
     bool setParameter(std::vector<std::shared_ptr<ExpressionVariable>> &parameters, std::string_view parameter,
                       ExpressionValue value);

--- a/src/procedure/nodes/node.h
+++ b/src/procedure/nodes/node.h
@@ -195,11 +195,13 @@ class ProcedureNode : public std::enable_shared_from_this<ProcedureNode>, public
                       ExpressionValue value);
 
     public:
+    // Add new parameter
+    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
     // Return the named parameter (if it exists)
-    virtual std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
-                                                             std::shared_ptr<ExpressionVariable> excludeParameter = nullptr);
+    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
+                                                     std::shared_ptr<ExpressionVariable> excludeParameter = nullptr);
     // Return references to all parameters for this node
-    virtual OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const;
+    const std::vector<std::shared_ptr<ExpressionVariable>> &parameters() const;
 
     /*
      * Execution

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -38,7 +38,7 @@ SerialisedValue ParametersProcedureNode::serialise() const
 {
     SerialisedValue result;
     for (auto &param : parameters_)
-        result[std::string(param->name())] = param->value();
+        result[std::string(param->baseName())] = param->value();
     return result;
 }
 

--- a/src/procedure/nodes/parameters.cpp
+++ b/src/procedure/nodes/parameters.cpp
@@ -20,33 +20,6 @@ ParametersProcedureNode::ParametersProcedureNode()
 bool ParametersProcedureNode::mustBeNamed() const { return false; }
 
 /*
- * Parameters
- */
-
-// Add new parameter
-std::shared_ptr<ExpressionVariable> ParametersProcedureNode::addParameter(std::string_view name, ExpressionValue initialValue)
-{
-    return parameters_.emplace_back(std::make_shared<ExpressionVariable>(name, initialValue));
-}
-
-// Return the named parameter (if it exists)
-std::shared_ptr<ExpressionVariable> ParametersProcedureNode::getParameter(std::string_view name,
-                                                                          std::shared_ptr<ExpressionVariable> excludeParameter)
-{
-    for (auto var : parameters_)
-        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
-            return var;
-
-    return nullptr;
-}
-
-// Return vector of all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> ParametersProcedureNode::parameters() const
-{
-    return parameters_;
-}
-
-/*
  * Execute
  */
 
@@ -55,6 +28,10 @@ bool ParametersProcedureNode::prepare(const ProcedureContext &procedureContext) 
 
 // Execute node
 bool ParametersProcedureNode::execute(const ProcedureContext &procedureContext) { return true; }
+
+/*
+ * I/O
+ */
 
 // Express as a serialisable value
 SerialisedValue ParametersProcedureNode::serialise() const

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -26,10 +26,6 @@ class ParametersProcedureNode : public ProcedureNode
     /*
      * Parameters
      */
-    private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
-
     public:
     // Add new parameter
     std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);

--- a/src/procedure/nodes/parameters.h
+++ b/src/procedure/nodes/parameters.h
@@ -24,22 +24,6 @@ class ParametersProcedureNode : public ProcedureNode
     bool mustBeNamed() const override;
 
     /*
-     * Parameters
-     */
-    public:
-    // Add new parameter
-    std::shared_ptr<ExpressionVariable> addParameter(std::string_view name, ExpressionValue initialValue);
-    // Return the named parameter (if it exists)
-    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
-                                                     std::shared_ptr<ExpressionVariable> excludeParameter) override;
-    // Return vector of all parameters for this node
-    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
-    // Express as a serialisable value
-    SerialisedValue serialise() const override;
-    // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
-
-    /*
      * Execute
      */
     public:
@@ -47,4 +31,13 @@ class ParametersProcedureNode : public ProcedureNode
     bool prepare(const ProcedureContext &procedureContext) override;
     // Execute node
     bool execute(const ProcedureContext &procedureContext) override;
+
+    /*
+     * I/O
+     */
+    public:
+    // Express as a serialisable value
+    SerialisedValue serialise() const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -70,27 +70,6 @@ void SelectProcedureNode::setName(std::string_view name)
 }
 
 /*
- * Parameters
- */
-
-// Return the named parameter (if it exists)
-std::shared_ptr<ExpressionVariable> SelectProcedureNode::getParameter(std::string_view name,
-                                                                      std::shared_ptr<ExpressionVariable> excludeParameter)
-{
-    for (auto var : parameters_)
-        if ((var != excludeParameter) && (DissolveSys::sameString(var->name(), name)))
-            return var;
-
-    return nullptr;
-}
-
-// Return vector of all parameters for this node
-OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> SelectProcedureNode::parameters() const
-{
-    return parameters_;
-}
-
-/*
  * Selection Targets
  */
 

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -47,26 +47,12 @@ SelectProcedureNode::SelectProcedureNode(std::vector<const SpeciesSite *> sites,
 
     keywords_.addHidden<NodeBranchKeyword>("ForEach", "Branch to run on each site selected", forEachBranch_);
 
-    nSelectedParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("nSelected"));
-    siteIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("siteIndex"));
-    stackIndexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("stackIndex"));
-    indexParameter_ = parameters_.emplace_back(std::make_shared<ExpressionVariable>("index"));
-}
-
-/*
- * Identity
- */
-
-// Set node name
-void SelectProcedureNode::setName(std::string_view name)
-{
-    name_ = DissolveSys::niceName(name);
-
-    // Update parameter names to match
-    nSelectedParameter_->setBaseName(fmt::format("{}.nSelected", name_));
-    siteIndexParameter_->setBaseName(fmt::format("{}.siteIndex", name_));
-    stackIndexParameter_->setBaseName(fmt::format("{}.stackIndex", name_));
-    indexParameter_->setBaseName(fmt::format("{}.index", name_));
+    // Need to make parameters_ private as a next step, to prevent direct initialisation like this... (use addParameter()
+    // instead)
+    nSelectedParameter_ = addParameter("nSelected");
+    siteIndexParameter_ = addParameter("siteIndex");
+    stackIndexParameter_ = addParameter("stackIndex");
+    indexParameter_ = addParameter("index");
 }
 
 /*

--- a/src/procedure/nodes/select.cpp
+++ b/src/procedure/nodes/select.cpp
@@ -63,10 +63,10 @@ void SelectProcedureNode::setName(std::string_view name)
     name_ = DissolveSys::niceName(name);
 
     // Update parameter names to match
-    nSelectedParameter_->setName(fmt::format("{}.nSelected", name_));
-    siteIndexParameter_->setName(fmt::format("{}.siteIndex", name_));
-    stackIndexParameter_->setName(fmt::format("{}.stackIndex", name_));
-    indexParameter_->setName(fmt::format("{}.index", name_));
+    nSelectedParameter_->setBaseName(fmt::format("{}.nSelected", name_));
+    siteIndexParameter_->setBaseName(fmt::format("{}.siteIndex", name_));
+    stackIndexParameter_->setBaseName(fmt::format("{}.stackIndex", name_));
+    indexParameter_->setBaseName(fmt::format("{}.index", name_));
 }
 
 /*

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -24,13 +24,6 @@ class SelectProcedureNode : public ProcedureNode
                                  bool axesRequired = false);
 
     /*
-     * Identity
-     */
-    public:
-    // Set node name
-    void setName(std::string_view name) override;
-
-    /*
      * Parameters
      */
     private:

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -34,8 +34,6 @@ class SelectProcedureNode : public ProcedureNode
      * Parameters
      */
     private:
-    // Defined parameters
-    std::vector<std::shared_ptr<ExpressionVariable>> parameters_;
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, stackIndexParameter_, indexParameter_;
 

--- a/src/procedure/nodes/select.h
+++ b/src/procedure/nodes/select.h
@@ -37,13 +37,6 @@ class SelectProcedureNode : public ProcedureNode
     // Pointers to individual parameters
     std::shared_ptr<ExpressionVariable> nSelectedParameter_, siteIndexParameter_, stackIndexParameter_, indexParameter_;
 
-    public:
-    // Return the named parameter (if it exists)
-    std::shared_ptr<ExpressionVariable> getParameter(std::string_view name,
-                                                     std::shared_ptr<ExpressionVariable> excludeParameter) override;
-    // Return vector of all parameters for this node
-    OptionalReferenceWrapper<const std::vector<std::shared_ptr<ExpressionVariable>>> parameters() const override;
-
     /*
      * Selection Targets
      */

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -337,12 +337,7 @@ std::vector<std::shared_ptr<ExpressionVariable>> ProcedureNodeSequence::paramete
     // Start from the target node and work backwards...
     for (const auto &node : range)
     {
-        auto optOtherParams = node->parameters();
-        if (optOtherParams)
-        {
-            const std::vector<std::shared_ptr<ExpressionVariable>> otherParams = (*optOtherParams);
-            parameters.insert(parameters.end(), otherParams.begin(), otherParams.end());
-        }
+        parameters.insert(parameters.end(), node->parameters().begin(), node->parameters().end());
     }
 
     // Recursively check our owner


### PR DESCRIPTION
This PR simplifies parameter (`ExpressionVariable`) creation, storage, and handling, moving it all to the `ProcedureNode` base class rather than requiring override functions in any node type that required to use them.

To handle the automatic prefixing of `ExpressionVariables` in the `parameters_` vector with the node's name (necessitating keeping a record of the original name), a couple of approaches were initially tried and discounted:
1) Modifying the storage of `parameters_` from `std::vector<std::shared_ptr<ExpressionVariable>>` to `std::vector<std::pair<std::shared_ptr<ExpressionVariable>,std::string>>` with the string component storing the original, base name of the variable for reference - this has the effect of "polluting" a lot of other routines using the parameters, and so was abandoned.
2) Determining the original basename of the variable by searching the string for the last `.` (if it existed). However this didn't feel particularly robust and required other routines to determine whether or not a prefix existed.

So, the preferred solution in the end was to extend `ExpressionVariable` to keep track of both it's original name _and_ any applied prefix. This way, impact on the rest of the code is kept to a minimum.

Closes #1505.