### PR TITLE
fix: Typo in NeutronSQ NormaliseTo Keyword

### DIFF
--- a/src/modules/neutronSQ/neutronSQ.cpp
+++ b/src/modules/neutronSQ/neutronSQ.cpp
@@ -23,7 +23,7 @@ NeutronSQModule::NeutronSQModule() : Module(ModuleTypes::NeutronSQ)
     keywords_.add<IsotopologueSetKeyword>("Isotopologue", "Set/add an isotopologue and its population for a particular species",
                                           isotopologueSet_);
     keywords_
-        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("normaliseTo",
+        .add<EnumOptionsKeyword<StructureFactors::NormalisationType>>("NormaliseTo",
                                                                       "Normalisation to apply to total weighted F(Q)",
                                                                       normaliseTo_, StructureFactors::normalisationTypes())
         ->setEditSignals({KeywordBase::ReloadExternalData, KeywordBase::RecreateRenderables});


### PR DESCRIPTION
Keyword is set to `normaliseTo` instead of `NormaliseTo` which prevents Dissolve-generated input files from being correctly deserialised.