### PR TITLE
Elapsed Timer Fix- zero on each run, update status label

### DIFF
--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -316,7 +316,7 @@ void DissolveWindow::updateStatusBar()
     }
     else if (!dissolveIterating_ && elapsedTimer_.secondsElapsed() > 0.0)
     {
-        statusLabel_->setText("Idle");
+        statusLabel_->setText("Stopped");
         statusIndicator_->setPixmap(QPixmap(":/general/icons/true.svg"));
         timerLabel_->setText(QString::fromStdString(fmt::format("Time elapsed: {}", elapsedTimer_.elapsedTimeString(true))));
     }

--- a/src/gui/guiFuncs.cpp
+++ b/src/gui/guiFuncs.cpp
@@ -316,6 +316,8 @@ void DissolveWindow::updateStatusBar()
     }
     else if (!dissolveIterating_ && elapsedTimer_.secondsElapsed() > 0.0)
     {
+        statusLabel_->setText("Idle");
+        statusIndicator_->setPixmap(QPixmap(":/general/icons/true.svg"));
         timerLabel_->setText(QString::fromStdString(fmt::format("Time elapsed: {}", elapsedTimer_.elapsedTimeString(true))));
     }
     else if (ui_.MainStack->currentIndex() == 1)

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -72,6 +72,7 @@ void DissolveWindow::setupIteration(int count)
     elapsedTimer_.zero();
     if (count == -1)
     {
+        elapsedTimer_.zero();
         elapsedTimer_.start();
     }
     else


### PR DESCRIPTION
The status bar is updated so that:
- Timer resets to zero on the start of each run
- The status label bug is fixed: said Dissolve was still running despite stopped

Closes #1707.