### PR TITLE
1709 Enabled Buttons for Modules

### DIFF
--- a/src/gui/layerTab.h
+++ b/src/gui/layerTab.h
@@ -71,7 +71,7 @@ class LayerTab : public QWidget, public MainTab
     void moduleNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
     void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);
     void updateModuleList();
-    void on_ModulesList_customContextMenuRequested(const QPoint &pos);
+    void on_ModulesTable_customContextMenuRequested(const QPoint &pos);
     void on_AvailableModulesTree_doubleClicked(const QModelIndex &index);
 
     public:

--- a/src/gui/layerTab.h
+++ b/src/gui/layerTab.h
@@ -67,8 +67,6 @@ class LayerTab : public QWidget, public MainTab
     void on_LayerFrequencySpin_valueChanged(int value);
     void on_RunControlEnergyStabilityCheck_clicked(bool checked);
     void on_RunControlSizeFactorsCheck_clicked(bool checked);
-    void on_ModuleEnabledButton_clicked(bool checked);
-    void on_ModuleFrequencySpin_valueChanged(int value);
     void moduleSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
     void moduleNameChanged(const QModelIndex &, const QString &oldName, const QString &newName);
     void layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &);

--- a/src/gui/layerTab.ui
+++ b/src/gui/layerTab.ui
@@ -333,7 +333,7 @@
          </widget>
         </item>
         <item>
-         <widget class="QListView" name="ModulesList">
+         <widget class="QTableView" name="ModulesTable">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -346,11 +346,20 @@
           <property name="dragEnabled">
            <bool>true</bool>
           </property>
+          <property name="dragDropOverwriteMode">
+           <bool>false</bool>
+          </property>
           <property name="dragDropMode">
-           <enum>QAbstractItemView::DragDrop</enum>
+           <enum>QAbstractItemView::InternalMove</enum>
           </property>
           <property name="defaultDropAction">
            <enum>Qt::MoveAction</enum>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::SingleSelection</enum>
+          </property>
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
           </property>
          </widget>
         </item>

--- a/src/gui/layerTab.ui
+++ b/src/gui/layerTab.ui
@@ -233,7 +233,7 @@
            <bool>false</bool>
           </property>
           <property name="dragDropMode">
-           <enum>QAbstractItemView::InternalMove</enum>
+           <enum>QAbstractItemView::DragDrop</enum>
           </property>
           <property name="defaultDropAction">
            <enum>Qt::MoveAction</enum>

--- a/src/gui/layerTab.ui
+++ b/src/gui/layerTab.ui
@@ -72,7 +72,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Enabled?</string>
+           <string>Layer Enabled?</string>
           </property>
          </widget>
         </item>
@@ -215,123 +215,6 @@
         <property name="bottomMargin">
          <number>4</number>
         </property>
-        <item>
-         <widget class="QFrame" name="ModuleControlFrame">
-          <property name="frameShape">
-           <enum>QFrame::StyledPanel</enum>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Raised</enum>
-          </property>
-          <layout class="QHBoxLayout" name="horizontalLayout_5">
-           <property name="spacing">
-            <number>4</number>
-           </property>
-           <property name="leftMargin">
-            <number>4</number>
-           </property>
-           <property name="topMargin">
-            <number>4</number>
-           </property>
-           <property name="rightMargin">
-            <number>4</number>
-           </property>
-           <property name="bottomMargin">
-            <number>4</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Enabled?</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QToolButton" name="ModuleEnabledButton">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>34</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="toolTip">
-              <string>Whether the layer is enabled</string>
-             </property>
-             <property name="text">
-              <string/>
-             </property>
-             <property name="icon">
-              <iconset resource="main.qrc">
-               <normaloff>:/general/icons/slider-off.svg</normaloff>
-               <normalon>:/general/icons/slider-on.svg</normalon>:/general/icons/slider-off.svg</iconset>
-             </property>
-             <property name="iconSize">
-              <size>
-               <width>32</width>
-               <height>16</height>
-              </size>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-             <property name="checked">
-              <bool>false</bool>
-             </property>
-             <property name="autoRaise">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="text">
-              <string>Frequency</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="ModuleFrequencySpin">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="toolTip">
-              <string>The layer's frequency, relative to the main iteration counter, at which the layer will be executed</string>
-             </property>
-             <property name="minimum">
-              <number>1</number>
-             </property>
-             <property name="maximum">
-              <number>1000</number>
-             </property>
-             <property name="value">
-              <number>10</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
         <item>
          <widget class="QTableView" name="ModulesTable">
           <property name="sizePolicy">

--- a/src/gui/layerTabFuncs.cpp
+++ b/src/gui/layerTabFuncs.cpp
@@ -29,11 +29,8 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
             SLOT(moduleNameChanged(const QModelIndex &, const QString &, const QString &)));
     ui_.ModulesTable->resizeColumnsToContents();
 
-    if (moduleLayer_->modules().size() >= 1)
-    {
-        auto firstIndex = moduleLayerModel_.index(0, 0);
-        ui_.ModulesTable->selectionModel()->setCurrentIndex(firstIndex, QItemSelectionModel::ClearAndSelect);
-    }
+    if (!moduleLayer_->modules().empty())
+        ui_.ModulesTable->selectRow(0);
 
     // Set up the available modules tree
     ui_.AvailableModulesTree->setModel(&modulePaletteModel_);
@@ -255,7 +252,7 @@ void LayerTab::updateModuleList()
         selectedIndex = ui_.ModulesTable->selectionModel()->selection().indexes().front();
     moduleLayerModel_.reset();
     if (selectedIndex)
-        ui_.ModulesTable->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
+        ui_.ModulesTable->selectRow(selectedIndex.value().row());
 }
 
 void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)

--- a/src/gui/layerTabFuncs.cpp
+++ b/src/gui/layerTabFuncs.cpp
@@ -19,9 +19,9 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
     moduleLayer_ = layer;
 
     // Set the module list model and connect signals
-    ui_.ModulesList->setModel(&moduleLayerModel_);
+    ui_.ModulesTable->setModel(&moduleLayerModel_);
     moduleLayerModel_.setData(moduleLayer_, dissolve.coreData());
-    connect(ui_.ModulesList->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
+    connect(ui_.ModulesTable->selectionModel(), SIGNAL(selectionChanged(const QItemSelection &, const QItemSelection &)), this,
             SLOT(moduleSelectionChanged(const QItemSelection &, const QItemSelection &)));
     connect(&moduleLayerModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)), this,
             SLOT(layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
@@ -31,7 +31,7 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
     if (moduleLayer_->modules().size() >= 1)
     {
         auto firstIndex = moduleLayerModel_.index(0, 0);
-        ui_.ModulesList->selectionModel()->setCurrentIndex(firstIndex, QItemSelectionModel::ClearAndSelect);
+        ui_.ModulesTable->selectionModel()->setCurrentIndex(firstIndex, QItemSelectionModel::ClearAndSelect);
     }
 
     // Set up the available modules tree
@@ -280,16 +280,16 @@ void LayerTab::updateModuleList()
 {
     // Refresh the module list
     std::optional<QModelIndex> selectedIndex;
-    if (!ui_.ModulesList->selectionModel()->selection().indexes().empty())
-        selectedIndex = ui_.ModulesList->selectionModel()->selection().indexes().front();
+    if (!ui_.ModulesTable->selectionModel()->selection().indexes().empty())
+        selectedIndex = ui_.ModulesTable->selectionModel()->selection().indexes().front();
     moduleLayerModel_.reset();
     if (selectedIndex)
-        ui_.ModulesList->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
+        ui_.ModulesTable->selectionModel()->select(selectedIndex.value(), QItemSelectionModel::ClearAndSelect);
 }
 
 void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
 {
-    auto index = ui_.ModulesList->indexAt(pos);
+    auto index = ui_.ModulesTable->indexAt(pos);
     if (!index.isValid())
         return;
     auto module = moduleLayerModel_.data(index, Qt::UserRole).value<Module *>();
@@ -312,7 +312,7 @@ void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
     auto *deleteModule = menu.addAction("&Delete");
     deleteModule->setIcon(QIcon(":/general/icons/cross.svg"));
 
-    auto *action = menu.exec(ui_.ModulesList->mapToGlobal(pos));
+    auto *action = menu.exec(ui_.ModulesTable->mapToGlobal(pos));
     if (action == enableModule)
         module->setEnabled(true);
     else if (action == disableModule)
@@ -402,8 +402,8 @@ void LayerTab::preventEditing()
     ui_.ModuleEnabledButton->setEnabled(false);
     ui_.ModuleFrequencySpin->setEnabled(false);
 
-    ui_.ModulesList->setEditTriggers(QAbstractItemView::NoEditTriggers);
-    ui_.ModulesList->setDragDropMode(QAbstractItemView::NoDragDrop);
+    ui_.ModulesTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    ui_.ModulesTable->setDragDropMode(QAbstractItemView::NoDragDrop);
     ui_.AvailableModulesTree->setEnabled(false);
     for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
@@ -422,8 +422,8 @@ void LayerTab::allowEditing()
     ui_.ModuleEnabledButton->setEnabled(ui_.ModuleControlsStack->currentIndex() != 0);
     ui_.ModuleFrequencySpin->setEnabled(ui_.ModuleControlsStack->currentIndex() != 0);
     ui_.AvailableModulesTree->setEnabled(true);
-    ui_.ModulesList->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
-    ui_.ModulesList->setDragDropMode(QAbstractItemView::DragDrop);
+    ui_.ModulesTable->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+    ui_.ModulesTable->setDragDropMode(QAbstractItemView::DragDrop);
     for (auto n = 0; n < ui_.ModuleControlsStack->count(); ++n)
     {
         auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->widget(n));

--- a/src/gui/layerTabFuncs.cpp
+++ b/src/gui/layerTabFuncs.cpp
@@ -27,6 +27,7 @@ LayerTab::LayerTab(DissolveWindow *dissolveWindow, Dissolve &dissolve, MainTabsW
             SLOT(layerDataChanged(const QModelIndex &, const QModelIndex &, const QList<int> &)));
     connect(&moduleLayerModel_, SIGNAL(moduleNameChanged(const QModelIndex &, const QString &, const QString &)), this,
             SLOT(moduleNameChanged(const QModelIndex &, const QString &, const QString &)));
+    ui_.ModulesTable->resizeColumnsToContents();
 
     if (moduleLayer_->modules().size() >= 1)
     {
@@ -187,32 +188,6 @@ void LayerTab::on_RunControlSizeFactorsCheck_clicked(bool checked)
     dissolveWindow_->setModified();
 }
 
-void LayerTab::on_ModuleEnabledButton_clicked(bool checked)
-{
-    if (refreshLock_.isLocked() || (!moduleLayer_))
-        return;
-
-    auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->currentWidget());
-    if (mcw)
-        mcw->module()->setEnabled(checked);
-
-    updateModuleList();
-
-    dissolveWindow_->setModified();
-}
-
-void LayerTab::on_ModuleFrequencySpin_valueChanged(int value)
-{
-    if (refreshLock_.isLocked() || (!moduleLayer_))
-        return;
-
-    auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->currentWidget());
-    if (mcw)
-        mcw->module()->setFrequency(value);
-
-    dissolveWindow_->setModified();
-}
-
 void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItemSelection &previous)
 {
     auto modelIndices = current.indexes();
@@ -233,10 +208,6 @@ void LayerTab::moduleSelectionChanged(const QItemSelection &current, const QItem
     }
 
     Locker refreshLocker(refreshLock_);
-
-    // Update the module control widgets
-    ui_.ModuleEnabledButton->setChecked(module->isEnabled());
-    ui_.ModuleFrequencySpin->setValue(module->frequency());
 
     // See if our stack already contains a control widget for the module - if not, create one
     auto *mcw = getControlWidget(module, true);
@@ -384,13 +355,7 @@ void LayerTab::updateControls()
 
     auto *mcw = dynamic_cast<ModuleControlWidget *>(ui_.ModuleControlsStack->currentWidget());
     if (mcw)
-    {
         mcw->updateControls();
-
-        // Update the module control widgets
-        ui_.ModuleEnabledButton->setChecked(mcw->module()->isEnabled());
-        ui_.ModuleFrequencySpin->setValue(mcw->module()->frequency());
-    }
 }
 
 // Prevent editing within tab
@@ -399,8 +364,6 @@ void LayerTab::preventEditing()
     ui_.LayerEnabledButton->setEnabled(false);
     ui_.LayerFrequencySpin->setEnabled(false);
     ui_.RunControlGroup->setEnabled(false);
-    ui_.ModuleEnabledButton->setEnabled(false);
-    ui_.ModuleFrequencySpin->setEnabled(false);
 
     ui_.ModulesTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
     ui_.ModulesTable->setDragDropMode(QAbstractItemView::NoDragDrop);
@@ -419,8 +382,6 @@ void LayerTab::allowEditing()
     ui_.LayerEnabledButton->setEnabled(true);
     ui_.LayerFrequencySpin->setEnabled(true);
     ui_.RunControlGroup->setEnabled(true);
-    ui_.ModuleEnabledButton->setEnabled(ui_.ModuleControlsStack->currentIndex() != 0);
-    ui_.ModuleFrequencySpin->setEnabled(ui_.ModuleControlsStack->currentIndex() != 0);
     ui_.AvailableModulesTree->setEnabled(true);
     ui_.ModulesTable->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
     ui_.ModulesTable->setDragDropMode(QAbstractItemView::DragDrop);

--- a/src/gui/layerTabFuncs.cpp
+++ b/src/gui/layerTabFuncs.cpp
@@ -255,7 +255,7 @@ void LayerTab::updateModuleList()
         ui_.ModulesTable->selectRow(selectedIndex.value().row());
 }
 
-void LayerTab::on_ModulesList_customContextMenuRequested(const QPoint &pos)
+void LayerTab::on_ModulesTable_customContextMenuRequested(const QPoint &pos)
 {
     auto index = ui_.ModulesTable->indexAt(pos);
     if (!index.isValid())

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -233,13 +233,8 @@ bool ModuleLayerModel::canDropMimeData(const QMimeData *data, Qt::DropAction act
     Q_UNUSED(row);
     Q_UNUSED(parent);
 
-    if (column > 0)
-        return false;
-
-    if (data->hasFormat("application/dissolve.module.move") || data->hasFormat("application/dissolve.module.create"))
-        return true;
-
-    return false;
+    return true;
+    return (data->hasFormat("application/dissolve.module.move") || data->hasFormat("application/dissolve.module.create"));
 }
 
 bool ModuleLayerModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -57,6 +57,8 @@ QVariant ModuleLayerModel::data(const QModelIndex &index, int role) const
                 return QString::fromStdString(fmt::format("{} [{}]", module->name(), module->frequency()));
         case (Qt::EditRole):
             return QString::fromStdString(std::string(module->name()));
+        case (Qt::CheckStateRole):
+            return module->isEnabled() ? Qt::Checked : Qt::Unchecked;
         case (Qt::UserRole):
             return QVariant::fromValue(module);
         case (Qt::DecorationRole):
@@ -85,6 +87,16 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 
         emit(dataChanged(index, index));
         emit(moduleNameChanged(index, oldName, QString::fromStdString(newName)));
+
+        return true;
+    }
+    else if (role == Qt::CheckStateRole)
+    {
+        auto *module = rawData(index);
+
+        module->setEnabled(value.toBool());
+
+        emit(dataChanged(index, index));
 
         return true;
     }
@@ -121,7 +133,8 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 
 Qt::ItemFlags ModuleLayerModel::flags(const QModelIndex &index) const
 {
-    return Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    return Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable | Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled |
+           Qt::ItemIsUserCheckable;
 }
 
 QVariant ModuleLayerModel::headerData(int section, Qt::Orientation orientation, int role) const

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -66,13 +66,7 @@ QVariant ModuleLayerModel::data(const QModelIndex &index, int role) const
         switch (role)
         {
             case (Qt::DisplayRole):
-                if (module->isDisabled())
-                    return QString::fromStdString(fmt::format("{} [{}] (disabled)", module->name(), module->frequency()));
-                else if (moduleLayer_->runControlFlags().isSet(ModuleLayer::RunControlFlag::Disabled))
-                    return QString::fromStdString(
-                        fmt::format("{} [{}] (disabled via layer)", module->name(), module->frequency()));
-                else
-                    return QString::fromStdString(fmt::format("{} [{}]", module->name(), module->frequency()));
+                return QString::fromStdString(fmt::format("{} [{}]", module->name(), ModuleTypes::moduleType(module->type())));
             case (Qt::EditRole):
                 return QString::fromStdString(std::string(module->name()));
             case (Qt::DecorationRole):

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -233,7 +233,6 @@ bool ModuleLayerModel::canDropMimeData(const QMimeData *data, Qt::DropAction act
     Q_UNUSED(row);
     Q_UNUSED(parent);
 
-    return true;
     return (data->hasFormat("application/dissolve.module.move") || data->hasFormat("application/dissolve.module.create"));
 }
 

--- a/src/gui/models/moduleLayerModel.h
+++ b/src/gui/models/moduleLayerModel.h
@@ -12,7 +12,7 @@
 // Forward Declarations
 class Dissolve;
 
-class ModuleLayerModel : public QAbstractListModel
+class ModuleLayerModel : public QAbstractTableModel
 {
     Q_OBJECT
 
@@ -39,9 +39,17 @@ class ModuleLayerModel : public QAbstractListModel
         MoveInternal = Qt::UserRole,
         CreateNew
     };
+    enum DataColumns
+    {
+        EnabledColumn,
+        NameColumn,
+        FrequencyColumn,
+        nDataColumns
+    };
 
     public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;


### PR DESCRIPTION
This PR moves the `ModuleLayerModel` from `QAbstractListModel` to `QAbstractTableModel` with a view to removing the "floating" controls for the enabled/disabled state and frequency of individual modules in the list.

Below, the old style is on the left, with this PR moving us to the right (see that we now have the means to clearly indicate the module type as well).
![image](https://github.com/disorderedmaterials/dissolve/assets/11457350/215557df-ae66-42fd-8ef7-37ed936fd7a4)

Closes #1709.
Closes #1677 (or at least obfuscates it).