### PR TITLE
Free up memory in GitHub runner

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -39,8 +39,8 @@ runs:
     if: "steps.nix-cache.outputs.cache-hit == 'true'"
     shell: bash
     run: |
-    nix-store --import < /tmp/nixcache
-    sudo rm -rf /tmp/nixcache
+      nix-store --import < /tmp/nixcache
+      sudo rm -rf /tmp/nixcache
 
   - name: Build
     shell: bash

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -38,7 +38,9 @@ runs:
   - name: Import Nix Store Cache
     if: "steps.nix-cache.outputs.cache-hit == 'true'"
     shell: bash
-    run: nix-store --import < /tmp/nixcache
+    run: |
+    nix-store --import < /tmp/nixcache
+    sudo rm -rf /tmp/nixcache
 
   - name: Build
     shell: bash

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -35,18 +35,22 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
     {
         case (TrajectoryImportFormat::DLPOLYFormatted):
             result = importDLPOLY(parser, r, unitCell);
+            if (result)
+            {
+                // All good, so copy atom coordinates over into our array
+                for (auto &&[i, ri] : zip(cfg->atoms(), r))
+                {
+                    i.setCoordinates(ri);
+                }
+            }
             break;
         case (TrajectoryImportFormat::XYZ):
-            return CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ)
-                .importData(parser, cfg);
+            result =
+                CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ).importData(parser, cfg);
         default:
             throw(std::runtime_error(fmt::format("Trajectory format '{}' import has not been implemented.\n",
                                                  formats_.keywordByIndex(*formatIndex_))));
     }
-
-    // All good, so copy atom coordinates over into our array
-    for (auto &&[i, ri] : zip(cfg->atoms(), r))
-        i.setCoordinates(ri);
 
     return result;
 }

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -45,8 +45,8 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
             }
             break;
         case (TrajectoryImportFormat::XYZ):
-            result =
-                CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ).importData(parser, cfg);
+            return CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ)
+                .importData(parser, cfg);
         default:
             throw(std::runtime_error(fmt::format("Trajectory format '{}' import has not been implemented.\n",
                                                  formats_.keywordByIndex(*formatIndex_))));

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -35,14 +35,6 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
     {
         case (TrajectoryImportFormat::DLPOLYFormatted):
             result = importDLPOLY(parser, r, unitCell);
-            if (result)
-            {
-                // All good, so copy atom coordinates over into our array
-                for (auto &&[i, ri] : zip(cfg->atoms(), r))
-                {
-                    i.setCoordinates(ri);
-                }
-            }
             break;
         case (TrajectoryImportFormat::XYZ):
             return CoordinateImportFileFormat("", CoordinateImportFileFormat::CoordinateImportFormat::XYZ)
@@ -51,6 +43,10 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
             throw(std::runtime_error(fmt::format("Trajectory format '{}' import has not been implemented.\n",
                                                  formats_.keywordByIndex(*formatIndex_))));
     }
+
+    // All good, so copy atom coordinates over into our array
+    for (auto &&[i, ri] : zip(cfg->atoms(), r))
+        i.setCoordinates(ri);
 
     return result;
 }


### PR DESCRIPTION
Build workflows are being terminated due to memory running out. This fix removes the nix store cache after importing it to free up additional memory.