### PR TITLE
Fix Benchmarks 2024 - FixUp

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,17 +35,21 @@ jobs:
           wget https://www.antlr.org/download/antlr-${{ env.antlrVersion }}-complete.jar -O antlr4.jar
       - name: Build
         run: |
+          set -ex
           mkdir build
           cd build
           conan install ../ -s compiler.libcxx=libstdc++11
           cmake ../ -G "Ninja" -DBUILD_BENCHMARKS:bool=true -DANTLR_EXECUTABLE:path=`pwd`/../antlr4.jar
           ninja
-
-          # Deploy Conan dependencies alongside binary so we can run it
-          cd bin
-          conan install ../.. -g deploy -s compiler.libcxx=libstdc++11
+      - name: Deploy Dependencies
+        run: |
+          mkdir deploy && cd deploy
+          conan install .. -g deploy -s compiler.libcxx=libstdc++11
       - name: Run benchmarks
-        run: ./build/bin/benchmarks --benchmark_format=json | tee benchmark_result.json
+        run: |
+          set -ex
+          export LD_LIBRARY_PATH=`pwd`/deploy/onetbb/lib
+          ./build/bin/benchmarks --benchmark_format=json | tee benchmark_result.json
       - name: Store benchmark result
         uses: rhysd/github-action-benchmark@v1
         if: ${{ github.ref_name == 'develop' }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -43,7 +43,7 @@ jobs:
 
           # Deploy Conan dependencies alongside binary so we can run it
           cd bin
-          conan install ../.. -g deploy
+          conan install ../.. -g deploy -s compiler.libcxx=libstdc++11
       - name: Run benchmarks
         run: ./build/bin/benchmarks --benchmark_format=json | tee benchmark_result.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -40,6 +40,10 @@ jobs:
           conan install ../ -s compiler.libcxx=libstdc++11
           cmake ../ -G "Ninja" -DBUILD_BENCHMARKS:bool=true -DANTLR_EXECUTABLE:path=`pwd`/../antlr4.jar
           ninja
+
+          # Deploy Conan dependencies alongside binary so we can run it
+          cd bin
+          conan install ../.. -g deploy
       - name: Run benchmarks
         run: ./build/bin/benchmarks --benchmark_format=json | tee benchmark_result.json
       - name: Store benchmark result


### PR DESCRIPTION
A PR to fix the fixed benchmarks.  Turns out that the generated `benchmarks` binary can't find the shared tbb lib and so immediately failed, but this didn't cause an error in the CI because we didn't have `set -ex` on the benchmark step.  The main `develop` run highlighted the issue when it tried to upload the benchmark results, which obviously didn't exist.