### PR TITLE
1689 Root Elements in Generated NETA

### DIFF
--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -104,7 +104,7 @@ std::string netaString(const SpeciesAtom *i, int currentDepth, const std::option
     // Add this atom to the path
     path.push_back(i);
 
-    auto neta = flags.isSet(NETADefinition::NETACreationFlags::IncludeRootElement)
+    auto neta = flags.isSet(NETADefinition::NETACreationFlags::IncludeRootElement) && currentDepth == 0
                     ? fmt::format("?{}, nbonds={}", Elements::symbol(i->Z()), i->nBonds())
                     : fmt::format("nbonds={}", i->nBonds());
 

--- a/tests/classes/neta.cpp
+++ b/tests/classes/neta.cpp
@@ -197,6 +197,9 @@ TEST_F(NETATest, Creation)
                 Flags<NETADefinition::NETACreationFlags>(NETADefinition::NETACreationFlags::IncludeRootElement));
     EXPECT_EQ(neta.definitionString(), "?H, nbonds=1,-C");
     testNETA("Hydrogen atom in methane", UnitTest::methaneSpecies(), neta, {1, 2, 3, 4});
+    neta.create(&UnitTest::methaneSpecies().atom(1), 1,
+                Flags<NETADefinition::NETACreationFlags>(NETADefinition::NETACreationFlags::IncludeRootElement));
+    EXPECT_EQ(neta.definitionString(), "?H, nbonds=1,-C(nbonds=4,nh=4)");
 }
 
 TEST_F(NETATest, Forcefield)


### PR DESCRIPTION
This PR fixes a small issue with autogenerated NETA descriptions which had the root element match (e.g. `?C`) added at every depth in the description, whereas it is only relevant at a depth of zero (i.e. the starting atom).

Closes #1689.