### PR TITLE
test: Show Testing Throws

### DIFF
--- a/tests/ff/testKulmala2010.cpp
+++ b/tests/ff/testKulmala2010.cpp
@@ -12,7 +12,7 @@ class Kulmala2010ForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-kulmala2010.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-kulmala2010.txt")); }
 };
 
 TEST_F(Kulmala2010ForcefieldTest, Hydronium)

--- a/tests/ff/testLudwig-py5.cpp
+++ b/tests/ff/testLudwig-py5.cpp
@@ -12,7 +12,7 @@ class LudwigPy5ForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-ludwig-py5.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-ludwig-py5.txt")); }
 };
 
 TEST_F(LudwigPy5ForcefieldTest, Py5)

--- a/tests/ff/testOPLSAA2005-alcohols.cpp
+++ b/tests/ff/testOPLSAA2005-alcohols.cpp
@@ -12,7 +12,7 @@ class OPLSAA2005AlcoholsForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-oplsaa2005-alcohols.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-oplsaa2005-alcohols.txt")); }
 };
 
 TEST_F(OPLSAA2005AlcoholsForcefieldTest, Methanol)

--- a/tests/ff/testOPLSAA2005-alkanes.cpp
+++ b/tests/ff/testOPLSAA2005-alkanes.cpp
@@ -12,7 +12,7 @@ class OPLSAA2005AlkanesForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-oplsaa2005-alkanes.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-oplsaa2005-alkanes.txt")); }
 };
 
 TEST_F(OPLSAA2005AlkanesForcefieldTest, Heptane)

--- a/tests/ff/testOPLSAA2005-aromatics.cpp
+++ b/tests/ff/testOPLSAA2005-aromatics.cpp
@@ -12,7 +12,7 @@ class OPLSAA2005AromaticsForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-oplsaa2005-aromatics.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-oplsaa2005-aromatics.txt")); }
 };
 
 TEST_F(OPLSAA2005AromaticsForcefieldTest, Benzene)

--- a/tests/ff/testPCL2019-anions.cpp
+++ b/tests/ff/testPCL2019-anions.cpp
@@ -12,7 +12,7 @@ class PCL2019AnionsForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-pcl2019-anions.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-pcl2019-anions.txt")); }
 };
 
 TEST_F(PCL2019AnionsForcefieldTest, beti)

--- a/tests/ff/testPCL2019-cations.cpp
+++ b/tests/ff/testPCL2019-cations.cpp
@@ -12,7 +12,7 @@ class PCL2019CationsForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-pcl2019-cations.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-pcl2019-cations.txt")); }
 };
 
 TEST_F(PCL2019CationsForcefieldTest, benzc1im)

--- a/tests/ff/testSPCFw.cpp
+++ b/tests/ff/testSPCFw.cpp
@@ -12,7 +12,7 @@ class SPCFwForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-spcfw.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-spcfw.txt")); }
 };
 
 TEST_F(SPCFwForcefieldTest, Water)

--- a/tests/ff/testUFF-nmethylformamide.cpp
+++ b/tests/ff/testUFF-nmethylformamide.cpp
@@ -12,7 +12,7 @@ class UFFNMethylFormamideForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-uff-nmethylformamide.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-uff-nmethylformamide.txt")); }
 };
 
 TEST_F(UFFNMethylFormamideForcefieldTest, NMethylFormamide)

--- a/tests/ff/testUFF4MOF-mof5.cpp
+++ b/tests/ff/testUFF4MOF-mof5.cpp
@@ -12,7 +12,7 @@ class UFF4MOFMOF5ForcefieldTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/ff-uff4mof-mof5.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/ff-uff4mof-mof5.txt")); }
 };
 
 TEST_F(UFF4MOFMOF5ForcefieldTest, MOF5)

--- a/tests/io/toml.cpp
+++ b/tests/io/toml.cpp
@@ -56,7 +56,7 @@ void runParse(std::filesystem::path input, int steps = 1)
         CoreData coreData2;
         Dissolve repeat(coreData2);
         repeat.setInputFilename(std::string(filename));
-        EXPECT_NO_THROW(repeat.deserialise(toml));
+        EXPECT_NO_THROW_VERBOSE(repeat.deserialise(toml));
         auto toml2 = repeat.serialise();
 
         compare_toml("", toml, toml2);

--- a/tests/modules/accumulate.cpp
+++ b/tests/modules/accumulate.cpp
@@ -14,7 +14,7 @@ class AccumulateModuleTest : public ::testing::Test
 
     void SetUp() override
     {
-        ASSERT_NO_THROW(systemTest.setUp("dissolve/input/accumulate.txt"));
+        ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/accumulate.txt"));
         ASSERT_TRUE(systemTest.dissolve().iterate(20));
     }
 };

--- a/tests/modules/angle.cpp
+++ b/tests/modules/angle.cpp
@@ -14,7 +14,7 @@ class AngleModuleTest : public ::testing::Test
 
 TEST_F(AngleModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/angle.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/angle.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/atomShake.cpp
+++ b/tests/modules/atomShake.cpp
@@ -14,7 +14,7 @@ class AtomShakeModuleTest : public ::testing::Test
 
     void SetUp() override
     {
-        ASSERT_NO_THROW(systemTest.setUp("dissolve/input/atomShake-water.txt"));
+        ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/atomShake-water.txt"));
         ASSERT_TRUE(systemTest.dissolve().iterate(100));
     }
 };

--- a/tests/modules/avgMol.cpp
+++ b/tests/modules/avgMol.cpp
@@ -15,7 +15,7 @@ class AvgMolModuleWaterTest : public ::testing::Test
 
     void SetUp() override
     {
-        ASSERT_NO_THROW(systemTest.setUp("dissolve/input/avgMol-water.txt"));
+        ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/avgMol-water.txt"));
         ASSERT_TRUE(systemTest.iterateRestart(95));
     }
 };
@@ -33,7 +33,7 @@ class AvgMolModuleBendyTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/avgMol-bendy.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/avgMol-bendy.txt")); }
 
     void checkCoordinates()
     {

--- a/tests/modules/axisAngle.cpp
+++ b/tests/modules/axisAngle.cpp
@@ -13,7 +13,7 @@ class AxisAngleModuleTest : public ::testing::Test
 
     void SetUp() override
     {
-        ASSERT_NO_THROW(systemTest.setUp("dissolve/input/axisAngle-benzene.txt"));
+        ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/axisAngle-benzene.txt"));
         ASSERT_TRUE(systemTest.iterateRestart(100));
     }
 };

--- a/tests/modules/bragg.cpp
+++ b/tests/modules/bragg.cpp
@@ -72,7 +72,7 @@ class BraggModuleTest : public ::testing::Test
 
 TEST_F(BraggModuleTest, MgO_Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/bragg-MgO.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/bragg-MgO.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Check Partial S(Q) data
@@ -252,12 +252,12 @@ TEST_F(BraggModuleTest, MgO_Full)
 
 TEST_F(BraggModuleTest, MgO_Intensities111)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/bragg-MgO.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/bragg-MgO.txt"));
 
     // Set multiplicities to (1,1,1)
     auto *braggModule = systemTest.coreData().findModule("Bragg01");
     ASSERT_TRUE(braggModule);
-    ASSERT_NO_THROW(braggModule->keywords().set("Multiplicity", Vec3<int>(1, 1, 1)));
+    ASSERT_NO_THROW_VERBOSE(braggModule->keywords().set("Multiplicity", Vec3<int>(1, 1, 1)));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 

--- a/tests/modules/broadening.cpp
+++ b/tests/modules/broadening.cpp
@@ -14,7 +14,7 @@ class BroadeningModuleTest : public ::testing::Test
     protected:
     DissolveSystemTest systemTest;
 
-    void SetUp() override { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/broadening-argon.txt")); }
+    void SetUp() override { ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/broadening-argon.txt")); }
 };
 
 TEST_F(BroadeningModuleTest, Dep1Indep2)
@@ -31,7 +31,7 @@ TEST_F(BroadeningModuleTest, Dep2Indep1)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW(
+    ASSERT_NO_THROW_VERBOSE(
         sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::GaussianC2, {0.1, 0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
@@ -46,7 +46,7 @@ TEST_F(BroadeningModuleTest, Dep1)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW(sqModule->keywords().set(
+    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set(
         "QBroadening", Functions::Function1DWrapper(Functions::Function1D::OmegaDependentGaussian, {0.1})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
@@ -61,7 +61,7 @@ TEST_F(BroadeningModuleTest, Dep2)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW(sqModule->keywords().set(
+    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set(
         "QBroadening", Functions::Function1DWrapper(Functions::Function1D::OmegaDependentGaussian, {0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
@@ -76,7 +76,7 @@ TEST_F(BroadeningModuleTest, Indep1)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW(
+    ASSERT_NO_THROW_VERBOSE(
         sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::Gaussian, {0.1})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
@@ -91,7 +91,7 @@ TEST_F(BroadeningModuleTest, Indep2)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW(
+    ASSERT_NO_THROW_VERBOSE(
         sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::Gaussian, {0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));

--- a/tests/modules/compare.cpp
+++ b/tests/modules/compare.cpp
@@ -17,7 +17,7 @@ class CompareModuleTest : public ::testing::Test
 
     void SetUp() override
     {
-        ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
+        ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
         ASSERT_TRUE(systemTest.dissolve().iterate(1));
     }
 };

--- a/tests/modules/dAngle.cpp
+++ b/tests/modules/dAngle.cpp
@@ -15,7 +15,7 @@ class DAngleModuleTest : public ::testing::Test
 
 TEST_F(DAngleModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/dAngle.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/dAngle.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/energy.cpp
+++ b/tests/modules/energy.cpp
@@ -19,7 +19,7 @@ class EnergyModuleTest : public ::testing::Test
 
 TEST_F(EnergyModuleTest, DLPOLYWater3000Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -34,14 +34,14 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Full)
 
 TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaals)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                         C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -52,14 +52,14 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaals)
 
 TEST_F(EnergyModuleTest, DLPOLYWater3000Electrostatics)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                         C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
@@ -75,13 +75,13 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Electrostatics)
 
 TEST_F(EnergyModuleTest, DLPOLYWater3000Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
@@ -91,7 +91,7 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000Bound)
 
 TEST_F(EnergyModuleTest, DLPOLYHexane1Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane1.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane1.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -106,7 +106,7 @@ TEST_F(EnergyModuleTest, DLPOLYHexane1Full)
 
 TEST_F(EnergyModuleTest, DLPOLYHexane2Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane2.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -121,7 +121,7 @@ TEST_F(EnergyModuleTest, DLPOLYHexane2Full)
 
 TEST_F(EnergyModuleTest, DLPOLYHexane200Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -136,14 +136,14 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Full)
 
 TEST_F(EnergyModuleTest, DLPOLYHexane200Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         for (auto at : C.atomTypes())
-                                             at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 for (auto at : C.atomTypes())
+                                                     at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -154,18 +154,18 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Bound)
 
 TEST_F(EnergyModuleTest, DLPOLYHexane200Torsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         for (auto at : C.atomTypes())
-                                             at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         for (auto b : C.masterBonds())
-                                             b->setInteractionParameters("k=0.0 eq=0.0");
-                                         for (auto a : C.masterAngles())
-                                             a->setInteractionParameters("k=0.0 eq=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 for (auto at : C.atomTypes())
+                                                     at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 for (auto b : C.masterBonds())
+                                                     b->setInteractionParameters("k=0.0 eq=0.0");
+                                                 for (auto a : C.masterAngles())
+                                                     a->setInteractionParameters("k=0.0 eq=0.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -175,7 +175,7 @@ TEST_F(EnergyModuleTest, DLPOLYHexane200Torsions)
 
 TEST_F(EnergyModuleTest, DLPOLYBenzene181Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -190,18 +190,18 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Full)
 
 TEST_F(EnergyModuleTest, DLPOLYBenzene181VanDerWaals)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         for (auto &b : C.masterBonds())
-                                             b->setInteractionForm(BondFunctions::Form::None);
-                                         for (auto &a : C.masterAngles())
-                                             a->setInteractionForm(AngleFunctions::Form::None);
-                                         for (auto &t : C.masterTorsions())
-                                             t->setInteractionForm(TorsionFunctions::Form::None);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 for (auto &b : C.masterBonds())
+                                                     b->setInteractionForm(BondFunctions::Form::None);
+                                                 for (auto &a : C.masterAngles())
+                                                     a->setInteractionForm(AngleFunctions::Form::None);
+                                                 for (auto &t : C.masterTorsions())
+                                                     t->setInteractionForm(TorsionFunctions::Form::None);
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -212,18 +212,18 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181VanDerWaals)
 
 TEST_F(EnergyModuleTest, DLPOLYBenzene181Electrostatics)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         for (auto &b : C.masterBonds())
-                                             b->setInteractionForm(BondFunctions::Form::None);
-                                         for (auto &a : C.masterAngles())
-                                             a->setInteractionForm(AngleFunctions::Form::None);
-                                         for (auto &t : C.masterTorsions())
-                                             t->setInteractionForm(TorsionFunctions::Form::None);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 for (auto &b : C.masterBonds())
+                                                     b->setInteractionForm(BondFunctions::Form::None);
+                                                 for (auto &a : C.masterAngles())
+                                                     a->setInteractionForm(AngleFunctions::Form::None);
+                                                 for (auto &t : C.masterTorsions())
+                                                     t->setInteractionForm(TorsionFunctions::Form::None);
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
@@ -234,13 +234,13 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Electrostatics)
 
 TEST_F(EnergyModuleTest, DLPOLYBenzene181Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     auto &intraEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//Bound");
@@ -252,7 +252,7 @@ TEST_F(EnergyModuleTest, DLPOLYBenzene181Bound)
 
 TEST_F(EnergyModuleTest, MoscitoPOETorsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-POE.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-POE.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -263,7 +263,7 @@ TEST_F(EnergyModuleTest, MoscitoPOETorsions)
 
 TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Torsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -274,7 +274,7 @@ TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Torsions)
 
 TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Impropers)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2-impropers.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2-impropers.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -285,7 +285,7 @@ TEST_F(EnergyModuleTest, MoscitoPy4OHNTf2Impropers)
 
 TEST_F(EnergyModuleTest, MoscitoPy5NTf2Torsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -296,7 +296,7 @@ TEST_F(EnergyModuleTest, MoscitoPy5NTf2Torsions)
 
 TEST_F(EnergyModuleTest, MoscitoPy5NTf2Impropers)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2-impropers.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2-impropers.txt"));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -58,7 +58,7 @@ class EPSRModuleTest : public ::testing::Test
 
 TEST_F(EPSRModuleTest, Water3NInpA)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-water-inpa.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-water-inpa.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Estimated Partials
@@ -108,7 +108,7 @@ TEST_F(EPSRModuleTest, Water3NInpA)
 
 TEST_F(EPSRModuleTest, Water3NX)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-water-3n-x.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-water-3n-x.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Test total neutron-weighted F(r)
@@ -139,7 +139,7 @@ TEST_F(EPSRModuleTest, Water3NX)
 
 TEST_F(EPSRModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Test total neutron-weighted F(r)
@@ -198,11 +198,14 @@ TEST_F(EPSRModuleTest, Benzene)
     }
 }
 
-TEST_F(EPSRModuleTest, BenzeneReadPCof) { ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n-pcof.txt")); }
+TEST_F(EPSRModuleTest, BenzeneReadPCof)
+{
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n-pcof.txt"));
+}
 
 TEST_F(EPSRModuleTest, ScatteringMatrix)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-5datasets.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-5datasets.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Find EPSR module
@@ -223,7 +226,7 @@ TEST_F(EPSRModuleTest, ScatteringMatrix)
 
 TEST_F(EPSRModuleTest, DataWeighting)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-5datasets-weighted.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-5datasets-weighted.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Find EPSR module

--- a/tests/modules/forces.cpp
+++ b/tests/modules/forces.cpp
@@ -23,7 +23,7 @@ class ForcesModuleTest : public ::testing::Test
 
 TEST_F(ForcesModuleTest, DLPOLYWater3000Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -34,14 +34,14 @@ TEST_F(ForcesModuleTest, DLPOLYWater3000Full)
 
 TEST_F(ForcesModuleTest, DLPOLYWater3000VanDerWaals)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                         C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -52,14 +52,14 @@ TEST_F(ForcesModuleTest, DLPOLYWater3000VanDerWaals)
 
 TEST_F(ForcesModuleTest, DLPOLYWater3000Electrostatics)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                         C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -78,13 +78,13 @@ TEST_F(ForcesModuleTest, DLPOLYWater3000Electrostatics)
 
 TEST_F(ForcesModuleTest, DLPOLYWater3000Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -95,7 +95,7 @@ TEST_F(ForcesModuleTest, DLPOLYWater3000Bound)
 
 TEST_F(ForcesModuleTest, DLPOLYHexane1Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane1.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane1.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -105,7 +105,7 @@ TEST_F(ForcesModuleTest, DLPOLYHexane1Full)
 
 TEST_F(ForcesModuleTest, DLPOLYHexane2Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane2.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -115,7 +115,7 @@ TEST_F(ForcesModuleTest, DLPOLYHexane2Full)
 
 TEST_F(ForcesModuleTest, DLPOLYHexane200Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     auto *forcesModule = systemTest.getModule<ForcesModule>("Forces01");
     forcesModule->keywords().set("TestThreshold", 2.0e-5);
@@ -127,16 +127,16 @@ TEST_F(ForcesModuleTest, DLPOLYHexane200Full)
 
 TEST_F(ForcesModuleTest, DLPOLYHexane200Unbound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         for (auto b : C.masterBonds())
-                                             b->setInteractionParameters("k=0.0 eq=0.0");
-                                         for (auto a : C.masterAngles())
-                                             a->setInteractionParameters("k=0.0 eq=0.0");
-                                         for (auto t : C.masterTorsions())
-                                             t->setInteractionParameters("k1=0.0 k2=0.0 k3=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 for (auto b : C.masterBonds())
+                                                     b->setInteractionParameters("k=0.0 eq=0.0");
+                                                 for (auto a : C.masterAngles())
+                                                     a->setInteractionParameters("k=0.0 eq=0.0");
+                                                 for (auto t : C.masterTorsions())
+                                                     t->setInteractionParameters("k1=0.0 k2=0.0 k3=0.0");
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     auto *forcesModule = systemTest.getModule<ForcesModule>("Forces01");
     forcesModule->keywords().set("TestThreshold", 5.0e-2);
@@ -148,14 +148,14 @@ TEST_F(ForcesModuleTest, DLPOLYHexane200Unbound)
 
 TEST_F(ForcesModuleTest, DLPOLYHexane200Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         for (auto at : C.atomTypes())
-                                             at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-hexane200.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 for (auto at : C.atomTypes())
+                                                     at->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -165,7 +165,7 @@ TEST_F(ForcesModuleTest, DLPOLYHexane200Bound)
 
 TEST_F(ForcesModuleTest, DLPOLYBenzene181Full)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -176,18 +176,18 @@ TEST_F(ForcesModuleTest, DLPOLYBenzene181Full)
 
 TEST_F(ForcesModuleTest, DLPOLYBenzene181VanDerWaals)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         for (auto &b : C.masterBonds())
-                                             b->setInteractionForm(BondFunctions::Form::None);
-                                         for (auto &a : C.masterAngles())
-                                             a->setInteractionForm(AngleFunctions::Form::None);
-                                         for (auto &t : C.masterTorsions())
-                                             t->setInteractionForm(TorsionFunctions::Form::None);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 for (auto &b : C.masterBonds())
+                                                     b->setInteractionForm(BondFunctions::Form::None);
+                                                 for (auto &a : C.masterAngles())
+                                                     a->setInteractionForm(AngleFunctions::Form::None);
+                                                 for (auto &t : C.masterTorsions())
+                                                     t->setInteractionForm(TorsionFunctions::Form::None);
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -198,18 +198,18 @@ TEST_F(ForcesModuleTest, DLPOLYBenzene181VanDerWaals)
 
 TEST_F(ForcesModuleTest, DLPOLYBenzene181Electrostatics)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         for (auto &b : C.masterBonds())
-                                             b->setInteractionForm(BondFunctions::Form::None);
-                                         for (auto &a : C.masterAngles())
-                                             a->setInteractionForm(AngleFunctions::Form::None);
-                                         for (auto &t : C.masterTorsions())
-                                             t->setInteractionForm(TorsionFunctions::Form::None);
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 for (auto &b : C.masterBonds())
+                                                     b->setInteractionForm(BondFunctions::Form::None);
+                                                 for (auto &a : C.masterAngles())
+                                                     a->setInteractionForm(AngleFunctions::Form::None);
+                                                 for (auto &t : C.masterTorsions())
+                                                     t->setInteractionForm(TorsionFunctions::Form::None);
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -221,13 +221,13 @@ TEST_F(ForcesModuleTest, DLPOLYBenzene181Electrostatics)
 
 TEST_F(ForcesModuleTest, DLPOLYBenzene181Bound)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                         C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-benzene181.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 C.atomType(0)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                                 C.atomType(1)->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0");
+                                             }));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -240,7 +240,7 @@ TEST_F(ForcesModuleTest, DLPOLYBenzene181Bound)
 
 TEST_F(ForcesModuleTest, MoscitoPOETorsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-POE.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-POE.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -251,7 +251,7 @@ TEST_F(ForcesModuleTest, MoscitoPOETorsions)
 
 TEST_F(ForcesModuleTest, MoscitoPy4OHNTf2Torsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -262,7 +262,7 @@ TEST_F(ForcesModuleTest, MoscitoPy4OHNTf2Torsions)
 
 TEST_F(ForcesModuleTest, MoscitoPy4OHNTf2Impropers)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2-impropers.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py4OH-NTf2-impropers.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -273,7 +273,7 @@ TEST_F(ForcesModuleTest, MoscitoPy4OHNTf2Impropers)
 
 TEST_F(ForcesModuleTest, MoscitoPy5NTf2Torsions)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -284,7 +284,7 @@ TEST_F(ForcesModuleTest, MoscitoPy5NTf2Torsions)
 
 TEST_F(ForcesModuleTest, MoscitoPy5NTf2Impropers)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2-impropers.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-Py5-NTf2-impropers.txt"));
     systemTest.setModuleEnabled("Energy01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 

--- a/tests/modules/gr.cpp
+++ b/tests/modules/gr.cpp
@@ -16,7 +16,7 @@ class GRModuleTest : public ::testing::Test
 
 TEST_F(GRModuleTest, Methods)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/rdfMethod.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/rdfMethod.txt"));
     auto *grModule = systemTest.getModule<GRModule>("GR01");
 
     // Simple method
@@ -31,7 +31,7 @@ TEST_F(GRModuleTest, Methods)
 
 TEST_F(GRModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-water.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Partial g(r) (unbound terms)
@@ -62,7 +62,7 @@ TEST_F(GRModuleTest, Water)
 
 TEST_F(GRModuleTest, WaterMethanol)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     /*
@@ -221,7 +221,7 @@ TEST_F(GRModuleTest, WaterMethanol)
 
 TEST_F(GRModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Partial g(r) (unbound terms)

--- a/tests/modules/histogramCN.cpp
+++ b/tests/modules/histogramCN.cpp
@@ -15,7 +15,7 @@ class HistogramCNModuleTest : public ::testing::Test
 
 TEST_F(HistogramCNModuleTest, Simple)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/histogramCN-simple.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/histogramCN-simple.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     EXPECT_TRUE(systemTest.checkData1D(
@@ -28,7 +28,7 @@ TEST_F(HistogramCNModuleTest, Simple)
 
 TEST_F(HistogramCNModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/histogramCN-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/histogramCN-water.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/intraAngle.cpp
+++ b/tests/modules/intraAngle.cpp
@@ -15,7 +15,7 @@ class IntraAngleModuleTest : public ::testing::Test
 
 TEST_F(IntraAngleModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/intraAngle.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/intraAngle.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/intraDistance.cpp
+++ b/tests/modules/intraDistance.cpp
@@ -15,7 +15,7 @@ class IntraDistanceModuleTest : public ::testing::Test
 
 TEST_F(IntraDistanceModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/intraDistance.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/intraDistance.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/md.cpp
+++ b/tests/modules/md.cpp
@@ -16,8 +16,8 @@ class MDModuleTest : public ::testing::Test
 
 TEST_F(MDModuleTest, BenzeneRestart)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/md-benzene.txt"));
-    ASSERT_NO_THROW(systemTest.loadRestart("dissolve/input/md-benzene.8.reference.restart"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/md-benzene.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.loadRestart("dissolve/input/md-benzene.8.reference.restart"));
     ASSERT_TRUE(systemTest.dissolve().iterate(2));
 
     systemTest.checkVec3Vector("Forces01//Bulk//Forces",

--- a/tests/modules/modifierOSites.cpp
+++ b/tests/modules/modifierOSites.cpp
@@ -15,7 +15,7 @@ class ModifierOSitesModuleTest : public ::testing::Test
 
 TEST_F(ModifierOSitesModuleTest, Simple)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/modifierOSites.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/modifierOSites.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     EXPECT_TRUE(systemTest.checkData1D(
@@ -26,7 +26,7 @@ TEST_F(ModifierOSitesModuleTest, Simple)
 }
 TEST_F(ModifierOSitesModuleTest, TotalOSites)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/modifierOSites-test2.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/modifierOSites-test2.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkData1D(
         "M//OTypes", {"dissolve/input/modifierOSites-test2.dat", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 2},

--- a/tests/modules/neutronSQ.cpp
+++ b/tests/modules/neutronSQ.cpp
@@ -15,7 +15,7 @@ class NeutronSQModuleTest : public ::testing::Test
 
 TEST_F(NeutronSQModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-water.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Total F(Q)
@@ -32,7 +32,7 @@ TEST_F(NeutronSQModuleTest, Water)
 
 TEST_F(NeutronSQModuleTest, WaterMethanol)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Total F(Q)
@@ -66,7 +66,7 @@ TEST_F(NeutronSQModuleTest, WaterMethanol)
 
 TEST_F(NeutronSQModuleTest, WaterReferenceFT)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-water-3n-x.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-water-3n-x.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     EXPECT_TRUE(systemTest.checkData1D(
@@ -85,7 +85,7 @@ TEST_F(NeutronSQModuleTest, WaterReferenceFT)
 
 TEST_F(NeutronSQModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Total F(Q)

--- a/tests/modules/orientedSDF.cpp
+++ b/tests/modules/orientedSDF.cpp
@@ -15,7 +15,7 @@ class OrientedSDFModuleTest : public ::testing::Test
 
 TEST_F(OrientedSDFModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/orientedSDF-benzene.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/orientedSDF-benzene.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(80));
 
     EXPECT_TRUE(systemTest.checkData3D(

--- a/tests/modules/qSpecies.cpp
+++ b/tests/modules/qSpecies.cpp
@@ -15,7 +15,7 @@ class QSpeciesModuleTest : public ::testing::Test
 
 TEST_F(QSpeciesModuleTest, Simple)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/qSpecies-simple.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/qSpecies-simple.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/sdf.cpp
+++ b/tests/modules/sdf.cpp
@@ -16,7 +16,7 @@ class SDFModuleTest : public ::testing::Test
 
 TEST_F(SDFModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/sdf-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/sdf-water.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     EXPECT_TRUE(systemTest.checkData3D(
@@ -26,7 +26,7 @@ TEST_F(SDFModuleTest, Water)
 
 TEST_F(SDFModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/sdf-benzene.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/sdf-benzene.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(80));
 
     EXPECT_TRUE(systemTest.checkData3D(

--- a/tests/modules/siteRDF.cpp
+++ b/tests/modules/siteRDF.cpp
@@ -15,7 +15,7 @@ class SiteRDFModuleTest : public ::testing::Test
 
 TEST_F(SiteRDFModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/siteRDF-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/siteRDF-water.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     // O-O RDF
@@ -53,7 +53,7 @@ TEST_F(SiteRDFModuleTest, Water)
 
 TEST_F(SiteRDFModuleTest, WaterNPT)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/siteRDF-waterNPT.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/siteRDF-waterNPT.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     // O-O RDF
@@ -83,7 +83,7 @@ TEST_F(SiteRDFModuleTest, WaterNPT)
 
 TEST_F(SiteRDFModuleTest, WaterDynamic)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/siteRDF-waterDynamic.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/siteRDF-waterDynamic.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     // O-O RDF
@@ -109,7 +109,7 @@ TEST_F(SiteRDFModuleTest, WaterDynamic)
 
 TEST_F(SiteRDFModuleTest, WaterFragments)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/siteRDF-waterFragments.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/siteRDF-waterFragments.txt"));
     ASSERT_TRUE(systemTest.iterateRestart(95));
 
     // O-O RDF

--- a/tests/modules/sq.cpp
+++ b/tests/modules/sq.cpp
@@ -15,7 +15,7 @@ class SQModuleTest : public ::testing::Test
 
 TEST_F(SQModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-water.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-water.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Partial S(Q) (unbound terms)
@@ -46,7 +46,7 @@ TEST_F(SQModuleTest, Water)
 
 TEST_F(SQModuleTest, WaterMethanol)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-waterMethanol.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     /*
@@ -205,7 +205,7 @@ TEST_F(SQModuleTest, WaterMethanol)
 
 TEST_F(SQModuleTest, Benzene)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/epsr-benzene-3n.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Partial S(Q) (unbound terms)

--- a/tests/modules/xRaySQ.cpp
+++ b/tests/modules/xRaySQ.cpp
@@ -15,7 +15,7 @@ class XRaySQModuleTest : public ::testing::Test
 
 TEST_F(XRaySQModuleTest, Water)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/correlations-waterXRay.txt"));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/correlations-waterXRay.txt"));
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
     // Total F(Q)

--- a/tests/testData.h
+++ b/tests/testData.h
@@ -56,7 +56,7 @@ enum TestFlags
 // Wrap a code block with try-catch, handle exceptions thrown, print them into std::cerr and rethrow.
 #define PRINT_STDERR_AND_RETHROW(CODE_BLOCK) PRINT_AND_RETHROW(CODE_BLOCK, std::cerr)
 #define EXPECT_NO_THROW_VERBOSE(CODE_BLOCK) EXPECT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
-#define ASSERT_NO_THROW_VERBOSE(CODE_BLOCK) ASSERT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
+#define ASSERT_NO_THROW_VERBOSE(CODE_BLOCK) ASSERT_NO_THROW_VERBOSE(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
 
 void compareToml(std::string location, SerialisedValue toml, SerialisedValue toml2)
 {

--- a/tests/testData.h
+++ b/tests/testData.h
@@ -30,6 +30,34 @@ enum TestFlags
     TomlFailure = 1, // tests where the TOML testing is known to fail
 };
 
+// Custom Macros
+// See https://stackoverflow.com/questions/42956538
+
+// Wrap a code block with try-catch, handle exceptions thrown, print them into EXCEPT_STREAM and rethrow.
+#define PRINT_AND_RETHROW(CODE_BLOCK, EXCEPT_STREAM)                                                                           \
+    try                                                                                                                        \
+    {                                                                                                                          \
+        do                                                                                                                     \
+        {                                                                                                                      \
+            CODE_BLOCK;                                                                                                        \
+        } while (0);                                                                                                           \
+    }                                                                                                                          \
+    catch (const std::exception &ex)                                                                                           \
+    {                                                                                                                          \
+        EXCEPT_STREAM << "std::exception thrown: " << ex.what() << std::endl;                                                  \
+        throw;                                                                                                                 \
+    }                                                                                                                          \
+    catch (...)                                                                                                                \
+    {                                                                                                                          \
+        EXCEPT_STREAM << "unknown structure thrown" << std::endl;                                                              \
+        throw;                                                                                                                 \
+    }
+
+// Wrap a code block with try-catch, handle exceptions thrown, print them into std::cerr and rethrow.
+#define PRINT_STDERR_AND_RETHROW(CODE_BLOCK) PRINT_AND_RETHROW(CODE_BLOCK, std::cerr)
+#define EXPECT_NO_THROW_VERBOSE(CODE_BLOCK) EXPECT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
+#define ASSERT_NO_THROW_VERBOSE(CODE_BLOCK) ASSERT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
+
 void compareToml(std::string location, SerialisedValue toml, SerialisedValue toml2)
 {
     if (toml.is_table())

--- a/tests/testData.h
+++ b/tests/testData.h
@@ -34,29 +34,14 @@ enum TestFlags
 // See https://stackoverflow.com/questions/42956538
 
 // Wrap a code block with try-catch, handle exceptions thrown, print them into EXCEPT_STREAM and rethrow.
-#define PRINT_AND_RETHROW(CODE_BLOCK, EXCEPT_STREAM)                                                                           \
-    try                                                                                                                        \
-    {                                                                                                                          \
-        do                                                                                                                     \
-        {                                                                                                                      \
-            CODE_BLOCK;                                                                                                        \
-        } while (0);                                                                                                           \
-    }                                                                                                                          \
-    catch (const std::exception &ex)                                                                                           \
-    {                                                                                                                          \
-        EXCEPT_STREAM << "std::exception thrown: " << ex.what() << std::endl;                                                  \
-        throw;                                                                                                                 \
-    }                                                                                                                          \
-    catch (...)                                                                                                                \
-    {                                                                                                                          \
-        EXCEPT_STREAM << "unknown structure thrown" << std::endl;                                                              \
-        throw;                                                                                                                 \
-    }
+// clang-format off
+#define PRINT_AND_RETHROW(CODE_BLOCK, EXCEPT_STREAM) try{CODE_BLOCK;}catch(const std::exception& ex){ EXCEPT_STREAM << "std::exception thrown: " << ex.what() << std::endl; throw;  }catch(...){ EXCEPT_STREAM << "unknown structure thrown" << std::endl; throw;}
+// clang-format on
 
 // Wrap a code block with try-catch, handle exceptions thrown, print them into std::cerr and rethrow.
 #define PRINT_STDERR_AND_RETHROW(CODE_BLOCK) PRINT_AND_RETHROW(CODE_BLOCK, std::cerr)
 #define EXPECT_NO_THROW_VERBOSE(CODE_BLOCK) EXPECT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
-#define ASSERT_NO_THROW_VERBOSE(CODE_BLOCK) ASSERT_NO_THROW_VERBOSE(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
+#define ASSERT_NO_THROW_VERBOSE(CODE_BLOCK) ASSERT_NO_THROW(PRINT_STDERR_AND_RETHROW(CODE_BLOCK))
 
 void compareToml(std::string location, SerialisedValue toml, SerialisedValue toml2)
 {


### PR DESCRIPTION
GTest catches exceptions when calling `ASSERT_NO_THROW` etc. but does not report what the thrown message was.

This PR adds some ugly macros to wrap a couple of GTest functions in a catch/re-throw in order to provide better feedback when testing.

Thoughts welcome!