### PR TITLE
Fix import of node name when deserialising

### DIFF
--- a/src/procedure/nodes/node.cpp
+++ b/src/procedure/nodes/node.cpp
@@ -371,6 +371,6 @@ SerialisedValue ProcedureNode::serialise() const
 void ProcedureNode::deserialise(const SerialisedValue &node, const CoreData &data)
 {
     if (mustBeNamed())
-        name_ = toml::find<std::string>(node, "name");
+        setName(toml::find<std::string>(node, "name"));
     keywords_.deserialiseFrom(node, data);
 }

--- a/tests/modules/histogramCN.cpp
+++ b/tests/modules/histogramCN.cpp
@@ -15,7 +15,7 @@ class HistogramCNModuleTest : public ::testing::Test
 
 TEST_F(HistogramCNModuleTest, Simple)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/histogramCN-simple.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/histogramCN-simple.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     EXPECT_TRUE(systemTest.checkData1D(
@@ -28,7 +28,7 @@ TEST_F(HistogramCNModuleTest, Simple)
 
 TEST_F(HistogramCNModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/histogramCN-water.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/histogramCN-water.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/orientedSDF.cpp
+++ b/tests/modules/orientedSDF.cpp
@@ -15,7 +15,7 @@ class OrientedSDFModuleTest : public ::testing::Test
 
 TEST_F(OrientedSDFModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/orientedSDF-benzene.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/orientedSDF-benzene.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(80));
 
     EXPECT_TRUE(systemTest.checkData3D(


### PR DESCRIPTION
This fixes the last three round trip issues with TOML.  I've marked those tests as working.