### PR TITLE
refactor: 1816 Rename Data Normaliser

### DIFF
--- a/src/analyser/CMakeLists.txt
+++ b/src/analyser/CMakeLists.txt
@@ -1,13 +1,13 @@
 add_library(
   analyser
   dataExporter.h
-  dataNormaliser1D.cpp
-  dataNormaliser1D.h
-  dataNormaliser2D.cpp
-  dataNormaliser2D.h
-  dataNormaliser3D.cpp
-  dataNormaliser3D.h
-  dataNormaliserBase.h
+  dataOperator1D.cpp
+  dataOperator1D.h
+  dataOperator2D.cpp
+  dataOperator2D.h
+  dataOperator3D.cpp
+  dataOperator3D.h
+  dataOperatorBase.h
   siteFilter.cpp
   siteFilter.h
   siteSelector.cpp

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024 Team Dissolve and contributors
 
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "math/data1D.h"
 #include "math/integrator.h"
 
-DataNormaliser1D::DataNormaliser1D(Data1D &targetData) : DataNormaliserBase<Data1D, NormalisationFunction1D>(targetData) {}
+DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, NormalisationFunction1D>(targetData) {}
 
-void DataNormaliser1D::normalise(NormalisationFunction1D normalisationFunction)
+void DataOperator1D::normalise(NormalisationFunction1D normalisationFunction)
 {
     const auto &xs = targetData_.xAxis();
     auto &values = targetData_.values();
@@ -18,9 +18,9 @@ void DataNormaliser1D::normalise(NormalisationFunction1D normalisationFunction)
         values.at(i) = normalisationFunction(xs[i], xDelta, values.at(i));
 }
 
-void DataNormaliser1D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 1D data."); }
+void DataOperator1D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 1D data."); }
 
-void DataNormaliser1D::normaliseBySphericalShell()
+void DataOperator1D::normaliseBySphericalShell()
 {
     // We expect x values to be centre-bin values, and regularly spaced
     const auto &xAxis = targetData_.xAxis();
@@ -52,7 +52,7 @@ void DataNormaliser1D::normaliseBySphericalShell()
     }
 }
 
-void DataNormaliser1D::normaliseTo(double value, bool absolute)
+void DataOperator1D::normaliseTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);
     targetData_ /= sum;

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -5,17 +5,15 @@
 #include "math/data1D.h"
 #include "math/integrator.h"
 
-DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, NormalisationFunction1D>(targetData) {}
+DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, OperateFunction1D>(targetData) {}
 
-void DataOperator1D::normalise(NormalisationFunction1D normalisationFunction)
+void DataOperator1D::operate(OperateFunction1D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
     auto &values = targetData_.values();
 
-    const auto xDelta = xs.size() > 1 ? xs[1] - xs[0] : 1.0;
-
     for (auto i = 0; i < xs.size(); ++i)
-        values.at(i) = normalisationFunction(xs[i], xDelta, values.at(i));
+        values.at(i) = operateFunction(xs[i], targetData_.error(i), values.at(i));
 }
 
 void DataOperator1D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 1D data."); }

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -19,7 +19,7 @@ void DataOperator1D::operate(OperateFunction1D operator)
     const auto xDelta = xs.size() > 1 ? xs[1] - xs[0] : 1.0;
 
     for (auto i = 0; i < xs.size(); ++i)
-        values.at(i) = operateFunction(xs[i], xDelta, values.at(i));
+        values.at(i) = operator(xs[i], xDelta, values.at(i));
 }
 
 /*

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -16,9 +16,10 @@ void DataOperator1D::operate(OperateFunction1D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
     auto &values = targetData_.values();
+    const auto xDelta = xs.size() > 1 ? xs[1] - xs[0] : 1.0;
 
     for (auto i = 0; i < xs.size(); ++i)
-        values.at(i) = operateFunction(xs[i], targetData_.error(i), values.at(i));
+        values.at(i) = operateFunction(xs[i], xDelta, values.at(i));
 }
 
 /*
@@ -62,7 +63,7 @@ void DataOperator1D::normaliseBySphericalShell()
 }
 
 // Normalise the target data to a given value
-void DataOperator1D::normaliseTo(double value, bool absolute)
+void DataOperator1D::normaliseSumTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);
     targetData_ /= sum;

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -12,7 +12,7 @@ DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, Op
  */
 
 // Generic operate function
-void DataOperator1D::operate(OperateFunction1D operator)
+void DataOperator1D::operate(OperateFunction1D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
     auto &values = targetData_.values();

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -7,6 +7,11 @@
 
 DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, OperateFunction1D>(targetData) {}
 
+/*
+ * Data Operation Functions
+ */
+
+// Generic operate function
 void DataOperator1D::operate(OperateFunction1D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
@@ -16,8 +21,14 @@ void DataOperator1D::operate(OperateFunction1D operateFunction)
         values.at(i) = operateFunction(xs[i], targetData_.error(i), values.at(i));
 }
 
+/*
+ * Normalisation Functions
+ */
+
+// Perform grid normalisation
 void DataOperator1D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 1D data."); }
 
+// Perform spherical shell normalisation
 void DataOperator1D::normaliseBySphericalShell()
 {
     // We expect x values to be centre-bin values, and regularly spaced
@@ -50,6 +61,7 @@ void DataOperator1D::normaliseBySphericalShell()
     }
 }
 
+// Normalise the target data to a given value
 void DataOperator1D::normaliseTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -12,7 +12,7 @@ DataOperator1D::DataOperator1D(Data1D &targetData) : DataOperatorBase<Data1D, Op
  */
 
 // Generic operate function
-void DataOperator1D::operate(OperateFunction1D operateFunction)
+void DataOperator1D::operate(OperateFunction1D operator)
 {
     const auto &xs = targetData_.xAxis();
     auto &values = targetData_.values();

--- a/src/analyser/dataOperator1D.cpp
+++ b/src/analyser/dataOperator1D.cpp
@@ -19,7 +19,7 @@ void DataOperator1D::operate(OperateFunction1D operator)
     const auto xDelta = xs.size() > 1 ? xs[1] - xs[0] : 1.0;
 
     for (auto i = 0; i < xs.size(); ++i)
-        values.at(i) = operator(xs[i], xDelta, values.at(i));
+        values.at(i) = operateFunction(xs[i], xDelta, values.at(i));
 }
 
 /*

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -6,17 +6,22 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data1D.h"
 
-using NormalisationFunction1D = std::function<double(const double &, const double &, const double &)>;
-class DataOperator1D : public DataOperatorBase<Data1D, NormalisationFunction1D>
+using OperateFunction1D = std::function<double(const double &, const double &, const double &)>;
+class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
 {
     public:
     DataOperator1D(Data1D &targetData);
 
     /*
-     * Normalisation functions
+     * Generic Operate Functions
      */
     public:
-    void normalise(NormalisationFunction1D normalisationFunction) override;
+    void operate(OperateFunction1D operateFunction) override;
+
+    /*
+     * Normalisation Functions
+     */
+    public:
     void normaliseByGrid() override;
     void normaliseBySphericalShell() override;
     void normaliseTo(double value = 1.0, bool absolute = true) override;

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -31,5 +31,5 @@ class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
     // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
     // Normalise the target data to a given value
-    void normaliseTo(double value = 1.0, bool absolute = true) override;
+    void normaliseSumTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -3,14 +3,14 @@
 
 #pragma once
 
-#include "analyser/dataNormaliserBase.h"
+#include "analyser/dataOperatorBase.h"
 #include "math/data1D.h"
 
 using NormalisationFunction1D = std::function<double(const double &, const double &, const double &)>;
-class DataNormaliser1D : public DataNormaliserBase<Data1D, NormalisationFunction1D>
+class DataOperator1D : public DataOperatorBase<Data1D, NormalisationFunction1D>
 {
     public:
-    DataNormaliser1D(Data1D &targetData);
+    DataOperator1D(Data1D &targetData);
 
     /*
      * Normalisation functions

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -13,16 +13,20 @@ class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
     DataOperator1D(Data1D &targetData);
 
     /*
-     * Generic Operate Functions
+     * Data Operation Functions
      */
     public:
+    // Generic operate function
     void operate(OperateFunction1D operateFunction) override;
 
     /*
      * Normalisation Functions
      */
     public:
+    // Perform grid normalisation
     void normaliseByGrid() override;
+    // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
+    // Normalise the target data to a given value
     void normaliseTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -20,7 +20,7 @@ class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
      */
     public:
     // Generic operate function
-    void operate(OperateFunction1D operator) override;
+    void operate(OperateFunction1D operateFunction) override;
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -6,7 +6,10 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data1D.h"
 
+// x, xDelta, value
 using OperateFunction1D = std::function<double(const double &, const double &, const double &)>;
+
+// Data Operator 1D
 class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
 {
     public:

--- a/src/analyser/dataOperator1D.h
+++ b/src/analyser/dataOperator1D.h
@@ -20,7 +20,7 @@ class DataOperator1D : public DataOperatorBase<Data1D, OperateFunction1D>
      */
     public:
     // Generic operate function
-    void operate(OperateFunction1D operateFunction) override;
+    void operate(OperateFunction1D operator) override;
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -12,7 +12,7 @@ DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, Op
  */
 
 // Generic operate function
-void DataOperator2D::operate(OperateFunction2D operator)
+void DataOperator2D::operate(OperateFunction2D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
     const auto &ys = targetData_.yAxis();
@@ -25,7 +25,7 @@ void DataOperator2D::operate(OperateFunction2D operator)
     {
         for (auto j = 0; j < ys.size(); ++j)
         {
-            values[{i, j}] = operator(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
+            values[{i, j}] = operateFunction(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
         }
     }
 }

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -12,7 +12,7 @@ DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, Op
  */
 
 // Generic operate function
-void DataOperator2D::operate(OperateFunction2D operateFunction)
+void DataOperator2D::operate(OperateFunction2D operator)
 {
     const auto &xs = targetData_.xAxis();
     const auto &ys = targetData_.yAxis();
@@ -25,7 +25,7 @@ void DataOperator2D::operate(OperateFunction2D operateFunction)
     {
         for (auto j = 0; j < ys.size(); ++j)
         {
-            values[{i, j}] = operateFunction(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
+            values[{i, j}] = operator(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
         }
     }
 }

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024 Team Dissolve and contributors
 
-#include "analyser/dataNormaliser2D.h"
+#include "analyser/dataOperator2D.h"
 #include "math/data2D.h"
 #include "math/integrator.h"
 
-DataNormaliser2D::DataNormaliser2D(Data2D &targetData) : DataNormaliserBase<Data2D, NormalisationFunction2D>(targetData) {}
+DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, NormalisationFunction2D>(targetData) {}
 
-void DataNormaliser2D::normalise(NormalisationFunction2D normalisationFunction)
+void DataOperator2D::normalise(NormalisationFunction2D normalisationFunction)
 {
     const auto &xs = targetData_.xAxis();
     const auto &ys = targetData_.yAxis();
@@ -25,9 +25,9 @@ void DataNormaliser2D::normalise(NormalisationFunction2D normalisationFunction)
     }
 }
 
-void DataNormaliser2D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 2D data."); }
+void DataOperator2D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 2D data."); }
 
-void DataNormaliser2D::normaliseBySphericalShell()
+void DataOperator2D::normaliseBySphericalShell()
 {
     // We expect x values to be centre-bin values, and regularly spaced
     const auto &xAxis = targetData_.xAxis();
@@ -64,7 +64,7 @@ void DataNormaliser2D::normaliseBySphericalShell()
     }
 }
 
-void DataNormaliser2D::normaliseTo(double value, bool absolute)
+void DataOperator2D::normaliseTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);
     targetData_ /= sum;

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -76,7 +76,7 @@ void DataOperator2D::normaliseBySphericalShell()
 }
 
 // Normalise the target data to a given value
-void DataOperator2D::normaliseTo(double value, bool absolute)
+void DataOperator2D::normaliseSumTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);
     targetData_ /= sum;

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -5,9 +5,9 @@
 #include "math/data2D.h"
 #include "math/integrator.h"
 
-DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, NormalisationFunction2D>(targetData) {}
+DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, OperateFunction2D>(targetData) {}
 
-void DataOperator2D::normalise(NormalisationFunction2D normalisationFunction)
+void DataOperator2D::operate(OperateFunction2D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
     const auto &ys = targetData_.yAxis();
@@ -20,7 +20,7 @@ void DataOperator2D::normalise(NormalisationFunction2D normalisationFunction)
     {
         for (auto j = 0; j < ys.size(); ++j)
         {
-            values[{i, j}] = normalisationFunction(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
+            values[{i, j}] = operateFunction(xs[i], xDelta, ys[j], yDelta, values[{i, j}]);
         }
     }
 }

--- a/src/analyser/dataOperator2D.cpp
+++ b/src/analyser/dataOperator2D.cpp
@@ -7,6 +7,11 @@
 
 DataOperator2D::DataOperator2D(Data2D &targetData) : DataOperatorBase<Data2D, OperateFunction2D>(targetData) {}
 
+/*
+ * Data Operation Functions
+ */
+
+// Generic operate function
 void DataOperator2D::operate(OperateFunction2D operateFunction)
 {
     const auto &xs = targetData_.xAxis();
@@ -25,8 +30,14 @@ void DataOperator2D::operate(OperateFunction2D operateFunction)
     }
 }
 
+/*
+ * Normalisation Functions
+ */
+
+// Perform grid normalisation
 void DataOperator2D::normaliseByGrid() { Messenger::warn("Grid normalisation not implemented for 2D data."); }
 
+// Perform spherical shell normalisation
 void DataOperator2D::normaliseBySphericalShell()
 {
     // We expect x values to be centre-bin values, and regularly spaced
@@ -64,6 +75,7 @@ void DataOperator2D::normaliseBySphericalShell()
     }
 }
 
+// Normalise the target data to a given value
 void DataOperator2D::normaliseTo(double value, bool absolute)
 {
     auto sum = absolute ? Integrator::absSum(targetData_) : Integrator::sum(targetData_);

--- a/src/analyser/dataOperator2D.h
+++ b/src/analyser/dataOperator2D.h
@@ -13,16 +13,20 @@ class DataOperator2D : public DataOperatorBase<Data2D, OperateFunction2D>
     DataOperator2D(Data2D &targetData);
 
     /*
-     * Generic Operate Functions
+     * Data Operation Functions
      */
     public:
+    // Generic operate function
     void operate(OperateFunction2D operateFunction) override;
 
     /*
      * Normalisation Functions
      */
     public:
+    // Perform grid normalisation
     void normaliseByGrid() override;
+    // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
+    // Normalise the target data to a given value
     void normaliseTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator2D.h
+++ b/src/analyser/dataOperator2D.h
@@ -6,7 +6,10 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data2D.h"
 
+// x, xDelta, y, yDelta, value
 using OperateFunction2D = std::function<double(const double &, const double &, const double &, const double &, const double &)>;
+
+// Data Operator 2D
 class DataOperator2D : public DataOperatorBase<Data2D, OperateFunction2D>
 {
     public:

--- a/src/analyser/dataOperator2D.h
+++ b/src/analyser/dataOperator2D.h
@@ -6,18 +6,22 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data2D.h"
 
-using NormalisationFunction2D =
-    std::function<double(const double &, const double &, const double &, const double &, const double &)>;
-class DataOperator2D : public DataOperatorBase<Data2D, NormalisationFunction2D>
+using OperateFunction2D = std::function<double(const double &, const double &, const double &, const double &, const double &)>;
+class DataOperator2D : public DataOperatorBase<Data2D, OperateFunction2D>
 {
     public:
     DataOperator2D(Data2D &targetData);
 
     /*
+     * Generic Operate Functions
+     */
+    public:
+    void operate(OperateFunction2D operateFunction) override;
+
+    /*
      * Normalisation Functions
      */
     public:
-    void normalise(NormalisationFunction2D normalisationFunction) override;
     void normaliseByGrid() override;
     void normaliseBySphericalShell() override;
     void normaliseTo(double value = 1.0, bool absolute = true) override;

--- a/src/analyser/dataOperator2D.h
+++ b/src/analyser/dataOperator2D.h
@@ -31,5 +31,5 @@ class DataOperator2D : public DataOperatorBase<Data2D, OperateFunction2D>
     // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
     // Normalise the target data to a given value
-    void normaliseTo(double value = 1.0, bool absolute = true) override;
+    void normaliseSumTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator2D.h
+++ b/src/analyser/dataOperator2D.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include "analyser/dataNormaliserBase.h"
+#include "analyser/dataOperatorBase.h"
 #include "math/data2D.h"
 
 using NormalisationFunction2D =
     std::function<double(const double &, const double &, const double &, const double &, const double &)>;
-class DataNormaliser2D : public DataNormaliserBase<Data2D, NormalisationFunction2D>
+class DataOperator2D : public DataOperatorBase<Data2D, NormalisationFunction2D>
 {
     public:
-    DataNormaliser2D(Data2D &targetData);
+    DataOperator2D(Data2D &targetData);
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperator3D.cpp
+++ b/src/analyser/dataOperator3D.cpp
@@ -39,7 +39,7 @@ void DataOperator3D::normaliseBySphericalShell()
 }
 
 // Normalise the target data to a given value
-void DataOperator3D::normaliseTo(double value, bool absolute)
+void DataOperator3D::normaliseSumTo(double value, bool absolute)
 {
     Messenger::warn("Value normalisation not implemented for 3D data.");
 }

--- a/src/analyser/dataOperator3D.cpp
+++ b/src/analyser/dataOperator3D.cpp
@@ -6,11 +6,21 @@
 
 DataOperator3D::DataOperator3D(Data3D &targetData) : DataOperatorBase<Data3D, OperateFunction3D>(targetData) {}
 
+/*
+ * Data Operation Functions
+ */
+
+// Generic operate function
 void DataOperator3D::operate(OperateFunction3D operateFunction)
 {
     Messenger::warn("Normalisation function not implemented for 3D data.");
 }
 
+/*
+ * Normalisation Functions
+ */
+
+// Perform grid normalisation
 void DataOperator3D::normaliseByGrid()
 {
     // Determine bin area from first points of data
@@ -22,11 +32,13 @@ void DataOperator3D::normaliseByGrid()
     targetData_ /= binVolume;
 }
 
+// Perform spherical shell normalisation
 void DataOperator3D::normaliseBySphericalShell()
 {
     Messenger::warn("Spherical shell normalisation not implemented for 3D data.");
 }
 
+// Normalise the target data to a given value
 void DataOperator3D::normaliseTo(double value, bool absolute)
 {
     Messenger::warn("Value normalisation not implemented for 3D data.");

--- a/src/analyser/dataOperator3D.cpp
+++ b/src/analyser/dataOperator3D.cpp
@@ -4,9 +4,9 @@
 #include "analyser/dataOperator3D.h"
 #include "math/data3D.h"
 
-DataOperator3D::DataOperator3D(Data3D &targetData) : DataOperatorBase<Data3D, NormalisationFunction3D>(targetData) {}
+DataOperator3D::DataOperator3D(Data3D &targetData) : DataOperatorBase<Data3D, OperateFunction3D>(targetData) {}
 
-void DataOperator3D::normalise(NormalisationFunction3D normalisationFunction)
+void DataOperator3D::operate(OperateFunction3D operateFunction)
 {
     Messenger::warn("Normalisation function not implemented for 3D data.");
 }

--- a/src/analyser/dataOperator3D.cpp
+++ b/src/analyser/dataOperator3D.cpp
@@ -13,7 +13,7 @@ DataOperator3D::DataOperator3D(Data3D &targetData) : DataOperatorBase<Data3D, Op
 // Generic operate function
 void DataOperator3D::operate(OperateFunction3D operateFunction)
 {
-    Messenger::warn("Normalisation function not implemented for 3D data.");
+    Messenger::warn("Data operate() function not implemented for 3D data.");
 }
 
 /*

--- a/src/analyser/dataOperator3D.cpp
+++ b/src/analyser/dataOperator3D.cpp
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024 Team Dissolve and contributors
 
-#include "analyser/dataNormaliser3D.h"
+#include "analyser/dataOperator3D.h"
 #include "math/data3D.h"
 
-DataNormaliser3D::DataNormaliser3D(Data3D &targetData) : DataNormaliserBase<Data3D, NormalisationFunction3D>(targetData) {}
+DataOperator3D::DataOperator3D(Data3D &targetData) : DataOperatorBase<Data3D, NormalisationFunction3D>(targetData) {}
 
-void DataNormaliser3D::normalise(NormalisationFunction3D normalisationFunction)
+void DataOperator3D::normalise(NormalisationFunction3D normalisationFunction)
 {
     Messenger::warn("Normalisation function not implemented for 3D data.");
 }
 
-void DataNormaliser3D::normaliseByGrid()
+void DataOperator3D::normaliseByGrid()
 {
     // Determine bin area from first points of data
     auto xBinWidth = targetData_.xAxis().at(1) - targetData_.xAxis().at(0);
@@ -22,12 +22,12 @@ void DataNormaliser3D::normaliseByGrid()
     targetData_ /= binVolume;
 }
 
-void DataNormaliser3D::normaliseBySphericalShell()
+void DataOperator3D::normaliseBySphericalShell()
 {
     Messenger::warn("Spherical shell normalisation not implemented for 3D data.");
 }
 
-void DataNormaliser3D::normaliseTo(double value, bool absolute)
+void DataOperator3D::normaliseTo(double value, bool absolute)
 {
     Messenger::warn("Value normalisation not implemented for 3D data.");
 }

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -32,5 +32,5 @@ class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
     // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
     // Normalise the target data to a given value
-    void normaliseTo(double value = 1.0, bool absolute = true) override;
+    void normaliseSumTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-#include "analyser/dataNormaliserBase.h"
+#include "analyser/dataOperatorBase.h"
 #include "math/data3D.h"
 
 using NormalisationFunction3D = std::function<double(const double &, const double &, const double &, const double &,
                                                      const double &, const double &, const double &)>;
-class DataNormaliser3D : public DataNormaliserBase<Data3D, NormalisationFunction3D>
+class DataOperator3D : public DataOperatorBase<Data3D, NormalisationFunction3D>
 {
     public:
-    DataNormaliser3D(Data3D &targetData);
+    DataOperator3D(Data3D &targetData);
 
     /*
      * Normalisation functions

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -14,16 +14,20 @@ class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
     DataOperator3D(Data3D &targetData);
 
     /*
-     * Generic Operate Functions
+     * Data Operation Functions
      */
     public:
+    // Generic operate function
     void operate(OperateFunction3D operateFunction) override;
 
     /*
      * Normalisation Functions
      */
     public:
+    // Perform grid normalisation
     void normaliseByGrid() override;
+    // Perform spherical shell normalisation
     void normaliseBySphericalShell() override;
+    // Normalise the target data to a given value
     void normaliseTo(double value = 1.0, bool absolute = true) override;
 };

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -21,7 +21,7 @@ class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
      */
     public:
     // Generic operate function
-    void operate(OperateFunction3D operateFunction) override;
+    void operate(OperateFunction3D operator) override;
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -21,7 +21,7 @@ class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
      */
     public:
     // Generic operate function
-    void operate(OperateFunction3D operator) override;
+    void operate(OperateFunction3D operateFunction) override;
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -6,18 +6,23 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data3D.h"
 
-using NormalisationFunction3D = std::function<double(const double &, const double &, const double &, const double &,
-                                                     const double &, const double &, const double &)>;
-class DataOperator3D : public DataOperatorBase<Data3D, NormalisationFunction3D>
+using OperateFunction3D = std::function<double(const double &, const double &, const double &, const double &, const double &,
+                                               const double &, const double &)>;
+class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
 {
     public:
     DataOperator3D(Data3D &targetData);
 
     /*
-     * Normalisation functions
+     * Generic Operate Functions
      */
     public:
-    void normalise(NormalisationFunction3D normalisationFunction) override;
+    void operate(OperateFunction3D operateFunction) override;
+
+    /*
+     * Normalisation Functions
+     */
+    public:
     void normaliseByGrid() override;
     void normaliseBySphericalShell() override;
     void normaliseTo(double value = 1.0, bool absolute = true) override;

--- a/src/analyser/dataOperator3D.h
+++ b/src/analyser/dataOperator3D.h
@@ -6,8 +6,11 @@
 #include "analyser/dataOperatorBase.h"
 #include "math/data3D.h"
 
+// x, xDelta, y, yDelta, z, zDelta, value
 using OperateFunction3D = std::function<double(const double &, const double &, const double &, const double &, const double &,
                                                const double &, const double &)>;
+
+// Data Operator 3D
 class DataOperator3D : public DataOperatorBase<Data3D, OperateFunction3D>
 {
     public:

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -28,7 +28,7 @@ template <typename DataND, typename OperateFunction> class DataOperatorBase
     // Multiply the target data by the multiplier
     void multiply(double multiplier) { targetData_ *= multiplier; }
     // Generic operate function
-    virtual void operate(OperateFunction operator) = 0;
+    virtual void operate(OperateFunction operateFunction) = 0;
 
     /*
      * Normalisation Functions

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -6,7 +6,7 @@
 #include "classes/configuration.h"
 #include <string_view>
 
-template <typename DataND, typename NormalisationFunction> class DataOperatorBase
+template <typename DataND, typename OperateFunction> class DataOperatorBase
 {
 
     public:
@@ -19,11 +19,16 @@ template <typename DataND, typename NormalisationFunction> class DataOperatorBas
     DataND &targetData_;
 
     /*
-     * Normalisation functions
+     * Generic Operate Functions
      */
     public:
-    void normaliseDivide(double divisor) { targetData_ /= divisor; }
-    virtual void normalise(NormalisationFunction normalisationFunction) = 0;
+    void divide(double divisor) { targetData_ /= divisor; }
+    void multiply(double multiplier) { targetData_ *= multiplier; }
+    virtual void operate(OperateFunction operateFunction) = 0;
+
+    /*
+     * Normalisation Functions
+     */
     virtual void normaliseByGrid() = 0;
     virtual void normaliseBySphericalShell() = 0;
     virtual void normaliseTo(double value = 1.0, bool absolute = true) = 0;

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -38,6 +38,6 @@ template <typename DataND, typename OperateFunction> class DataOperatorBase
     virtual void normaliseByGrid() = 0;
     // Perform spherical shell normalisation
     virtual void normaliseBySphericalShell() = 0;
-    // Normalise the target data to a given value
-    virtual void normaliseTo(double value = 1.0, bool absolute = true) = 0;
+    // Normalise the sum of the target data to a given value
+    virtual void normaliseSumTo(double value = 1.0, bool absolute = true) = 0;
 };

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -6,6 +6,7 @@
 #include "classes/configuration.h"
 #include <string_view>
 
+// Data Operator Base
 template <typename DataND, typename OperateFunction> class DataOperatorBase
 {
 

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -19,17 +19,24 @@ template <typename DataND, typename OperateFunction> class DataOperatorBase
     DataND &targetData_;
 
     /*
-     * Generic Operate Functions
+     * Data Operation Functions
      */
     public:
+    // Divide the target data by the divisor
     void divide(double divisor) { targetData_ /= divisor; }
+    // Multiply the target data by the multiplier
     void multiply(double multiplier) { targetData_ *= multiplier; }
+    // Generic operate function
     virtual void operate(OperateFunction operateFunction) = 0;
 
     /*
      * Normalisation Functions
      */
+    public:
+    // Perform grid normalisation
     virtual void normaliseByGrid() = 0;
+    // Perform spherical shell normalisation
     virtual void normaliseBySphericalShell() = 0;
+    // Normalise the target data to a given value
     virtual void normaliseTo(double value = 1.0, bool absolute = true) = 0;
 };

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -6,11 +6,11 @@
 #include "classes/configuration.h"
 #include <string_view>
 
-template <typename DataND, typename NormalisationFunction> class DataNormaliserBase
+template <typename DataND, typename NormalisationFunction> class DataOperatorBase
 {
 
     public:
-    DataNormaliserBase(DataND &targetData) : targetData_(targetData) {}
+    DataOperatorBase(DataND &targetData) : targetData_(targetData) {}
 
     /*
      * Targets

--- a/src/analyser/dataOperatorBase.h
+++ b/src/analyser/dataOperatorBase.h
@@ -28,7 +28,7 @@ template <typename DataND, typename OperateFunction> class DataOperatorBase
     // Multiply the target data by the multiplier
     void multiply(double multiplier) { targetData_ *= multiplier; }
     // Generic operate function
-    virtual void operate(OperateFunction operateFunction) = 0;
+    virtual void operate(OperateFunction operator) = 0;
 
     /*
      * Normalisation Functions

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -170,7 +170,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // Normalise by value / sin(x)
     normaliserAngle.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
-    normaliserAngle.normaliseTo();
+    normaliserAngle.normaliseSumTo();
 
     // DAngle((A-B)-C)
     auto &normalisedDAngleAB = processingData.realise<Data2D>("DAngle((A-B)-C)", name(), GenericItem::InRestartFileFlag);

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -144,9 +144,9 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     normalisedAB = rAB.accumulatedData();
     DataOperator1D normaliserAB(normalisedAB);
     // Normalise by A site population
-    normaliserAB.normaliseDivide(double(nACumulative) / nASelections);
+    normaliserAB.divide(double(nACumulative) / nASelections);
     // Normalise by B site population density
-    normaliserAB.normaliseDivide((double(nBCumulative) / nBSelections) / targetConfiguration_->box()->volume());
+    normaliserAB.divide((double(nBCumulative) / nBSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     normaliserAB.normaliseBySphericalShell();
 
@@ -155,11 +155,11 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     normalisedBC = rBC.accumulatedData();
     DataOperator1D normaliserBC(normalisedBC);
     // Normalise by A site population
-    normaliserBC.normaliseDivide(double(nACumulative) / nASelections);
+    normaliserBC.divide(double(nACumulative) / nASelections);
     // Normalise by B site population
-    normaliserBC.normaliseDivide(double(nBCumulative) / nBSelections);
+    normaliserBC.divide(double(nBCumulative) / nBSelections);
     // Normalise by C site population density
-    normaliserBC.normaliseDivide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
+    normaliserBC.divide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     normaliserBC.normaliseBySphericalShell();
 
@@ -168,7 +168,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     normalisedAngle = aABC.accumulatedData();
     DataOperator1D normaliserAngle(normalisedAngle);
     // Normalise by value / sin(x)
-    normaliserAngle.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
+    normaliserAngle.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
     normaliserAngle.normaliseTo();
 
@@ -177,14 +177,14 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     normalisedDAngleAB = dAngleAB.accumulatedData();
     DataOperator2D normaliserDAngleAB(normalisedDAngleAB);
     // Normalise by value / sin(y) / sin(yDelta)
-    normaliserDAngleAB.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
-                                 { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
+    normaliserDAngleAB.operate([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+                               { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
     // Normalise by A site population
-    normaliserDAngleAB.normaliseDivide(double(nACumulative) / nASelections);
+    normaliserDAngleAB.divide(double(nACumulative) / nASelections);
     // Normalise by C site population
-    normaliserDAngleAB.normaliseDivide(double(nCCumulative) / nCSelections);
+    normaliserDAngleAB.divide(double(nCCumulative) / nCSelections);
     // Normalise by B site population density
-    normaliserDAngleAB.normaliseDivide((double(nBAvailable) / nBSelections) / targetConfiguration_->box()->volume());
+    normaliserDAngleAB.divide((double(nBAvailable) / nBSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     normaliserDAngleAB.normaliseBySphericalShell();
 
@@ -193,14 +193,14 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     normalisedDAngleBC = dAngleBC.accumulatedData();
     DataOperator2D normaliserDAngleBC(normalisedDAngleBC);
     // Normalise by value / sin(y) / sin(yDelta)
-    normaliserDAngleBC.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
-                                 { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
+    normaliserDAngleBC.operate([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+                               { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
     // Normalise by A site population
-    normaliserDAngleBC.normaliseDivide(double(nACumulative) / nASelections);
+    normaliserDAngleBC.divide(double(nACumulative) / nASelections);
     // Normalise by B site population
-    normaliserDAngleBC.normaliseDivide(double(nBCumulative) / nBSelections);
+    normaliserDAngleBC.divide(double(nBCumulative) / nBSelections);
     // Normalise by C site population density
-    normaliserDAngleBC.normaliseDivide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
+    normaliserDAngleBC.divide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     normaliserDAngleBC.normaliseBySphericalShell();
 

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -2,9 +2,9 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
-#include "analyser/dataNormaliser2D.h"
-#include "analyser/dataNormaliser3D.h"
+#include "analyser/dataOperator1D.h"
+#include "analyser/dataOperator2D.h"
+#include "analyser/dataOperator3D.h"
 #include "analyser/siteSelector.h"
 #include "main/dissolve.h"
 #include "math/histogram1D.h"
@@ -142,7 +142,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // RDF(A-B)
     auto &normalisedAB = processingData.realise<Data1D>("RDF(AB)", name(), GenericItem::InRestartFileFlag);
     normalisedAB = rAB.accumulatedData();
-    DataNormaliser1D normaliserAB(normalisedAB);
+    DataOperator1D normaliserAB(normalisedAB);
     // Normalise by A site population
     normaliserAB.normaliseDivide(double(nACumulative) / nASelections);
     // Normalise by B site population density
@@ -153,7 +153,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // RDF(B-C)
     auto &normalisedBC = processingData.realise<Data1D>("RDF(BC)", name(), GenericItem::InRestartFileFlag);
     normalisedBC = rBC.accumulatedData();
-    DataNormaliser1D normaliserBC(normalisedBC);
+    DataOperator1D normaliserBC(normalisedBC);
     // Normalise by A site population
     normaliserBC.normaliseDivide(double(nACumulative) / nASelections);
     // Normalise by B site population
@@ -166,7 +166,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // Angle(A-B-C)
     auto &normalisedAngle = processingData.realise<Data1D>("Angle(ABC)", name(), GenericItem::InRestartFileFlag);
     normalisedAngle = aABC.accumulatedData();
-    DataNormaliser1D normaliserAngle(normalisedAngle);
+    DataOperator1D normaliserAngle(normalisedAngle);
     // Normalise by value / sin(x)
     normaliserAngle.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
@@ -175,7 +175,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // DAngle((A-B)-C)
     auto &normalisedDAngleAB = processingData.realise<Data2D>("DAngle((A-B)-C)", name(), GenericItem::InRestartFileFlag);
     normalisedDAngleAB = dAngleAB.accumulatedData();
-    DataNormaliser2D normaliserDAngleAB(normalisedDAngleAB);
+    DataOperator2D normaliserDAngleAB(normalisedDAngleAB);
     // Normalise by value / sin(y) / sin(yDelta)
     normaliserDAngleAB.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
                                  { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
@@ -191,7 +191,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     // DAngle(A-(B-C))
     auto &normalisedDAngleBC = processingData.realise<Data2D>("DAngle(A-(B-C))", name(), GenericItem::InRestartFileFlag);
     normalisedDAngleBC = dAngleBC.accumulatedData();
-    DataNormaliser2D normaliserDAngleBC(normalisedDAngleBC);
+    DataOperator2D normaliserDAngleBC(normalisedDAngleBC);
     // Normalise by value / sin(y) / sin(yDelta)
     normaliserDAngleBC.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
                                  { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
-#include "analyser/dataNormaliser2D.h"
+#include "analyser/dataOperator1D.h"
+#include "analyser/dataOperator2D.h"
 #include "analyser/siteSelector.h"
 #include "base/sysFunc.h"
 #include "main/dissolve.h"
@@ -79,7 +79,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     // RDF(A-B)
     auto &rABNormalised = processingData.realise<Data1D>("RDF(AB)", name(), GenericItem::InRestartFileFlag);
     rABNormalised = rAB.accumulatedData();
-    DataNormaliser1D rABNormaliser(rABNormalised);
+    DataOperator1D rABNormaliser(rABNormalised);
 
     // Normalise by A site population
     rABNormaliser.normaliseDivide(double(a.sites().size()));
@@ -91,7 +91,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     // AxisAngle(A-B)
     auto &aABNormalised = processingData.realise<Data1D>("AxisAngle(AB)", name(), GenericItem::InRestartFileFlag);
     aABNormalised = aAB.accumulatedData();
-    DataNormaliser1D aABNormaliser(aABNormalised);
+    DataOperator1D aABNormaliser(aABNormalised);
     // Normalise by value / sin(x)
     aABNormaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
@@ -100,7 +100,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     // DAxisAngle(A-B)
     auto &dAxisAngleNormalised = processingData.realise<Data2D>("DAxisAngle", name(), GenericItem::InRestartFileFlag);
     dAxisAngleNormalised = dAxisAngle.accumulatedData();
-    DataNormaliser2D dAxisAngleNormaliser(dAxisAngleNormalised);
+    DataOperator2D dAxisAngleNormaliser(dAxisAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
     dAxisAngleNormaliser.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
                                    { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -95,7 +95,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     // Normalise by value / sin(x)
     aABNormaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
-    aABNormaliser.normaliseTo();
+    aABNormaliser.normaliseSumTo();
 
     // DAxisAngle(A-B)
     auto &dAxisAngleNormalised = processingData.realise<Data2D>("DAxisAngle", name(), GenericItem::InRestartFileFlag);

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -82,9 +82,9 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     DataOperator1D rABNormaliser(rABNormalised);
 
     // Normalise by A site population
-    rABNormaliser.normaliseDivide(double(a.sites().size()));
+    rABNormaliser.divide(double(a.sites().size()));
     // Normalise by B site population density
-    rABNormaliser.normaliseDivide(double(b.sites().size()) / targetConfiguration_->box()->volume());
+    rABNormaliser.divide(double(b.sites().size()) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     rABNormaliser.normaliseBySphericalShell();
 
@@ -93,7 +93,7 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     aABNormalised = aAB.accumulatedData();
     DataOperator1D aABNormaliser(aABNormalised);
     // Normalise by value / sin(x)
-    aABNormaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
+    aABNormaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
     aABNormaliser.normaliseTo();
 
@@ -102,12 +102,12 @@ Module::ExecutionResult AxisAngleModule::process(ModuleContext &moduleContext)
     dAxisAngleNormalised = dAxisAngle.accumulatedData();
     DataOperator2D dAxisAngleNormaliser(dAxisAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
-    dAxisAngleNormaliser.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
-                                   { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
+    dAxisAngleNormaliser.operate([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+                                 { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
     // Normalise by A site population
-    dAxisAngleNormaliser.normaliseDivide(double(a.sites().size()));
+    dAxisAngleNormaliser.divide(double(a.sites().size()));
     // Normalise by B site population density
-    dAxisAngleNormaliser.normaliseDivide(double(b.sites().size()) / targetConfiguration_->box()->volume());
+    dAxisAngleNormaliser.divide(double(b.sites().size()) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     dAxisAngleNormaliser.normaliseBySphericalShell();
 

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
-#include "analyser/dataNormaliser2D.h"
+#include "analyser/dataOperator1D.h"
+#include "analyser/dataOperator2D.h"
 #include "analyser/siteSelector.h"
 #include "base/sysFunc.h"
 #include "main/dissolve.h"
@@ -102,7 +102,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     // RDF(B-C)
     auto &rBCNormalised = processingData.realise<Data1D>("RDF(BC)", name(), GenericItem::InRestartFileFlag);
     rBCNormalised = rBC.accumulatedData();
-    DataNormaliser1D rBCNormaliser(rBCNormalised);
+    DataOperator1D rBCNormaliser(rBCNormalised);
     // Normalise by A site population
     rBCNormaliser.normaliseDivide(double(nACumulative) / nASelections);
     // Normalise by B site population
@@ -114,7 +114,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
 
     auto &aABCNormalised = processingData.realise<Data1D>("Angle(ABC)", name(), GenericItem::InRestartFileFlag);
     aABCNormalised = aABC.accumulatedData();
-    DataNormaliser1D aABCNormaliser(aABCNormalised);
+    DataOperator1D aABCNormaliser(aABCNormalised);
     // Normalise by value / sin(x)
     aABCNormaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
@@ -122,7 +122,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
 
     auto &dAngleNormalised = processingData.realise<Data2D>("DAngle(A-BC)", name(), GenericItem::InRestartFileFlag);
     dAngleNormalised = dAngle.accumulatedData();
-    DataNormaliser2D dAngleNormaliser(dAngleNormalised);
+    DataOperator2D dAngleNormaliser(dAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
     dAngleNormaliser.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
                                { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -118,7 +118,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     // Normalise by value / sin(x)
     aABCNormaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
-    aABCNormaliser.normaliseTo();
+    aABCNormaliser.normaliseSumTo();
 
     auto &dAngleNormalised = processingData.realise<Data2D>("DAngle(A-BC)", name(), GenericItem::InRestartFileFlag);
     dAngleNormalised = dAngle.accumulatedData();

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -104,11 +104,11 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     rBCNormalised = rBC.accumulatedData();
     DataOperator1D rBCNormaliser(rBCNormalised);
     // Normalise by A site population
-    rBCNormaliser.normaliseDivide(double(nACumulative) / nASelections);
+    rBCNormaliser.divide(double(nACumulative) / nASelections);
     // Normalise by B site population
-    rBCNormaliser.normaliseDivide(double(nBCumulative) / nBSelections);
+    rBCNormaliser.divide(double(nBCumulative) / nBSelections);
     // Normalise by C site population density
-    rBCNormaliser.normaliseDivide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
+    rBCNormaliser.divide((double(nCAvailable) / nCSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     rBCNormaliser.normaliseBySphericalShell();
 
@@ -116,7 +116,7 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     aABCNormalised = aABC.accumulatedData();
     DataOperator1D aABCNormaliser(aABCNormalised);
     // Normalise by value / sin(x)
-    aABCNormaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
+    aABCNormaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise to 1.0
     aABCNormaliser.normaliseTo();
 
@@ -124,12 +124,12 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     dAngleNormalised = dAngle.accumulatedData();
     DataOperator2D dAngleNormaliser(dAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
-    dAngleNormaliser.normalise([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
-                               { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
+    dAngleNormaliser.operate([&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+                             { return (symmetric_ ? value : value * 2.0) / sin(y / DEGRAD) / sin(yDelta / DEGRAD); });
     // Normalise by A site population
-    dAngleNormaliser.normaliseDivide(double(nACumulative) / nASelections);
+    dAngleNormaliser.divide(double(nACumulative) / nASelections);
     // Normalise by B site population density
-    dAngleNormaliser.normaliseDivide((double(nBAvailable) / nBSelections) / targetConfiguration_->box()->volume());
+    dAngleNormaliser.divide((double(nBAvailable) / nBSelections) / targetConfiguration_->box()->volume());
     // Normalise by spherical shell
     dAngleNormaliser.normaliseBySphericalShell();
 

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -447,7 +447,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             auto refMinusIntra = originalReferenceData;
             Interpolator::addInterpolated(weightedSQ.boundTotal(), refMinusIntra, -1.0);
 
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseSumTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseTo");
             if (normType == StructureFactors::SquareOfAverageNormalisation)
             {
                 // Remove square of average normalisation, and apply average of squares

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -424,7 +424,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
 
             // Always add absolute data to the scattering matrix - if the calculated data has been normalised, remove this
             // normalisation from the reference data (we assume that the two are consistent)
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseSumTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseTo");
             if (normType == StructureFactors::AverageOfSquaresNormalisation)
                 refMinusIntra *= weights.boundCoherentAverageOfSquares();
             else if (normType == StructureFactors::SquareOfAverageNormalisation)

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -424,7 +424,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
 
             // Always add absolute data to the scattering matrix - if the calculated data has been normalised, remove this
             // normalisation from the reference data (we assume that the two are consistent)
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("NormaliseTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseSumTo");
             if (normType == StructureFactors::AverageOfSquaresNormalisation)
                 refMinusIntra *= weights.boundCoherentAverageOfSquares();
             else if (normType == StructureFactors::SquareOfAverageNormalisation)
@@ -447,7 +447,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             auto refMinusIntra = originalReferenceData;
             Interpolator::addInterpolated(weightedSQ.boundTotal(), refMinusIntra, -1.0);
 
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("NormaliseTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseSumTo");
             if (normType == StructureFactors::SquareOfAverageNormalisation)
             {
                 // Remove square of average normalisation, and apply average of squares

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -424,7 +424,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
 
             // Always add absolute data to the scattering matrix - if the calculated data has been normalised, remove this
             // normalisation from the reference data (we assume that the two are consistent)
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("NormaliseTo");
             if (normType == StructureFactors::AverageOfSquaresNormalisation)
                 refMinusIntra *= weights.boundCoherentAverageOfSquares();
             else if (normType == StructureFactors::SquareOfAverageNormalisation)
@@ -447,7 +447,7 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             auto refMinusIntra = originalReferenceData;
             Interpolator::addInterpolated(weightedSQ.boundTotal(), refMinusIntra, -1.0);
 
-            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("normaliseTo");
+            auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("NormaliseTo");
             if (normType == StructureFactors::SquareOfAverageNormalisation)
             {
                 // Remove square of average normalisation, and apply average of squares

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "analyser/siteSelector.h"
 #include "base/sysFunc.h"
 #include "io/export/data1D.h"
@@ -59,7 +59,7 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
     dataCN = hist.accumulatedData();
 
     // Normalise CN
-    DataNormaliser1D normaliserCN(dataCN);
+    DataOperator1D normaliserCN(dataCN);
     // Normalise by value
     normaliserCN.normaliseTo();
 

--- a/src/modules/histogramCN/process.cpp
+++ b/src/modules/histogramCN/process.cpp
@@ -61,7 +61,7 @@ Module::ExecutionResult HistogramCNModule::process(ModuleContext &moduleContext)
     // Normalise CN
     DataOperator1D normaliserCN(dataCN);
     // Normalise by value
-    normaliserCN.normaliseTo();
+    normaliserCN.normaliseSumTo();
 
     // Save CN data?
     if (!DataExporter<Data1D, Data1DExportFileFormat>::exportData(dataCN, exportFileAndFormat_, moduleContext.processPool()))

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -86,7 +86,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     // Normalise by sin(x)
     normaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise by value
-    normaliser.normaliseTo();
+    normaliser.normaliseSumTo();
 
     // Save Angle(A-B-C) data?
     if (!DataExporter<Data1D, Data1DExportFileFormat>::exportData(dataNormalisedHisto, exportFileAndFormat_,

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "analyser/siteSelector.h"
 #include "expression/variable.h"
 #include "main/dissolve.h"
@@ -82,7 +82,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     dataNormalisedHisto = hist.accumulatedData();
 
     // Normalise
-    DataNormaliser1D normaliser(dataNormalisedHisto);
+    DataOperator1D normaliser(dataNormalisedHisto);
     // Normalise by sin(x)
     normaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise by value

--- a/src/modules/intraAngle/process.cpp
+++ b/src/modules/intraAngle/process.cpp
@@ -84,7 +84,7 @@ Module::ExecutionResult IntraAngleModule::process(ModuleContext &moduleContext)
     // Normalise
     DataOperator1D normaliser(dataNormalisedHisto);
     // Normalise by sin(x)
-    normaliser.normalise([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
+    normaliser.operate([](const auto &x, const auto &xDelta, const auto &value) { return value / sin(x / DEGRAD); });
     // Normalise by value
     normaliser.normaliseTo();
 

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "analyser/siteSelector.h"
 #include "io/export/data1D.h"
 #include "main/dissolve.h"
@@ -54,7 +54,7 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
     dataNormalisedHisto = histAB.accumulatedData();
 
     // Normalise
-    DataNormaliser1D histogramNormaliser(dataNormalisedHisto);
+    DataOperator1D histogramNormaliser(dataNormalisedHisto);
     // Normalise by value
     histogramNormaliser.normaliseTo();
 

--- a/src/modules/intraDistance/process.cpp
+++ b/src/modules/intraDistance/process.cpp
@@ -56,7 +56,7 @@ Module::ExecutionResult IntraDistanceModule::process(ModuleContext &moduleContex
     // Normalise
     DataOperator1D histogramNormaliser(dataNormalisedHisto);
     // Normalise by value
-    histogramNormaliser.normaliseTo();
+    histogramNormaliser.normaliseSumTo();
 
     // Save Distance(A-B) data?
     if (!DataExporter<Data1D, Data1DExportFileFormat>::exportData(dataNormalisedHisto, exportFileAndFormat_,

--- a/src/modules/neutronSQ/neutronSQ.cpp
+++ b/src/modules/neutronSQ/neutronSQ.cpp
@@ -23,9 +23,9 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
     keywords_.add<IsotopologueSetKeyword>("Isotopologue", "Set/add an isotopologue and its population for a particular species",
                                           isotopologueSet_);
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("NormaliseTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseSumTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseTo_, StructureFactors::normalisationTypes())
+                                                                      normaliseSumTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -69,7 +69,8 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo_, StructureFactors::normalisationTypes());
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseSumTo_,
+        StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,
         StructureFactors::normalisationTypes());

--- a/src/modules/neutronSQ/neutronSQ.cpp
+++ b/src/modules/neutronSQ/neutronSQ.cpp
@@ -25,7 +25,7 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseTotructureFactors::normalisationTypes())
+                                                                      normaliseTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -69,8 +69,7 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo,
-        StructureFactors::normalisationTypes());
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo_, StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,
         StructureFactors::normalisationTypes());

--- a/src/modules/neutronSQ/neutronSQ.cpp
+++ b/src/modules/neutronSQ/neutronSQ.cpp
@@ -23,9 +23,9 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
     keywords_.add<IsotopologueSetKeyword>("Isotopologue", "Set/add an isotopologue and its population for a particular species",
                                           isotopologueSet_);
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseSumTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseSumTo_, StructureFactors::normalisationTypes())
+                                                                      normaliseTotructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -69,7 +69,7 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseSumTo_,
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo,
         StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,

--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -31,7 +31,7 @@ class NeutronSQModule : public Module
     // Isotopologues to use in weighting
     IsotopologueSet isotopologueSet_;
     // Normalisation to apply to calculated total F(Q)
-    StructureFactors::NormalisationType normaliseTo_{StructureFactors::NoNormalisation};
+    StructureFactors::NormalisationType normaliseSumTo_{StructureFactors::NoNormalisation};
     // Reference F(Q) file and format
     Data1DImportFileFormat referenceFQ_;
     // Minimum Q value to use when Fourier-transforming the data

--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -31,7 +31,7 @@ class NeutronSQModule : public Module
     // Isotopologues to use in weighting
     IsotopologueSet isotopologueSet_;
     // Normalisation to apply to calculated total F(Q)
-    StructureFactors::NormalisationType normaliseSumTo_{StructureFactors::NoNormalisation};
+    StructureFactors::NormalisationType normaliseTo_{StructureFactors::NoNormalisation};
     // Reference F(Q) file and format
     Data1DImportFileFormat referenceFQ_;
     // Minimum Q value to use when Fourier-transforming the data

--- a/src/modules/neutronSQ/process.cpp
+++ b/src/modules/neutronSQ/process.cpp
@@ -44,7 +44,7 @@ bool NeutronSQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Key
             return Messenger::error("[SETUP {}] A source GR module (in the SQ module) must be provided.\n", name_);
 
         // Normalise reference data to be consistent with the calculated data
-        if (referenceNormalisedTo_ != normaliseSumTo_)
+        if (referenceNormalisedTo_ != normaliseTo_)
         {
             // We need the neutron weights in order to do the normalisation
             NeutronWeights weights;
@@ -55,18 +55,18 @@ bool NeutronSQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Key
             switch (referenceNormalisedTo_)
             {
                 case (StructureFactors::NoNormalisation):
-                    factor = 1.0 / normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation
+                    factor = 1.0 / normaliseTo_ == StructureFactors::SquareOfAverageNormalisation
                                  ? weights.boundCoherentSquareOfAverage()
                                  : weights.boundCoherentAverageOfSquares();
                     break;
                 case (StructureFactors::SquareOfAverageNormalisation):
                     factor = weights.boundCoherentSquareOfAverage();
-                    if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
+                    if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
                         factor /= weights.boundCoherentAverageOfSquares();
                     break;
                 case (StructureFactors::AverageOfSquaresNormalisation):
                     factor = weights.boundCoherentAverageOfSquares();
-                    if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
+                    if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
                         factor /= weights.boundCoherentSquareOfAverage();
                     break;
                 default:
@@ -164,11 +164,11 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
     else
         Messenger::print("Window function to be applied when calculating representative g(r) from S(Q) is {}.",
                          WindowFunction::forms().keyword(referenceWindowFunction_));
-    if (normaliseSumTo_ == StructureFactors::NoNormalisation)
+    if (normaliseTo_ == StructureFactors::NoNormalisation)
         Messenger::print("NeutronSQ: No normalisation will be applied to total F(Q).\n");
-    else if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
+    else if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
         Messenger::print("NeutronSQ: Total F(Q) will be normalised to <b**2>");
-    else if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
+    else if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
         Messenger::print("NeutronSQ: Total F(Q) will be normalised to <b>**2");
     if (saveSQ_)
         Messenger::print("NeutronSQ: Weighted partial S(Q) and total F(Q) will be saved.\n");
@@ -205,7 +205,7 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
         weightedSQ.setUpPartials(unweightedSQ.atomTypeMix());
 
     // Calculate weighted S(Q)
-    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseSumTo_);
+    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseTo_);
 
     // Save data if requested
     if (saveSQ_ && (!MPIRunMaster(moduleContext.processPool(), weightedSQ.save(name_, "WeightedSQ", "sq", "Q, 1/Angstroms"))))
@@ -232,7 +232,7 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
         weightedGR.setUpPartials(unweightedGR.atomTypeMix());
 
     // Calculate weighted g(r)
-    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseSumTo_);
+    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseTo_);
 
     // Save data if requested
     if (saveGR_ && (!MPIRunMaster(moduleContext.processPool(), weightedGR.save(name_, "WeightedGR", "gr", "r, Angstroms"))))

--- a/src/modules/neutronSQ/process.cpp
+++ b/src/modules/neutronSQ/process.cpp
@@ -44,7 +44,7 @@ bool NeutronSQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Key
             return Messenger::error("[SETUP {}] A source GR module (in the SQ module) must be provided.\n", name_);
 
         // Normalise reference data to be consistent with the calculated data
-        if (referenceNormalisedTo_ != normaliseTo_)
+        if (referenceNormalisedTo_ != normaliseSumTo_)
         {
             // We need the neutron weights in order to do the normalisation
             NeutronWeights weights;
@@ -55,18 +55,18 @@ bool NeutronSQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Key
             switch (referenceNormalisedTo_)
             {
                 case (StructureFactors::NoNormalisation):
-                    factor = 1.0 / normaliseTo_ == StructureFactors::SquareOfAverageNormalisation
+                    factor = 1.0 / normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation
                                  ? weights.boundCoherentSquareOfAverage()
                                  : weights.boundCoherentAverageOfSquares();
                     break;
                 case (StructureFactors::SquareOfAverageNormalisation):
                     factor = weights.boundCoherentSquareOfAverage();
-                    if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
+                    if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
                         factor /= weights.boundCoherentAverageOfSquares();
                     break;
                 case (StructureFactors::AverageOfSquaresNormalisation):
                     factor = weights.boundCoherentAverageOfSquares();
-                    if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
+                    if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
                         factor /= weights.boundCoherentSquareOfAverage();
                     break;
                 default:
@@ -164,11 +164,11 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
     else
         Messenger::print("Window function to be applied when calculating representative g(r) from S(Q) is {}.",
                          WindowFunction::forms().keyword(referenceWindowFunction_));
-    if (normaliseTo_ == StructureFactors::NoNormalisation)
+    if (normaliseSumTo_ == StructureFactors::NoNormalisation)
         Messenger::print("NeutronSQ: No normalisation will be applied to total F(Q).\n");
-    else if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
+    else if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
         Messenger::print("NeutronSQ: Total F(Q) will be normalised to <b**2>");
-    else if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
+    else if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
         Messenger::print("NeutronSQ: Total F(Q) will be normalised to <b>**2");
     if (saveSQ_)
         Messenger::print("NeutronSQ: Weighted partial S(Q) and total F(Q) will be saved.\n");
@@ -205,7 +205,7 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
         weightedSQ.setUpPartials(unweightedSQ.atomTypeMix());
 
     // Calculate weighted S(Q)
-    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseTo_);
+    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseSumTo_);
 
     // Save data if requested
     if (saveSQ_ && (!MPIRunMaster(moduleContext.processPool(), weightedSQ.save(name_, "WeightedSQ", "sq", "Q, 1/Angstroms"))))
@@ -232,7 +232,7 @@ Module::ExecutionResult NeutronSQModule::process(ModuleContext &moduleContext)
         weightedGR.setUpPartials(unweightedGR.atomTypeMix());
 
     // Calculate weighted g(r)
-    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseTo_);
+    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseSumTo_);
 
     // Save data if requested
     if (saveGR_ && (!MPIRunMaster(moduleContext.processPool(), weightedGR.save(name_, "WeightedGR", "gr", "r, Angstroms"))))

--- a/src/modules/orientedSDF/process.cpp
+++ b/src/modules/orientedSDF/process.cpp
@@ -66,7 +66,7 @@ Module::ExecutionResult OrientedSDFModule::process(ModuleContext &moduleContext)
     // Normalise
     DataOperator3D normaliserOrientedSDF(dataOrientedSDF);
     // Normalise by A site population
-    normaliserOrientedSDF.normaliseDivide(double(a.sites().size()));
+    normaliserOrientedSDF.divide(double(a.sites().size()));
     // Normalise by grid
     normaliserOrientedSDF.normaliseByGrid();
 

--- a/src/modules/orientedSDF/process.cpp
+++ b/src/modules/orientedSDF/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser3D.h"
+#include "analyser/dataOperator3D.h"
 #include "analyser/siteSelector.h"
 #include "main/dissolve.h"
 #include "math/histogram3D.h"
@@ -64,7 +64,7 @@ Module::ExecutionResult OrientedSDFModule::process(ModuleContext &moduleContext)
     dataOrientedSDF = hist.accumulatedData();
 
     // Normalise
-    DataNormaliser3D normaliserOrientedSDF(dataOrientedSDF);
+    DataOperator3D normaliserOrientedSDF(dataOrientedSDF);
     // Normalise by A site population
     normaliserOrientedSDF.normaliseDivide(double(a.sites().size()));
     // Normalise by grid

--- a/src/modules/qSpecies/process.cpp
+++ b/src/modules/qSpecies/process.cpp
@@ -83,7 +83,7 @@ Module::ExecutionResult QSpeciesModule::process(ModuleContext &moduleContext)
     // Averaged values for Q-Species
     Data1D accumulatedQData = qSpeciesHistogram.accumulatedData();
     DataOperator1D normaliserQ(accumulatedQData);
-    normaliserQ.normaliseTo();
+    normaliserQ.normaliseSumTo();
 
     // Averaged values for oxygen sites
     auto freeOxygens = oxygenSitesHistogram.accumulatedData().value(0);

--- a/src/modules/qSpecies/process.cpp
+++ b/src/modules/qSpecies/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "analyser/siteFilter.h"
 #include "analyser/siteSelector.h"
 #include "main/dissolve.h"
@@ -82,7 +82,7 @@ Module::ExecutionResult QSpeciesModule::process(ModuleContext &moduleContext)
 
     // Averaged values for Q-Species
     Data1D accumulatedQData = qSpeciesHistogram.accumulatedData();
-    DataNormaliser1D normaliserQ(accumulatedQData);
+    DataOperator1D normaliserQ(accumulatedQData);
     normaliserQ.normaliseTo();
 
     // Averaged values for oxygen sites

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser3D.h"
+#include "analyser/dataOperator3D.h"
 #include "analyser/siteSelector.h"
 #include "base/sysFunc.h"
 #include "main/dissolve.h"
@@ -56,7 +56,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
     dataSDF = hist.accumulatedData();
 
     // Normalise
-    DataNormaliser3D normaliserSDF(dataSDF);
+    DataOperator3D normaliserSDF(dataSDF);
     // Normalise by A site population
     normaliserSDF.normaliseDivide(double(a.sites().size()));
     // Normalise by grid

--- a/src/modules/sdf/process.cpp
+++ b/src/modules/sdf/process.cpp
@@ -58,7 +58,7 @@ Module::ExecutionResult SDFModule::process(ModuleContext &moduleContext)
     // Normalise
     DataOperator3D normaliserSDF(dataSDF);
     // Normalise by A site population
-    normaliserSDF.normaliseDivide(double(a.sites().size()));
+    normaliserSDF.divide(double(a.sites().size()));
     // Normalise by grid
     normaliserSDF.normaliseByGrid();
 

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -55,10 +55,10 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     // Normalise
     DataOperator1D normaliserRDF(dataRDF);
     // Normalise by A site population
-    normaliserRDF.normaliseDivide(double(a.sites().size()));
+    normaliserRDF.divide(double(a.sites().size()));
 
     // Normalise by B site population density
-    normaliserRDF.normaliseDivide(double(b.sites().size()) / targetConfiguration_->box()->volume());
+    normaliserRDF.divide(double(b.sites().size()) / targetConfiguration_->box()->volume());
 
     // Normalise by spherical shell
     normaliserRDF.normaliseBySphericalShell();
@@ -70,7 +70,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     // Normalise
     DataOperator1D normaliserCN(dataCN);
     // Normalise by A site population
-    normaliserCN.normaliseDivide(double(a.sites().size()));
+    normaliserCN.divide(double(a.sites().size()));
 
     const std::vector<std::string> rangeNames = {"A", "B", "C"};
     for (int i = 0; i < 3; ++i)

--- a/src/modules/siteRDF/process.cpp
+++ b/src/modules/siteRDF/process.cpp
@@ -2,7 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "analyser/dataExporter.h"
-#include "analyser/dataNormaliser1D.h"
+#include "analyser/dataOperator1D.h"
 #include "base/sysFunc.h"
 #include "io/export/data1D.h"
 #include "main/dissolve.h"
@@ -53,7 +53,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     dataRDF = histAB.accumulatedData();
 
     // Normalise
-    DataNormaliser1D normaliserRDF(dataRDF);
+    DataOperator1D normaliserRDF(dataRDF);
     // Normalise by A site population
     normaliserRDF.normaliseDivide(double(a.sites().size()));
 
@@ -68,7 +68,7 @@ Module::ExecutionResult SiteRDFModule::process(ModuleContext &moduleContext)
     dataCN = histAB.accumulatedData();
 
     // Normalise
-    DataNormaliser1D normaliserCN(dataCN);
+    DataOperator1D normaliserCN(dataCN);
     // Normalise by A site population
     normaliserCN.normaliseDivide(double(a.sites().size()));
 

--- a/src/modules/xRaySQ/process.cpp
+++ b/src/modules/xRaySQ/process.cpp
@@ -45,7 +45,7 @@ bool XRaySQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Keywor
             return Messenger::error("[SETUP {}] A source GR module (in the SQ module) must be provided.\n", name_);
 
         // Normalise reference data to be consistent with the calculated data
-        if (referenceNormalisedTo_ != normaliseTo_)
+        if (referenceNormalisedTo_ != normaliseSumTo_)
         {
             // We need the x-ray weights in order to do the normalisation
             XRayWeights weights;
@@ -58,20 +58,20 @@ bool XRaySQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Keywor
             switch (referenceNormalisedTo_)
             {
                 case (StructureFactors::NoNormalisation):
-                    factors = normaliseTo_ == StructureFactors::SquareOfAverageNormalisation ? bBarSquareOfAverage
-                                                                                             : bBarAverageOfSquares;
+                    factors = normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation ? bBarSquareOfAverage
+                                                                                                : bBarAverageOfSquares;
                     std::transform(factors.begin(), factors.end(), factors.begin(),
                                    [](const auto factor) { return 1.0 / factor; });
                     break;
                 case (StructureFactors::SquareOfAverageNormalisation):
                     factors = bBarSquareOfAverage;
-                    if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
+                    if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
                         std::transform(factors.begin(), factors.end(), bBarAverageOfSquares.begin(), factors.begin(),
                                        std::divides<>());
                     break;
                 case (StructureFactors::AverageOfSquaresNormalisation):
                     factors = bBarAverageOfSquares;
-                    if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
+                    if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
                         std::transform(factors.begin(), factors.end(), bBarSquareOfAverage.begin(), factors.begin(),
                                        std::divides<>());
                     break;
@@ -166,11 +166,11 @@ Module::ExecutionResult XRaySQModule::process(ModuleContext &moduleContext)
     // Print argument/parameter summary
     Messenger::print("XRaySQ: Source unweighted S(Q) will be taken from module '{}'.\n", sourceSQ_->name());
     Messenger::print("XRaySQ: Form factors to use are '{}'.\n", XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
-    if (normaliseTo_ == StructureFactors::NoNormalisation)
+    if (normaliseSumTo_ == StructureFactors::NoNormalisation)
         Messenger::print("XRaySQ: No normalisation will be applied to total F(Q).\n");
-    else if (normaliseTo_ == StructureFactors::AverageOfSquaresNormalisation)
+    else if (normaliseSumTo_ == StructureFactors::AverageOfSquaresNormalisation)
         Messenger::print("XRaySQ: Total F(Q) will be normalised to <b**2>");
-    else if (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation)
+    else if (normaliseSumTo_ == StructureFactors::SquareOfAverageNormalisation)
         Messenger::print("XRaySQ: Total F(Q) will be normalised to <b>**2");
     if (referenceWindowFunction_ == WindowFunction::Form::None)
         Messenger::print("XRaySQ: No window function will be applied when calculating representative g(r) from S(Q).");
@@ -214,7 +214,7 @@ Module::ExecutionResult XRaySQModule::process(ModuleContext &moduleContext)
         weightedSQ.setUpPartials(unweightedSQ.atomTypeMix());
 
     // Calculate weighted S(Q)
-    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseTo_);
+    calculateWeightedSQ(unweightedSQ, weightedSQ, weights, normaliseSumTo_);
 
     // Save data if requested
     if (saveSQ_ && (!MPIRunMaster(moduleContext.processPool(), weightedSQ.save(name_, "WeightedSQ", "sq", "Q, 1/Angstroms"))))
@@ -283,7 +283,7 @@ Module::ExecutionResult XRaySQModule::process(ModuleContext &moduleContext)
         weightedGR.setUpPartials(unweightedSQ.atomTypeMix());
 
     // Calculate weighted g(r)
-    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseTo_);
+    calculateWeightedGR(unweightedGR, weightedGR, weights, normaliseSumTo_);
 
     // Calculate representative total g(r) from FT of calculated F(Q)
     auto &repGR = moduleContext.dissolve().processingModuleData().realise<Data1D>("RepresentativeTotalGR", name_,

--- a/src/modules/xRaySQ/xRaySQ.cpp
+++ b/src/modules/xRaySQ/xRaySQ.cpp
@@ -20,9 +20,9 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
     keywords_.add<EnumOptionsKeyword<XRayFormFactors::XRayFormFactorData>>(
         "FormFactors", "Atomic form factors to use for weighting", formFactors_, XRayFormFactors::xRayFormFactorData());
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("NormaliseTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseSumTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseTo_, StructureFactors::normalisationTypes())
+                                                                      normaliseSumTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -68,7 +68,8 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo_, StructureFactors::normalisationTypes());
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseSumTo_,
+        StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,
         StructureFactors::normalisationTypes());

--- a/src/modules/xRaySQ/xRaySQ.cpp
+++ b/src/modules/xRaySQ/xRaySQ.cpp
@@ -22,7 +22,7 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
     keywords_
         .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseTo, StructureFactors::normalisationTypes())
+                                                                      normaliseTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -68,8 +68,7 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo,
-        StructureFactors::normalisationTypes());
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo_, StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,
         StructureFactors::normalisationTypes());

--- a/src/modules/xRaySQ/xRaySQ.cpp
+++ b/src/modules/xRaySQ/xRaySQ.cpp
@@ -20,9 +20,9 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
     keywords_.add<EnumOptionsKeyword<XRayFormFactors::XRayFormFactorData>>(
         "FormFactors", "Atomic form factors to use for weighting", formFactors_, XRayFormFactors::xRayFormFactorData());
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseSumTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
-                                                                      normaliseSumTo_, StructureFactors::normalisationTypes())
+                                                                      normaliseTo, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});
 
     keywords_.setOrganisation("Options", "Reference Data",
@@ -68,7 +68,7 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
 
     // Deprecated keywords
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
-        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseSumTo_,
+        "Normalisation", "Normalisation to apply to total weighted F(Q)", normaliseTo,
         StructureFactors::normalisationTypes());
     keywords_.addDeprecated<EnumOptionsKeyword<StructureFactors::NormalisationType>>(
         "ReferenceNormalisation", "Normalisation to remove from reference data before use", referenceNormalisedTo_,

--- a/src/modules/xRaySQ/xRaySQ.cpp
+++ b/src/modules/xRaySQ/xRaySQ.cpp
@@ -20,7 +20,7 @@ XRaySQModule::XRaySQModule() : Module(ModuleTypes::XRaySQ)
     keywords_.add<EnumOptionsKeyword<XRayFormFactors::XRayFormFactorData>>(
         "FormFactors", "Atomic form factors to use for weighting", formFactors_, XRayFormFactors::xRayFormFactorData());
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("NormaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
                                                                       normaliseTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});

--- a/src/modules/xRaySQ/xRaySQ.h
+++ b/src/modules/xRaySQ/xRaySQ.h
@@ -30,7 +30,7 @@ class XRaySQModule : public Module
     // Atomic form factors to use for weighting
     XRayFormFactors::XRayFormFactorData formFactors_{XRayFormFactors::WaasmaierKirfel1995};
     // Normalisation to apply to calculated total F(Q)
-    StructureFactors::NormalisationType normaliseSumTo_{StructureFactors::NoNormalisation};
+    StructureFactors::NormalisationType normaliseTo_{StructureFactors::NoNormalisation};
     // Reference F(Q) file and format
     Data1DImportFileFormat referenceFQ_;
     // Minimum Q value to use when Fourier-transforming the data

--- a/src/modules/xRaySQ/xRaySQ.h
+++ b/src/modules/xRaySQ/xRaySQ.h
@@ -30,7 +30,7 @@ class XRaySQModule : public Module
     // Atomic form factors to use for weighting
     XRayFormFactors::XRayFormFactorData formFactors_{XRayFormFactors::WaasmaierKirfel1995};
     // Normalisation to apply to calculated total F(Q)
-    StructureFactors::NormalisationType normaliseTo_{StructureFactors::NoNormalisation};
+    StructureFactors::NormalisationType normaliseSumTo_{StructureFactors::NoNormalisation};
     // Reference F(Q) file and format
     Data1DImportFileFormat referenceFQ_;
     // Minimum Q value to use when Fourier-transforming the data


### PR DESCRIPTION
Small PR renaming `DataNormaliserND` to `DataOperatorND` (this also applies to the subclasses), also adds some additional comments to the relevant classes for clarity.

Closes #1816.
