### PR TITLE
1718 Separate Interatomic Energy

### DIFF
--- a/benchmark/energy/energy_benchmark.cpp
+++ b/benchmark/energy/energy_benchmark.cpp
@@ -34,7 +34,7 @@ static void BM_CalculateEnergy_SpeciesInterAtomicEnergy(benchmark::State &state)
     auto &procPool = problemDef.dissolve_.worldPool();
     const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
     for (auto _ : state)
-        EnergyModule::interAtomicEnergy(procPool, species, potentialMap);
+        EnergyModule::pairPotentialEnergy(procPool, species, potentialMap);
 }
 
 template <ProblemType problem, Population population> static void BM_CalculateEnergy_MoleculeEnergy(benchmark::State &state)
@@ -102,7 +102,7 @@ static void BM_CalculateEnergy_TotalInterAtomicEnergy(benchmark::State &state)
     auto &procPool = problemDef.dissolve_.worldPool();
     const PotentialMap &potentialMap = problemDef.dissolve_.potentialMap();
     for (auto _ : state)
-        EnergyModule::interAtomicEnergy(procPool, problemDef.cfg_, potentialMap);
+        EnergyModule::pairPotentialEnergy(procPool, problemDef.cfg_, potentialMap);
 }
 
 template <ProblemType problem, Population population>

--- a/src/kernels/energy.h
+++ b/src/kernels/energy.h
@@ -22,23 +22,48 @@ class SpeciesAngle;
 class SpeciesImproper;
 class SpeciesTorsion;
 
+// PairPotential Energy Value
+class PairPotentialEnergyValue
+{
+    public:
+    PairPotentialEnergyValue(double inter = 0.0, double intra = 0.0);
+    PairPotentialEnergyValue operator+(const PairPotentialEnergyValue &value) const;
+    PairPotentialEnergyValue operator-(const PairPotentialEnergyValue &value) const;
+    PairPotentialEnergyValue &operator+=(const PairPotentialEnergyValue &value);
+    PairPotentialEnergyValue &operator*=(const double scale);
+
+    private:
+    // Energy values
+    double interMolecular_{0.0}, intraMolecular_{0.0};
+
+    public:
+    // Increment Energies
+    void addInterMolecular(double e);
+    void addIntraMolecular(double e);
+    // Return Energies
+    double interMolecular() const;
+    double intraMolecular() const;
+    double total() const;
+};
+
 // Energy Result
 class EnergyResult
 {
     public:
-    EnergyResult(double pp = 0.0, double geom = 0.0, double ext = 0.0)
-        : total_(pp + geom + ext), pairPotential_(pp), geometry_(geom), extended_(ext){};
+    EnergyResult(PairPotentialEnergyValue pp = {}, double geom = 0.0, double ext = 0.0)
+        : total_(pp.total() + geom + ext), pairPotential_(pp), geometry_(geom), extended_(ext){};
 
     private:
     // Components
-    double total_, pairPotential_, geometry_, extended_;
+    PairPotentialEnergyValue pairPotential_;
+    double total_, geometry_, extended_;
 
     public:
     double total() const { return total_; };
-    double pairPotential() const { return pairPotential_; };
+    PairPotentialEnergyValue pairPotential() const { return pairPotential_; };
     double geometry() const { return geometry_; };
     double extended() const { return extended_; };
-    double totalUnbound() const { return pairPotential_ + extended_; }
+    double totalUnbound() const { return pairPotential_.total() + extended_; }
 };
 
 // Standard Energy Kernel, inheriting GeometryKernel
@@ -67,13 +92,14 @@ class EnergyKernel : public GeometryKernel
      */
     private:
     // Return PairPotential energy of atoms in the supplied cell
-    double cellEnergy(const Cell &cell, bool includeIntraMolecular) const;
+    PairPotentialEnergyValue cellEnergy(const Cell &cell, bool includeIntraMolecular) const;
     // Return PairPotential energy between two cells
-    double cellToCellEnergy(const Cell &cell, const Cell &otherCell, bool applyMim, bool includeIntraMolecular) const;
+    PairPotentialEnergyValue cellToCellEnergy(const Cell &cell, const Cell &otherCell, bool applyMim,
+                                              bool includeIntraMolecular) const;
     // Return PairPotential energy of atom with world
     double pairPotentialEnergy(const Atom &i) const;
     // Return PairPotential energy of Molecule with world
-    double pairPotentialEnergy(const Molecule &mol, bool includeIntraMolecular) const;
+    PairPotentialEnergyValue pairPotentialEnergy(const Molecule &mol, bool includeIntraMolecular) const;
 
     /*
      * Extended Terms
@@ -99,9 +125,9 @@ class EnergyKernel : public GeometryKernel
 
     public:
     // Return total interatomic PairPotential energy of the world
-    double totalPairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
+    PairPotentialEnergyValue totalPairPotentialEnergy(bool includeIntraMolecular, ProcessPool::DivisionStrategy strategy) const;
     // Return total interatomic PairPotential energy from summation of molecules
-    double totalMoleculePairPotentialEnergy(bool includeIntraMolecular) const;
+    PairPotentialEnergyValue totalMoleculePairPotentialEnergy(bool includeIntraMolecular) const;
     // Return total energy of supplied atom with the world
     EnergyResult totalEnergy(const Atom &i) const;
     // Return total energy of supplied molecule with the world

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -128,8 +128,8 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
         {
             Timer timer;
             Messenger::mute();
-            EnergyModule::interAtomicEnergy(moduleContext.processPool(), targetConfiguration_,
-                                            moduleContext.dissolve().potentialMap());
+            EnergyModule::pairPotentialEnergy(moduleContext.processPool(), targetConfiguration_,
+                                              moduleContext.dissolve().potentialMap());
             Messenger::unMute();
             timing += timer.split();
         }

--- a/src/modules/energy/energy.h
+++ b/src/modules/energy/energy.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "kernels//energy.h"
 #include "module/module.h"
 
 // Forward Declarations
@@ -43,10 +44,11 @@ class EnergyModule : public Module
         EnergyStable = 0,
         EnergyUnstable = 1
     };
-    // Return total interatomic energy of Configuration
-    static double interAtomicEnergy(const ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
-    // Return total interatomic energy of Species
-    static double interAtomicEnergy(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap);
+    // Return total pair potential energy of Configuration
+    static PairPotentialEnergyValue pairPotentialEnergy(const ProcessPool &procPool, const Configuration *cfg,
+                                                        const PotentialMap &potentialMap);
+    // Return total pair potential energy of Species
+    static double pairPotentialEnergy(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap);
     // Return total intermolecular energy
     static double interMolecularEnergy(const ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total intramolecular energy of Configuration
@@ -60,8 +62,8 @@ class EnergyModule : public Module
     static double totalEnergy(const ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap);
     // Return total energy (interatomic and intramolecular) of Configuration, storing components in provided variables
     static double totalEnergy(const ProcessPool &procPool, const Configuration *cfg, const PotentialMap &potentialMap,
-                              double &interEnergy, double &bondEnergy, double &angleEnergy, double &torsionEnergy,
-                              double &improperEnergy);
+                              PairPotentialEnergyValue &ppEnergy, double &bondEnergy, double &angleEnergy,
+                              double &torsionEnergy, double &improperEnergy);
     // Return total energy (interatomic and intramolecular) of Species
     static double totalEnergy(const ProcessPool &procPool, const Species *sp, const PotentialMap &potentialMap);
     // Check energy stability of specified Configuration

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -48,16 +48,16 @@ double EnergyModule::interAtomicEnergy(const ProcessPool &procPool, const Config
     ProcessPool::DivisionStrategy strategy = ProcessPool::PoolStrategy;
 
     // Grab the Cell array and calculate total energy
-    double totalEnergy = kernel->totalPairPotentialEnergy(true, strategy);
+    auto ppEnergy = kernel->totalPairPotentialEnergy(true, strategy).total();
 
     // Print process-local energy
-    Messenger::printVerbose("Interatomic Energy (Local) is {:15.9e}\n", totalEnergy);
+    Messenger::printVerbose("Interatomic Energy (Local) is {:15.9e}\n", ppEnergy);
 
     // Sum energy over all processes in the pool and print
-    procPool.allSum(&totalEnergy, 1, strategy);
-    Messenger::printVerbose("Interatomic Energy (World) is {:15.9e}\n", totalEnergy);
+    procPool.allSum(&ppEnergy, 1, strategy);
+    Messenger::printVerbose("Interatomic Energy (World) is {:15.9e}\n", ppEnergy);
 
-    return totalEnergy;
+    return ppEnergy;
 }
 
 // Return total interatomic energy of Species
@@ -72,7 +72,7 @@ double EnergyModule::interAtomicEnergy(const ProcessPool &procPool, const Specie
     auto [loopStart, loopEnd] = chop_range(0, comb.getNumCombinations(), nChunks, offset);
 
     double energy = dissolve::transform_reduce(ParallelPolicies::par, dissolve::counting_iterator<int>(loopStart),
-                                               dissolve::counting_iterator<int>(loopEnd), 0.0, std::plus<double>(),
+                                               dissolve::counting_iterator<int>(loopEnd), 0.0, std::plus<>(),
                                                [&](const auto idx)
                                                {
                                                    auto [n, m] = comb.nthCombination(idx);
@@ -117,16 +117,16 @@ double EnergyModule::interMolecularEnergy(const ProcessPool &procPool, const Con
     ProcessPool::DivisionStrategy strategy = ProcessPool::PoolStrategy;
 
     // Grab the Cell array and calculate total energy
-    double totalEnergy = kernel->totalPairPotentialEnergy(false, strategy);
+    auto ppEnergy = kernel->totalPairPotentialEnergy(false, strategy).total();
 
     // Print process-local energy
-    Messenger::printVerbose("Intermolecular Energy (Local) is {:15.9e}\n", totalEnergy);
+    Messenger::printVerbose("Intermolecular Energy (Local) is {:15.9e}\n", ppEnergy);
 
     // Sum energy over all processes in the pool and print
-    procPool.allSum(&totalEnergy, 1, strategy);
-    Messenger::printVerbose("Intermolecular Energy (World) is {:15.9e}\n", totalEnergy);
+    procPool.allSum(&ppEnergy, 1, strategy);
+    Messenger::printVerbose("Intermolecular Energy (World) is {:15.9e}\n", ppEnergy);
 
-    return totalEnergy;
+    return ppEnergy;
 }
 
 // Return total intramolecular energy of Configuration

--- a/src/modules/energy/gui/energyWidgetFuncs.cpp
+++ b/src/modules/energy/gui/energyWidgetFuncs.cpp
@@ -64,8 +64,11 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
             ->setColour(StockColours::RedStockColour);
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Bound", prefix), "Bound", "Totals")
             ->setColour(StockColours::BlueStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Cohesive", prefix), "Cohesive", "Totals")
-            ->setColour(StockColours::LightRedStockColour);
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Cohesive", prefix), "CohesivePP", "PairPotential")
+            ->setColour(StockColours::RedStockColour);
+        energyGraph_
+            ->createRenderable<RenderableData1D>(fmt::format("{}//IntraPP", prefix), "IntramolecularPP", "PairPotential")
+            ->setColour(StockColours::BlueStockColour);
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Bond", prefix), "Bond", "Bound")
             ->setColour(StockColours::GreenStockColour);
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Angle", prefix), "Angle", "Bound")
@@ -74,6 +77,7 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
             ->setColour(StockColours::OrangeStockColour);
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Improper", prefix), "Improper", "Bound")
             ->setColour(StockColours::CyanStockColour);
+        energyGraph_->groupManager().setGroupStipple("PairPotential", LineStipple::DotStipple);
     }
 
     // Validate renderables if they need it

--- a/src/modules/energy/gui/energyWidgetFuncs.cpp
+++ b/src/modules/energy/gui/energyWidgetFuncs.cpp
@@ -60,17 +60,19 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
 
         auto prefix = fmt::format("{}//{}", module_->name(), cfg->niceName());
         energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Total", prefix), "Total", "Totals");
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Inter", prefix), "Inter", "Totals")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//PairPotential", prefix), "PairPotential", "Totals")
             ->setColour(StockColours::RedStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Intra", prefix), "Intra", "Totals")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Bound", prefix), "Bound", "Totals")
             ->setColour(StockColours::BlueStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Bond", prefix), "Bond", "Intramolecular")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Cohesive", prefix), "Cohesive", "Totals")
+            ->setColour(StockColours::LightRedStockColour);
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Bond", prefix), "Bond", "Bound")
             ->setColour(StockColours::GreenStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Angle", prefix), "Angle", "Intramolecular")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Angle", prefix), "Angle", "Bound")
             ->setColour(StockColours::PurpleStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Torsion", prefix), "Torsion", "Intramolecular")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Torsion", prefix), "Torsion", "Bound")
             ->setColour(StockColours::OrangeStockColour);
-        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Improper", prefix), "Improper", "Intramolecular")
+        energyGraph_->createRenderable<RenderableData1D>(fmt::format("{}//Improper", prefix), "Improper", "Bound")
             ->setColour(StockColours::CyanStockColour);
     }
 

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -47,36 +47,36 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
      * This is a serial routine (subroutines called from within are parallel).
      */
 
-    // Calculate intermolecular energy
+    // Calculate pair potential energy
     Timer interTimer;
-    auto interEnergy =
-        interAtomicEnergy(moduleContext.processPool(), targetConfiguration_, moduleContext.dissolve().potentialMap());
+    auto ppEnergy =
+        pairPotentialEnergy(moduleContext.processPool(), targetConfiguration_, moduleContext.dissolve().potentialMap());
     interTimer.stop();
 
-    // Calculate intramolecular and intermolecular correction energy
+    // Calculate intra-molecular (bound) energy
     Timer intraTimer;
     double bondEnergy, angleEnergy, torsionEnergy, improperEnergy;
-    auto intraEnergy =
+    auto boundEnergy =
         intraMolecularEnergy(moduleContext.processPool(), targetConfiguration_, moduleContext.dissolve().potentialMap(),
                              bondEnergy, angleEnergy, torsionEnergy, improperEnergy);
     intraTimer.stop();
 
     Messenger::print("Time to do interatomic energy was {}, intramolecular energy was {}.\n", interTimer.totalTimeString(),
                      intraTimer.totalTimeString());
-    Messenger::print("Total Energy (World) is {:15.9e} kJ/mol ({:15.9e} kJ/mol interatomic + {:15.9e} kJ/mol "
+    Messenger::print("Total Energy (World) is {:15.9e} kJ/mol ({:15.9e} kJ/mol pair potential + {:15.9e} kJ/mol "
                      "intramolecular).\n",
-                     interEnergy + intraEnergy, interEnergy, intraEnergy);
+                     ppEnergy.total() + boundEnergy, ppEnergy.total(), boundEnergy);
     Messenger::print("Intramolecular contributions are - bonds = {:15.9e} kJ/mol, angles = {:15.9e} kJ/mol, "
                      "torsions = {:15.9e} kJ/mol, impropers = {:15.9e} kJ/mol.\n",
                      bondEnergy, angleEnergy, torsionEnergy, improperEnergy);
 
     // Store current energies in the Configuration in case somebody else needs them
     auto &interData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        fmt::format("{}//Inter", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
-    interData.addPoint(moduleContext.dissolve().iteration(), interEnergy);
+        fmt::format("{}//PairPotential", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+    interData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.total());
     auto &intraData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        fmt::format("{}//Intra", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
-    intraData.addPoint(moduleContext.dissolve().iteration(), intraEnergy);
+        fmt::format("{}//Bound", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+    intraData.addPoint(moduleContext.dissolve().iteration(), boundEnergy);
     auto &bondData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
         fmt::format("{}//Bond", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     bondData.addPoint(moduleContext.dissolve().iteration(), bondEnergy);
@@ -89,11 +89,14 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
     auto &improperData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
         fmt::format("{}//Improper", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     improperData.addPoint(moduleContext.dissolve().iteration(), improperEnergy);
+    auto &cohesiveData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
+        fmt::format("{}//Cohesive", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+    cohesiveData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.interMolecular());
 
     // Append to arrays of total energies
     auto &totalEnergyArray = moduleContext.dissolve().processingModuleData().realise<Data1D>(
         fmt::format("{}//Total", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
-    totalEnergyArray.addPoint(moduleContext.dissolve().iteration(), interEnergy + intraEnergy);
+    totalEnergyArray.addPoint(moduleContext.dissolve().iteration(), ppEnergy.total() + boundEnergy);
 
     // Determine stability of energy
     // Check number of points already stored for the Configuration
@@ -135,9 +138,9 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         }
         else
             parser.appendOutput(filename);
-        parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
-                          moduleContext.dissolve().iteration(), interEnergy + intraEnergy, interEnergy, bondEnergy, angleEnergy,
-                          torsionEnergy, improperEnergy, grad, stable);
+        parser.writeLineF("  {:10d}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {:12.6e}  {}\n",
+                          moduleContext.dissolve().iteration(), ppEnergy.total() + boundEnergy, ppEnergy.total(),
+                          ppEnergy.interMolecular(), bondEnergy, angleEnergy, torsionEnergy, improperEnergy, grad, stable);
         parser.closeFiles();
     }
 
@@ -290,17 +293,17 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         molecularPPEnergy += correctSelfEnergy;
         moleculeTimer.stop();
 
-        Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", interEnergy);
-        Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", intraEnergy);
-        Messenger::print("Total production energy is {:15.9e} kJ/mol\n", interEnergy + intraEnergy);
+        Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", ppEnergy.total());
+        Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", boundEnergy);
+        Messenger::print("Total production energy is {:15.9e} kJ/mol\n", ppEnergy.total() + boundEnergy);
         Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularPPEnergy);
         Messenger::print("Time to do interatomic energy was {}.\n", interTimer.totalTimeString());
         Messenger::print("Time to do intramolecular energy was {}.\n", intraTimer.totalTimeString());
         Messenger::print("Time to do intermolecular energy was {}.\n", moleculeTimer.totalTimeString());
 
         // Compare production vs 'correct' values
-        auto interDelta = correctInterEnergy - interEnergy;
-        auto intraDelta = correctIntraEnergy - intraEnergy;
+        auto interDelta = correctInterEnergy - ppEnergy.total();
+        auto intraDelta = correctIntraEnergy - boundEnergy;
         auto moleculeDelta = correctInterEnergy - molecularPPEnergy;
         Messenger::print("Comparing 'correct' with production values...\n");
         Messenger::print("Interatomic energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n", interDelta,

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -92,6 +92,9 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
     auto &cohesiveData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
         fmt::format("{}//Cohesive", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
     cohesiveData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.interMolecular());
+    auto &intraPPData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
+        fmt::format("{}//IntraPP", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+    intraPPData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.intraMolecular());
 
     // Append to arrays of total energies
     auto &totalEnergyArray = moduleContext.dissolve().processingModuleData().realise<Data1D>(

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -286,14 +286,14 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         Timer moleculeTimer;
         auto kernel = KernelProducer::energyKernel(targetConfiguration_, moduleContext.processPool(),
                                                    moduleContext.dissolve().potentialMap(), cutoff);
-        auto molecularEnergy = kernel->totalMoleculePairPotentialEnergy(false);
-        molecularEnergy += correctSelfEnergy;
+        auto molecularPPEnergy = kernel->totalMoleculePairPotentialEnergy(false).total();
+        molecularPPEnergy += correctSelfEnergy;
         moleculeTimer.stop();
 
         Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", interEnergy);
         Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", intraEnergy);
         Messenger::print("Total production energy is {:15.9e} kJ/mol\n", interEnergy + intraEnergy);
-        Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularEnergy);
+        Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularPPEnergy);
         Messenger::print("Time to do interatomic energy was {}.\n", interTimer.totalTimeString());
         Messenger::print("Time to do intramolecular energy was {}.\n", intraTimer.totalTimeString());
         Messenger::print("Time to do intermolecular energy was {}.\n", moleculeTimer.totalTimeString());
@@ -301,7 +301,7 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         // Compare production vs 'correct' values
         auto interDelta = correctInterEnergy - interEnergy;
         auto intraDelta = correctIntraEnergy - intraEnergy;
-        auto moleculeDelta = correctInterEnergy - molecularEnergy;
+        auto moleculeDelta = correctInterEnergy - molecularPPEnergy;
         Messenger::print("Comparing 'correct' with production values...\n");
         Messenger::print("Interatomic energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n", interDelta,
                          fabs(interDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -81,7 +81,8 @@ Module::ExecutionResult MDModule::process(ModuleContext &moduleContext)
     // Variables
     auto nCapped = 0;
     auto &atoms = targetConfiguration_->atoms();
-    double tInstant, ke, tScale, peInter, peIntra;
+    double tInstant, ke, tScale, peBound;
+    PairPotentialEnergyValue pePP;
 
     // Determine target molecules from the restrictedSpecies vector (if any)
     std::vector<const Molecule *> targetMolecules;
@@ -328,12 +329,12 @@ Module::ExecutionResult MDModule::process(ModuleContext &moduleContext)
             // Include total energy term?
             if (energyFrequency_ && (step % energyFrequency_.value() == 0))
             {
-                peInter = EnergyModule::interAtomicEnergy(moduleContext.processPool(), targetConfiguration_,
-                                                          moduleContext.dissolve().potentialMap());
-                peIntra = EnergyModule::intraMolecularEnergy(moduleContext.processPool(), targetConfiguration_,
+                pePP = EnergyModule::pairPotentialEnergy(moduleContext.processPool(), targetConfiguration_,
+                                                         moduleContext.dissolve().potentialMap());
+                peBound = EnergyModule::intraMolecularEnergy(moduleContext.processPool(), targetConfiguration_,
                                                              moduleContext.dissolve().potentialMap());
                 Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}   {:10.3e}\n", step,
-                                 tInstant, ke, peInter, peIntra, ke + peIntra + peInter, dT);
+                                 tInstant, ke, pePP.total(), peBound, ke + peBound + pePP.total(), dT);
             }
             else
                 Messenger::print("  {:<10d}    {:10.3e}   {:10.3e}                                          {:10.3e}\n", step,
@@ -351,8 +352,8 @@ Module::ExecutionResult MDModule::process(ModuleContext &moduleContext)
                 // Construct and write header
                 std::string header = fmt::format("Step {} of {}, T = {:10.3e}, ke = {:10.3e}", step, nSteps_, tInstant, ke);
                 if (energyFrequency_ && (step % energyFrequency_.value() == 0))
-                    header += fmt::format(", inter = {:10.3e}, intra = {:10.3e}, tot = {:10.3e}", peInter, peIntra,
-                                          ke + peInter + peIntra);
+                    header += fmt::format(", inter = {:10.3e}, intra = {:10.3e}, tot = {:10.3e}", pePP.total(), peBound,
+                                          ke + pePP.total() + peBound);
                 if (!trajParser.writeLine(header))
                 {
                     moduleContext.processPool().decideFalse();

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -91,7 +91,7 @@ TEST(CellsTest, Basic)
         cfg->updateAtomLocations(true);
 
         // Calculate total Cell-based energy
-        EXPECT_NEAR(refEnergy, kernel->totalPairPotentialEnergy(false, ProcessPool::PoolStrategy), 1.0e-4);
+        EXPECT_NEAR(refEnergy, kernel->totalPairPotentialEnergy(false, ProcessPool::PoolStrategy).total(), 1.0e-4);
 
         // Calculate atomic energy from the Ar
         EXPECT_NEAR(refEnergy, kernel->totalEnergy(cfg->atom(0)).total(), 1.0e-4);

--- a/tests/modules/energy.cpp
+++ b/tests/modules/energy.cpp
@@ -24,11 +24,11 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Full)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full interatomic energy: 1770.1666370083758 LJ + -29163.384451743802 Coulomb (LJ correction accounted for)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic energy", interEnergy.values().back(), -27393.217815, 4.5e-2));
 
     // Full intramolecular energy
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 5584.45180873, 3.5e-3));
 }
 
@@ -45,7 +45,7 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaals)
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
     EXPECT_TRUE(
         systemTest.checkDouble("interatomic van der Waals energy", interEnergy.values().back(), 1770.1666370083758, 6.0e-2));
 }
@@ -62,7 +62,7 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Electrostatics)
                                      }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
 
     // Shifted coulomb sum
     EXPECT_TRUE(systemTest.checkDouble("shifted coulomb energy", interEnergy.values().back(), -29163.384451743802, 1.1e-2));
@@ -84,7 +84,7 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Bound)
                                      }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
 
     EXPECT_TRUE(systemTest.checkDouble("bound term", intraEnergy.values().back(), 5584.45180873, 3.5e-3));
 }
@@ -96,11 +96,11 @@ TEST_F(EnergyModuleTest, DLPOLYHexane1Full)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full interatomic energy: LJ (3.504968) + Coul (10.081520) - LJCorrect (-0.00501830)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic energy", interEnergy.values().back(), 14.32518630, 5.0e-4));
 
     // Full intramolecular energy
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 71.59299, 6.0e-4));
 }
 
@@ -111,11 +111,11 @@ TEST_F(EnergyModuleTest, DLPOLYHexane2Full)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full interatomic energy: LJ (5.2003) + Coul (21.523) - LJCorrect (-0.0200732)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic energy", interEnergy.values().back(), 26.743373, 5.0e-4));
 
     // Full intramolecular energy: Bond (33.91651) + Angle (72.22392) + Torsion (24.49599)
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 130.636420, 6.0e-4));
 }
 
@@ -126,11 +126,11 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Full)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full interatomic energy:  LJ (-5124.720) + Coul (2020.063) - LJ correct (-200.732)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic energy", interEnergy.values().back(), -2903.925, 5.0e-2));
 
     // Full intramolecular energy
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 11488.122, 6.0e-4));
 }
 
@@ -148,7 +148,7 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Bound)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full intramolecular energy
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 11488.122, 6.0e-4));
 }
 
@@ -169,7 +169,7 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Torsions)
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Liquid//Bound");
     EXPECT_TRUE(systemTest.checkDouble("torsion energy", intraEnergy.values().back(), 2173.978, 5.0e-4));
 }
 
@@ -180,11 +180,11 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Full)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full interatomic energy: -5.911071e+02   # 5.612389E+02 (elec) - 1.334653E+03 (VDW) + 0.182307E+03 (VDW LR correction)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic energy", interEnergy.values().back(), -5.911071e2, 3.5e-2));
 
     // Full intramolecular energy
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
     EXPECT_TRUE(systemTest.checkDouble("intramolecular energy", intraEnergy.values().back(), 5.901646e+03, 3.5e-3));
 }
 
@@ -206,7 +206,7 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181VanDerWaals)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Full van der Waals Energy: -1.152346e+03   # -1.334653E+03 (full) + 0.182307E+03 (LR correction)
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
     EXPECT_TRUE(systemTest.checkDouble("interatomic van der Waals energy", interEnergy.values().back(), -1.152346e+03, 3.5e-2));
 }
 
@@ -226,7 +226,7 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Electrostatics)
                                      }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
-    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Inter");
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
 
     // Shifted coulomb sum
     EXPECT_TRUE(systemTest.checkDouble("shifted coulomb energy", interEnergy.values().back(), 5.612389E+02, 1.8e-4));
@@ -243,7 +243,7 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Bound)
                                      }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
 
     EXPECT_TRUE(systemTest.checkDouble("bound term", intraEnergy.values().back(), 5.901646e+03, 3.5e-3));
 }
@@ -257,7 +257,7 @@ TEST_F(EnergyModuleTest, MoscitoPOETorsions)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Intramolecular energy: 183.4801   # (2.866876 per molecule) * 64 molecules
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//POE//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//POE//Bound");
     EXPECT_TRUE(systemTest.checkDouble("torsion energy", intraEnergy.values().back(), 183.4801, 1.0e-2));
 }
 
@@ -268,7 +268,7 @@ TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Torsions)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Intramolecular energy: 51.050222   # (25.525111 per molecule) * 2 molecules
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py4OH-NTf2//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py4OH-NTf2//Bound");
     EXPECT_TRUE(systemTest.checkDouble("torsion energy", intraEnergy.values().back(), 51.050222, 2.0e-5));
 }
 
@@ -279,7 +279,7 @@ TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Impropers)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Intramolecular energy: 0.055228   # (0.027614 per molecule) * 2 molecules
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py4OH-NTf2//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py4OH-NTf2//Bound");
     EXPECT_TRUE(systemTest.checkDouble("improper energy", intraEnergy.values().back(), 0.055228, 2.0e-5));
 }
 
@@ -290,7 +290,7 @@ TEST_F(EnergyModuleTest, MoscitoPy5NTf2Torsions)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Intramolecular energy: 39.29711  # (19.648555 per molecule) * 2 molecules
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py5-NTf2//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py5-NTf2//Bound");
     EXPECT_TRUE(systemTest.checkDouble("torsion energy", intraEnergy.values().back(), 39.29711, 5.0e-5));
 }
 
@@ -301,7 +301,7 @@ TEST_F(EnergyModuleTest, MoscitoPy5NTf2Impropers)
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Intramolecular energy: 0.34961  # (0.174805 per molecule) * 2 molecules
-    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py5-NTf2//Intra");
+    auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Py5-NTf2//Bound");
     EXPECT_TRUE(systemTest.checkDouble("improper energy", intraEnergy.values().back(), 0.34961, 5.0e-5));
 }
 


### PR DESCRIPTION
Here we add in the calculation and display of "separated" pairpotential energies. Within a typical molecular simulation one determines whether a condensed phase really is a condensed phase via the cohesive energy of the system, which strictly speaking is the contributions from interatomic (i.e. pairpotential) energy and forces between different molecules. Previously we calculated the total pairpotential energy including that occuring within individual molecules, so here we make the effort to partition those two terms for clarity.

This has involved some renaming of the data saved / plotted on the `EnergyModule`s output graph, meaning that old simulations will lose their historic energy output for some quantities.  However, this isn't a breaking change, more of a minor annoyance, and I'll capture the information in the release notes for 1.4.

Closes #1718.