### PR TITLE
Fix EPSR Toml parsing

### DIFF
--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -92,6 +92,7 @@ SerialisedValue AtomType::serialise() const
 {
     SerialisedValue atomType;
 
+    atomType["name"] = name_;
     atomType["z"] = Z_;
     atomType["charge"] = charge_;
     atomType["form"] = ShortRangeFunctions::forms().keyword(interactionPotential_.form());

--- a/src/classes/serializablePairPotential.cpp
+++ b/src/classes/serializablePairPotential.cpp
@@ -52,8 +52,7 @@ SerialisedValue SerializablePairPotential::serialise() const
         pairPotentials["forceChargeSource"] = true;
     if (atomTypeChargeSource_)
         pairPotentials["includeCoulomb"] = true;
-    for (auto &atomType : atomTypes_)
-        pairPotentials["atomTypes"][atomType->name().data()] = atomType->serialise();
+    Serialisable::fromVector(atomTypes_, "atomTypes", pairPotentials);
     return pairPotentials;
 }
 
@@ -71,7 +70,8 @@ void SerializablePairPotential::deserialise(const SerialisedValue &node)
     shortRangeTruncationScheme_ = PairPotential::shortRangeTruncationSchemes().deserialise(
         toml::find_or<std::string>(node, "shortRangeTruncation", "Shifted"));
 
-    toMap(node, "atomTypes",
-          [this](const auto &name, const auto &data)
-          { atomTypes_.emplace_back(std::make_unique<AtomType>(name))->deserialise(data); });
+    toVector(node, "atomTypes",
+             [this](const auto &data) {
+                 atomTypes_.emplace_back(std::make_unique<AtomType>(toml::find<std::string>(data, "name")))->deserialise(data);
+             });
 }

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -58,7 +58,7 @@ class EPSRModuleTest : public ::testing::Test
 
 TEST_F(EPSRModuleTest, Water3NInpA)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/epsr-water-inpa.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-water-inpa.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Estimated Partials
@@ -107,7 +107,7 @@ TEST_F(EPSRModuleTest, Water3NInpA)
 
 TEST_F(EPSRModuleTest, Water3NX)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/epsr-water-3n-x.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-water-3n-x.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Test total neutron-weighted F(r)
@@ -138,7 +138,7 @@ TEST_F(EPSRModuleTest, Water3NX)
 
 TEST_F(EPSRModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/epsr-benzene-3n.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Test total neutron-weighted F(r)
@@ -200,7 +200,7 @@ TEST_F(EPSRModuleTest, BenzeneReadPCof) { ASSERT_NO_THROW(systemTest.setUp("diss
 
 TEST_F(EPSRModuleTest, ScatteringMatrix)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/epsr-5datasets.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-5datasets.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Find EPSR module
@@ -221,7 +221,7 @@ TEST_F(EPSRModuleTest, ScatteringMatrix)
 
 TEST_F(EPSRModuleTest, DataWeighting)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/epsr-5datasets-weighted.txt"));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-5datasets-weighted.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Find EPSR module


### PR DESCRIPTION
Add EPSR terms in TOML as vector instead of a map.  This preserves order, but we may switch this back if we can replace the std::unordered_map with std::map