### PR TITLE
Actually assign intramolecular terms in add forcefield dialog

### DIFF
--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -248,8 +248,7 @@ void AddForcefieldDialogModel::finalise()
     }
 
     // Assign intramolecular terms if we need to
-    // if (!intramolecularTermsAssigned_)
-    //	assignIntramolecularTerms(ui_.ForcefieldWidget->currentForcefield().get());
+    assignIntramolecularTerms(ff_);
 
     // Copy intramolecular terms
     if (intramolecularRadio_ != Radio::None)
@@ -392,4 +391,33 @@ void AddForcefieldDialogModel::setFf(Forcefield *f)
 {
     ff_ = f;
     Q_EMIT progressionAllowedChanged();
+}
+
+// Assign intramolecular terms to species
+void AddForcefieldDialogModel::assignIntramolecularTerms(const Forcefield *ff)
+{
+    // Detach any MasterTerm references, and delete the MasterTerms
+    modifiedSpecies_->detachFromMasterTerms();
+    temporaryCoreData_.clearMasterTerms();
+
+    // Assign intramolecular terms
+    if (intramolecularRadio_ != Radio::None)
+    {
+        auto flags = 0;
+        if (ignoreCurrentTypes_)
+            flags += Forcefield::DetermineTypesFlag;
+        if (!noImproperTerms_)
+            flags += Forcefield::GenerateImpropersFlag;
+        if (intramolecularRadio_ == Radio::Selected)
+            flags += Forcefield::SelectionOnlyFlag;
+
+        if (!ff->assignIntramolecular(modifiedSpecies_, flags))
+            // Assigning failed
+            return;
+
+        // Reduce to master terms?
+        if (!noMasterTerms_)
+            modifiedSpecies_->reduceToMasterTerms(temporaryCoreData_, intramolecularRadio_ == Radio::Selected);
+    }
+    return;
 }

--- a/src/gui/models/addForcefieldDialogModel.h
+++ b/src/gui/models/addForcefieldDialogModel.h
@@ -116,6 +116,9 @@ class AddForcefieldDialogModel : public QObject
     Radio atomTypeRadio_ = Radio::All;
     // The choice for how to handle intramolecular terms
     Radio intramolecularRadio_ = Radio::All;
+
+    private:
+    // Assign intramolecular terms to species
     void assignIntramolecularTerms(const Forcefield *ff);
 
     public:

--- a/src/gui/models/addForcefieldDialogModel.h
+++ b/src/gui/models/addForcefieldDialogModel.h
@@ -116,6 +116,7 @@ class AddForcefieldDialogModel : public QObject
     Radio atomTypeRadio_ = Radio::All;
     // The choice for how to handle intramolecular terms
     Radio intramolecularRadio_ = Radio::All;
+    void assignIntramolecularTerms(const Forcefield *ff);
 
     public:
     // Instantiate the model


### PR DESCRIPTION
So the assigning of intramolecular terms was not actually getting called in the Add Forcefield Dialog.  This should fix the issues with the medic.  As basic testing, I created a methanol molecule, added the forcefield, and successfully ran the medic afterwards.

Closes #1750