### PR TITLE
fix: Allow non-pr runs to pass ci

### DIFF
--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -19,7 +19,9 @@ runs:
       set -ex
       TITLE="${{ github.event.pull_request.title }}"
       if [ -z "$TITLE" ]
+      then
       TITLE=Continuous
+      fi
       fi
       echo  | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -22,7 +22,6 @@ runs:
       then
       TITLE=Continuous
       fi
-      fi
       echo  | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 
   - name: C++ Formatting

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -22,7 +22,7 @@ runs:
       then
       TITLE=Continuous
       fi
-      echo  | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
+      echo $TITLE | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 
   - name: C++ Formatting
     shell: bash

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -18,7 +18,7 @@ runs:
     shell: bash
     run: |
       set -ex
-      echo ${{ github.event.pull_request.title }} | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
+      echo ${{ github.event.pull_request.title }} | awk "/(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 
   - name: C++ Formatting
     shell: bash

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -14,15 +14,11 @@ runs:
 
   - name: Check Conventional Commits
     # Ensure that the PR title fits the conventional commits framework
+    if: github.event_name == 'pull_request'
     shell: bash
     run: |
       set -ex
-      TITLE="${{ github.event.pull_request.title }}"
-      if [ -z "$TITLE" ]
-      then
-      TITLE=Continuous
-      fi
-      echo $TITLE | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
+      echo ${{ github.event.pull_request.title }} | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 
   - name: C++ Formatting
     shell: bash

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -17,7 +17,11 @@ runs:
     shell: bash
     run: |
       set -ex
-      echo ${{ github.event.pull_request.title }} | awk "/(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
+      TITLE="${{ github.event.pull_request.title }}"
+      if [ -z "$TITLE" ]
+      TITLE=Continuous
+      fi
+      echo  | awk "/(Continuous)|(^feat:)|(^fix:)|(^doc:)|(^perf:)|(^refactor:)|(^style:)|(^test:)|(^chore:)|(^revert:)|(^build:)/" | grep .
 
   - name: C++ Formatting
     shell: bash


### PR DESCRIPTION
This will enable GitHub runners that do not have a PR title (e.g. the continuous runn) to automatically pass the conventional commit checks.