### PR TITLE
fix: 1844 - QML ScaleLayout scale charges dialog to accept floats

### DIFF
--- a/src/gui/qml/modifyCharges/ScaleLayout.qml
+++ b/src/gui/qml/modifyCharges/ScaleLayout.qml
@@ -19,25 +19,24 @@ ColumnLayout {
         width: parent.width - 2 * parent.spacing
         wrapMode: Text.WordWrap
     }
-
     SpinBox {
         id: spinBox
         readonly property int decimalFactor: Math.pow(10, decimals)
         property int decimals: 2
         property real realValue: value / 100
-        
+
         Layout.alignment: Qt.AlignRight
         Layout.fillWidth: true
         editable: true
         from: decimalToInt(-100)
         objectName: "scaleSpinBox"
         stepSize: 1
-        textFromValue: function(value) {
+        textFromValue: function (value) {
             return String((parseFloat(value) / decimalFactor).toFixed(decimals));
         }
         to: decimalToInt(100)
         value: decimalToInt(dialogModel.scaleValue)
-        valueFromText: function(text) {
+        valueFromText: function (text) {
             return Math.round(parseFloat(text) * decimalFactor);
         }
 

--- a/src/gui/qml/modifyCharges/ScaleLayout.qml
+++ b/src/gui/qml/modifyCharges/ScaleLayout.qml
@@ -51,6 +51,40 @@ ColumnLayout {
             return Math.round(parseFloat(text) * decimalFactor);
         }
     }
+    SpinBox {
+        id: spinBox
+        readonly property int decimalFactor: Math.pow(10, decimals)
+        property int decimals: 2
+        property real realValue: value / 100
+
+        Layout.alignment: Qt.AlignRight
+        Layout.fillWidth: true
+        objectName: "scaleSpinBox"
+        editable: true
+        from: decimalToInt(-100)
+        stepSize: 1
+        to: decimalToInt(100)
+        value: decimalToInt(dialogModel.scaleValue)
+
+        validator: DoubleValidator {
+            bottom: Math.min(spinBox.from, spinBox.to)
+            top: Math.max(spinBox.from, spinBox.to)
+            decimals: spinBox.decimals
+            notation: DoubleValidator.StandardNotation
+        }
+
+        textFromValue: function(value) {
+            return String((parseFloat(value) / decimalFactor).toFixed(decimals));
+        }
+
+        valueFromText: function(text) {
+            return Math.round(parseFloat(text) * decimalFactor);
+        }
+
+        function decimalToInt(decimal) {
+            return decimal * decimalFactor;
+        }
+    }
     RowLayout {
         Layout.alignment: Qt.AlignRight
         spacing: 10

--- a/src/gui/qml/modifyCharges/ScaleLayout.qml
+++ b/src/gui/qml/modifyCharges/ScaleLayout.qml
@@ -19,38 +19,7 @@ ColumnLayout {
         width: parent.width - 2 * parent.spacing
         wrapMode: Text.WordWrap
     }
-    SpinBox {
-        id: spinBox
-        Layout.alignment: Qt.AlignRight
-        Layout.fillWidth: true
-        objectName: "scaleSpinBox"
-        editable: true
-        from: decimalToInt(-100)
-        stepSize: 1
-        to: decimalToInt(100)
-        value: decimalToInt(dialogModel.scaleValue)
 
-        property int decimals: 2
-        property real realValue: value / 100
-        readonly property int decimalFactor: Math.pow(10, decimals)
-
-        function decimalToInt(decimal) {
-            return decimal * decimalFactor
-        }
-
-        validator: DoubleValidator {
-            bottom: Math.min(spinBox.from, spinBox.to)
-            top:  Math.max(spinBox.from, spinBox.to)
-            decimals: spinBox.decimals
-            notation: DoubleValidator.StandardNotation
-        }
-        textFromValue: function(value) {
-            return String((parseFloat(value) / decimalFactor).toFixed(decimals));
-        }
-        valueFromText: function(text) {
-            return Math.round(parseFloat(text) * decimalFactor);
-        }
-    }
     SpinBox {
         id: spinBox
         readonly property int decimalFactor: Math.pow(10, decimals)

--- a/src/gui/qml/modifyCharges/ScaleLayout.qml
+++ b/src/gui/qml/modifyCharges/ScaleLayout.qml
@@ -23,12 +23,33 @@ ColumnLayout {
         id: spinBox
         Layout.alignment: Qt.AlignRight
         Layout.fillWidth: true
-        editable: true
-        from: -100
         objectName: "scaleSpinBox"
+        editable: true
+        from: decimalToInt(-100)
         stepSize: 1
-        to: 100
-        value: dialogModel.scaleValue
+        to: decimalToInt(100)
+        value: decimalToInt(dialogModel.scaleValue)
+
+        property int decimals: 2
+        property real realValue: value / 100
+        readonly property int decimalFactor: Math.pow(10, decimals)
+
+        function decimalToInt(decimal) {
+            return decimal * decimalFactor
+        }
+
+        validator: DoubleValidator {
+            bottom: Math.min(spinBox.from, spinBox.to)
+            top:  Math.max(spinBox.from, spinBox.to)
+            decimals: spinBox.decimals
+            notation: DoubleValidator.StandardNotation
+        }
+        textFromValue: function(value) {
+            return String((parseFloat(value) / decimalFactor).toFixed(decimals));
+        }
+        valueFromText: function(text) {
+            return Math.round(parseFloat(text) * decimalFactor);
+        }
     }
     RowLayout {
         Layout.alignment: Qt.AlignRight
@@ -41,7 +62,7 @@ ColumnLayout {
 
             onClicked: {
                 dialogModel.cancelSelection();
-                spinBox.value = dialogModel.scaleValue;
+                spinBox.realValue = dialogModel.scaleValue;
             }
         }
         D.Button {
@@ -51,7 +72,7 @@ ColumnLayout {
 
             onClicked: {
                 dialogModel.setScaleType(dialogModel.Scale);
-                dialogModel.updateScaleValue(spinBox.value);
+                dialogModel.updateScaleValue(spinBox.realValue);
                 dialogModel.acceptSelection();
             }
         }
@@ -62,7 +83,7 @@ ColumnLayout {
 
             onClicked: {
                 dialogModel.setScaleType(dialogModel.ScaleTo);
-                dialogModel.updateScaleValue(spinBox.value);
+                dialogModel.updateScaleValue(spinBox.realValue);
                 dialogModel.acceptSelection();
             }
         }

--- a/src/gui/qml/modifyCharges/ScaleLayout.qml
+++ b/src/gui/qml/modifyCharges/ScaleLayout.qml
@@ -56,33 +56,31 @@ ColumnLayout {
         readonly property int decimalFactor: Math.pow(10, decimals)
         property int decimals: 2
         property real realValue: value / 100
-
+        
         Layout.alignment: Qt.AlignRight
         Layout.fillWidth: true
-        objectName: "scaleSpinBox"
         editable: true
         from: decimalToInt(-100)
+        objectName: "scaleSpinBox"
         stepSize: 1
-        to: decimalToInt(100)
-        value: decimalToInt(dialogModel.scaleValue)
-
-        validator: DoubleValidator {
-            bottom: Math.min(spinBox.from, spinBox.to)
-            top: Math.max(spinBox.from, spinBox.to)
-            decimals: spinBox.decimals
-            notation: DoubleValidator.StandardNotation
-        }
-
         textFromValue: function(value) {
             return String((parseFloat(value) / decimalFactor).toFixed(decimals));
         }
-
+        to: decimalToInt(100)
+        value: decimalToInt(dialogModel.scaleValue)
         valueFromText: function(text) {
             return Math.round(parseFloat(text) * decimalFactor);
         }
 
         function decimalToInt(decimal) {
             return decimal * decimalFactor;
+        }
+
+        validator: DoubleValidator {
+            bottom: Math.min(spinBox.from, spinBox.to)
+            decimals: spinBox.decimals
+            notation: DoubleValidator.StandardNotation
+            top: Math.max(spinBox.from, spinBox.to)
         }
     }
     RowLayout {


### PR DESCRIPTION
Closes #1847

Creates a custom QML SpinBox that allows for floating-point values with a precision of `0.01`.