### PR TITLE
#1076 enable backward compatibility

### DIFF
--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   main
   comms.cpp
+  compatibility.cpp
   cli.cpp
   dissolve.cpp
   io.cpp
@@ -14,6 +15,7 @@ add_library(
   simulation.cpp
   version.cpp
   cli.h
+  compatibility.h
   dissolve.h
   keywords.h
   version.h

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -13,8 +13,8 @@ namespace dissolve
 SerialisedValue unrealUpgrade(SerialisedValue contents)
 {
     if (contents["pairPotentials"].contains("coulombTruncation"))
-	contents["pairPotentials"]["coulombTruncation"] =
-	    toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
+        contents["pairPotentials"]["coulombTruncation"] =
+            toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
 
     return contents;
 }
@@ -32,12 +32,12 @@ SerialisedValue backwardsUpgrade(SerialisedValue contents)
 
     for (auto &[key, value] : breakingChanges)
     {
-	DissolveVersion next(key);
-	if (current < next)
-	{
-	    contents = value(contents);
-	    current = next;
-	}
+        DissolveVersion next(key);
+        if (current < next)
+        {
+            contents = value(contents);
+            current = next;
+        }
     }
 
     return contents;

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -10,8 +10,8 @@
 SerialisedValue unreal_upgrade(SerialisedValue contents)
 {
     if (contents["pairPotentials"].contains("coulombTruncation"))
-	contents["pairPotentials"]["coulombTruncation"] =
-	    toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
+        contents["pairPotentials"]["coulombTruncation"] =
+            toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
 
     return contents;
 }
@@ -29,12 +29,12 @@ SerialisedValue backwards_upgrade(SerialisedValue contents)
 
     for (auto &[key, value] : breaking_changes)
     {
-	DissolveVersion next(key);
-	if (current < next)
-	{
-	    contents = value(contents);
-	    current = next;
-	}
+        DissolveVersion next(key);
+        if (current < next)
+        {
+            contents = value(contents);
+            current = next;
+        }
     }
 
     return contents;

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "main/compatibility.h"
+
+SerialisedValue unreal_upgrade(SerialisedValue contents)
+{
+    contents["unreal"] = false;
+    return contents;
+}
+
+SerialisedValue backwards_upgrade(SerialisedValue contents)
+{
+    using Version::DissolveVersion;
+    std::map<std::string, std::function<SerialisedValue(SerialisedValue)>> breaking_changes = {{"1.2.0", unreal_upgrade}};
+
+    DissolveVersion current(toml::find<std::string>(contents, "version"));
+
+    for (auto &[key, value] : breaking_changes)
+    {
+	DissolveVersion next(key);
+	if (current < next)
+	{
+	    contents = value(contents);
+	    current = next;
+	}
+    }
+
+    return contents;
+}

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "main/compatibility.h"
+#include <functional>
 #include <iostream>
 
 namespace dissolve

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -4,38 +4,43 @@
 #include "main/compatibility.h"
 #include <iostream>
 
+namespace dissolve
+{
+
 // Upgrade from version zero, which never supported TOML in the first
 // place.  This exists purely to allow testing the backward
 // compatibility code before there is any pass worth checking.
-SerialisedValue unreal_upgrade(SerialisedValue contents)
+SerialisedValue unrealUpgrade(SerialisedValue contents)
 {
     if (contents["pairPotentials"].contains("coulombTruncation"))
-        contents["pairPotentials"]["coulombTruncation"] =
-            toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
+	contents["pairPotentials"]["coulombTruncation"] =
+	    toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
 
     return contents;
 }
 
 // Upgrade a file to the current version.
-SerialisedValue backwards_upgrade(SerialisedValue contents)
+SerialisedValue backwardsUpgrade(SerialisedValue contents)
 {
     using Version::DissolveVersion;
 
     // A map of version numbers and the corresponding function to
     // upgrade the file.
-    std::map<std::string, std::function<SerialisedValue(SerialisedValue)>> breaking_changes = {{"1.2.0", unreal_upgrade}};
+    std::map<std::string, std::function<SerialisedValue(SerialisedValue)>> breakingChanges = {{"1.2.0", unrealUpgrade}};
 
     DissolveVersion current(toml::find<std::string>(contents, "version"));
 
-    for (auto &[key, value] : breaking_changes)
+    for (auto &[key, value] : breakingChanges)
     {
-        DissolveVersion next(key);
-        if (current < next)
-        {
-            contents = value(contents);
-            current = next;
-        }
+	DissolveVersion next(key);
+	if (current < next)
+	{
+	    contents = value(contents);
+	    current = next;
+	}
     }
 
     return contents;
 }
+
+} // namespace dissolve

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -2,10 +2,14 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "main/compatibility.h"
+#include <iostream>
 
 SerialisedValue unreal_upgrade(SerialisedValue contents)
 {
-    contents["unreal"] = false;
+    if (contents["pairPotentials"].contains("coulombTruncation"))
+	contents["pairPotentials"]["coulombTruncation"] =
+	    toml::find<std::string>(contents["pairPotentials"], "coulombTruncation") + "ed";
+
     return contents;
 }
 

--- a/src/main/compatibility.cpp
+++ b/src/main/compatibility.cpp
@@ -4,6 +4,9 @@
 #include "main/compatibility.h"
 #include <iostream>
 
+// Upgrade from version zero, which never supported TOML in the first
+// place.  This exists purely to allow testing the backward
+// compatibility code before there is any pass worth checking.
 SerialisedValue unreal_upgrade(SerialisedValue contents)
 {
     if (contents["pairPotentials"].contains("coulombTruncation"))
@@ -13,9 +16,13 @@ SerialisedValue unreal_upgrade(SerialisedValue contents)
     return contents;
 }
 
+// Upgrade a file to the current version.
 SerialisedValue backwards_upgrade(SerialisedValue contents)
 {
     using Version::DissolveVersion;
+
+    // A map of version numbers and the corresponding function to
+    // upgrade the file.
     std::map<std::string, std::function<SerialisedValue(SerialisedValue)>> breaking_changes = {{"1.2.0", unreal_upgrade}};
 
     DissolveVersion current(toml::find<std::string>(contents, "version"));

--- a/src/main/compatibility.h
+++ b/src/main/compatibility.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/serialiser.h"
+#include "main/version.h"
+
+SerialisedValue backwards_upgrade(SerialisedValue contents);

--- a/src/main/compatibility.h
+++ b/src/main/compatibility.h
@@ -6,7 +6,8 @@
 #include "base/serialiser.h"
 #include "main/version.h"
 
-namespace dissolve {
+namespace dissolve
+{
 
 SerialisedValue backwardsUpgrade(SerialisedValue contents);
 

--- a/src/main/compatibility.h
+++ b/src/main/compatibility.h
@@ -6,4 +6,8 @@
 #include "base/serialiser.h"
 #include "main/version.h"
 
-SerialisedValue backwards_upgrade(SerialisedValue contents);
+namespace dissolve {
+
+SerialisedValue backwardsUpgrade(SerialisedValue contents);
+
+}

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -190,13 +190,13 @@ void Dissolve::deserialisePairPotentials(const SerialisedValue &node)
 }
 
 // Read values from a serialisable value
-void Dissolve::deserialise(const SerialisedValue &node_orig)
+void Dissolve::deserialise(const SerialisedValue &originalNode)
 {
     // Default to current version if no version info is given.
-    bool hasVersion = node_orig.contains("version");
+    auto hasVersion = originalNode.contains("version");
     if (!hasVersion)
         Messenger::warn("File does not contain version information.  Assuming the current version: {}", Version::semantic());
-    const SerialisedValue node = hasVersion ? backwards_upgrade(node_orig) : node_orig;
+    const SerialisedValue node = hasVersion ? dissolve::backwardsUpgrade(originalNode) : originalNode;
 
     Serialisable::optionalOn(node, "pairPotentials", [this](const auto node) { deserialisePairPotentials(node); });
     Serialisable::optionalOn(node, "master", [this](const auto node) { coreData_.deserialiseMaster(node); });

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -7,38 +7,13 @@
 #include "classes/atomType.h"
 #include "classes/species.h"
 #include "data/isotopes.h"
+#include "main/compatibility.h"
 #include "main/dissolve.h"
 #include "main/keywords.h"
 #include "main/version.h"
 #include <cstring>
 #include <functional>
 #include <map>
-
-SerialisedValue unreal_upgrade(SerialisedValue contents)
-{
-    contents["unreal"] = false;
-    return contents;
-}
-
-SerialisedValue backwards_upgrade(SerialisedValue contents)
-{
-    using Version::DissolveVersion;
-    std::map<std::string, std::function<SerialisedValue(SerialisedValue)>> breaking_changes = {{"1.2.0", unreal_upgrade}};
-
-    DissolveVersion current(toml::find<std::string>(contents, "version"));
-
-    for (auto &[key, value] : breaking_changes)
-    {
-        DissolveVersion next(key);
-        if (current < next)
-        {
-            contents = value(contents);
-            current = next;
-        }
-    }
-
-    return contents;
-}
 
 // Load input file through supplied parser
 bool Dissolve::loadInput(LineParser &parser)

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "base/lineParser.h"
+#include "base/messenger.h"
 #include "base/serialiser.h"
 #include "base/sysFunc.h"
 #include "classes/atomType.h"
@@ -191,7 +192,11 @@ void Dissolve::deserialisePairPotentials(const SerialisedValue &node)
 // Read values from a serialisable value
 void Dissolve::deserialise(const SerialisedValue &node_orig)
 {
-    const SerialisedValue node = backwards_upgrade(node_orig);
+    // Default to current version if no version info is given.
+    bool hasVersion = node_orig.contains("version");
+    if (!hasVersion)
+        Messenger::warn("File does not contain version information.  Assuming the current version: {}", Version::semantic());
+    const SerialisedValue node = hasVersion ? backwards_upgrade(node_orig) : node_orig;
 
     Serialisable::optionalOn(node, "pairPotentials", [this](const auto node) { deserialisePairPotentials(node); });
     Serialisable::optionalOn(node, "master", [this](const auto node) { coreData_.deserialiseMaster(node); });

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -144,6 +144,8 @@ SerialisedValue Dissolve::serialise() const
 {
     SerialisedValue root;
 
+    root["version"] = Version::semantic();
+
     if (!coreData_.masterBonds().empty() || !coreData_.masterAngles().empty() || !coreData_.masterTorsions().empty() ||
         !coreData_.masterImpropers().empty())
         root["master"] = coreData_.serialiseMaster();

--- a/src/main/version.cpp
+++ b/src/main/version.cpp
@@ -3,6 +3,7 @@
 
 #include "main/version.h"
 #include <fmt/format.h>
+#include <iostream>
 
 #define DISSOLVEVERSION "1.4.0"
 #define DISSOLVESHORTHASH ""

--- a/src/main/version.cpp
+++ b/src/main/version.cpp
@@ -50,4 +50,33 @@ std::string_view appType()
 #endif
 }
 
+DissolveVersion::DissolveVersion(std::string_view version)
+{
+    auto dot = version.find(".");
+    major_ = std::stoi(std::string(version.substr(0, dot)));
+    auto rest = version.substr(dot + 1);
+    dot = rest.find(".");
+    minor_ = std::stoi(std::string(rest.substr(0, dot)));
+    patch_ = std::stoi(std::string(rest.substr(dot + 1)));
+}
+
+bool DissolveVersion::operator<(const DissolveVersion &other) const
+{
+    if (major_ != other.major_)
+        return major_ < other.major_;
+    if (minor_ != other.minor_)
+        return minor_ < other.minor_;
+    return patch_ < other.patch_;
+}
+
+bool DissolveVersion::operator==(const DissolveVersion &other) const
+{
+    return major_ == other.major_ && minor_ == other.minor_ && patch_ == other.patch_;
+}
+
+std::ostream &operator<<(std::ostream &os, const DissolveVersion &version)
+{
+    os << fmt::format("{}.{}.{}", version.major_, version.minor_, version.patch_);
+    return os;
+}
 }; // namespace Version

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -17,7 +17,7 @@ std::string_view repoUrl();
 std::string_view appType();
 
 // This class handles the version numbers of the app in a structured
-// manor.
+// manner.
 class DissolveVersion
 {
     private:

--- a/src/main/version.h
+++ b/src/main/version.h
@@ -15,4 +15,21 @@ std::string_view info();
 std::string_view repoUrl();
 // Return app type
 std::string_view appType();
+
+// This class handles the version numbers of the app in a structured
+// manor.
+class DissolveVersion
+{
+    private:
+    int major_;
+    int minor_;
+    int patch_;
+
+    public:
+    DissolveVersion(std::string_view version);
+    bool operator<(const DissolveVersion &other) const;
+    bool operator==(const DissolveVersion &other) const;
+    friend std::ostream &operator<<(std::ostream &os, const DissolveVersion &version);
+};
+
 }; // namespace Version

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -1,2 +1,3 @@
 dissolve_add_test(SRC cif.cpp)
 dissolve_add_test(SRC intraParameterParse.cpp)
+dissolve_add_test(SRC version.cpp)

--- a/tests/io/version.cpp
+++ b/tests/io/version.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2023 Team Dissolve and contributors
 
 #include "main/version.h"
+#include "base/serialiser.h"
 #include "main/dissolve.h"
 #include <gtest/gtest.h>
 
@@ -39,6 +40,18 @@ TEST(VersionTest, VersionInfo)
     Version::DissolveVersion fileVersion(serialised["version"].as_string().str), actual(Version::semantic());
 
     EXPECT_EQ(fileVersion, actual);
+}
+
+TEST(VersionTest, VersionUpgrade)
+{
+    CoreData coreData;
+    Dissolve dissolve(coreData);
+
+    SerialisedValue old;
+    old["version"] = "0.0.0";
+    old["pairPotentials"] = {{"coulombTruncation", "Shift"}};
+
+    dissolve.deserialise(old);
 }
 
 } // namespace UnitTest

--- a/tests/io/version.cpp
+++ b/tests/io/version.cpp
@@ -8,6 +8,27 @@
 namespace UnitTest
 {
 
+TEST(VersionTest, VersionClass)
+{
+    using Version::DissolveVersion;
+    DissolveVersion first{"1.10.3"}, second{"2.1.12"}, minor{"2.2.1"}, patch{"2.2.2"}, third{"3.0.0"};
+
+    // Main sequence
+    EXPECT_LT(first, second);
+    EXPECT_LT(second, minor);
+    EXPECT_LT(minor, patch);
+    EXPECT_LT(patch, third);
+
+    // Full combinatorial
+    EXPECT_LT(first, minor);
+    EXPECT_LT(first, patch);
+    EXPECT_LT(first, third);
+    EXPECT_LT(second, minor);
+    EXPECT_LT(second, patch);
+    EXPECT_LT(second, third);
+    EXPECT_LT(minor, third);
+}
+
 TEST(VersionTest, VersionInfo)
 {
     CoreData coreData;
@@ -15,7 +36,9 @@ TEST(VersionTest, VersionInfo)
     dissolve.loadInput("dissolve/input/rdfMethod.txt");
     auto serialised = dissolve.serialise();
 
-    EXPECT_EQ(serialised["version"].as_string().str, Version::semantic());
+    Version::DissolveVersion fileVersion(serialised["version"].as_string().str), actual(Version::semantic());
+
+    EXPECT_EQ(fileVersion, actual);
 }
 
 } // namespace UnitTest

--- a/tests/io/version.cpp
+++ b/tests/io/version.cpp
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Team Dissolve and contributors
+
+#include "main/version.h"
+#include "main/dissolve.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+
+TEST(VersionTest, VersionInfo)
+{
+    CoreData coreData;
+    Dissolve dissolve(coreData);
+    dissolve.loadInput("dissolve/input/rdfMethod.txt");
+    auto serialised = dissolve.serialise();
+
+    EXPECT_EQ(serialised["version"].as_string().str, Version::semantic());
+}
+
+} // namespace UnitTest


### PR DESCRIPTION
This PR adds the framework for backward compatibility.  This includes some code for upgrading files from version 0.

To ease users who are creating files by hand, including a version is optional.  This will cause the program to assume that the file was written for the current version.  This *will* trigger a warning to alert the user.  Files saves by Dissolve will always include the version number.

Closes #1076