### PR TITLE
Energy module output graph misses torsions / impropers

### DIFF
--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -84,10 +84,10 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         fmt::format("{}//Angle", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     angleData.addPoint(moduleContext.dissolve().iteration(), angleEnergy);
     auto &torsionData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        fmt::format("{}//Torsions", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        fmt::format("{}//Torsion", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     torsionData.addPoint(moduleContext.dissolve().iteration(), torsionEnergy);
     auto &improperData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        fmt::format("{}//Impropers", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        fmt::format("{}//Improper", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     improperData.addPoint(moduleContext.dissolve().iteration(), improperEnergy);
 
     // Append to arrays of total energies


### PR DESCRIPTION
closes #1687. Neither torsion or improper energies are plotted on the graph widget. This is probably a very simple case of something being clumsily renamed (e.g. "Torsion" -> "Torsions", for instance)

Closes #1687.