### PR TITLE
Remove need for QC before build workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,6 @@ jobs:
       uses: "./.github/workflows/qc"
 
   Build:
-    needs: QC
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +52,6 @@ jobs:
         uses: "./.github/workflows/build"
 
   BuildLinux:
-    needs: QC
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Have the QC workflow act as a soft-check instead of a hard-check, as currently the other tests won't run if the QC fails.