### PR TITLE
Conan & Benchmarks Workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -30,7 +30,7 @@ jobs:
         - name: Install Conan
           run: |
             sudo pip3 install wheel
-            sudo pip3 install conan==1.58
+            sudo pip3 install conan==1.60
         - name: Retrieve ANTLR4 Java
           run: |
             wget https://www.antlr.org/download/antlr-4.9.3-complete.jar -O antlr4.jar

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - '*'
     paths-ignore:
-    - '.github/workflows/benchmarks.yml'
+    - '.github/workflows/benchmark.yml'
     - '.github/workflows/cacheConan.yml'
     - '.github/workflows/cacheNix.yml'
     - '.github/workflows/continuous.yml'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches:
     - 'release/*'
     paths-ignore:
-    - '.github/workflows/benchmarks.yml'
+    - '.github/workflows/benchmark.yml'
     - '.github/workflows/cacheConan.yml'
     - '.github/workflows/cacheNix.yml'
     - '.github/workflows/pr.yml'


### PR DESCRIPTION
This PR fixes the benchmarks workflow - essentially the version of Conan we had pinned (1.58) made the onetbb/2020.3 recipe fail. Updating to 1.60 fixes the issue.