### PR TITLE
fix: Creating configuration for CuBTC example (#1854)

### DIFF
--- a/src/gui/importCIFDialog.ui
+++ b/src/gui/importCIFDialog.ui
@@ -135,7 +135,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>162</width>
+                <width>292</width>
                 <height>639</height>
                </rect>
               </property>
@@ -392,8 +392,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>407</width>
-                <height>675</height>
+                <width>296</width>
+                <height>625</height>
                </rect>
               </property>
               <attribute name="icon">
@@ -482,7 +482,7 @@
                      <string>Remove any water molecules or coordinated oxygens without hydrogens</string>
                     </property>
                     <property name="text">
-                     <string>Remove water and coordinated oxygen</string>
+                     <string>Remove water and coordinated oxygens</string>
                     </property>
                    </widget>
                   </item>
@@ -598,8 +598,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>407</width>
-                <height>675</height>
+                <width>276</width>
+                <height>93</height>
                </rect>
               </property>
               <attribute name="icon">
@@ -691,8 +691,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>407</width>
-                <height>675</height>
+                <width>96</width>
+                <height>78</height>
                </rect>
               </property>
               <attribute name="icon">
@@ -728,6 +728,14 @@
               </layout>
              </widget>
              <widget class="QWidget" name="DetectedSpeciesToolBoxPage">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>96</width>
+                <height>78</height>
+               </rect>
+              </property>
               <attribute name="icon">
                <iconset resource="main.qrc">
                 <normaloff>:/general/icons/threeSpecies.svg</normaloff>:/general/icons/threeSpecies.svg</iconset>
@@ -757,6 +765,14 @@
               </layout>
              </widget>
              <widget class="QWidget" name="SupercellToolBoxPage">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>167</width>
+                <height>142</height>
+               </rect>
+              </property>
               <attribute name="icon">
                <iconset resource="main.qrc">
                 <normaloff>:/general/icons/configuration.svg</normaloff>:/general/icons/configuration.svg</iconset>

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -973,12 +973,14 @@ void CIFHandler::finalise(CoreData &coreData, const Flags<OutputFlags> &flags) c
     {
         auto *sp = coreData.addSpecies();
         sp->copyBasic(&supercellSpecies_);
-        if (flags.isSet(OutputFlags::OutputFramework))
+        if (flags.isSet(OutputFlags::OutputSupermolecule))
         {
             sp->removePeriodicBonds();
             sp->updateIntramolecularTerms();
             sp->removeBox();
         }
+        else
+            sp->createBox(supercellSpecies_.box()->axisLengths(), supercellSpecies_.box()->axisAngles());
 
         if (flags.isSet(OutputFlags::OutputConfiguration))
         {

--- a/src/io/import/cif.h
+++ b/src/io/import/cif.h
@@ -119,7 +119,7 @@ class CIFHandler
     // Bonding tolerance, if calculating bonding rather than using CIF definitions
     double bondingTolerance_{1.1};
     // Whether to prevent metallic bonding
-    bool preventMetallicBonds_{false};
+    bool preventMetallicBonds_{true};
     // Whether to remove free atomic moieties in clean-up
     bool removeAtomics_{false};
     // Whether to remove water and coordinated oxygen atoms in clean-up

--- a/web/docs/examples/cu-btc/step1.md
+++ b/web/docs/examples/cu-btc/step1.md
@@ -22,7 +22,7 @@ The default options get us most of the way there, but it's instructive to take a
 
 Before we proceed, make sure that the default Cu-BTC groups (`Global/Default`, `B/Default`, and `A/1`) are the only ones enabled.
 
-Now, if you look closely at the crystal structure you'll see "extra" oxygen atoms attached to the copper sites:
+Now, if you look closely at the crystal structure you'll see some oxygen atoms floating around in space...
 
 {{< cimage src="../cu-btc-default-zoom.png" caption="Dangling oxygens on Cu sites" >}}
 
@@ -30,9 +30,9 @@ These are in fact from coordinated water molecules present when the crystal stru
 
 {{< action type="mouse" >}}Open the {{<gui-button icon="delete" text="Structure Cleanup">}} section{{< /action >}}
 
-The _Structure Cleanup_ page has several options for cleaning up various aspects of the structure we currently have, for example removing free atoms/ions. We want to use the option to remove water molecules, which will also remove terminal oxygen atoms based on the assumption that hydrogen positions were not available in the CIF. So:
+The _Structure Cleanup_ page has several options for cleaning up various aspects of the structure we currently have, for example removing free atoms/ions. There is a specific option for removing water molecules (_Remove water and coordinated oxygens_) which will also remove terminal oxygen atoms based on the assumption that hydrogen positions were not available in the CIF. Ours are just free atoms, however, so:
 
-{{< action type="check" >}}Enable the _Remove water and coordinated oxygen_ option{{< /action >}}
+{{< action type="check" >}}Enable the _Remove unbound atoms_ option{{< /action >}}
 
 You should see those terminal oxygen atoms disappear from the structure, leaving us with a "pure" Cu-BTC framework. There are a couple of pages left in the wizard which allow us to create a supercell from the unit cell,
 


### PR DESCRIPTION
Fixes creation of periodic species in the CIF import dialog and updates the CuBTC example documentation to be consistent with the updated UI.

Closes #1856.