### PR TITLE
EmpiricalFormula - The Next Generation

### DIFF
--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(
   configuration_upkeep.cpp
   coreData.cpp
   distributor.cpp
+  empiricalFormula.cpp
   isotopeData.cpp
   isotopologue.cpp
   isotopologues.cpp

--- a/src/classes/empiricalFormula.cpp
+++ b/src/classes/empiricalFormula.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "classes/empiricalFormula.h"
+
+// Return empirical formula for specified composition
+std::string EmpiricalFormula::formula(const EmpiricalFormulaMap &elementCounts, bool richText)
+{
+    std::string empiricalFormula;
+
+    for (auto it = elementCounts.crbegin(); it != elementCounts.crend(); ++it)
+    {
+        auto &[Z, count] = *it;
+        if (count == 0)
+        {
+            continue;
+        }
+        else if (count == 1)
+        {
+            empiricalFormula += fmt::format("{}", Elements::symbol(Z));
+        }
+        else
+        {
+            if (richText)
+                empiricalFormula += fmt::format("{}<sub>{}</sub>", Elements::symbol(Z), count);
+            else
+                empiricalFormula += fmt::format("{}{}", Elements::symbol(Z), count);
+        }
+    }
+
+    return empiricalFormula;
+}

--- a/src/classes/empiricalFormula.h
+++ b/src/classes/empiricalFormula.h
@@ -9,36 +9,19 @@
 
 namespace EmpiricalFormula
 {
+using EmpiricalFormulaMap = std::map<Elements::Element, int>;
+
+// Return empirical formula for specified composition
+std::string formula(const EmpiricalFormulaMap &elementCounts, bool richText = false);
+
 // Return empirical formula for range
-template <class Class, class Lam> std::string formula(const Class &range, Lam lambda, bool richText = false)
+template <class Range, class Lam> std::string formula(const Range &range, Lam lambda, bool richText = false)
 {
-    std::vector<int> elCounts(Elements::nElements, 0);
+    EmpiricalFormulaMap map;
 
     for (const auto &obj : range)
-    {
-        Elements::Element Z = lambda(obj);
-        ++elCounts[Z];
-    }
+        ++map[lambda(obj)];
 
-    // Loop over elements in descending order and construct formula string
-    std::string formula;
-    for (auto n = Elements::nElements - 1; n >= 0; --n)
-    {
-        if (elCounts[n] == 0)
-            continue;
-
-        auto Z = Elements::element(n);
-        if (elCounts[n] > 1)
-        {
-            if (richText)
-                formula += fmt::format("{}<sub>{}</sub>", Elements::symbol(Z), elCounts[n]);
-            else
-                formula += fmt::format("{}{}", Elements::symbol(Z), elCounts[n]);
-        }
-        else
-            formula += fmt::format("{}", Elements::symbol(Z));
-    }
-
-    return formula;
+    return formula(map, richText);
 }
 }; // namespace EmpiricalFormula

--- a/tests/classes/CMakeLists.txt
+++ b/tests/classes/CMakeLists.txt
@@ -1,6 +1,7 @@
 dissolve_add_test(SRC box.cpp)
 dissolve_add_test(SRC cells.cpp)
 dissolve_add_test(SRC elements.cpp)
+dissolve_add_test(SRC empiricalFormula.cpp)
 dissolve_add_test(SRC enumOptions.cpp)
 dissolve_add_test(SRC flags.cpp)
 dissolve_add_test(SRC genericList.cpp)

--- a/tests/classes/empiricalFormula.cpp
+++ b/tests/classes/empiricalFormula.cpp
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "classes/empiricalFormula.h"
+#include "tests/testData.h"
+#include <gtest/gtest.h>
+
+TEST(EmpiricalFormulaTest, Order)
+{
+    EmpiricalFormula::EmpiricalFormulaMap testMap;
+    testMap[Elements::H] = 3;
+    testMap[Elements::N] = 1;
+    testMap[Elements::C] = 2;
+    EXPECT_EQ(EmpiricalFormula::formula(testMap), "NC2H3");
+}
+
+TEST(EmpiricalFormulaTest, Zeroes)
+{
+    EmpiricalFormula::EmpiricalFormulaMap testMap;
+    testMap[Elements::Na] = 0;
+    testMap[Elements::Mg] = 1;
+    testMap[Elements::Al] = 0;
+    EXPECT_EQ(EmpiricalFormula::formula(testMap), "Mg");
+}
+
+TEST(EmpiricalFormulaTest, Examples)
+{
+    EXPECT_EQ(EmpiricalFormula::formula(UnitTest::benzeneSpecies().atoms(), [](const auto &i) { return i.Z(); }), "C6H6");
+    EXPECT_EQ(EmpiricalFormula::formula(UnitTest::methaneSpecies().atoms(), [](const auto &i) { return i.Z(); }), "CH4");
+    EXPECT_EQ(EmpiricalFormula::formula(UnitTest::methanolSpecies().atoms(), [](const auto &i) { return i.Z(); }), "OCH4");
+}


### PR DESCRIPTION
This unexpected PR updates the `EmpiricalFormula` functions to be a little more useful, principally the ability to generate a formula without a `Range` of some objects, which has become a requirement in #1607.

The pre-sized counting `std::vector` is replaced with a `std::map` since it is ordered by default, and a simple reverse iterator over the map generates the formula string in order of decreasing atomic mass. All in all, a very pleasing little bit of code.