### PR TITLE
1614 explicit toml context

### DIFF
--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -31,7 +31,8 @@ template <typename... Contexts> class Serialisable
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 
-    template <typename = std::enable_if<sizeof...(Contexts) == 1>> void deserialise(const SerialisedValue &node)
+    template <typename = std::enable_if<sizeof...(Contexts) == 1 && (std::is_empty<Contexts>::value && ...)>>
+    void deserialise(const SerialisedValue &node)
     {
         deserialise(node, {});
     }

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -11,6 +11,13 @@
 // The type we use for the nodes of our serialisation tree
 using SerialisedValue = toml::value;
 
+// The associated context for type T
+template <typename T> struct SerialisableContext
+{
+    using type = void;
+};
+
+
 // An interface for classes that can be serialised into an input file
 template <typename... Contexts> class Serialisable
 {

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -11,15 +11,10 @@
 // The type we use for the nodes of our serialisation tree
 using SerialisedValue = toml::value;
 
-// An empty structure for when we have no data
-struct SerialisableEmpty
-{
-};
-
 // The associated context for type T
 template <typename T> struct SerialisableContext
 {
-    using type = SerialisableEmpty;
+    using type = SerialisableContext<void>;
 };
 
 // An interface for classes that can be serialised into an input file

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -11,12 +11,16 @@
 // The type we use for the nodes of our serialisation tree
 using SerialisedValue = toml::value;
 
+// An empty structure for when we have no data
+struct SerialisableEmpty
+{
+};
+
 // The associated context for type T
 template <typename T> struct SerialisableContext
 {
-    using type = void;
+    using type = SerialisableEmpty;
 };
-
 
 // An interface for classes that can be serialised into an input file
 template <typename... Contexts> class Serialisable
@@ -26,6 +30,11 @@ template <typename... Contexts> class Serialisable
     virtual SerialisedValue serialise() const = 0;
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
+
+    template <typename = std::enable_if<sizeof...(Contexts) == 1>> void deserialise(const SerialisedValue &node)
+    {
+        deserialise(node, {});
+    }
 
     /* Functions that hook into the toml11 library */
     // Wrapper for deserialise that toml11 will check for

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -11,7 +11,16 @@
 // The type we use for the nodes of our serialisation tree
 using SerialisedValue = toml::value;
 
-// The associated context for type T
+// The associated context for type T This type does double duty.
+// First, since the struct has not actual members, it is a Unit type
+// (a type with only one possible value).  This is why the default
+// inner type is SerialisableContext<void> - says that we have no
+// context and the type has no size.  The second duty is acting as a
+// type level function.  Normally, you would just add an inner type to
+// a class (e.g. NodeValue::Context) to perform this function.
+// Unfortunately, you can't add an inner type to a primative type
+// (e.g. float).  By specialising this template, we can create a
+// mapping between types and the context that they require.
 template <typename T> struct SerialisableContext
 {
     using type = SerialisableContext<void>;
@@ -26,6 +35,14 @@ template <typename... Contexts> class Serialisable
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 
+    // When a type has only one context and that context is empty
+    // (i.e. is a Unit type), then we can create a simple overload
+    // that skips the need to add the second parameter.  This does not
+    // conflict with the definition above because it only becomes
+    // instantiated when the Contexts pack is not empty, so the above
+    // definition of deserialise takes two parameters.  We also insist
+    // that it is only called for empty types to ensure that we do not
+    // accidentally create a value with its default constructor.
     template <typename = std::enable_if<sizeof...(Contexts) == 1 && (std::is_empty<Contexts>::value && ...)>>
     void deserialise(const SerialisedValue &node)
     {

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -442,8 +442,12 @@ template <class T> class Vec3 : public Serialisable<typename SerialisableContext
     }
 
     // Read values from a serialisable value when no context is required
-    // This will throw an exception for types that require context (i.e. NodeValue)
-    void deserialise(const SerialisedValue &node) { deserialise(node, {}); }
+    // This method will only be instantiated for types with no context.
+    template <typename = std::enable_if<std::is_empty<typename SerialisableContext<T>::type>::value>>
+    void deserialise(const SerialisedValue &node)
+    {
+        deserialise(node, {});
+    }
 
     // Read values from a serialisable value with a required context
     void deserialise(const SerialisedValue &node, typename SerialisableContext<T>::type context) override

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -11,9 +11,15 @@
 #include <stdexcept>
 
 class NodeValue;
+class ExpressionVariable;
+
+template <> struct SerialisableContext<NodeValue>
+{
+    using type = std::vector<std::shared_ptr<ExpressionVariable>>;
+};
 
 // 3D vector
-template <class T> class Vec3 : public Serialisable<>
+template <class T> class Vec3 : public Serialisable<typename SerialisableContext<T>::type>
 {
     public:
     Vec3<T>() : x(T()), y(T()), z(T()){};
@@ -437,23 +443,22 @@ template <class T> class Vec3 : public Serialisable<>
 
     // Read values from a serialisable value when no context is required
     // This will throw an exception for types that require context (i.e. NodeValue)
-    void deserialise(const SerialisedValue &node) override
+    void deserialise(const SerialisedValue &node) { deserialise(node, {}); }
+
+    // Read values from a serialisable value with a required context
+    void deserialise(const SerialisedValue &node, typename SerialisableContext<T>::type context) override
     {
-        if constexpr (std::is_same_v<T, NodeValue>)
-            throw std::runtime_error("Cannot build NodeValue witout context");
-        else
+        if constexpr (std::is_empty_v<typename SerialisableContext<T>::type>)
         {
             x = toml::get<T>(node[0]);
             y = toml::get<T>(node[1]);
             z = toml::get<T>(node[2]);
         }
-    }
-
-    // Read values from a serialisable value with a required context
-    template <typename... Context> void deserialise(const SerialisedValue &node, Context... context)
-    {
-        x.deserialise(node[0], context...);
-        y.deserialise(node[1], context...);
-        z.deserialise(node[2], context...);
+        else
+        {
+            x.deserialise(node[0], context);
+            y.deserialise(node[1], context);
+            z.deserialise(node[2], context);
+        }
     }
 };


### PR DESCRIPTION
All the real information is contained in the issue below.  The short version is that calling `deserialise(node)` on a `Vec3<NodeValue>` would cause Dissolve to crash.  We never actually called that function, but the inheritance semantics insisted that it had to exist.  I've added a phantom type `SerialisableContext` to enable us to attach a context to primitive types, not just classes.  I've also created a unit type `SerialisableEmpty` to denote data types that have no context.

Closes #1614