### PR TITLE
refactor: Clarify forces and derivatives

### DIFF
--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -411,7 +411,7 @@ double PairPotential::force(double r)
 {
     assert(r >= 0);
 
-    return dUFullInterpolation_.y(r, r * rDelta_);
+    return -dUFullInterpolation_.y(r, r * rDelta_);
 }
 
 // Return analytic force at specified r

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -212,11 +212,17 @@ double PairPotential::analyticShortRangeForce(double r, PairPotential::ShortRang
              * Parameter 1 = Sigma
              */
 
-            // f = -48*epsilon*((sigma**12/x**13)-0.5*(sigma**6/x**7))
+            /*
+             * dU/dr = -48*epsilon*((sigma**12/x**13)-0.5*(sigma**6/x**7))
+             *
+             *                        signa**6   (   sigma**6        )
+             *       = 48 * epsilon * -------- * ( - --------- + 0.5 ) * r**-1
+             *                          r**6     (     r**6          )
+             */
 
             auto sigmar = params[1] / r;
             auto sigmar6 = pow(sigmar, 6.0);
-            force = 48.0 * params[0] * sigmar6 * (-sigmar6 + 0.5) / r;
+            force = -48.0 * params[0] * sigmar6 * (-sigmar6 + 0.5) / r;
         }
         break;
         default:
@@ -436,11 +442,23 @@ double PairPotential::analyticForce(double qiqj, double r, double elecScale, dou
 // Return analytic coulomb force of specified charges
 double PairPotential::analyticCoulombForce(double qiqj, double r, PairPotential::CoulombTruncationScheme truncation) const
 {
+    /*
+     * Derivative of Coulomb's Law is:
+     *
+     *           dU  q(i)*q(j)       q(i)*q(j)
+     *  dU/dr =  --  ---------  =  - ---------
+     *           dr      r              r*r
+     *
+     *                         q(i)*q(j)
+     * The force is -(dU/dr) = ---------
+     *                            r*r
+     */
+
     // Calculate based on truncation scheme
     if (truncation == PairPotential::NoCoulombTruncation)
-        return -COULCONVERT * qiqj / (r * r);
+        return COULCONVERT * qiqj / (r * r);
     else if (truncation == PairPotential::ShiftedCoulombTruncation)
-        return -COULCONVERT * qiqj * (1.0 / (r * r) - 1.0 / (range_ * range_));
+        return COULCONVERT * qiqj * (1.0 / (r * r) - 1.0 / (range_ * range_));
 
     return 0.0;
 }

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -376,9 +376,7 @@ double PairPotential::analyticEnergy(double r) const
         return 0.0;
 
     // Short-range potential and Coulomb contribution
-    auto energy = analyticShortRangeEnergy(r) + analyticCoulombEnergy(chargeI_ * chargeJ_, r);
-
-    return energy;
+    return analyticShortRangeEnergy(r) + analyticCoulombEnergy(chargeI_ * chargeJ_, r);
 }
 
 // Return analytic potential at specified r, including Coulomb term from supplied charge product

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -375,11 +375,8 @@ double PairPotential::analyticEnergy(double r) const
     if (r > range_)
         return 0.0;
 
-    // Short-range potential
-    auto energy = analyticShortRangeEnergy(r);
-
-    // Coulomb contribution
-    energy += analyticCoulombEnergy(chargeI_ * chargeJ_, r);
+    // Short-range potential and Coulomb contribution
+    auto energy = analyticShortRangeEnergy(r) + analyticCoulombEnergy(chargeI_ * chargeJ_, r);
 
     return energy;
 }
@@ -420,11 +417,8 @@ double PairPotential::analyticForce(double r) const
     if (r > range_)
         return 0.0;
 
-    // Short-range potential
-    double force = analyticShortRangeForce(r);
-
-    // Coulomb contribution
-    force += analyticCoulombForce(chargeI_ * chargeJ_, r);
+    // Short-range potential and Coulomb contribution
+    auto force = analyticShortRangeForce(r) + analyticCoulombForce(chargeI_ * chargeJ_, r);
 
     return force;
 }

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -187,7 +187,7 @@ double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRan
     // Apply the selected truncation scheme
     if (truncation == PairPotential::ShiftedShortRangeTruncation)
     {
-        energy += -(r - range_) * shortRangeForceAtCutoff_ - shortRangeEnergyAtCutoff_;
+        energy += (r - range_) * shortRangeForceAtCutoff_ - shortRangeEnergyAtCutoff_;
     }
 
     return energy;

--- a/src/io/export/pairPotential.cpp
+++ b/src/io/export/pairPotential.cpp
@@ -30,10 +30,10 @@ bool PairPotentialExportFileFormat::exportBlock(LineParser &parser, PairPotentia
 
     // Write header comment
     if (!parser.writeLineF("#{:9}  {:12}  {:12}  {:12}  {:12}  {:12}  {:12}\n", "", "Full", "Derivative", "Original",
-                           "Additional", "Exact(Orig)", "Exact(Deriv)"))
+                           "Additional", "Exact(Orig)", "Exact(Force)"))
         return false;
     if (!parser.writeLineF("#{:9}  {:12}  {:12}  {:12}  {:12}  {:12}  {:12}\n", "r(Angs)", "U(kJ/mol)", "dU(kJ/mol/Ang)",
-                           "U(kJ/mol)", "U(kJ/mol)", "U(kJ/mol)", "dU(kJ/mol/Ang)"))
+                           "U(kJ/mol)", "U(kJ/mol)", "U(kJ/mol)", "F(kJ/mol/Ang)"))
         return false;
 
     for (auto n = 0; n < nPoints; ++n)

--- a/src/kernels/force.cpp
+++ b/src/kernels/force.cpp
@@ -30,59 +30,59 @@ ForceKernel::ForceKernel(const Box *box, const ProcessPool &procPool, const Pote
 // Calculate PairPotential forces between Atoms provided
 void ForceKernel::forcesWithoutMim(const Atom &i, int indexI, const Atom &j, int indexJ, ForceVector &f) const
 {
-    auto force = j.r() - i.r();
-    auto distanceSq = force.magnitudeSq();
+    auto vij = j.r() - i.r();
+    auto distanceSq = vij.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
         return;
     auto r = sqrt(distanceSq);
-    force /= r;
-    force *= potentialMap_.force(i, j, r);
-    f[indexI] += force;
-    f[indexJ] -= force;
+    vij /= r;
+    vij *= potentialMap_.force(i, j, r);
+    f[indexI] -= vij;
+    f[indexJ] += vij;
 }
 
 // Calculate inter-particle forces between Atoms provided, scaling electrostatic and van der Waals components
 void ForceKernel::forcesWithoutMim(const Atom &i, int indexI, const Atom &j, int indexJ, ForceVector &f, double elecScale,
                                    double vdwScale) const
 {
-    auto force = j.r() - i.r();
-    auto distanceSq = force.magnitudeSq();
+    auto vij = j.r() - i.r();
+    auto distanceSq = vij.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
         return;
     auto r = sqrt(distanceSq);
-    force /= r;
-    force *= potentialMap_.force(i, j, r, elecScale, vdwScale);
-    f[indexI] += force;
-    f[indexJ] -= force;
+    vij /= r;
+    vij *= potentialMap_.force(i, j, r, elecScale, vdwScale);
+    f[indexI] -= vij;
+    f[indexJ] += vij;
 }
 
 // Calculate PairPotential forces between Atoms provided
 void ForceKernel::forcesWithMim(const Atom &i, int indexI, const Atom &j, int indexJ, ForceVector &f) const
 {
-    auto force = box_->minimumVector(i.r(), j.r());
-    auto distanceSq = force.magnitudeSq();
+    auto vij = box_->minimumVector(i.r(), j.r());
+    auto distanceSq = vij.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
         return;
     auto r = sqrt(distanceSq);
-    force /= r;
-    force *= potentialMap_.force(i, j, r);
-    f[indexI] += force;
-    f[indexJ] -= force;
+    vij /= r;
+    vij *= potentialMap_.force(i, j, r);
+    f[indexI] -= vij;
+    f[indexJ] += vij;
 }
 
 // Calculate inter-particle forces between Atoms provided, scaling electrostatic and van der Waals components
 void ForceKernel::forcesWithMim(const Atom &i, int indexI, const Atom &j, int indexJ, ForceVector &f, double elecScale,
                                 double vdwScale) const
 {
-    auto force = box_->minimumVector(i.r(), j.r());
-    auto distanceSq = force.magnitudeSq();
+    auto vij = box_->minimumVector(i.r(), j.r());
+    auto distanceSq = vij.magnitudeSq();
     if (distanceSq > cutoffDistanceSquared_)
         return;
     auto r = sqrt(distanceSq);
-    force /= r;
-    force *= potentialMap_.force(i, j, r, elecScale, vdwScale);
-    f[indexI] += force;
-    f[indexJ] -= force;
+    vij /= r;
+    vij *= potentialMap_.force(i, j, r, elecScale, vdwScale);
+    f[indexI] -= vij;
+    f[indexJ] += vij;
 }
 
 /*

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -115,8 +115,8 @@ void ForcesModule::totalForces(const ProcessPool &procPool, const Species *sp, c
             vecij *= potentialMap.force(&i, &j, r, elec14, vdw14);
 
         auto &fLocal = combinableUnbound.local();
-        fLocal[indexI] += vecij;
-        fLocal[indexJ] -= vecij;
+        fLocal[indexI] -= vecij;
+        fLocal[indexJ] += vecij;
     };
 
     // Calculate pairwise forces between atoms

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -74,7 +74,7 @@ Module::ExecutionResult ForcesModule::process(ModuleContext &moduleContext)
 
         double magjisq, magji, magjk, dp, force, r;
         Atom *i, *j, *k, *l;
-        Vec3<double> vecji, vecjk, veckl, forcei, forcek;
+        Vec3<double> vecij, veckj, veclk, forcei, forcek;
         Vec3<double> xpj, xpk, temp;
         double du_dphi;
         std::shared_ptr<Molecule> molN, molM;
@@ -108,20 +108,20 @@ Module::ExecutionResult ForcesModule::process(ModuleContext &moduleContext)
                         continue;
 
                     // Determine final forces
-                    vecji = box->minimumVector(i->r(), j->r());
-                    magjisq = vecji.magnitudeSq();
+                    vecij = box->minimumVector(i->r(), j->r());
+                    magjisq = vecij.magnitudeSq();
                     if (magjisq > cutoffSq)
                         continue;
                     r = sqrt(magjisq);
-                    vecji /= r;
+                    vecij /= r;
 
                     if (scalingType == SpeciesAtom::ScaledInteraction::NotScaled)
-                        vecji *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r);
+                        vecij *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r);
                     else if (scalingType == SpeciesAtom::ScaledInteraction::Scaled)
-                        vecji *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r, elec14, vdw14);
+                        vecij *= potentialMap.analyticForce(molN->atom(ii), molN->atom(jj), r, elec14, vdw14);
 
-                    fInter[offsetN + ii] += vecji;
-                    fInter[offsetN + jj] -= vecji;
+                    fInter[offsetN + ii] -= vecij;
+                    fInter[offsetN + jj] += vecij;
                 }
             }
 
@@ -141,17 +141,17 @@ Module::ExecutionResult ForcesModule::process(ModuleContext &moduleContext)
                         j = molM->atom(jj);
 
                         // Determine final forces
-                        vecji = box->minimumVector(i->r(), j->r());
-                        magjisq = vecji.magnitudeSq();
+                        vecij = box->minimumVector(i->r(), j->r());
+                        magjisq = vecij.magnitudeSq();
                         if (magjisq > cutoffSq)
                             continue;
                         r = sqrt(magjisq);
-                        vecji /= r;
+                        vecij /= r;
 
-                        vecji *= potentialMap.analyticForce(i, j, r);
+                        vecij *= potentialMap.analyticForce(i, j, r);
 
-                        fInter[offsetN + ii] += vecji;
-                        fInter[offsetM + jj] -= vecji;
+                        fInter[offsetN + ii] -= vecij;
+                        fInter[offsetM + jj] += vecij;
                     }
                 }
             }
@@ -164,12 +164,12 @@ Module::ExecutionResult ForcesModule::process(ModuleContext &moduleContext)
                 j = molN->atom(bond.indexJ());
 
                 // Determine final forces
-                vecji = box->minimumVector(i->r(), j->r());
-                r = vecji.magAndNormalise();
-                vecji *= bond.force(r);
+                vecij = box->minimumVector(i->r(), j->r());
+                r = vecij.magAndNormalise();
+                vecij *= bond.force(r);
 
-                fIntra[offsetN + bond.indexI()] -= vecji;
-                fIntra[offsetN + bond.indexJ()] += vecji;
+                fIntra[offsetN + bond.indexI()] -= vecij;
+                fIntra[offsetN + bond.indexJ()] += vecij;
             }
 
             // Angle forces


### PR DESCRIPTION
Depends on #1837.

This PR clarifies forces vs derivatives in interatomic (through-space) force calculations. While the forces calculated throughout were correct at the endpoint, the signs of various terms were mixed throughout.

### Rationale

If the energy of a given interaction between two unconnected atoms at a given distance `r` is `E = U(r)` (for instance via the Lennard-Jones potential) then the force acting on those atoms is equal to the negative of the derivative of the energy, i.e. `F = -dU/dr`. For a pair of atoms `i` and `j` at a distance  `r` the vector between them is `vij = r(j) - r(i)`, and the forces acting on them are given by `F(i) = -F.vij` and `F(j) = F.vij`.

So, as you can see there are plenty of opportunities for absorbing (mistakenly or otherwise) negatives into equations! This PR tidies up the following things and gives us consistency ahead of moving the functions around in the next PR.
1. The `PairPotential` class functions `analyticShortRangeForce()` and `analyticCoulombForce()` actually just returned the derivatives of the functions (i.e. the negation was missing). These functions are used to seed the tabulated potentials.
2. Because of 1) the tabulated values in `dUFull_` were, as the variable name suggested, the derivatives and not the force, but the `PairPotential::force()` function returns the actual values without a negation, and so was returning the derivatives and not the force.
3. All of the `ForceKernel::forcesWith(out)Mim` functions correctly calculated the vectors the forces were acting on as `i -> j` as written above, but added to atom `i` and subtracted from atom `j`, providing the final correcting "reversal" of the signs.

### Outcome

Once all of these aspects were fixed and made consistent all tests passed save for one - `MDModule.BenzeneRestart` - where the forces calculated were slightly different from the reference values in the test data. This turned out to be an age-old bug where the corrective force term in the shifted truncation scheme was correctly used for the energy (upon which tabulated simulation forces are created) but not the analytic forces. This did not affect simulation results.