### PR TITLE
Fix serialisation of Species Site with TOML

### DIFF
--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -749,28 +749,55 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
 SerialisedValue SpeciesSite::serialise() const
 {
     SerialisedValue site;
-    if (type_ == SiteType::Dynamic)
-        site["dynamic"] = true;
-    Serialisable::fromVector(staticOriginAtoms_, "originAtoms", site, [](const auto &item) { return item->index(); });
-    Serialisable::fromVector(staticXAxisAtoms_, "xAxisAtoms", site, [](const auto &item) { return item->index(); });
-    Serialisable::fromVector(staticYAxisAtoms_, "yAxisAtoms", site, [](const auto &item) { return item->index(); });
-    Serialisable::fromVector(dynamicElements_, "elements", site, [](const auto &item) { return Elements::symbol(item); });
-    Serialisable::fromVector(dynamicAtomTypes_, "atomTypes", site, [](const auto &item) { return item->name(); });
-    site["originMassWeighted"] = originMassWeighted_;
+    switch (type_)
+    {
+        case SiteType::Dynamic:
+            site["type"] = "Dynamic";
+            site["element"] = dynamicElements_;
+            break;
+        case SiteType::Static:
+            Serialisable::fromVector(staticOriginAtoms_, "originAtoms", site, [](const auto &item) { return item->index(); });
+            Serialisable::fromVector(staticXAxisAtoms_, "xAxisAtoms", site, [](const auto &item) { return item->index(); });
+            Serialisable::fromVector(staticYAxisAtoms_, "yAxisAtoms", site, [](const auto &item) { return item->index(); });
+            Serialisable::fromVector(dynamicElements_, "elements", site,
+                                     [](const auto &item) { return Elements::symbol(item); });
+            Serialisable::fromVector(dynamicAtomTypes_, "atomTypes", site, [](const auto &item) { return item->name(); });
+            site["originMassWeighted"] = originMassWeighted_;
+            break;
+    }
     return site;
 }
 
 void SpeciesSite::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
-    if (node.contains("dynamic"))
+    auto typeString = toml::find_or<std::string>(node, "type", "Static");
+    if (typeString == "Static")
+        type_ = SiteType::Static;
+    else if (typeString == "Fragment")
+        type_ = SiteType::Fragment;
+    else if (typeString == "Dynamic")
         type_ = SiteType::Dynamic;
+    else
+        throw toml::syntax_error(fmt::format("Cannot comprehend species site type {}.\n", typeString), node.location());
 
-    toVector(node, "originAtoms", [this](const auto &originAtom) { addStaticOriginAtom(originAtom.as_integer()); });
-    toVector(node, "xAxisAtoms", [this](const auto &xAxisAtom) { addStaticXAxisAtom(xAxisAtom.as_integer()); });
-    toVector(node, "yAxisAtoms", [this](const auto &yAxisAtom) { addStaticYAxisAtom(yAxisAtom.as_integer()); });
-    toVector(node, "elements", [this](const auto &el) { addDynamicElement(Elements::element(std::string(el.as_string()))); });
-    toVector(node, "atomTypes",
-             [&, this](const auto &at) { addDynamicAtomType(coreData.findAtomType(std::string(at.as_string()))); });
+    switch (type_)
+    {
+        case SiteType::Static:
+            toVector(node, "originAtoms", [this](const auto &originAtom) { addStaticOriginAtom(originAtom.as_integer()); });
+            toVector(node, "xAxisAtoms", [this](const auto &xAxisAtom) { addStaticXAxisAtom(xAxisAtom.as_integer()); });
+            toVector(node, "yAxisAtoms", [this](const auto &yAxisAtom) { addStaticYAxisAtom(yAxisAtom.as_integer()); });
+            toVector(node, "elements",
+                     [this](const auto &el) { addDynamicElement(Elements::element(std::string(el.as_string()))); });
+            toVector(node, "atomTypes",
+                     [&, this](const auto &at) { addDynamicAtomType(coreData.findAtomType(std::string(at.as_string()))); });
 
-    originMassWeighted_ = toml::find_or<bool>(node, "originMassWeighted", false);
+            originMassWeighted_ = toml::find_or<bool>(node, "originMassWeighted", false);
+            break;
+        case SiteType::Fragment:
+            break;
+        case SiteType::Dynamic:
+            toVector(node, "element",
+                     [this](const auto &element) { addDynamicElement(toml::get<Elements::Element>(element)); });
+            break;
+    }
 }

--- a/tests/modules/siteRDF.cpp
+++ b/tests/modules/siteRDF.cpp
@@ -109,8 +109,8 @@ TEST_F(SiteRDFModuleTest, WaterDynamic)
 
 TEST_F(SiteRDFModuleTest, WaterFragments)
 {
-    ASSERT_NO_THROW(systemTest.setUp<TomlFailure>("dissolve/input/siteRDF-waterFragments.txt"));
-    ASSERT_TRUE(systemTest.iterateRestart<TomlFailure>(95));
+    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/siteRDF-waterFragments.txt"));
+    ASSERT_TRUE(systemTest.iterateRestart(95));
 
     // O-O RDF
     EXPECT_TRUE(systemTest.checkData1D(


### PR DESCRIPTION
Support for Dynamic and Fragment sites has now been added.  Please note that

* Dynamic Sites support a *list* of `element`.
* Fragment Sites take a `description` string
* *All* site types support an `originMassWeighted` toggle

I'm happy to add other parameters if they are need.  These were just the ones required to pass the tests.