### PR TITLE
Link qt-idaaas nixpkgs version to our primary nixpkgs version

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -196,22 +196,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1680334310,
-        "narHash": "sha256-ISWz16oGxBhF7wqAxefMPwFag6SlsA9up8muV79V9ck=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "884e3b68be02ff9d61a042bc9bd9dd2a358f95da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "outdated": {
       "locked": {
         "lastModified": 1659914493,
@@ -230,7 +214,9 @@
     },
     "qt-idaaas": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1686232008,

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
     qt-idaaas.url = "github:disorderedmaterials/qt-idaaas";
+    qt-idaaas.inputs.nixpkgs.follows = "nixpkgs";
   };
   outputs = { self, nixpkgs, outdated, home-manager, flake-utils, bundlers, nixGL-src
     , qt-idaaas}:


### PR DESCRIPTION
This should fix the issue with Qt Designer.  It will also ensure that future upgrades of nixpkgs will also upgrade the nixpkgs of our patched Qt.  Granted, I'm hoping that IDAaaS will have upgraded to a more modern kernel before the next nixpkgs release and we won't still be patching Qt.