### PR TITLE
Fix Add Forcefield Dialog

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -620,6 +620,9 @@ SerialisedValue CoreData::Masters::serialise() const
 // Read values from a serialisable value
 void CoreData::Masters::deserialise(const SerialisedValue &node)
 {
+    if (node.is_uninitialized())
+        // There are no master terms
+        return;
     Serialisable::toMap(node, "bonds",
                         [this](const std::string &name, const SerialisedValue &bond)
                         { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -609,7 +609,8 @@ std::string_view CoreData::inputFilename() const { return inputFilename_; }
 // Express as a serialisable value
 SerialisedValue CoreData::Masters::serialise() const
 {
-    SerialisedValue node;
+    toml::table table;
+    SerialisedValue node = table;
     Serialisable::fromVectorToTable<>(bonds, "bonds", node);
     Serialisable::fromVectorToTable<>(angles, "angles", node);
     Serialisable::fromVectorToTable<>(torsions, "torsions", node);
@@ -620,9 +621,6 @@ SerialisedValue CoreData::Masters::serialise() const
 // Read values from a serialisable value
 void CoreData::Masters::deserialise(const SerialisedValue &node)
 {
-    if (node.is_uninitialized())
-        // There are no master terms
-        return;
     Serialisable::toMap(node, "bonds",
                         [this](const std::string &name, const SerialisedValue &bond)
                         { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });


### PR DESCRIPTION
The Add Forcefield Dialog has a bug where that causes a crash if there are no Master terms.  Since no values were ever added to the node while serialising, the node was never properly registered as a `table`.  I've now intialised it to an empty table so that the deserialiser can correctly load the result.