### PR TITLE
1779 Upgrade GH Upload/Download

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -53,8 +53,8 @@ runs:
       nix build -L .#$singularityTarget
 
       # Assemble artifacts
-      mkdir packages
-      cp -v result packages/${{ inputs.target }}-${{ env.dissolveVersion }}.sif
+      mkdir packages-sif
+      cp -v result packages-sif/${{ inputs.target }}-${{ env.dissolveVersion }}.sif
 
   - name: Bundle Executable
     shell: bash
@@ -64,7 +64,8 @@ runs:
       nix bundle -L .#${{ inputs.target }} -o binary
 
       # Assemble artifacts
-      cp -v binary packages/${{ inputs.target }}-${{ env.dissolveVersion }}
+      mkdir packages-binary
+      cp -v binary packages-binary/${{ inputs.target }}-${{ env.dissolveVersion }}
 
   - name: Tidy nix Store
     if: ${{ inputs.cacheOnly == 'true' }}
@@ -82,9 +83,16 @@ runs:
     shell: bash
     run: nix-store --export $(find /nix/store -maxdepth 1 -name '*-*') > /tmp/nixcache
 
-  - name: Upload Package Artifacts
+  - name: Upload Package Artifacts (Binary)
     if: ${{ inputs.cacheOnly == 'false' }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
-      name: packages
-      path: ${{ github.workspace }}/packages
+      name: packages-nix-binary
+      path: ${{ github.workspace }}/packages-binary
+
+  - name: Upload Package Artifacts (sif)
+    if: ${{ inputs.cacheOnly == 'false' }}
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-nix-sif
+      path: ${{ github.workspace }}/packages-sif

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -87,12 +87,12 @@ runs:
     if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v4
     with:
-      name: packages-nix-binary
+      name: packages-nix-${{ inputs.target }}-binary
       path: ${{ github.workspace }}/packages-binary
 
   - name: Upload Package Artifacts (sif)
     if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v4
     with:
-      name: packages-nix-sif
+      name: packages-nix-${{ inputs.target }}-sif
       path: ${{ github.workspace }}/packages-sif

--- a/.github/workflows/build/osx-intel/action.yml
+++ b/.github/workflows/build/osx-intel/action.yml
@@ -105,7 +105,7 @@ runs:
 
   - name: Upload Raw Build Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: osx-build-artifacts
       path: |

--- a/.github/workflows/build/osx-silicon/action.yml
+++ b/.github/workflows/build/osx-silicon/action.yml
@@ -123,7 +123,7 @@ runs:
 
   - name: Upload Raw Build Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: osx-build-artifacts-silicon
       path: |

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -188,7 +188,7 @@ runs:
 
   - name: Upload Raw Build Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
       name: windows-build-artifacts
       path: |

--- a/.github/workflows/package/osx-intel/action.yml
+++ b/.github/workflows/package/osx-intel/action.yml
@@ -17,7 +17,7 @@ runs:
       path: ${{ runner.temp }}/qt
 
   - name: Download Raw Build Artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name: osx-build-artifacts
       path: ${{ github.workspace }}
@@ -71,7 +71,7 @@ runs:
       mv Dissolve-GUI-${dissolveVersion}.dmg packages/
 
   - name: Upload Package Artifacts
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
-      name: packages
+      name: packages-osx-intel
       path: ${{ github.workspace }}/packages

--- a/.github/workflows/package/osx-silicon/action.yml
+++ b/.github/workflows/package/osx-silicon/action.yml
@@ -17,7 +17,7 @@ runs:
       path: ${{ runner.temp }}/qt
 
   - name: Download Raw Build Artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name: osx-build-artifacts-silicon
       path: ${{ github.workspace }}
@@ -77,7 +77,7 @@ runs:
       mv Dissolve-GUI-${dissolveVersion}.dmg packages/
 
   - name: Upload Package Artifacts
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
-      name: packages
+      name: packages-osx-silicon
       path: ${{ github.workspace }}/packages

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -17,7 +17,7 @@ runs:
       path: ${{ runner.temp }}/qt
 
   - name: Download Raw Build Artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name: osx-build-artifacts
       path: ${{ github.workspace }}
@@ -71,7 +71,7 @@ runs:
       mv Dissolve-GUI-${dissolveVersion}.dmg packages/
 
   - name: Upload Package Artifacts
-    uses: actions/upload-artifact@v3
+    uses: actions/upload-artifact@v4
     with:
-      name: packages
+      name: packages-osx
       path: ${{ github.workspace }}/packages

--- a/.github/workflows/package/windows/action.yml
+++ b/.github/workflows/package/windows/action.yml
@@ -32,7 +32,7 @@ runs:
         ${{ runner.temp }}\freetype-install
 
   - name: Download Raw Build Artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
       name: windows-build-artifacts
       path: ${{ github.workspace }}
@@ -72,12 +72,19 @@ runs:
       zip -r $zipFile $exeBase
       
       # Collect artifacts
-      mkdir packages
-      mv $zipFile packages
-      mv $exe packages
+      mkdir packages-zip
+      mv $zipFile packages-zip
+      mkdir packages-installer
+      mv $exe packages-installer
 
-  - name: Upload Package Artifacts
-    uses: actions/upload-artifact@v3
+  - name: Upload Package Artifacts (Zip)
+    uses: actions/upload-artifact@v4
     with:
-      name: packages
-      path: ${{ github.workspace }}\packages
+      name: packages-windows-zip
+      path: ${{ github.workspace }}\packages-zip
+
+  - name: Upload Package Artifacts (Installer)
+    uses: actions/upload-artifact@v4
+    with:
+      name: packages-windows-installer
+      path: ${{ github.workspace }}\packages-installer

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -19,9 +19,10 @@ runs:
       singularity-version: 3.8.3
 
   - name: Download Artifacts
-    uses: actions/download-artifact@v3
+    uses: actions/download-artifact@v4
     with:
-      name: packages
+      pattern: packages-*
+      merge-multiple: true
       path: ${{ github.workspace }}/packages
 
   - name: Download Prerequisites

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -13,10 +13,10 @@ runs:
   using: "composite"
   steps:
 
-  - name: Install singularity
-    uses: eWaterCycle/setup-singularity@v7
+  - name: Install Apptainer
+    uses: eWaterCycle/setup-apptainer@v2
     with:
-      singularity-version: 3.8.3
+      apptainer-version: 1.2.5
 
   - name: Download Artifacts
     uses: actions/download-artifact@v4
@@ -61,13 +61,13 @@ runs:
     shell: bash
     run: |
       echo "Release tag will be: latest"
-      singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      ${SINGULARITY_ROOT}/bin/singularity push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
+      apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+      apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
 
   - name: Publish on Harbor (Continuous)
     if: ${{ inputs.publish == 'true' && inputs.isRelease == 'false' }}
     shell: bash
     run: |
       echo "Release tag will be: continuous"
-      singularity remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      ${SINGULARITY_ROOT}/bin/singularity push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous
+      apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+      apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous


### PR DESCRIPTION
This PR upgrades the `upload-artifact` and `download-artifact` GH actions to v4. We now split up generated artifacts rather than having a monolithic zip file at the end.

Closes #1779.