### PR TITLE
1600 procedure model issues

### DIFF
--- a/src/gui/configurationTab.h
+++ b/src/gui/configurationTab.h
@@ -84,9 +84,7 @@ class ConfigurationTab : public QWidget, public MainTab
      * Signals / Slots
      */
     private slots:
-    // Generate
     void on_GenerateButton_clicked(bool checked);
-    // Density units changed
     void on_DensityUnitsCombo_currentIndexChanged(int index);
-    void buttonGroupToggled(QAbstractButton *button, bool checked);
+    void on_ConfigurationButtonGroup_buttonToggled(QAbstractButton *button, bool checked);
 };

--- a/src/gui/configurationTabFuncs.cpp
+++ b/src/gui/configurationTabFuncs.cpp
@@ -55,8 +55,6 @@ ConfigurationTab::ConfigurationTab(DissolveWindow *dissolveWindow, Dissolve &dis
 
     ui_.GlobalPotentialsFrame->setHidden(true);
     ui_.TargetedPotentialsFrame->setHidden(true);
-    connect(ui_.ConfigurationButtonGroup, SIGNAL(buttonToggled(QAbstractButton *, bool)), this,
-            SLOT(buttonGroupToggled(QAbstractButton *, bool)));
 }
 
 /*
@@ -212,11 +210,9 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     dissolveWindow_->updateStatusBar();
 }
 
-// Density units changed
 void ConfigurationTab::on_DensityUnitsCombo_currentIndexChanged(int index) { updateDensityLabel(); }
 
-// Button group toggled
-void ConfigurationTab::buttonGroupToggled(QAbstractButton *button, bool checked)
+void ConfigurationTab::on_ConfigurationButtonGroup_buttonToggled(QAbstractButton *button, bool checked)
 {
     if (button == ui_.GeneratorPushButton)
     {

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -474,7 +474,7 @@ QModelIndex ProcedureModel::appendNew(const QString &nodeTypeString)
     // Check the node type string is valid
     if (!ProcedureNode::nodeTypes().isValid(nodeTypeString.toStdString()))
         return {};
-    
+
     // Convert the node type string to its enumeration
     auto nodeType = ProcedureNode::nodeTypes().enumeration(nodeTypeString.toStdString());
     // Create a node of the node type

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -369,6 +369,7 @@ bool ProcedureModel::dropMimeData(const QMimeData *data, Qt::DropAction action, 
         auto mimeData = static_cast<const ProcedureModelMimeData *>(data);
         if (!mimeData)
             return false;
+
         // Retrieve the old node data
         auto optOldIndex = mimeData->nodeIndex();
         if (!optOldIndex)
@@ -470,6 +471,10 @@ bool ProcedureModel::removeRows(int row, int count, const QModelIndex &parent)
 
 QModelIndex ProcedureModel::appendNew(const QString &nodeTypeString)
 {
+    // Check the node type string is valid
+    if (!ProcedureNode::nodeTypes().isValid(nodeTypeString.toStdString()))
+        return {};
+    
     // Convert the node type string to its enumeration
     auto nodeType = ProcedureNode::nodeTypes().enumeration(nodeTypeString.toStdString());
     // Create a node of the node type

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -488,6 +488,10 @@ QModelIndex ProcedureModel::appendNew(const QString &nodeTypeString)
     // Get the parent scope, we know this is the root sequence, but use getScope for consistency
     auto scope = getScope(QModelIndex());
 
+    // Check if the node is relevant to the context of the scope
+    if (!node->isContextRelevant(scope->get().context()))
+        return {};
+
     // Get the target row for the new node
     auto insertAtRow = rowCount();
 

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -470,7 +470,7 @@ bool ProcedureModel::removeRows(int row, int count, const QModelIndex &parent)
 
     beginRemoveRows(parent, row, row + count - 1);
     for (auto i = 0; i < count; ++i)
-        scope->get().removeNode(data(index(row + i, 0), Qt::UserRole).value<std::shared_ptr<ProcedureNode>>());
+        scope->get().removeNode(data(index(row + i, 0, parent), Qt::UserRole).value<std::shared_ptr<ProcedureNode>>());
     endRemoveRows();
 
     emit(dataChanged(QModelIndex(), QModelIndex()));

--- a/src/gui/models/procedureModel.cpp
+++ b/src/gui/models/procedureModel.cpp
@@ -411,6 +411,9 @@ bool ProcedureModel::dropMimeData(const QMimeData *data, Qt::DropAction action, 
         oldScope.sequence().erase(oldScope.sequence().begin() + oldNodeRow);
         endRemoveRows();
 
+        beginResetModel();
+        endResetModel();
+
         // Set the new data - we call this just to emit dataChanged() from the correct place.
         auto idx = index(insertAtRow, 0, newParent);
         return setData(idx, QVariant::fromValue(mimeData->node()), ProcedureModelAction::MoveInternal);

--- a/src/gui/models/procedureModel.h
+++ b/src/gui/models/procedureModel.h
@@ -59,6 +59,7 @@ class ProcedureModel : public QAbstractItemModel
     bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &newParent) override;
     bool insertRows(int row, int count, const QModelIndex &parent) override;
     bool removeRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
+    QModelIndex appendNew(const QString &nodeTypeString);
 
     signals:
     void nodeNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);

--- a/src/gui/procedureWidgetFuncs.cpp
+++ b/src/gui/procedureWidgetFuncs.cpp
@@ -192,7 +192,7 @@ void ProcedureWidget::on_NodesTree_customContextMenuRequested(const QPoint &pos)
 
 void ProcedureWidget::on_AvailableNodesTree_doubleClicked(const QModelIndex &index)
 {
-    //    nodeLayerModel_.appendNew(nodePaletteModel_.data(index, Qt::DisplayRole).toString());
+    procedureModel_.appendNew(nodePaletteFilterProxy_.data(index, Qt::DisplayRole).toString());
 }
 
 // Delete the currently selected node, and its children

--- a/src/procedure/nodes/sequence.cpp
+++ b/src/procedure/nodes/sequence.cpp
@@ -78,19 +78,6 @@ int ProcedureNodeSequence::nNodes() const { return sequence_.size(); }
 // Return whether the sequence is empty
 bool ProcedureNodeSequence::empty() const { return sequence_.empty(); }
 
-// Remove a node
-bool ProcedureNodeSequence::removeNode(NodeRef node)
-{
-    // Find the node in the sequence
-    auto it = std::find_if(sequence_.begin(), sequence_.end(), [node](const auto &n) { return n.get() == node.get(); });
-    if (it != sequence_.end())
-    {
-        sequence_.erase(it);
-        return true;
-    }
-    return false;
-}
-
 /*
  * Scope
  */

--- a/src/procedure/nodes/sequence.h
+++ b/src/procedure/nodes/sequence.h
@@ -63,8 +63,6 @@ class ProcedureNodeSequence : public Serialisable<const CoreData &>
     int nNodes() const;
     // Return whether the sequence is empty
     bool empty() const;
-    // Remove a node
-    bool removeNode(NodeRef node);
 
     /*
      * Scope

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -42,8 +42,6 @@ std::vector<ConstNodeRef> Procedure::nodes(std::optional<ProcedureNode::NodeType
     return rootSequence_.nodes(optNodeType, optNodeClass);
 }
 
-// Remove a node
-bool Procedure::removeNode(NodeRef node) { return rootSequence_.removeNode(node); }
 
 /*
  * Execute

--- a/src/procedure/procedure.cpp
+++ b/src/procedure/procedure.cpp
@@ -42,7 +42,6 @@ std::vector<ConstNodeRef> Procedure::nodes(std::optional<ProcedureNode::NodeType
     return rootSequence_.nodes(optNodeType, optNodeClass);
 }
 
-
 /*
  * Execute
  */

--- a/src/procedure/procedure.h
+++ b/src/procedure/procedure.h
@@ -47,9 +47,6 @@ class Procedure : public Serialisable<const CoreData &>
     std::vector<ConstNodeRef> nodes(std::optional<ProcedureNode::NodeType> optNodeType = std::nullopt,
                                     std::optional<ProcedureNode::NodeClass> optNodeClass = std::nullopt) const;
 
-    // Remove a node
-    bool removeNode(NodeRef node);
-
     /*
      * Execute
      */


### PR DESCRIPTION
This PR fixes some issues with the `ProcedureModel`, enables appending nodes by double clicking (similar to the functionality available for the `Module` palette, and also cleans up the slots of the `ConfigurationTab` a tad.

This turned out to be an interesting one, that required a deep-dive into the almost non-existent docs. It seems like the issues came down to fact that `dropMimeData` already results in a call to  `removeRows` on `Qt::MoveAction`. So, we were actually trying to remove the rows twice. Also, I think the call to `setData`, and thus emitting `dataChanged`, was troublesome (and now I believe unnecessary) too. 

Edit: There still seems to be a problem with nodes that have a `branch`...

Closes #1600.