### PR TITLE
EPSR Prune AtomTypes mk2

### DIFF
--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -23,8 +23,8 @@ bool ScatteringMatrix::qDependentWeighting() const
     return std::find_if(xRayData_.begin(), xRayData_.end(), [](auto data) { return std::get<0>(data); }) != xRayData_.end();
 }
 
-// Return index of specified AtomType pair
-int ScatteringMatrix::pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
+// Return column index of specified AtomType pair
+int ScatteringMatrix::columnIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const
 {
     auto index = 0;
     for (auto [i, j] : typePairs_)
@@ -360,7 +360,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const Neutro
     {
         for (auto m = n; m < nUsedTypes; ++m)
         {
-            auto colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
+            auto colIndex = columnIndex(usedTypes.atomType(n), usedTypes.atomType(m));
             if (colIndex == -1)
                 return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
                                         "('{}' and/or '{}').\n",
@@ -398,7 +398,7 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
     {
         for (int m = n; m < nUsedTypes; ++m)
         {
-            auto colIndex = pairIndex(usedTypes.atomType(n), usedTypes.atomType(m));
+            auto colIndex = columnIndex(usedTypes.atomType(n), usedTypes.atomType(m));
             if (colIndex == -1)
                 return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
                                         "('{}' and/or '{}').\n",
@@ -440,7 +440,7 @@ bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::
     A_.addRow(typePairs_.size());
     const auto rowIndex = A_.nRows() - 1;
 
-    auto colIndex = pairIndex(at1, at2);
+    auto colIndex = columnIndex(at1, at2);
     if (colIndex == -1)
         return Messenger::error(
             "Weights associated to reference data contain one or more unknown AtomTypes ('{}' and/or '{}').\n", at1->name(),

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -11,8 +11,6 @@
 #include <algorithm>
 #include <utility>
 
-ScatteringMatrix::ScatteringMatrix() = default;
-
 /*
  * Data
  */

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -29,6 +29,8 @@ class ScatteringMatrix
      * 	[  n,1     n,n ] [ xn ]   [ Bn ]
      */
     private:
+    // Source AtomTypes involved
+    std::vector<std::shared_ptr<AtomType>> atomTypes_;
     // Reference pairs of AtomTypes
     std::vector<std::tuple<std::shared_ptr<AtomType>, std::shared_ptr<AtomType>>> typePairs_;
     // Coefficients matrix (A) (ci * cj * bi * bj * (typei == typej ? 1 : 2)) (n * n)
@@ -47,6 +49,16 @@ class ScatteringMatrix
     bool qDependentWeighting() const;
 
     public:
+    // Return number of AtomTypes involved
+    int nAtomTypes() const;
+    // Return atom types
+    const std::vector<std::shared_ptr<AtomType>> &atomTypes() const;
+    // Return atom type at index specified
+    std::shared_ptr<AtomType> atomType(int index) const;
+    // Return index of atom type in our local vector
+    int indexOf(const std::shared_ptr<AtomType> &typeI) const;
+    // Return index pair of atom types in our local vector
+    std::tuple<int, int> pairIndexOf(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Return column of specified AtomType pair
     int columnIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Generate matrices
@@ -71,7 +83,7 @@ class ScatteringMatrix
      */
     public:
     // Initialise from supplied list of AtomTypes
-    void initialise(const std::vector<std::shared_ptr<AtomType>> &types, Array2D<Data1D> &estimatedSQ);
+    void initialise(const AtomTypeMix &typeMix, Array2D<Data1D> &estimatedSQ);
     // Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
     bool addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor = 1.0);
     // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -50,8 +50,8 @@ class ScatteringMatrix
     bool qDependentWeighting() const;
 
     public:
-    // Return index of specified AtomType pair
-    int pairIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
+    // Return column of specified AtomType pair
+    int columnIndex(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ) const;
     // Generate matrices
     void generateMatrices();
     // Return the precalculated Q = 0.0 scattering matrix inverse

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -19,9 +19,6 @@ class AtomType;
 // Scattering Matrix Container
 class ScatteringMatrix
 {
-    public:
-    ScatteringMatrix();
-
     /*
      * Data
      *

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -118,8 +118,8 @@ class EPSRModule : public Module
     Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
                                                         std::optional<int> ncoeffp = std::nullopt);
     // Generate empirical potentials from current coefficients
-    bool generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::ExpansionFunctionType functionType, double rho,
-                                     std::optional<int> ncoeffp, double rminpt, double rmaxpt, double sigma1, double sigma2);
+    bool generateEmpiricalPotentials(Dissolve &dissolve, double rho, std::optional<int> ncoeffp, double rminpt, double rmaxpt,
+                                     double sigma1, double sigma2);
     // Generate and return single empirical potential function
     Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n);
     // Calculate absolute energy of empirical potentials

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -123,7 +123,7 @@ class EPSRModule : public Module
     // Generate and return single empirical potential function
     Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n);
     // Calculate absolute energy of empirical potentials
-    double absEnergyEP(Dissolve &dissolve);
+    double absEnergyEP(GenericList &moduleData);
     // Truncate the supplied data
     void truncate(Data1D &data, double rMin, double rMax);
 

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -115,7 +115,7 @@ class EPSRModule : public Module
 
     public:
     // Create / retrieve arrays for storage of empirical potential coefficients
-    Array2D<std::vector<double>> &potentialCoefficients(Dissolve &dissolve, const int nAtomTypes,
+    Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
                                                         std::optional<int> ncoeffp = std::nullopt);
     // Generate empirical potentials from current coefficients
     bool generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::ExpansionFunctionType functionType, double rho,

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -41,11 +41,11 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWra
 }
 
 // Create / retrieve arrays for storage of empirical potential coefficients
-Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(Dissolve &dissolve, const int nAtomTypes,
+Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
                                                                 std::optional<int> ncoeffp)
 {
-    auto &coefficients = dissolve.processingModuleData().realise<Array2D<std::vector<double>>>("PotentialCoefficients", name_,
-                                                                                               GenericItem::InRestartFileFlag);
+    auto &coefficients =
+        moduleData.realise<Array2D<std::vector<double>>>("PotentialCoefficients", name_, GenericItem::InRestartFileFlag);
 
     auto arrayNCoeffP = (coefficients.nRows() && coefficients.nColumns() ? coefficients[{0, 0}].size() : 0);
     if ((coefficients.nRows() != nAtomTypes) || (coefficients.nColumns() != nAtomTypes) ||
@@ -71,7 +71,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::Exp
     const auto nAtomTypes = dissolve.coreData().nAtomTypes();
 
     // Get coefficients array
-    Array2D<std::vector<double>> &coefficients = potentialCoefficients(dissolve, nAtomTypes, ncoeffp);
+    Array2D<std::vector<double>> &coefficients = potentialCoefficients(dissolve.processingModuleData(), nAtomTypes, ncoeffp);
 
     auto result = for_each_pair_early(
         dissolve.coreData().atomTypes().begin(), dissolve.coreData().atomTypes().end(),
@@ -132,7 +132,7 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
     nCoeffP_ = nCoeffP_ <= 0 ? std::min(int(10.0 * rmaxpt + 0.0001), mcoeff) : nCoeffP_;
 
     // Get coefficients array
-    auto &coefficients = potentialCoefficients(dissolve, nAtomTypes);
+    auto &coefficients = potentialCoefficients(dissolve.processingModuleData(), nAtomTypes);
     auto &potCoeff = coefficients[{i, j}];
 
     // Regenerate empirical potential from the stored coefficients
@@ -170,7 +170,7 @@ double EPSRModule::absEnergyEP(Dissolve &dissolve)
      */
 
     // Get coefficients array
-    auto &coefficients = potentialCoefficients(dissolve, dissolve.coreData().nAtomTypes());
+    auto &coefficients = potentialCoefficients(dissolve.processingModuleData(), dissolve.coreData().nAtomTypes());
     if (coefficients.empty())
         return 0.0;
 

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -64,7 +64,7 @@ Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &mod
 }
 
 // Generate empirical potentials from current coefficients
-bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, EPSRModule::ExpansionFunctionType expansionFunction_,
+bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve,
                                              double averagedRho, std::optional<int> ncoeffp, double rminpt, double rmaxpt,
                                              double sigma1, double sigma2)
 {

--- a/src/modules/epsr/gui/epsrWidgetFuncs.cpp
+++ b/src/modules/epsr/gui/epsrWidgetFuncs.cpp
@@ -67,6 +67,9 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
     {
         ui_.PlotWidget->clearRenderableData();
 
+        const auto &atomTypes = module_->scatteringMatrix().atomTypes();
+        const auto nAtomTypes = atomTypes.size();
+
         // Set the relevant graph targets
         if (ui_.TotalFQButton->isChecked())
         {
@@ -104,24 +107,24 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         else if (ui_.EstimatedSQButton->isChecked())
         {
             // Add experimentally-determined partial S(Q)
-            for (auto [first, second] : PairIterator(dissolve_.coreData().atomTypes().size()))
-            {
-                auto &at1 = dissolve_.coreData().atomTypes()[first];
-                auto &at2 = dissolve_.coreData().atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+            dissolve::for_each_pair(
+                ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),
+                [&](int typeI, const auto &at1, int typeJ, const auto &at2)
+                {
+                    const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
-                // Unweighted estimated partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->name(), id),
-                                                           fmt::format("{} (Estimated)", id), "Estimated");
+                    // Unweighted estimated partial
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedSQ//{}", module_->name(), id),
+                                                               fmt::format("{} (Estimated)", id), "Estimated");
 
-                // Calculated / summed partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->name(), id),
-                                                           fmt::format("{} (Calc)", id), "Calc");
+                    // Calculated / summed partial
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedSQ//{}", module_->name(), id),
+                                                               fmt::format("{} (Calc)", id), "Calc");
 
-                // Deltas
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->name(), id),
-                                                           fmt::format("{} (Delta)", id), "Delta");
-            }
+                    // Deltas
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//DeltaSQ//{}", module_->name(), id),
+                                                               fmt::format("{} (Delta)", id), "Delta");
+                });
         }
         else if (ui_.EstimatedGRButton->isChecked())
         {
@@ -147,21 +150,20 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             }
 
             // Add experimentally-determined partial g(r)
-            PairIterator pairs(dissolve_.coreData().atomTypes().size());
-            for (auto [first, second] : pairs)
-            {
-                auto &at1 = dissolve_.coreData().atomTypes()[first];
-                auto &at2 = dissolve_.coreData().atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+            dissolve::for_each_pair(
+                ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),
+                [&](int typeI, const auto &at1, int typeJ, const auto &at2)
+                {
+                    const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
-                // Experimentally-determined unweighted partial
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedGR//{}", module_->name(), id),
-                                                           fmt::format("{} (Estimated)", id), "Estimated");
+                    // Experimentally-determined unweighted partial
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//EstimatedGR//{}", module_->name(), id),
+                                                               fmt::format("{} (Estimated)", id), "Estimated");
 
-                // Calculated / summed partials, taken from the RDF module referenced by the first module target
-                graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedGR//{}//Full", rdfModuleName, id),
-                                                           fmt::format("{} (Calc)", id), "Calc");
-            }
+                    // Calculated / summed partials, taken from the RDF module referenced by the first module target
+                    graph_->createRenderable<RenderableData1D>(fmt::format("{}//UnweightedGR//{}//Full", rdfModuleName, id),
+                                                               fmt::format("{} (Calc)", id), "Calc");
+                });
         }
         else if (ui_.TotalGRButton->isChecked())
         {
@@ -180,17 +182,16 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         else if (ui_.PotentialsButton->isChecked())
         {
             // Add on additional potentials
-            PairIterator pairs(dissolve_.coreData().atomTypes().size());
-            for (auto [first, second] : pairs)
-            {
-                auto &at1 = dissolve_.coreData().atomTypes()[first];
-                auto &at2 = dissolve_.coreData().atomTypes()[second];
-                const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
+            dissolve::for_each_pair(ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),
+                                    [&](int typeI, const auto &at1, int typeJ, const auto &at2)
+                                    {
+                                        const std::string id = fmt::format("{}-{}", at1->name(), at2->name());
 
-                auto pp = dissolve_.pairPotential(at1, at2);
-                if (pp)
-                    graph_->createRenderable<RenderableData1D>(fmt::format("Dissolve//Potential_{}_Additional", id), id, "Phi");
-            }
+                                        auto pp = dissolve_.pairPotential(at1, at2);
+                                        if (pp)
+                                            graph_->createRenderable<RenderableData1D>(
+                                                fmt::format("Dissolve//Potential_{}_Additional", id), id, "Phi");
+                                    });
         }
         else if (ui_.RFactorButton->isChecked())
         {

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -695,7 +695,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
     if (modifyPotential_ && (runCount % *modifyPotential_ == 0))
     {
         // Sum fluctuation coefficients in to the potential coefficients
-        auto &coefficients = potentialCoefficients(moduleContext.dissolve(), nAtomTypes, ncoeffp);
+        auto &coefficients = potentialCoefficients(moduleContext.dissolve().processingModuleData(), nAtomTypes, ncoeffp);
         dissolve::for_each_pair(ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),
                                 [&](int i, auto at1, int j, auto at2)
                                 {
@@ -788,7 +788,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
     {
         if (moduleContext.processPool().isMaster())
         {
-            auto &coefficients = potentialCoefficients(moduleContext.dissolve(), nAtomTypes, ncoeffp);
+            auto &coefficients = potentialCoefficients(moduleContext.dissolve().processingModuleData(), nAtomTypes, ncoeffp);
 
             dissolve::for_each_pair(
                 ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -202,7 +202,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
      */
 
     // Set up storage for the changes to coefficients used to generate the empirical potentials
-    const auto &atomTypes = moduleContext.dissolve().coreData().atomTypes();
+    const auto &atomTypes = scatteringMatrix_.atomTypes();
     const auto nAtomTypes = atomTypes.size();
 
     Array3D<double> fluctuationCoefficients(nAtomTypes, nAtomTypes, ncoeffp);

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -2,15 +2,12 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "base/sysFunc.h"
-#include "classes/atomType.h"
 #include "classes/neutronWeights.h"
 #include "classes/partialSet.h"
 #include "classes/scatteringMatrix.h"
 #include "classes/xRayWeights.h"
-#include "data/isotopes.h"
 #include "io/export/data1D.h"
 #include "keywords/module.h"
-#include "keywords/rangeVector.h"
 #include "main/dissolve.h"
 #include "math/error.h"
 #include "math/filters.h"
@@ -24,7 +21,6 @@
 #include "modules/gr/gr.h"
 #include "modules/neutronSQ/neutronSQ.h"
 #include "modules/sq/sq.h"
-#include "modules/xRaySQ/xRaySQ.h"
 #include "templates/algorithms.h"
 #include "templates/array3D.h"
 #include <functional>

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -91,16 +91,16 @@ bool EPSRModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordS
         auto rminpt = rMinPT_ ? rMinPT_.value() : rmaxpt - 2.0;
         if (expansionFunction_ == EPSRModule::GaussianExpansionFunction)
         {
-            if (!generateEmpiricalPotentials(moduleContext.dissolve(), expansionFunction_, rho.value_or(0.1), nCoeffP_, rminpt,
-                                             rmaxpt, gSigma1_, gSigma2_))
+            if (!generateEmpiricalPotentials(moduleContext.dissolve(), rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt, gSigma1_,
+                                             gSigma2_))
             {
                 return false;
             }
         }
         else
         {
-            if (!generateEmpiricalPotentials(moduleContext.dissolve(), expansionFunction_, rho.value_or(0.1), nCoeffP_, rminpt,
-                                             rmaxpt, pSigma1_, pSigma2_))
+            if (!generateEmpiricalPotentials(moduleContext.dissolve(), rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt, pSigma1_,
+                                             pSigma2_))
             {
                 return false;
             }
@@ -755,8 +755,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
         auto sigma1 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma1_ : gSigma1_;
         auto sigma2 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma2_ : gSigma2_;
 
-        if (!generateEmpiricalPotentials(moduleContext.dissolve(), expansionFunction_, rho, ncoeffp, rminpt, rmaxpt, sigma1,
-                                         sigma2))
+        if (!generateEmpiricalPotentials(moduleContext.dissolve(), rho, ncoeffp, rminpt, rmaxpt, sigma1, sigma2))
             return ExecutionResult::Failed;
     }
     else

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -661,7 +661,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             ParallelPolicies::seq, atomTypes.begin(), atomTypes.end(),
             [&](int i, auto at1, int j, auto at2)
             {
-                auto weight = scatteringMatrix_.qZeroMatrixInverse()[{scatteringMatrix_.pairIndex(at1, at2), dataIndex}];
+                auto weight = scatteringMatrix_.qZeroMatrixInverse()[{scatteringMatrix_.columnIndex(at1, at2), dataIndex}];
 
                 /*
                  * EPSR assembles the potential coefficients from the deltaFQ fit coefficients as a linear

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -715,7 +715,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
                                 });
 
         // Determine absolute energy of empirical potentials
-        energabs = absEnergyEP(moduleContext.dissolve());
+        energabs = absEnergyEP(moduleContext.dissolve().processingModuleData());
 
         /*
          * Determine the scaling we will apply to the coefficients (if any)
@@ -759,7 +759,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             return ExecutionResult::Failed;
     }
     else
-        energabs = absEnergyEP(moduleContext.dissolve());
+        energabs = absEnergyEP(moduleContext.dissolve().processingModuleData());
 
     // Save data?
     if (saveEmpiricalPotentials_)

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -32,11 +32,6 @@
 // Run set-up stage
 bool EPSRModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordSignal> actionSignals)
 {
-    // Realise storage for generated S(Q), and initialise a scattering matrix
-    auto &estimatedSQ = moduleContext.dissolve().processingModuleData().realise<Array2D<Data1D>>(
-        "EstimatedSQ", name_, GenericItem::InRestartFileFlag);
-    scatteringMatrix_.initialise(moduleContext.dissolve().coreData().atomTypes(), estimatedSQ);
-
     // Check for exactly one Configuration referenced through target modules
     targetConfiguration_ = nullptr;
     std::optional<double> rho;
@@ -76,6 +71,11 @@ bool EPSRModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordS
 
         rho = targetConfiguration_->atomicDensity();
     }
+
+    // Realise storage for generated S(Q), and initialise a scattering matrix
+    auto &estimatedSQ = moduleContext.dissolve().processingModuleData().realise<Array2D<Data1D>>(
+        "EstimatedSQ", name_, GenericItem::InRestartFileFlag);
+    scatteringMatrix_.initialise(targetConfiguration_->atomTypes(), estimatedSQ);
 
     // If a pcof file was provided, read in the parameters from it here
     if (!pCofFilename_.empty())

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -188,7 +188,8 @@ TEST_F(EPSRModuleTest, Benzene)
 
     // Absolute magnitudes of EP
     auto *epsrModule = systemTest.getModule<EPSRModule>("EPSR01");
-    auto &coefficients = epsrModule->potentialCoefficients(systemTest.dissolve(), systemTest.coreData().nAtomTypes());
+    auto &coefficients =
+        epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData(), systemTest.coreData().nAtomTypes());
     ASSERT_FALSE(coefficients.empty());
     std::vector<std::tuple<int, int, double>> expectedEPMagnitudes = {{0, 0, 0.4023}, {0, 1, 0.1966}, {1, 1, 0.2491}};
     for (auto &&[i, j, epMag] : expectedEPMagnitudes)

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -96,7 +96,8 @@ TEST_F(EPSRModuleTest, Water3NInpA)
 
     // Absolute magnitudes of EP
     auto *epsrModule = systemTest.getModule<EPSRModule>("EPSR01");
-    auto &coefficients = epsrModule->potentialCoefficients(systemTest.dissolve(), systemTest.coreData().nAtomTypes());
+    auto &coefficients =
+        epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData(), systemTest.coreData().nAtomTypes());
     ASSERT_FALSE(coefficients.empty());
     std::vector<std::tuple<int, int, double>> expectedEPMagnitudes = {{0, 0, 0.2475}, {0, 1, 0.3722}, {1, 1, 0.4567}};
     for (auto &&[i, j, epMag] : expectedEPMagnitudes)


### PR DESCRIPTION
This PR supersedes #931, and modifies the EPSR module to only attempt to generate potentials for atom types present in the `Configuration` targeted by the module's reference datasets, rather than doing it for every defined atom type in `CoreData`.

The original emphasis of this work was to circumvent crashes when unused atom types were present, but since we now prune these before starting the simulation this should no longer be relevant.  A much more relevant, current focus is the hope that this will address crashes when legitimately running multi-configuration simulations where atom types are not guaranteed to be present in all `Configuration`s all of the time.