### PR TITLE
Module Add Crash

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -38,8 +38,8 @@ std::shared_ptr<AtomType> CoreData::addAtomType(Elements::Element Z)
     atomTypes_.push_back(newAtomType);
 
     // Create a suitable unique name
-    newAtomType->setName(DissolveSys::uniqueName(
-        Elements::symbol(Z), atomTypes_, [&](const auto &at) { return newAtomType == at ? std::string() : at->name(); }));
+    newAtomType->setName(DissolveSys::uniqueName(Elements::symbol(Z), atomTypes_,
+                                                 [&](const auto &at) { return newAtomType == at ? "" : at->name(); }));
 
     // Set data
     newAtomType->setZ(Z);
@@ -309,8 +309,8 @@ Species *CoreData::addSpecies()
     auto &newSpecies = species_.emplace_back(std::make_unique<Species>());
 
     // Create a suitable unique name
-    newSpecies->setName(DissolveSys::uniqueName("NewSpecies", species_,
-                                                [&](const auto &sp) { return newSpecies == sp ? std::string() : sp->name(); }));
+    newSpecies->setName(
+        DissolveSys::uniqueName("NewSpecies", species_, [&](const auto &sp) { return newSpecies == sp ? "" : sp->name(); }));
 
     return newSpecies.get();
 }
@@ -433,8 +433,8 @@ Species *CoreData::copySpecies(const Species *species)
 {
     // Create our new Species
     Species *newSpecies = addSpecies();
-    newSpecies->setName(DissolveSys::uniqueName(
-        species->name(), species_, [&](const auto &sp) { return newSpecies == sp.get() ? std::string() : sp->name(); }));
+    newSpecies->setName(DissolveSys::uniqueName(species->name(), species_,
+                                                [&](const auto &sp) { return newSpecies == sp.get() ? "" : sp->name(); }));
 
     // Copy Box definition if one exists
     if (species->box()->type() != Box::BoxType::NonPeriodic)
@@ -497,9 +497,8 @@ Configuration *CoreData::addConfiguration()
     auto &newConfiguration = configurations_.emplace_back(std::make_unique<Configuration>());
 
     // Create a suitable unique name
-    newConfiguration->setName(DissolveSys::uniqueName("NewConfiguration", configurations_,
-                                                      [&](const auto &cfg)
-                                                      { return newConfiguration == cfg ? std::string() : cfg->name(); }));
+    newConfiguration->setName(DissolveSys::uniqueName(
+        "NewConfiguration", configurations_, [&](const auto &cfg) { return newConfiguration == cfg ? "" : cfg->name(); }));
 
     return newConfiguration.get();
 }

--- a/src/classes/species_isotopologues.cpp
+++ b/src/classes/species_isotopologues.cpp
@@ -24,8 +24,7 @@ Isotopologue *Species::addIsotopologue(std::string_view baseName)
 {
     auto &iso = isotopologues_.emplace_back(std::make_unique<Isotopologue>());
     iso->setParent(this);
-    iso->setName(
-        DissolveSys::uniqueName(baseName, isotopologues_, [&](const auto &i) { return iso == i ? std::string() : i->name(); }));
+    iso->setName(DissolveSys::uniqueName(baseName, isotopologues_, [&](const auto &i) { return iso == i ? "" : i->name(); }));
     iso->update();
 
     return iso.get();

--- a/src/gui/menu_layer.cpp
+++ b/src/gui/menu_layer.cpp
@@ -26,7 +26,7 @@ void DissolveWindow::on_LayerCreateEvolveBasicAtomicAction_triggered(bool checke
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Basic Atomic)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
 
     Module *module;
     auto *firstCfg =
@@ -54,7 +54,7 @@ void DissolveWindow::on_LayerCreateEvolveAtomicAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Atomic)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
 
     Module *module;
     auto *firstCfg =
@@ -87,7 +87,7 @@ void DissolveWindow::on_LayerCreateEvolveMolecularAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (Standard)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
 
     Module *module;
     auto *firstCfg =
@@ -120,7 +120,7 @@ void DissolveWindow::on_LayerCreateEvolveMDAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (MD)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
 
     Module *module;
     auto *firstCfg =
@@ -151,7 +151,7 @@ void DissolveWindow::on_LayerCreateEvolveEPSRAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Evolve (EPSR)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
 
     Module *module;
     auto *firstCfg =
@@ -183,7 +183,7 @@ void DissolveWindow::on_LayerCreateRefineEPSRAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Refine (EPSR)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlags(ModuleLayer::RunControlFlag::EnergyStability,
                                          ModuleLayer::RunControlFlag::SizeFactors);
@@ -208,7 +208,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("G(r)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
@@ -229,7 +229,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFStructureFactorAction_triggere
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("G(r) / Unweighted S(Q)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
@@ -253,7 +253,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronAction_triggered(bool c
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("G(r) / Neutron S(Q)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
@@ -280,7 +280,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFXRayAction_triggered(bool chec
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("G(r) / X-ray S(Q)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
@@ -307,7 +307,7 @@ void DissolveWindow::on_LayerCreateCorrelationsRDFNeutronXRayAction_triggered(bo
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("G(r) / Neutron S(Q) / X-ray S(Q)", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->setFrequency(5);
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
@@ -337,7 +337,7 @@ void DissolveWindow::on_LayerCreateAnalyseRDFCNAction_triggered(bool checked)
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Analyse RDF/CN", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     auto firstCfg =
@@ -361,7 +361,7 @@ void DissolveWindow::on_LayerCreateAnalyseAvgMolSDFAction_triggered(bool checked
 {
     auto *newLayer = dissolve_.coreData().addProcessingLayer();
     newLayer->setName(DissolveSys::uniqueName("Analyse AvgMol/SDF", dissolve_.coreData().processingLayers(),
-                                              [&](const auto &l) { return newLayer == l.get() ? std::string() : l->name(); }));
+                                              [&](const auto &l) { return newLayer == l.get() ? "" : l->name(); }));
     newLayer->runControlFlags().setFlag(ModuleLayer::RunControlFlag::SizeFactors);
 
     auto firstCfg =

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -39,8 +39,7 @@ void DissolveWindow::on_SpeciesCreateAtomicAction_triggered(bool checked)
     auto *newSpecies = dissolve_.coreData().addSpecies();
     newSpecies->addAtom(Z, Vec3<double>());
     newSpecies->setName(DissolveSys::uniqueName(Elements::symbol(Z), dissolve().coreData().species(),
-                                                [&](const auto &sp)
-                                                { return newSpecies == sp.get() ? std::string() : sp->name(); }));
+                                                [&](const auto &sp) { return newSpecies == sp.get() ? "" : sp->name(); }));
 
     setModified();
     fullUpdate();

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -153,7 +153,7 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
                 if (coreData_)
                     atomType->setName(DissolveSys::uniqueName(value.toString().toStdString(), coreData_->get().atomTypes(),
                                                               [&atomType](const auto &at)
-                                                              { return atomType == at ? std::string() : at->name(); }));
+                                                              { return atomType == at ? "" : at->name(); }));
                 else
                     atomType->setName(value.toString().toStdString());
                 break;

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -130,7 +130,7 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
             auto oldName = QString::fromStdString(std::string(module->name()));
             auto newName =
                 DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), coreData_->moduleInstances(),
-                                        [&](const auto &inst) { return inst == module ? std::string() : inst->name(); });
+                                        [&](const auto &inst) { return inst == module ? "" : inst->name(); });
             module->setName(newName);
 
             Q_EMIT(dataChanged(index, index));

--- a/src/gui/models/moduleLayerModel.cpp
+++ b/src/gui/models/moduleLayerModel.cpp
@@ -103,20 +103,6 @@ bool ModuleLayerModel::setData(const QModelIndex &index, const QVariant &value, 
 
         return true;
     }
-    else if (role == ModuleLayerModelAction::CreateNew)
-    {
-        if (!coreData_)
-            return false;
-        // Probably indicates a drop operation - the "value" is the type of the module to create at the specified index
-        auto moduleType = (ModuleTypes::ModuleType)value.toInt();
-        moduleLayer_->modules()[index.row()] = ModuleRegistry::create(*coreData_, moduleType);
-        auto *modulePtr = moduleLayer_->modules()[index.row()].get();
-        modulePtr->setTargets(coreData_->configurations(), moduleLayer_->modulesAsMap(modulePtr));
-
-        Q_EMIT dataChanged(index, index);
-
-        return true;
-    }
 
     auto *module = rawData(index);
 
@@ -283,12 +269,17 @@ bool ModuleLayerModel::dropMimeData(const QMimeData *data, Qt::DropAction action
         if (insertAtRow == -1)
             insertAtRow = rowCount();
 
+        // Create a new module of the specified type
+        auto newModule = ModuleRegistry::create(*coreData_, *moduleType);
+        newModule->setTargets(coreData_->configurations(), moduleLayer_->modulesAsMap(newModule.get()));
+
         // Create a new row to store the data (the soon-to-be-empty row will be deleted automatically by the model)
         insertRows(insertAtRow, 1, QModelIndex());
         auto idx = index(insertAtRow, 0, QModelIndex());
+        moduleLayer_->modules()[idx.row()] = std::move(newModule);
 
-        // Create a new module of the specified type at the index we just inserted
-        setData(idx, *moduleType, ModuleLayerModelAction::CreateNew);
+        // Update the model
+        Q_EMIT dataChanged(idx, idx);
 
         return true;
     }
@@ -337,12 +328,17 @@ QModelIndex ModuleLayerModel::appendNew(const QString &moduleTypeString)
     // Get the target row for the new module
     auto insertAtRow = rowCount();
 
+    // Create a new module of the specified type
+    auto newModule = ModuleRegistry::create(*coreData_, *moduleType);
+    newModule->setTargets(coreData_->configurations(), moduleLayer_->modulesAsMap(newModule.get()));
+
     // Create a new row to store the data (the soon-to-be-empty row will be deleted automatically by the model)
     insertRows(insertAtRow, 1, QModelIndex());
     auto idx = index(insertAtRow, 0, QModelIndex());
+    moduleLayer_->modules()[idx.row()] = std::move(newModule);
 
-    // Create a new module of the specified type at the index we just inserted
-    setData(idx, *moduleType, ModuleLayerModelAction::CreateNew);
+    // Update the model
+    Q_EMIT dataChanged(idx, idx);
 
     return idx;
 }

--- a/src/gui/models/moduleLayerModel.h
+++ b/src/gui/models/moduleLayerModel.h
@@ -36,8 +36,7 @@ class ModuleLayerModel : public QAbstractTableModel
     private:
     enum ModuleLayerModelAction
     {
-        MoveInternal = Qt::UserRole,
-        CreateNew
+        MoveInternal = Qt::UserRole
     };
     enum DataColumns
     {

--- a/src/gui/models/speciesIsoModel.cpp
+++ b/src/gui/models/speciesIsoModel.cpp
@@ -135,7 +135,7 @@ bool SpeciesIsoModel::setData(const QModelIndex &index, const QVariant &value, i
     {
         auto iso = species_.isotopologue(index.row());
         iso->setName(DissolveSys::uniqueName(DissolveSys::niceName(value.toString().toStdString()), species_.isotopologues(),
-                                             [&](const auto &i) { return iso == i.get() ? std::string() : i->name(); }));
+                                             [&](const auto &i) { return iso == i.get() ? "" : i->name(); }));
         Q_EMIT(dataChanged(index, index));
         return true;
     }

--- a/src/gui/speciesTab_isotopologues.cpp
+++ b/src/gui/speciesTab_isotopologues.cpp
@@ -65,10 +65,9 @@ void SpeciesTab::on_IsotopologuesTree_customContextMenuRequested(const QPoint &p
 
         // Set a unique name for the new isotopologue
         auto newIso = isos_.data(newIndex, Qt::UserRole).value<Isotopologue *>();
-        isos_.setData(newIndex,
-                      QString::fromStdString(DissolveSys::uniqueName(
-                          iso->name(), species_->isotopologues(),
-                          [newIso](const auto &oldIso) { return newIso == oldIso.get() ? std::string() : oldIso->name(); })));
+        isos_.setData(newIndex, QString::fromStdString(DissolveSys::uniqueName(
+                                    iso->name(), species_->isotopologues(),
+                                    [newIso](const auto &oldIso) { return newIso == oldIso.get() ? "" : oldIso->name(); })));
 
         auto row = 0;
         for (const auto &[atomType, tope] : iso->isotopes())

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -68,10 +68,13 @@ bool EPSRModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordS
         rho = targetConfiguration_->atomicDensity();
     }
 
-    // Realise storage for generated S(Q), and initialise a scattering matrix
-    auto &estimatedSQ = moduleContext.dissolve().processingModuleData().realise<Array2D<Data1D>>(
-        "EstimatedSQ", name_, GenericItem::InRestartFileFlag);
-    scatteringMatrix_.initialise(targetConfiguration_->atomTypes(), estimatedSQ);
+    // Realise storage for generated S(Q), and initialise a scattering matrix, but only if we have a valid configuration
+    if (targetConfiguration_)
+    {
+        auto &estimatedSQ = moduleContext.dissolve().processingModuleData().realise<Array2D<Data1D>>(
+            "EstimatedSQ", name_, GenericItem::InRestartFileFlag);
+        scatteringMatrix_.initialise(targetConfiguration_->atomTypes(), estimatedSQ);
+    }
 
     // If a pcof file was provided, read in the parameters from it here
     if (!pCofFilename_.empty())

--- a/src/modules/registry.cpp
+++ b/src/modules/registry.cpp
@@ -136,7 +136,7 @@ std::unique_ptr<Module> ModuleRegistry::create(CoreData &coreData, ModuleTypes::
 
     if (m)
         m->setName(DissolveSys::uniqueName(ModuleTypes::moduleType(m->type()), coreData.moduleInstances(),
-                                           [&](const auto &inst) { return inst == m.get() ? std::string() : inst->name(); }));
+                                           [&](const auto &inst) { return inst == m.get() ? "" : inst->name(); }));
     return m;
 }
 

--- a/tests/algorithms/sysFunc.cpp
+++ b/tests/algorithms/sysFunc.cpp
@@ -128,9 +128,8 @@ TEST(SysFunc, StringManipulation)
     auto &exc = names.emplace_back("IAmUnique01");
     EXPECT_FALSE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique01");
     EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique02");
-    EXPECT_TRUE(
-        DissolveSys::uniqueName("IAmUnique", names, [&](const auto &obj) { return &exc == &obj ? std::string() : obj.name; }) ==
-        "IAmUnique01");
+    EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [&](const auto &obj) { return &exc == &obj ? "" : obj.name; }) ==
+                "IAmUnique01");
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR addresses a critical issue with adding modules to any layer.  The root cause was a bit of bad interplay between the renovated `CoreData` function to return all module instances and the `ModuleLayerModel`.  Basically, the model would create an empty slot in a layer containing a null pointer ready to receive the newly-created module pointer in a different model function, but in-between we attempt to create a unique name which involves iterating over a list of all module instances.  This contains our null pointer placeholder, and so the `DissolveSys::uniqueName()` function would cause a segfault when it tried to get the name of this null module.

Rather than modifying the `CoreData` routine to avoid null pointers I have modified the model to create the new `Module`s at the point of requirement.