### PR TITLE
feat: wrap QSortFilterProxy so it is accessible from QML

### DIFF
--- a/src/gui/dataManagerDialog.cpp
+++ b/src/gui/dataManagerDialog.cpp
@@ -15,8 +15,6 @@ DataManagerDialog::DataManagerDialog(QWidget *parent, Dissolve &dissolve, Generi
     : QDialog(parent), dissolve_(dissolve), simModel_(dissolve, items)
 {
     view_ = new QQuickWidget(this);
-    simProxy_.setSourceModel(&simModel_);
-    view_->rootContext()->setContextProperty("simProxy", &simProxy_);
     view_->rootContext()->setContextProperty("simModel", &simModel_);
     view_->setSource(QUrl("qrc:/dialogs/qml/simulationDataManager/SimulationDataManager.qml"));
 

--- a/src/gui/dataManagerDialog.h
+++ b/src/gui/dataManagerDialog.h
@@ -7,7 +7,6 @@
 #include "items/list.h"
 #include <QDialog>
 #include <QQuickWidget>
-#include <QSortFilterProxyModel>
 #include <vector>
 
 // Forward Declarations
@@ -27,8 +26,6 @@ class DataManagerDialog : public QDialog
     Dissolve &dissolve_;
     // Simulation Model
     DataManagerSimulationModel simModel_;
-    // Simulation Proxy
-    QSortFilterProxyModel simProxy_;
 
     /*
      * UI

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -96,6 +96,7 @@ set(models_SRCS
     renderableGroupManagerModel.cpp
     sitesFilterProxy.cpp
     sitesModel.cpp
+    sortFilterProxy.cpp
     speciesAngleModel.cpp
     speciesAtomModel.cpp
     speciesBondModel.cpp

--- a/src/gui/models/CMakeLists.txt
+++ b/src/gui/models/CMakeLists.txt
@@ -31,6 +31,7 @@ set(models_MOC_HDRS
     renderableGroupManagerModel.h
     sitesFilterProxy.h
     sitesModel.h
+    sortFilterProxy.h
     speciesFilterProxy.h
     speciesModel.h
     speciesSiteFilterProxy.h
@@ -127,6 +128,7 @@ qt6_wrap_cpp(
   isotopologueSetModel.h
   pairPotentialModel.h
   rangeVectorModel.h
+  sortFilterProxy.h
   speciesAngleModel.h
   speciesAtomModel.h
   speciesBondModel.h

--- a/src/gui/models/sortFilterProxy.cpp
+++ b/src/gui/models/sortFilterProxy.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "gui/models/sortFilterProxy.h"
+
+SortFilterProxy::SortFilterProxy(QObject *parent) : QSortFilterProxyModel(parent) {}
+
+void SortFilterProxy::setModel(const QAbstractItemModel *model) {setSourceModel(const_cast<QAbstractItemModel *>(model));}

--- a/src/gui/models/sortFilterProxy.cpp
+++ b/src/gui/models/sortFilterProxy.cpp
@@ -5,4 +5,4 @@
 
 SortFilterProxy::SortFilterProxy(QObject *parent) : QSortFilterProxyModel(parent) {}
 
-void SortFilterProxy::setModel(const QAbstractItemModel *model) {setSourceModel(const_cast<QAbstractItemModel *>(model));}
+void SortFilterProxy::setModel(const QAbstractItemModel *model) { setSourceModel(const_cast<QAbstractItemModel *>(model)); }

--- a/src/gui/models/sortFilterProxy.h
+++ b/src/gui/models/sortFilterProxy.h
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+#include <QSortFilterProxyModel>
+
+class SortFilterProxy : public QSortFilterProxyModel {
+  Q_OBJECT
+  // The model to proxy
+  Q_PROPERTY(const QAbstractItemModel *model WRITE setModel NOTIFY read)
+
+public:
+  SortFilterProxy(QObject *parent = nullptr) : QSortFilterProxyModel(parent) {}
+  void setModel(const QAbstractItemModel *model) {setSourceModel(const_cast<QAbstractItemModel *>(model));}
+
+};

--- a/src/gui/models/sortFilterProxy.h
+++ b/src/gui/models/sortFilterProxy.h
@@ -11,7 +11,7 @@ class SortFilterProxy : public QSortFilterProxyModel {
   Q_PROPERTY(const QAbstractItemModel *model WRITE setModel NOTIFY read)
 
 public:
-  SortFilterProxy(QObject *parent = nullptr) : QSortFilterProxyModel(parent) {}
-  void setModel(const QAbstractItemModel *model) {setSourceModel(const_cast<QAbstractItemModel *>(model));}
+  SortFilterProxy(QObject *parent = nullptr);
+  void setModel(const QAbstractItemModel *model);
 
 };

--- a/src/gui/models/sortFilterProxy.h
+++ b/src/gui/models/sortFilterProxy.h
@@ -5,13 +5,13 @@
 
 #include <QSortFilterProxyModel>
 
-class SortFilterProxy : public QSortFilterProxyModel {
-  Q_OBJECT
-  // The model to proxy
-  Q_PROPERTY(const QAbstractItemModel *model WRITE setModel NOTIFY read)
+class SortFilterProxy : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    // The model to proxy
+    Q_PROPERTY(const QAbstractItemModel *model WRITE setModel NOTIFY read)
 
-public:
-  SortFilterProxy(QObject *parent = nullptr);
-  void setModel(const QAbstractItemModel *model);
-
+    public:
+    SortFilterProxy(QObject *parent = nullptr);
+    void setModel(const QAbstractItemModel *model);
 };

--- a/src/gui/qml/simulationDataManager/SimulationDataManager.qml
+++ b/src/gui/qml/simulationDataManager/SimulationDataManager.qml
@@ -6,10 +6,6 @@ import "../widgets" as D
 
 Page {
     id: root
-    height: 500
-    visible: true
-    width: 670
-
     function filterByRegExp(proxy, text) {
         proxy.filterRegularExpression = RegExp(text);
     }
@@ -21,12 +17,15 @@ Page {
         return headerArray;
     }
 
-    SortFilterProxy {
-        id: proxy;
-        filterRegularExpression: RegExp(searchBox.text);
-        model: simModel;
-    }
+    height: 500
+    visible: true
+    width: 670
 
+    SortFilterProxy {
+        id: proxy
+        filterRegularExpression: RegExp(searchBox.text)
+        model: simModel
+    }
     D.GroupBox {
         id: gb
         anchors.fill: parent
@@ -53,6 +52,7 @@ Page {
             }
             TableView {
                 id: table
+
                 property variant colWidths: [300, 300, 50]
 
                 Layout.fillHeight: true

--- a/src/gui/qml/simulationDataManager/SimulationDataManager.qml
+++ b/src/gui/qml/simulationDataManager/SimulationDataManager.qml
@@ -6,6 +6,10 @@ import "../widgets" as D
 
 Page {
     id: root
+    height: 500
+    visible: true
+    width: 670
+
     function filterByRegExp(proxy, text) {
         proxy.filterRegularExpression = RegExp(text);
     }
@@ -16,10 +20,6 @@ Page {
         }
         return headerArray;
     }
-
-    height: 500
-    visible: true
-    width: 670
 
     SortFilterProxy {
         id: proxy
@@ -52,7 +52,6 @@ Page {
             }
             TableView {
                 id: table
-
                 property variant colWidths: [300, 300, 50]
 
                 Layout.fillHeight: true

--- a/src/gui/qml/simulationDataManager/SimulationDataManager.qml
+++ b/src/gui/qml/simulationDataManager/SimulationDataManager.qml
@@ -21,6 +21,12 @@ Page {
         return headerArray;
     }
 
+    SortFilterProxy {
+        id: proxy;
+        filterRegularExpression: RegExp(searchBox.text);
+        model: simModel;
+    }
+
     D.GroupBox {
         id: gb
         anchors.fill: parent
@@ -34,13 +40,6 @@ Page {
                 Layout.alignment: Qt.AlignRight
                 Layout.preferredWidth: gb.width / 4
                 placeholderText: qsTr("Search...")
-
-                onEditingFinished: {
-                    filterByRegExp(simProxy, searchBox.text);
-                    if (simProxy.rowCount() == 0) {
-                        filterByRegExp(simProxy, "");
-                    }
-                }
             }
             HorizontalHeaderView {
                 id: header
@@ -64,7 +63,7 @@ Page {
                 columnWidthProvider: function (column) {
                     return colWidths[column];
                 }
-                model: simProxy
+                model: proxy
                 rowSpacing: 1
 
                 delegate: Rectangle {

--- a/src/gui/types.cpp
+++ b/src/gui/types.cpp
@@ -10,8 +10,8 @@
 #include "gui/models/masterTermTreeModel.h"
 #include "gui/models/modifyChargesModel.h"
 #include "gui/models/moduleLayersModel.h"
-#include "gui/models/speciesModel.h"
 #include "gui/models/sortFilterProxy.h"
+#include "gui/models/speciesModel.h"
 #include <QQmlEngine>
 #include <QSortFilterProxyModel>
 

--- a/src/gui/types.cpp
+++ b/src/gui/types.cpp
@@ -11,7 +11,9 @@
 #include "gui/models/modifyChargesModel.h"
 #include "gui/models/moduleLayersModel.h"
 #include "gui/models/speciesModel.h"
+#include "gui/models/sortFilterProxy.h"
 #include <QQmlEngine>
+#include <QSortFilterProxyModel>
 
 void Types::registerDissolveQmlTypes()
 {
@@ -27,4 +29,5 @@ void Types::registerDissolveQmlTypes()
     qmlRegisterType<MasterImproperModel>(PROJECT, 1, 0, "MasterImproperModel");
     qmlRegisterType<MasterTorsionModel>(PROJECT, 1, 0, "MasterTorsionModel");
     qmlRegisterType<ModifyChargesModel>(PROJECT, 1, 0, "ModifyChargesModel");
+    qmlRegisterType<SortFilterProxy>(PROJECT, 1, 0, "SortFilterProxy");
 }


### PR DESCRIPTION
This PR creates a tiny wrapper that make the QSortFilterProxy accessible from QML.  I've then applied this to the Data Manager dialog so that the table is filtered the moment a user types a character, instead of waiting for a carriage return.

closes #1812 