### PR TITLE
fix: removed broken assertion

### DIFF
--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -171,7 +171,7 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
     return true;
 }
 
-//  Set Data1D names from source AtomTypes
+// Set Data1D names from source AtomTypes
 void PairPotential::setData1DNames()
 {
     uFull_.setTag(fmt::format("{}-{}", nameI_, nameJ_));

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -174,9 +174,6 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
 // Set Data1D names from source AtomTypes
 void PairPotential::setData1DNames()
 {
-    // Check for NULL pointers
-    assert(atomTypeI_ && atomTypeJ_);
-
     uFull_.setTag(fmt::format("{}-{}", nameI_, nameJ_));
 
     uAdditional_.setTag(fmt::format("{}-{} (Add)", nameI_, nameJ_));

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -171,7 +171,7 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
     return true;
 }
 
-// Set Data1D names from source AtomTypes
+//  Set Data1D names from source AtomTypes
 void PairPotential::setData1DNames()
 {
     uFull_.setTag(fmt::format("{}-{}", nameI_, nameJ_));


### PR DESCRIPTION
`develop` branch was failing due to an undeclared variable `atomTypeI_` that had somehow got through unit tests