### PR TITLE
refactor: Rework Function1D, add derivatives

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -126,7 +126,7 @@ void CoreData::clearAtomTypes() { atomTypes_.clear(); }
 // Create new pair potential override
 PairPotentialOverride *CoreData::addPairPotentialOverride(std::string_view matchI, std::string_view matchJ,
                                                           PairPotentialOverride::PairPotentialOverrideType overrideType,
-                                                          const InteractionPotential<ShortRangeFunctions> &potential)
+                                                          const InteractionPotential<Functions1D> &potential)
 {
     auto &pp =
         pairPotentialOverrides_.emplace_back(std::make_unique<PairPotentialOverride>(matchI, matchJ, overrideType, potential));

--- a/src/classes/coreData.h
+++ b/src/classes/coreData.h
@@ -77,8 +77,7 @@ class CoreData
     PairPotentialOverride *addPairPotentialOverride(
         std::string_view matchI = "", std::string_view matchJ = "",
         PairPotentialOverride::PairPotentialOverrideType overrideType = PairPotentialOverride::PairPotentialOverrideType::Off,
-        const InteractionPotential<ShortRangeFunctions> &potential =
-            InteractionPotential<ShortRangeFunctions>(ShortRangeFunctions::Form::None));
+        const InteractionPotential<Functions1D> &potential = {});
     // Return defined overrides for PairPotentials
     std::vector<std::unique_ptr<PairPotentialOverride>> &pairPotentialOverrides();
     const std::vector<std::unique_ptr<PairPotentialOverride>> &pairPotentialOverrides() const;

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -174,7 +174,7 @@ double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRan
 // Return analytic short range force
 double PairPotential::analyticShortRangeForce(double r, PairPotential::ShortRangeTruncationScheme truncation) const
 {
-    // Assess stored potential function derivative at specified r
+    // Assess stored potential function derivative at specified r and negate to get force
     auto force = -potentialFunction_.dYdX(r);
 
     // Apply the selected truncation scheme

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -282,19 +282,14 @@ double PairPotential::delta() const { return delta_; }
 // (Re)generate potential from current parameters
 void PairPotential::calculateUOriginal(bool recalculateUFull)
 {
-    // Create a wrapper for the energy function
-    Function1DWrapper energyFunction(interactionPotential_.form(), interactionPotential_.parameters());
-
+    // Loop over points
     for (auto n = 1; n < nPoints_; ++n)
     {
         auto r = n * delta_;
         uOriginal_.xAxis(n) = r;
 
-        // Construct potential
-        uOriginal_.value(n) = 0.0;
-
-        // Short-range potential contribution
-        uOriginal_.value(n) += analyticShortRangeEnergy(r);
+        // Set short-range potential contribution
+        uOriginal_.value(n) = analyticShortRangeEnergy(r);
 
         // -- Add Coulomb contribution
         if (includeAtomTypeCharges_)

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -30,6 +30,7 @@ PairPotential::PairPotential(std::string_view nameI, std::string_view nameJ, con
     : includeAtomTypeCharges_(false), nameI_(nameI), nameJ_(nameJ), interactionPotential_(potential),
       uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {
+    potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
 }
 
 // Return enum option info for CoulombTruncationScheme

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -15,19 +15,19 @@ PairPotential::ShortRangeTruncationScheme PairPotential::shortRangeTruncationSch
     PairPotential::ShiftedShortRangeTruncation;
 
 PairPotential::PairPotential()
-    : interactionPotential_(ShortRangeFunctions::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
+    : interactionPotential_(Functions1D::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {
 }
 
 PairPotential::PairPotential(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ,
                              bool includeCharges)
-    : interactionPotential_(ShortRangeFunctions::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
+    : interactionPotential_(Functions1D::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {
     setUp(typeI, typeJ, includeCharges);
 }
 
 PairPotential::PairPotential(std::string_view nameI, std::string_view nameJ,
-                             const InteractionPotential<ShortRangeFunctions> &potential)
+                             const InteractionPotential<Functions1D> &potential)
     : includeAtomTypeCharges_(false), nameI_(nameI), nameJ_(nameJ), interactionPotential_(potential),
       uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -175,8 +175,7 @@ double PairPotential::analyticShortRangeEnergy(double r, PairPotential::ShortRan
 double PairPotential::analyticShortRangeForce(double r, PairPotential::ShortRangeTruncationScheme truncation) const
 {
     // Assess stored potential function derivative at specified r
-    auto force = 0.0; // potentialFunction_.dy(r);
-    throw(std::runtime_error("Short-range interaction force needs implementing.\n"));
+    auto force = -potentialFunction_.dYdX(r);
 
     // Apply the selected truncation scheme
     if (truncation == PairPotential::ShiftedShortRangeTruncation)

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -5,6 +5,7 @@
 
 #include "data/ff/ff.h"
 #include "math/data1D.h"
+#include "math/function1D.h"
 #include "math/interpolator.h"
 #include <memory>
 
@@ -19,7 +20,7 @@ class PairPotential
     public:
     PairPotential();
     PairPotential(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges);
-    PairPotential(std::string_view nameI, std::string_view nameJ, const InteractionPotential<ShortRangeFunctions> &potential);
+    PairPotential(std::string_view nameI, std::string_view nameJ, const InteractionPotential<Functions1D> &potential);
     // Coulomb Truncation Scheme enum
     enum CoulombTruncationScheme
     {
@@ -79,7 +80,7 @@ class PairPotential
     // Names reflecting source parameters
     std::string nameI_, nameJ_;
     // Interaction potential
-    InteractionPotential<ShortRangeFunctions> interactionPotential_;
+    InteractionPotential<Functions1D> interactionPotential_;
     // Charge on I (taken from AtomType)
     double chargeI_{0.0};
     // Charge on J (taken from AtomType)

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -79,8 +79,9 @@ class PairPotential
     private:
     // Names reflecting source parameters
     std::string nameI_, nameJ_;
-    // Interaction potential
+    // Interaction potential and function
     InteractionPotential<Functions1D> interactionPotential_;
+    Function1DWrapper potentialFunction_;
     // Charge on I (taken from AtomType)
     double chargeI_{0.0};
     // Charge on J (taken from AtomType)
@@ -98,8 +99,8 @@ class PairPotential
     // Return name for second source parameters
     std::string_view nameJ() const;
     // Return interaction potential
-    InteractionPotential<ShortRangeFunctions> &interactionPotential();
-    const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;
+    InteractionPotential<Functions1D> &interactionPotential();
+    const InteractionPotential<Functions1D> &interactionPotential() const;
     // Set charge I
     void setChargeI(double value);
     // Return charge I

--- a/src/classes/pairPotentialOverride.cpp
+++ b/src/classes/pairPotentialOverride.cpp
@@ -4,11 +4,11 @@
 #include "classes/pairPotentialOverride.h"
 #include "classes/atomType.h"
 
-PairPotentialOverride::PairPotentialOverride() : interactionPotential_(ShortRangeFunctions::Form::None) {}
+PairPotentialOverride::PairPotentialOverride() : interactionPotential_(Functions1D::Form::None) {}
 
 PairPotentialOverride::PairPotentialOverride(std::string_view matchI, std::string_view matchJ,
                                              PairPotentialOverride::PairPotentialOverrideType overrideType,
-                                             const InteractionPotential<ShortRangeFunctions> &potential)
+                                             const InteractionPotential<Functions1D> &potential)
     : matchI_(matchI), matchJ_(matchJ), type_(overrideType), interactionPotential_(potential)
 {
 }
@@ -41,11 +41,8 @@ void PairPotentialOverride::setType(PairPotentialOverrideType overrideType) { ty
 PairPotentialOverride::PairPotentialOverrideType PairPotentialOverride::type() const { return type_; }
 
 // Return interaction potential
-InteractionPotential<ShortRangeFunctions> &PairPotentialOverride::interactionPotential() { return interactionPotential_; }
-const InteractionPotential<ShortRangeFunctions> &PairPotentialOverride::interactionPotential() const
-{
-    return interactionPotential_;
-}
+InteractionPotential<Functions1D> &PairPotentialOverride::interactionPotential() { return interactionPotential_; }
+const InteractionPotential<Functions1D> &PairPotentialOverride::interactionPotential() const { return interactionPotential_; }
 
 /*
  * I/O
@@ -60,12 +57,12 @@ SerialisedValue PairPotentialOverride::serialise() const
     value["matchJ"] = matchJ_;
     value["type"] = pairPotentialOverrideTypes().keyword(type_);
 
-    value["form"] = ShortRangeFunctions::forms().keyword(interactionPotential_.form());
+    value["form"] = Functions1D::forms().keyword(interactionPotential_.form());
     auto &values = interactionPotential().parameters();
     if (!values.empty())
     {
         SerialisedValue interactionParameters;
-        auto &parameters = ShortRangeFunctions::parameters(interactionPotential_.form());
+        auto &parameters = Functions1D::parameters(interactionPotential_.form());
         for (auto &&[parameter, value] : zip(parameters, values))
             interactionParameters[parameter] = value;
         value["parameters"] = interactionParameters;
@@ -84,15 +81,15 @@ void PairPotentialOverride::deserialise(const SerialisedValue &node)
                              [this](const auto node)
                              { type_ = pairPotentialOverrideTypes().enumeration(std::string(node.as_string())); });
 
-    Serialisable::optionalOn(
-        node, "form",
-        [this](const auto node)
-        { interactionPotential_.setForm(ShortRangeFunctions::forms().enumeration(std::string(node.as_string()))); });
+    Serialisable::optionalOn(node, "form",
+                             [this](const auto node) {
+                                 interactionPotential_.setForm(Functions1D::forms().enumeration(std::string(node.as_string())));
+                             });
 
     Serialisable::optionalOn(node, "parameters",
                              [this](const auto node)
                              {
-                                 auto &parameters = ShortRangeFunctions::parameters(interactionPotential_.form());
+                                 auto &parameters = Functions1D::parameters(interactionPotential_.form());
                                  std::vector<double> values;
                                  std::transform(parameters.begin(), parameters.end(), std::back_inserter(values),
                                                 [&node](const auto parameter) { return node.at(parameter).as_floating(); });

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "classes/atomType.h"
+#include "math/function1D.h"
 #include <memory>
 #include <string>
 
@@ -23,7 +24,7 @@ class PairPotentialOverride : public Serialisable<>
     PairPotentialOverride();
     PairPotentialOverride(std::string_view matchI, std::string_view matchJ,
                           PairPotentialOverride::PairPotentialOverrideType overrideType,
-                          const InteractionPotential<ShortRangeFunctions> &potential);
+                          const InteractionPotential<Functions1D> &potential);
 
     private:
     // AtomType names to match
@@ -31,7 +32,7 @@ class PairPotentialOverride : public Serialisable<>
     // Override type
     PairPotentialOverrideType type_{PairPotentialOverrideType::Add};
     // Interaction potential
-    InteractionPotential<ShortRangeFunctions> interactionPotential_;
+    InteractionPotential<Functions1D> interactionPotential_;
 
     public:
     // Set first AtomType name to match
@@ -47,8 +48,8 @@ class PairPotentialOverride : public Serialisable<>
     // Return override type
     PairPotentialOverrideType type() const;
     // Return interaction potential
-    InteractionPotential<ShortRangeFunctions> &interactionPotential();
-    const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;
+    InteractionPotential<Functions1D> &interactionPotential();
+    const InteractionPotential<Functions1D> &interactionPotential() const;
 
     /*
      * I/O

--- a/src/classes/shortRangeFunctions.cpp
+++ b/src/classes/shortRangeFunctions.cpp
@@ -45,7 +45,7 @@ InteractionPotential<Functions1D> ShortRangeFunctions::combine(const Interaction
         switch (srI.form())
         {
             case (Form::None):
-                break;
+                return {Functions1D::Form::None};
             case (Form::LennardJones):
                 /*
                  * Combine parameters (Lorentz-Berthelot):

--- a/src/classes/shortRangeFunctions.cpp
+++ b/src/classes/shortRangeFunctions.cpp
@@ -36,8 +36,8 @@ std::optional<int> ShortRangeFunctions::parameterIndex(Form form, std::string_vi
  */
 
 // Combine parameters for the two atom types using suitable rules
-InteractionPotential<ShortRangeFunctions> ShortRangeFunctions::combine(const InteractionPotential<ShortRangeFunctions> &srI,
-                                                                       const InteractionPotential<ShortRangeFunctions> &srJ)
+InteractionPotential<Functions1D> ShortRangeFunctions::combine(const InteractionPotential<ShortRangeFunctions> &srI,
+                                                               const InteractionPotential<ShortRangeFunctions> &srJ)
 {
     // Equivalent functional forms?
     if (srI.form() == srJ.form())
@@ -52,16 +52,16 @@ InteractionPotential<ShortRangeFunctions> ShortRangeFunctions::combine(const Int
                  * Parameter 0 = Epsilon
                  * Parameter 1 = Sigma
                  */
-                return {srI.form(), std::vector<double>{sqrt(srI.parameters()[0] * srJ.parameters()[0]),
-                                                        (srI.parameters()[1] + srJ.parameters()[1]) * 0.5}};
+                return {Functions1D::Form::LennardJones126,
+                        {sqrt(srI.parameters()[0] * srJ.parameters()[0]), (srI.parameters()[1] + srJ.parameters()[1]) * 0.5}};
             case (Form::LennardJonesGeometric):
                 /*
                  * Combine parameters (Geometric):
                  * Parameter 0 = Epsilon
                  * Parameter 1 = Sigma
                  */
-                return {srI.form(), std::vector<double>{sqrt(srI.parameters()[0] * srJ.parameters()[0]),
-                                                        sqrt(srI.parameters()[1] * srJ.parameters()[1])}};
+                return {Functions1D::Form::LennardJones126,
+                        {sqrt(srI.parameters()[0] * srJ.parameters()[0]), sqrt(srI.parameters()[1] * srJ.parameters()[1])}};
                 break;
             default:
                 throw(std::runtime_error(
@@ -85,8 +85,8 @@ InteractionPotential<ShortRangeFunctions> ShortRangeFunctions::combine(const Int
              * Parameter 0 = Epsilon
              * Parameter 1 = Sigma
              */
-            return {Form::LennardJones, std::vector<double>{sqrt(srI.parameters()[0] * srJ.parameters()[0]),
-                                                            (srI.parameters()[1] + srJ.parameters()[1]) * 0.5}};
+            return {Functions1D::Form::LennardJones126,
+                    {sqrt(srI.parameters()[0] * srJ.parameters()[0]), (srI.parameters()[1] + srJ.parameters()[1]) * 0.5}};
         }
         else
             Messenger::error("Can't combine parameters between dislike ShortRangeFunctions {} and {}.\n",

--- a/src/classes/shortRangeFunctions.h
+++ b/src/classes/shortRangeFunctions.h
@@ -5,6 +5,7 @@
 
 #include "base/enumOptions.h"
 #include "classes/interactionPotential.h"
+#include "math/function1D.h"
 #include <optional>
 
 // Short-range functional forms
@@ -31,6 +32,6 @@ class ShortRangeFunctions
      */
     public:
     // Combine parameters for the two atom types using suitable rules
-    static InteractionPotential<ShortRangeFunctions> combine(const InteractionPotential<ShortRangeFunctions> &srI,
-                                                             const InteractionPotential<ShortRangeFunctions> &srJ);
+    static InteractionPotential<Functions1D> combine(const InteractionPotential<ShortRangeFunctions> &srI,
+                                                     const InteractionPotential<ShortRangeFunctions> &srJ);
 };

--- a/src/gui/keywordWidgets/function1D.cpp
+++ b/src/gui/keywordWidgets/function1D.cpp
@@ -30,7 +30,7 @@ Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, Function1DKeyw
     auto &function = keyword_->data();
 
     // Get relevant function types to show in combo
-    auto availableFunctions = Functions::matchingFunction1D(keyword_->functionProperties());
+    auto availableFunctions = Functions1D::matchingFunction1D(keyword_->functionProperties());
     if (availableFunctions.empty())
     {
         ui_.FunctionCombo->addItem("<None Available>");
@@ -41,9 +41,9 @@ Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, Function1DKeyw
         auto i = 0;
         for (auto func : availableFunctions)
         {
-            ui_.FunctionCombo->addItem(QString::fromStdString(Functions::function1D().keyword(func)),
+            ui_.FunctionCombo->addItem(QString::fromStdString(Functions1D::function1D().keyword(func)),
                                        QVariant::fromValue(func));
-            if (func == function.type())
+            if (func == function.form())
                 ui_.FunctionCombo->setCurrentIndex(i);
             ++i;
         }
@@ -107,7 +107,7 @@ void Function1DKeywordWidget::updateWidgetsFromData()
     // Grab the target Function1D
     auto &function = keyword_->data();
 
-    ui_.FunctionCombo->setCurrentIndex(ui_.FunctionCombo->findData(QVariant::fromValue(function.type())));
+    ui_.FunctionCombo->setCurrentIndex(ui_.FunctionCombo->findData(QVariant::fromValue(function.form())));
 
     const auto nParams = function.nParameters();
     for (auto n = 0; n < MaxParams; ++n)
@@ -131,9 +131,9 @@ void Function1DKeywordWidget::updateValue(const Flags<DissolveSignals::DataMutat
 void Function1DKeywordWidget::updateKeywordData()
 {
     // Get current data from widgets
-    auto func = ui_.FunctionCombo->currentData().value<Functions::Function1D>();
+    auto func = ui_.FunctionCombo->currentData().value<Functions1D::Form>();
     std::vector<double> newParams;
-    for (auto n = 0; n < Functions::functionDefinition1D(func).nParameters(); ++n)
+    for (auto n = 0; n < Functions1D::functionDefinition1D(func).nParameters(); ++n)
         newParams.push_back(spins_[n]->value());
 
     // Set new data
@@ -149,6 +149,6 @@ void Function1DKeywordWidget::updateSummaryText()
     // Summary text on KeywordDropDown button
     setSummaryText(QString::fromStdString(
         function.nParameters() == 0
-            ? Functions::function1D().keyword(function.type())
-            : fmt::format("{} ({})", Functions::function1D().keyword(function.type()), function.parameterSummary())));
+            ? Functions1D::function1D().keyword(function.form())
+            : fmt::format("{} ({})", Functions1D::function1D().keyword(function.form()), function.parameterSummary())));
 }

--- a/src/gui/keywordWidgets/function1D.cpp
+++ b/src/gui/keywordWidgets/function1D.cpp
@@ -41,8 +41,7 @@ Function1DKeywordWidget::Function1DKeywordWidget(QWidget *parent, Function1DKeyw
         auto i = 0;
         for (auto func : availableFunctions)
         {
-            ui_.FunctionCombo->addItem(QString::fromStdString(Functions1D::function1D().keyword(func)),
-                                       QVariant::fromValue(func));
+            ui_.FunctionCombo->addItem(QString::fromStdString(Functions1D::forms().keyword(func)), QVariant::fromValue(func));
             if (func == function.form())
                 ui_.FunctionCombo->setCurrentIndex(i);
             ++i;
@@ -149,6 +148,6 @@ void Function1DKeywordWidget::updateSummaryText()
     // Summary text on KeywordDropDown button
     setSummaryText(QString::fromStdString(
         function.nParameters() == 0
-            ? Functions1D::function1D().keyword(function.form())
-            : fmt::format("{} ({})", Functions1D::function1D().keyword(function.form()), function.parameterSummary())));
+            ? Functions1D::forms().keyword(function.form())
+            : fmt::format("{} ({})", Functions1D::forms().keyword(function.form()), function.parameterSummary())));
 }

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -48,7 +48,7 @@ QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
                 return QString::fromStdString(std::string(pp->nameJ()));
             // Form
             case (2):
-                return QString::fromStdString(ShortRangeFunctions::forms().keyword(pp->interactionPotential().form()));
+                return QString::fromStdString(Functions1D::forms().keyword(pp->interactionPotential().form()));
             // Charges
             case (3):
                 return pp->includeAtomTypeCharges() ? QString::number(pp->chargeI()) : QString();

--- a/src/gui/models/pairPotentialOverrideModel.cpp
+++ b/src/gui/models/pairPotentialOverrideModel.cpp
@@ -48,7 +48,7 @@ QVariant PairPotentialOverrideModel::data(const QModelIndex &index, int role) co
             case (ColumnData::OverrideType):
                 return QString::fromStdString(PairPotentialOverride::pairPotentialOverrideTypes().keyword(ppOverride->type()));
             case (ColumnData::ShortRangeForm):
-                return QString::fromStdString(ShortRangeFunctions::forms().keyword(ppOverride->interactionPotential().form()));
+                return QString::fromStdString(Functions1D::forms().keyword(ppOverride->interactionPotential().form()));
             case (ColumnData::ShortRangeParameters):
                 return QString::fromStdString(ppOverride->interactionPotential().parametersAsString());
             default:
@@ -82,7 +82,7 @@ bool PairPotentialOverrideModel::setData(const QModelIndex &index, const QVarian
             break;
         case (ColumnData::ShortRangeForm):
             ppOverride->interactionPotential().setForm(
-                ShortRangeFunctions::forms().enumeration(value.toString().toStdString()));
+                Functions1D::forms().enumeration(value.toString().toStdString()));
             break;
         case (ColumnData::ShortRangeParameters):
             if (!ppOverride->interactionPotential().parseParameters(value.toString().toStdString()))

--- a/src/gui/models/pairPotentialOverrideModel.cpp
+++ b/src/gui/models/pairPotentialOverrideModel.cpp
@@ -81,8 +81,7 @@ bool PairPotentialOverrideModel::setData(const QModelIndex &index, const QVarian
                 PairPotentialOverride::pairPotentialOverrideTypes().enumeration(value.toString().toStdString()));
             break;
         case (ColumnData::ShortRangeForm):
-            ppOverride->interactionPotential().setForm(
-                Functions1D::forms().enumeration(value.toString().toStdString()));
+            ppOverride->interactionPotential().setForm(Functions1D::forms().enumeration(value.toString().toStdString()));
             break;
         case (ColumnData::ShortRangeParameters):
             if (!ppOverride->interactionPotential().parseParameters(value.toString().toStdString()))

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -5,7 +5,8 @@
 #include "base/lineParser.h"
 #include "templates/algorithms.h"
 
-Function1DKeyword::Function1DKeyword(Functions::Function1DWrapper &data, int functionProperties)
+Function1DKeyword::Function1DKeyword(Functions::Function1DWrapper &data,
+                                     const Flags<FunctionProperties::FunctionProperty> &functionProperties)
     : KeywordBase(typeid(this)), data_(data), functionProperties_(functionProperties)
 {
 }
@@ -24,7 +25,7 @@ bool Function1DKeyword::setData(const Functions::Function1DWrapper &data)
 }
 
 // Return requested function properties
-int Function1DKeyword::functionProperties() const { return functionProperties_; }
+const Flags<FunctionProperties::FunctionProperty> &Function1DKeyword::functionProperties() const { return functionProperties_; }
 
 /*
  * Arguments

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -38,15 +38,15 @@ std::optional<int> Function1DKeyword::maxArguments() const { return std::nullopt
 bool Function1DKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
     // Check function name
-    if (!Functions1D::function1D().isValid(parser.argsv(startArg)))
-        return Functions1D::function1D().errorAndPrintValid(parser.argsv(startArg));
-    auto func = Functions1D::function1D().enumeration(parser.argsv(startArg));
+    if (!Functions1D::forms().isValid(parser.argsv(startArg)))
+        return Functions1D::forms().errorAndPrintValid(parser.argsv(startArg));
+    auto func = Functions1D::forms().enumeration(parser.argsv(startArg));
 
     // Check properties
     if (!Functions1D::validFunction1DProperties(func, functionProperties_))
         return Messenger::error(
             "1D function type {} can't be set in keyword '{}' as it does not have the correct properties.\n",
-            Functions1D::function1D().keyword(func), name());
+            Functions1D::forms().keyword(func), name());
 
     // Get parameters if they were given
     auto params = parser.hasArg(startArg + 1) ? parser.argvd(startArg + 1) : std::vector<double>();
@@ -57,19 +57,19 @@ bool Function1DKeyword::deserialise(LineParser &parser, int startArg, const Core
 // Serialise data to specified LineParser
 bool Function1DKeyword::serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
-    return parser.writeLineF("{}{}  '{}'  {}\n", prefix, keywordName, Functions1D::function1D().keyword(data_.form()),
+    return parser.writeLineF("{}{}  '{}'  {}\n", prefix, keywordName, Functions1D::forms().keyword(data_.form()),
                              joinStrings(data_.parameters(), "  "));
 }
 
 // Express as a serialisable value
 SerialisedValue Function1DKeyword::serialise() const
 {
-    return {{"type", Functions1D::function1D().serialise(data_.form())}, {"parameters", data_.parameters()}};
+    return {{"type", Functions1D::forms().serialise(data_.form())}, {"parameters", data_.parameters()}};
 }
 
 // Read values from a serialisable value
 void Function1DKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
 {
-    data_.setFormAndParameters(Functions1D::function1D().deserialise(node.at("type")),
+    data_.setFormAndParameters(Functions1D::forms().deserialise(node.at("type")),
                                toml::find<std::vector<double>>(node, "parameters"));
 }

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -5,7 +5,7 @@
 #include "base/lineParser.h"
 #include "templates/algorithms.h"
 
-Function1DKeyword::Function1DKeyword(Functions::Function1DWrapper &data,
+Function1DKeyword::Function1DKeyword(Function1DWrapper &data,
                                      const Flags<FunctionProperties::FunctionProperty> &functionProperties)
     : KeywordBase(typeid(this)), data_(data), functionProperties_(functionProperties)
 {
@@ -16,12 +16,12 @@ Function1DKeyword::Function1DKeyword(Functions::Function1DWrapper &data,
  */
 
 // Return reference to data
-const Functions::Function1DWrapper &Function1DKeyword::data() const { return data_; }
+const Function1DWrapper &Function1DKeyword::data() const { return data_; }
 
 // Set data
-bool Function1DKeyword::setData(const Functions::Function1DWrapper &data)
+bool Function1DKeyword::setData(const Function1DWrapper &data)
 {
-    return data_.setFunctionAndParameters(data.type(), data.parameters());
+    return data_.setFormAndParameters(data.form(), data.parameters());
 }
 
 // Return requested function properties
@@ -38,38 +38,38 @@ std::optional<int> Function1DKeyword::maxArguments() const { return std::nullopt
 bool Function1DKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
     // Check function name
-    if (!Functions::function1D().isValid(parser.argsv(startArg)))
-        return Functions::function1D().errorAndPrintValid(parser.argsv(startArg));
-    auto func = Functions::function1D().enumeration(parser.argsv(startArg));
+    if (!Functions1D::function1D().isValid(parser.argsv(startArg)))
+        return Functions1D::function1D().errorAndPrintValid(parser.argsv(startArg));
+    auto func = Functions1D::function1D().enumeration(parser.argsv(startArg));
 
     // Check properties
-    if (!Functions::validFunction1DProperties(func, functionProperties_))
+    if (!Functions1D::validFunction1DProperties(func, functionProperties_))
         return Messenger::error(
             "1D function type {} can't be set in keyword '{}' as it does not have the correct properties.\n",
-            Functions::function1D().keyword(func), name());
+            Functions1D::function1D().keyword(func), name());
 
     // Get parameters if they were given
     auto params = parser.hasArg(startArg + 1) ? parser.argvd(startArg + 1) : std::vector<double>();
 
-    return data_.setFunctionAndParameters(func, params);
+    return data_.setFormAndParameters(func, params);
 }
 
 // Serialise data to specified LineParser
 bool Function1DKeyword::serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const
 {
-    return parser.writeLineF("{}{}  '{}'  {}\n", prefix, keywordName, Functions::function1D().keyword(data_.type()),
+    return parser.writeLineF("{}{}  '{}'  {}\n", prefix, keywordName, Functions1D::function1D().keyword(data_.form()),
                              joinStrings(data_.parameters(), "  "));
 }
 
 // Express as a serialisable value
 SerialisedValue Function1DKeyword::serialise() const
 {
-    return {{"type", Functions::function1D().serialise(data_.type())}, {"parameters", data_.parameters()}};
+    return {{"type", Functions1D::function1D().serialise(data_.form())}, {"parameters", data_.parameters()}};
 }
 
 // Read values from a serialisable value
 void Function1DKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
 {
-    data_.setFunctionAndParameters(Functions::function1D().deserialise(node.at("type")),
-                                   toml::find<std::vector<double>>(node, "parameters"));
+    data_.setFormAndParameters(Functions1D::function1D().deserialise(node.at("type")),
+                               toml::find<std::vector<double>>(node, "parameters"));
 }

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -10,7 +10,7 @@
 class Function1DKeyword : public KeywordBase
 {
     public:
-    Function1DKeyword(Functions::Function1DWrapper &data,
+    Function1DKeyword(Function1DWrapper &data,
                       const Flags<FunctionProperties::FunctionProperty> &properties = {FunctionProperties::None});
     ~Function1DKeyword() override = default;
 
@@ -19,15 +19,15 @@ class Function1DKeyword : public KeywordBase
      */
     private:
     // Reference to data
-    Functions::Function1DWrapper &data_;
+    Function1DWrapper &data_;
     // Requested function properties
-    const Flags<FunctionProperties::FunctionProperty> &functionProperties_;
+    Flags<FunctionProperties::FunctionProperty> functionProperties_;
 
     public:
     // Return reference to data
-    const Functions::Function1DWrapper &data() const;
+    const Function1DWrapper &data() const;
     // Set data
-    bool setData(const Functions::Function1DWrapper &data);
+    bool setData(const Function1DWrapper &data);
     // Return requested function properties
     const Flags<FunctionProperties::FunctionProperty> &functionProperties() const;
 

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -10,7 +10,8 @@
 class Function1DKeyword : public KeywordBase
 {
     public:
-    Function1DKeyword(Functions::Function1DWrapper &data, int functionProperties = FunctionProperties::None);
+    Function1DKeyword(Functions::Function1DWrapper &data,
+                      const Flags<FunctionProperties::FunctionProperty> &properties = {FunctionProperties::None});
     ~Function1DKeyword() override = default;
 
     /*
@@ -20,7 +21,7 @@ class Function1DKeyword : public KeywordBase
     // Reference to data
     Functions::Function1DWrapper &data_;
     // Requested function properties
-    int functionProperties_;
+    const Flags<FunctionProperties::FunctionProperty> &functionProperties_;
 
     public:
     // Return reference to data
@@ -28,7 +29,7 @@ class Function1DKeyword : public KeywordBase
     // Set data
     bool setData(const Functions::Function1DWrapper &data);
     // Return requested function properties
-    int functionProperties() const;
+    const Flags<FunctionProperties::FunctionProperty> &functionProperties() const;
 
     /*
      * Arguments

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -10,8 +10,7 @@
 class Function1DKeyword : public KeywordBase
 {
     public:
-    Function1DKeyword(Function1DWrapper &data,
-                      const Flags<FunctionProperties::FunctionProperty> &properties = {FunctionProperties::None});
+    Function1DKeyword(Function1DWrapper &data, const Flags<FunctionProperties::FunctionProperty> &properties = {});
     ~Function1DKeyword() override = default;
 
     /*

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -235,7 +235,7 @@ bool KeywordStore::set(std::string_view name, const std::string value)
     getKeyword<StringKeyword>(name, find(name))->data() = value;
     return true;
 }
-bool KeywordStore::set(std::string_view name, const Functions::Function1DWrapper value)
+bool KeywordStore::set(std::string_view name, const Function1DWrapper value)
 {
     return getKeyword<Function1DKeyword>(name, find(name))->setData(value);
 }

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -165,7 +165,7 @@ class KeywordStore
     bool set(std::string_view name, const double value);
     bool set(std::string_view name, const int value);
     bool set(std::string_view name, const std::string value);
-    bool set(std::string_view name, const Functions::Function1DWrapper value);
+    bool set(std::string_view name, const Function1DWrapper value);
     bool set(std::string_view name, const NodeValueProxy value);
     bool set(std::string_view name, const Vec3<double> value);
     bool set(std::string_view name, const Vec3<int> value);

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -390,7 +390,7 @@ bool Dissolve::saveInput(std::string_view filename)
                                PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::OverrideKeyword),
                                ppOverride->matchI(), ppOverride->matchJ(),
                                PairPotentialOverride::pairPotentialOverrideTypes().keyword(ppOverride->type()),
-                               ShortRangeFunctions::forms().keyword(ppOverride->interactionPotential().form()),
+                               Functions1D::forms().keyword(ppOverride->interactionPotential().form()),
                                ppOverride->interactionPotential().parametersAsString()))
             return false;
 

--- a/src/main/keywords_pairPotentials.cpp
+++ b/src/main/keywords_pairPotentials.cpp
@@ -95,13 +95,13 @@ bool PairPotentialsBlock::parse(LineParser &parser, Dissolve *dissolve)
                 }
 
                 // Check / set interaction potential
-                if (!ShortRangeFunctions::forms().isValid(parser.argsv(4)))
+                if (!Functions1D::forms().isValid(parser.argsv(4)))
                 {
-                    ShortRangeFunctions::forms().errorAndPrintValid(parser.argsv(4));
+                    Functions1D::forms().errorAndPrintValid(parser.argsv(4));
                     errorsEncountered = true;
                     break;
                 }
-                InteractionPotential<ShortRangeFunctions> potential(ShortRangeFunctions::forms().enumeration(parser.argsv(4)));
+                InteractionPotential<Functions1D> potential(Functions1D::forms().enumeration(parser.argsv(4)));
                 if (!potential.parseParameters(parser, 5))
                 {
                     errorsEncountered = true;

--- a/src/main/pairPotentials.cpp
+++ b/src/main/pairPotentials.cpp
@@ -125,7 +125,7 @@ bool Dissolve::regeneratePairPotentials()
     {
         Messenger::print("Pair potential override between '{}' and '{}' ({}, {}, '{}') ...\n", override->matchI(),
                          override->matchJ(), PairPotentialOverride::pairPotentialOverrideTypes().keyword(override->type()),
-                         ShortRangeFunctions::forms().keyword(override->interactionPotential().form()),
+                         Functions1D::forms().keyword(override->interactionPotential().form()),
                          override->interactionPotential().parametersAsString());
 
         // Is the override enabled?

--- a/src/math/filters.cpp
+++ b/src/math/filters.cpp
@@ -9,10 +9,10 @@
 namespace Filters
 {
 // Perform point-wise convolution of data with the supplied BroadeningFunction
-void convolve(Data1D &data, const Functions::Function1DWrapper function, bool variableOmega, bool normalise)
+void convolve(Data1D &data, const Function1DWrapper function, bool variableOmega, bool normalise)
 {
     // Check for no function specified
-    if (function.type() == Functions::Function1D::None)
+    if (function.form() == Functions1D::Form::None)
         return;
 
     // Grab x and y arrays
@@ -56,10 +56,10 @@ void convolve(Data1D &data, const Functions::Function1DWrapper function, bool va
 }
 
 // Perform convolution of the supplied delta function into the supplied data
-void convolve(double xCentre, double value, const Functions::Function1DWrapper function, Data1D &dest)
+void convolve(double xCentre, double value, const Function1DWrapper function, Data1D &dest)
 {
     // Check for no function specified
-    if (function.type() == Functions::Function1D::None)
+    if (function.form() == Functions1D::Form::None)
         return;
 
     // Grab x and y arrays

--- a/src/math/filters.h
+++ b/src/math/filters.h
@@ -12,9 +12,9 @@ class Data1D;
 namespace Filters
 {
 // Perform point-wise convolution of data with the supplied BroadeningFunction
-void convolve(Data1D &data, const Functions::Function1DWrapper function, bool variableOmega = false, bool normalise = false);
+void convolve(Data1D &data, const Function1DWrapper function, bool variableOmega = false, bool normalise = false);
 // Perform convolution of the supplied delta function into the supplied data
-void convolve(double xCentre, double value, const Functions::Function1DWrapper function, Data1D &dest);
+void convolve(double xCentre, double value, const Function1DWrapper function, Data1D &dest);
 // Apply Kolmogorov–Zurbenko filter to data
 void kolmogorovZurbenko(Data1D &data, int k, int m, bool normalised = false);
 // Apply median filter to data

--- a/src/math/ft.cpp
+++ b/src/math/ft.cpp
@@ -15,7 +15,7 @@ namespace Fourier
 // Perform Fourier sine transform of current distribution function, over range specified, and with specified broadening
 // function, modification function, and window applied (if requested)
 bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax, WindowFunction windowFunction,
-            const Functions::Function1DWrapper &broadening)
+            const Function1DWrapper &broadening)
 {
     /*
      * Perform sine Fourier transform of current data. Function has no notion of forward or backwards transforms -

--- a/src/math/ft.cpp
+++ b/src/math/ft.cpp
@@ -57,30 +57,59 @@ bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double w
     dissolve::transform(ParallelPolicies::par, product.begin(), product.end(), deltas.begin() + 1, product.begin(),
                         std::multiplies());
 
-    // Perform Fourier sine transform, apply general and omega-dependent broadening, as well as window function
-    dissolve::transform(ParallelPolicies::par, newX.begin(), newX.end(), newY.begin(),
-                        [normFactor, &product, &x, &windowFunction, &broadening](const auto omega)
-                        {
-                            double ft = 0.0;
+    // Perform Fourier sine transform, apply general and omega-dependent broadening (if requested), as well as window function
+    if (broadening.form() != Functions1D::Form::None)
+    {
+        // Broadening
+        dissolve::transform(ParallelPolicies::par, newX.begin(), newX.end(), newY.begin(),
+                            [normFactor, &product, &x, &windowFunction, &broadening](const auto omega)
+                            {
+                                double ft = 0.0;
 
-                            if (omega > 0.0)
-                                ft = std::transform_reduce(
-                                    product.begin(), product.end(), x.begin(), 0.0, std::plus(),
-                                    [omega, &windowFunction, &broadening](const auto r, const auto x)
-                                    { return r * sin(x * omega) * windowFunction.y(x, omega) * broadening.yFT(x, omega); });
-                            else
-                                ft = std::transform_reduce(product.begin(), product.end(), x.begin(), 0.0, std::plus(),
-                                                           [omega, &windowFunction, &broadening](const auto r, const auto x) {
-                                                               return r * windowFunction.y(x, omega) * broadening.yFT(x, omega);
-                                                           });
+                                if (omega > 0.0)
+                                    ft = std::transform_reduce(
+                                        product.begin(), product.end(), x.begin(), 0.0, std::plus(),
+                                        [omega, &windowFunction, &broadening](const auto r, const auto x)
+                                        { return r * sin(x * omega) * windowFunction.y(x, omega) * broadening.yFT(x, omega); });
+                                else
+                                    ft = std::transform_reduce(
+                                        product.begin(), product.end(), x.begin(), 0.0, std::plus(),
+                                        [omega, &windowFunction, &broadening](const auto r, const auto x)
+                                        { return r * windowFunction.y(x, omega) * broadening.yFT(x, omega); });
 
-                            // Normalise w.r.t. omega
-                            if (omega > 0.0)
-                                ft /= omega;
+                                // Normalise w.r.t. omega
+                                if (omega > 0.0)
+                                    ft /= omega;
 
-                            // Add point
-                            return ft * normFactor;
-                        });
+                                // Add point
+                                return ft * normFactor;
+                            });
+    }
+    else
+    {
+        // No broadening
+        dissolve::transform(ParallelPolicies::par, newX.begin(), newX.end(), newY.begin(),
+                            [normFactor, &product, &x, &windowFunction](const auto omega)
+                            {
+                                double ft = 0.0;
+
+                                if (omega > 0.0)
+                                    ft = std::transform_reduce(product.begin(), product.end(), x.begin(), 0.0, std::plus(),
+                                                               [omega, &windowFunction](const auto r, const auto x)
+                                                               { return r * sin(x * omega) * windowFunction.y(x, omega); });
+                                else
+                                    ft = std::transform_reduce(product.begin(), product.end(), x.begin(), 0.0, std::plus(),
+                                                               [omega, &windowFunction](const auto r, const auto x)
+                                                               { return r * windowFunction.y(x, omega); });
+
+                                // Normalise w.r.t. omega
+                                if (omega > 0.0)
+                                    ft /= omega;
+
+                                // Add point
+                                return ft * normFactor;
+                            });
+    }
 
     // Transfer working arrays to this object
     data.xAxis() = newX;

--- a/src/math/ft.h
+++ b/src/math/ft.h
@@ -15,6 +15,5 @@ namespace Fourier
 // Perform Fourier sine transform of supplied data, over range specified, and with specified window and broadening
 // functions applied
 bool sineFT(Data1D &data, double normFactor, double wMin, double wStep, double wMax,
-            WindowFunction windowFunction = WindowFunction(),
-            const Functions::Function1DWrapper &broadening = Functions::Function1DWrapper());
+            WindowFunction windowFunction = WindowFunction(), const Function1DWrapper &broadening = Function1DWrapper());
 }; // namespace Fourier

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -43,13 +43,12 @@ Function1DOmega Function1DDefinition::normalisation() const { return normaliser_
 
 // One-Dimensional Function Definitions
 static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
-    // No Function - always returns 1.0
+    // No Function - returns zero
     {Functions1D::Form::None,
      {{},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params) { return params; },
-      [](double x, double omega, const std::vector<double> &params) { return 1.0; },
-      [](double x, double omega, const std::vector<double> &params) { return 1.0; }}},
+      [](double x, double omega, const std::vector<double> &params) { return 0.0; }}},
     /*
      * Gaussian
      *

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -48,7 +48,9 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
      {{},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params) { return params; },
-      [](double x, double omega, const std::vector<double> &params) { return 0.0; }}},
+      [](double x, double omega, const std::vector<double> &params) { return 0.0; },
+      [](double x, double omega, const std::vector<double> &params) { return 0.0; },
+      [](double omega, const std::vector<double> &params) { return 0.0; }}},
     /*
      * Gaussian
      *

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -257,12 +257,13 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
 // Return enum option info for forms
 EnumOptions<Functions1D::Form> Functions1D::forms()
 {
-    return EnumOptions<Functions1D::Form>("Function1D", {{Functions1D::Form::None, "None"},
-                                                         {Functions1D::Form::Gaussian, "Gaussian"},
-                                                         {Functions1D::Form::ScaledGaussian, "ScaledGaussian"},
-                                                         {Functions1D::Form::OmegaDependentGaussian, "OmegaDependentGaussian"},
-                                                         {Functions1D::Form::GaussianC2, "GaussianC2"},
-                                                         {Functions1D::Form::LennardJones126, "LennardJones126"}});
+    return EnumOptions<Functions1D::Form>("Function1D",
+                                          {{Functions1D::Form::None, "None"},
+                                           {Functions1D::Form::Gaussian, "Gaussian", 1},
+                                           {Functions1D::Form::ScaledGaussian, "ScaledGaussian", 2},
+                                           {Functions1D::Form::OmegaDependentGaussian, "OmegaDependentGaussian", 1},
+                                           {Functions1D::Form::GaussianC2, "GaussianC2", 2},
+                                           {Functions1D::Form::LennardJones126, "LennardJones126", 2}});
 }
 
 // Return parameters for specified form

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -216,9 +216,9 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
       {},
       [](std::vector<double> params) { return params; },
       /*
-       *                      ( sigma )**12   ( sigma )**6
-       * F(x) = 4 * epsilon * ( ----- )     - ( ----- )
-       *                      (   x   )       (   x   )
+       *                      [ ( sigma )**12   ( sigma )**6 ]
+       * F(x) = 4 * epsilon * [ ( ----- )     - ( ----- )    ]
+       *                      [ (   x   )       (   x   )    ]
        */
       [](double x, double omega, const std::vector<double> &params)
       {

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -220,13 +220,13 @@ EnumOptions<Function1D> function1D()
 FunctionDefinition1D functionDefinition1D(Functions::Function1D func) { return functions1D_.at(func); }
 
 // Check function properties against those supplied, returning truth if the function meets all requirements
-bool validFunction1DProperties(Function1D func, int properties)
+bool validFunction1DProperties(Function1D func, const Flags<FunctionProperties::FunctionProperty> &properties)
 {
     return properties == FunctionProperties::None || (functions1D_.at(func).properties() & properties) == properties;
 }
 
 // Return all available functions with properties matching those provided
-std::vector<Function1D> matchingFunction1D(int properties)
+std::vector<Function1D> matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties)
 {
     std::vector<Function1D> matches;
     for (auto n = 0; n < function1D().nOptions(); ++n)

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -241,9 +241,9 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
           return 4.0 * params[0] * (sigmar12 - sigmar6);
       },
       /*
-       *                          [ ( sigma**12 )         ( sigma**6 ) ]
-       * dYdX(x) = 48 * epsilon * [ ( --------- ) - 0.5 * ( -------- ) ]
-       *                          [ (   x**13   )         (   x**7   ) ]
+       *                           [ ( sigma**12 )         ( sigma**6 ) ]
+       * dYdX(x) = -48 * epsilon * [ ( --------- ) - 0.5 * ( -------- ) ]
+       *                           [ (   x**13   )         (   x**7   ) ]
        */
       [](double x, double omega, const std::vector<double> &params)
       {

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -201,7 +201,32 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
        *        (c1 + c2 omega) sqrt(2 pi)
        */
       [](double omega, const std::vector<double> &params)
-      { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); }}}};
+      { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); }}},
+    /*
+     * Lennard-Jones 12-6 Potential
+     *
+     * Parameters:
+     *  INPUT  0 = epsilon
+     *  INPUT  1 = sigma
+     */
+    {Functions1D::Form::LennardJones126,
+     {{"epsilon", "sigma"},
+      {},
+      [](std::vector<double> params) { return params; },
+      /*
+       *                      ( sigma )**12   ( sigma )**6
+       * F(x) = 4 * epsilon * ( ----- )     - ( ----- )
+       *                      (   x   )       (   x   )
+       */
+      [](double x, double omega, const std::vector<double> &params)
+      {
+          auto sigmar = params[1] / x;
+          auto sigmar6 = pow(sigmar, 6.0);
+          auto sigmar12 = sigmar6 * sigmar6;
+          return 4.0 * params[0] * (sigmar12 - sigmar6);
+      },
+      {},
+      {}}}};
 
 // Return enum option info for forms
 EnumOptions<Functions1D::Form> Functions1D::forms()
@@ -210,7 +235,8 @@ EnumOptions<Functions1D::Form> Functions1D::forms()
                                                          {Functions1D::Form::Gaussian, "Gaussian"},
                                                          {Functions1D::Form::ScaledGaussian, "ScaledGaussian"},
                                                          {Functions1D::Form::OmegaDependentGaussian, "OmegaDependentGaussian"},
-                                                         {Functions1D::Form::GaussianC2, "GaussianC2"}});
+                                                         {Functions1D::Form::GaussianC2, "GaussianC2"},
+                                                         {Functions1D::Form::LennardJones126, "LennardJones126"}});
 }
 
 // Return parameters for specified form

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -204,14 +204,29 @@ static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
       [](double omega, const std::vector<double> &params)
       { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); }}}};
 
-// Return enum option info for Function1D
-EnumOptions<Functions1D::Form> Functions1D::function1D()
+// Return enum option info for forms
+EnumOptions<Functions1D::Form> Functions1D::forms()
 {
     return EnumOptions<Functions1D::Form>("Function1D", {{Functions1D::Form::None, "None"},
                                                          {Functions1D::Form::Gaussian, "Gaussian"},
                                                          {Functions1D::Form::ScaledGaussian, "ScaledGaussian"},
                                                          {Functions1D::Form::OmegaDependentGaussian, "OmegaDependentGaussian"},
                                                          {Functions1D::Form::GaussianC2, "GaussianC2"}});
+}
+
+// Return parameters for specified form
+const std::vector<std::string> &Functions1D::parameters(Form form) { return functions1D_.at(form).parameterNames(); }
+
+// Return nth parameter for the given form
+std::string Functions1D::parameter(Form form, int n) { return functions1D_.at(form).parameterNames()[n]; }
+
+// Return index of parameter in the given form
+std::optional<int> Functions1D::parameterIndex(Form form, std::string_view name)
+{
+    auto it = std::find(functions1D_.at(form).parameterNames().begin(), functions1D_.at(form).parameterNames().end(), name);
+    if (it == functions1D_.at(form).parameterNames().end())
+        return {};
+    return it - functions1D_.at(form).parameterNames().begin();
 }
 
 // Return base function requested
@@ -228,9 +243,9 @@ bool Functions1D::validFunction1DProperties(Functions1D::Form form,
 std::vector<Functions1D::Form> Functions1D::matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties)
 {
     std::vector<Functions1D::Form> matches;
-    for (auto n = 0; n < function1D().nOptions(); ++n)
-        if (validFunction1DProperties(function1D().enumerationByIndex(n), properties))
-            matches.push_back(function1D().enumerationByIndex(n));
+    for (auto n = 0; n < forms().nOptions(); ++n)
+        if (validFunction1DProperties(forms().enumerationByIndex(n), properties))
+            matches.push_back(forms().enumerationByIndex(n));
     return matches;
 }
 
@@ -255,7 +270,7 @@ bool Function1DWrapper::setFormAndParameters(Functions1D::Form form, const std::
 
     if (params.size() != function_.nParameters())
         return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n",
-                                Functions1D::function1D().keyword(form_), function_.nParameters(), params.size());
+                                Functions1D::forms().keyword(form_), function_.nParameters(), params.size());
 
     parameters_ = params;
     calculateInternalParameters();
@@ -279,7 +294,7 @@ bool Function1DWrapper::setParameters(const std::vector<double> &params)
 {
     if (params.size() != function_.nParameters())
         return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n",
-                                Functions1D::function1D().keyword(form_), function_.nParameters(), params.size());
+                                Functions1D::forms().keyword(form_), function_.nParameters(), params.size());
 
     parameters_ = params;
     calculateInternalParameters();

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -8,14 +8,12 @@
 
 #include <map>
 
-namespace Functions
-{
 /*
  * One-Dimensional Function Definition
  */
 
-FunctionDefinition1D::FunctionDefinition1D(const std::vector<std::string> &parameterNames,
-                                           const Flags<FunctionProperties::FunctionProperty> &properties, FunctionSetup setup,
+Function1DDefinition::Function1DDefinition(const std::vector<std::string> &parameterNames,
+                                           const Flags<FunctionProperties::FunctionProperty> &properties, Function1DSetup setup,
                                            Function1DXOmega y, Function1DXOmega yFT, Function1DOmega norm)
     : parameterNames_(parameterNames), properties_(properties), setup_(std::move(setup)), y_(std::move(y)),
       yFT_(std::move(yFT)), normaliser_(std::move(norm))
@@ -23,30 +21,30 @@ FunctionDefinition1D::FunctionDefinition1D(const std::vector<std::string> &param
 }
 
 // Return number of parameters the function requires
-int FunctionDefinition1D::nParameters() const { return parameterNames_.size(); }
+int Function1DDefinition::nParameters() const { return parameterNames_.size(); }
 
 // Return parameter names
-const std::vector<std::string> &FunctionDefinition1D::parameterNames() const { return parameterNames_; }
+const std::vector<std::string> &Function1DDefinition::parameterNames() const { return parameterNames_; }
 
 // Return properties of the function
-const Flags<FunctionProperties::FunctionProperty> &FunctionDefinition1D::properties() const { return properties_; }
+const Flags<FunctionProperties::FunctionProperty> &Function1DDefinition::properties() const { return properties_; }
 
 // Return function for setup
-FunctionSetup FunctionDefinition1D::setup() const { return setup_; }
+Function1DSetup Function1DDefinition::setup() const { return setup_; }
 
 // Return function for y value at specified x, omega
-Function1DXOmega FunctionDefinition1D::y() const { return y_; }
+Function1DXOmega Function1DDefinition::y() const { return y_; }
 
 // Return function for FT of y value at the specified x, omega
-Function1DXOmega FunctionDefinition1D::yFT() const { return yFT_; }
+Function1DXOmega Function1DDefinition::yFT() const { return yFT_; }
 
 // Return normalisation function
-Function1DOmega FunctionDefinition1D::normalisation() const { return normaliser_; }
+Function1DOmega Function1DDefinition::normalisation() const { return normaliser_; }
 
 // One-Dimensional Function Definitions
-static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
+static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
     // No Function - always returns 1.0
-    {Function1D::None,
+    {Functions1D::Form::None,
      {{},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params) { return params; },
@@ -60,7 +58,7 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
      *  CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
      *  CALC   2 = 1.0 / c
      */
-    {Function1D::Gaussian,
+    {Functions1D::Form::Gaussian,
      {{"fwhm"},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params)
@@ -96,7 +94,7 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
      *  CALC   2 = c = fwhm / (2 * sqrt(2 ln 2))
      *  CALC   3 = 1.0 / c
      */
-    {Function1D::ScaledGaussian,
+    {Functions1D::Form::ScaledGaussian,
      {{"A", "fwhm"},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params)
@@ -133,7 +131,7 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
      * CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
      * CALC   2 = 1.0 / c
      */
-    {Function1D::OmegaDependentGaussian,
+    {Functions1D::Form::OmegaDependentGaussian,
      {{"fwhm(x)"},
       {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
       [](std::vector<double> params)
@@ -173,7 +171,7 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
      *  CALC   4 = 1.0 / c1
      *  CALC   5 = 1.0 / c2
      */
-    {Function1D::GaussianC2,
+    {Functions1D::Form::GaussianC2,
      {{"fwhm", "fwhm(x)"},
       {FunctionProperties::FourierTransform},
       [](std::vector<double> params)
@@ -207,28 +205,29 @@ static std::map<Function1D, FunctionDefinition1D> functions1D_ = {
       { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); }}}};
 
 // Return enum option info for Function1D
-EnumOptions<Function1D> function1D()
+EnumOptions<Functions1D::Form> Functions1D::function1D()
 {
-    return EnumOptions<Function1D>("Function1D", {{Function1D::None, "None"},
-                                                  {Function1D::Gaussian, "Gaussian"},
-                                                  {Function1D::ScaledGaussian, "ScaledGaussian"},
-                                                  {Function1D::OmegaDependentGaussian, "OmegaDependentGaussian"},
-                                                  {Function1D::GaussianC2, "GaussianC2"}});
+    return EnumOptions<Functions1D::Form>("Function1D", {{Functions1D::Form::None, "None"},
+                                                         {Functions1D::Form::Gaussian, "Gaussian"},
+                                                         {Functions1D::Form::ScaledGaussian, "ScaledGaussian"},
+                                                         {Functions1D::Form::OmegaDependentGaussian, "OmegaDependentGaussian"},
+                                                         {Functions1D::Form::GaussianC2, "GaussianC2"}});
 }
 
 // Return base function requested
-FunctionDefinition1D functionDefinition1D(Functions::Function1D func) { return functions1D_.at(func); }
+Function1DDefinition Functions1D::functionDefinition1D(Functions1D::Form form) { return functions1D_.at(form); }
 
 // Check function properties against those supplied, returning truth if the function meets all requirements
-bool validFunction1DProperties(Function1D func, const Flags<FunctionProperties::FunctionProperty> &properties)
+bool Functions1D::validFunction1DProperties(Functions1D::Form form,
+                                            const Flags<FunctionProperties::FunctionProperty> &properties)
 {
-    return properties == FunctionProperties::None || (functions1D_.at(func).properties() & properties) == properties;
+    return properties == FunctionProperties::None || (functions1D_.at(form).properties() & properties) == properties;
 }
 
 // Return all available functions with properties matching those provided
-std::vector<Function1D> matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties)
+std::vector<Functions1D::Form> Functions1D::matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties)
 {
-    std::vector<Function1D> matches;
+    std::vector<Functions1D::Form> matches;
     for (auto n = 0; n < function1D().nOptions(); ++n)
         if (validFunction1DProperties(function1D().enumerationByIndex(n), properties))
             matches.push_back(function1D().enumerationByIndex(n));
@@ -239,8 +238,8 @@ std::vector<Function1D> matchingFunction1D(const Flags<FunctionProperties::Funct
  * One-Dimensional Function Wrapper
  */
 
-Function1DWrapper::Function1DWrapper(Function1D func, const std::vector<double> &params)
-    : type_(func), function_(functions1D_.at(func)), parameters_(params)
+Function1DWrapper::Function1DWrapper(Functions1D::Form form, const std::vector<double> &params)
+    : form_(form), function_(functions1D_.at(form)), parameters_(params)
 {
     calculateInternalParameters();
 }
@@ -249,14 +248,14 @@ Function1DWrapper::Function1DWrapper(Function1D func, const std::vector<double> 
 void Function1DWrapper::calculateInternalParameters() { internalParameters_ = function_.setup()(parameters_); }
 
 // Set function type and parameters
-bool Function1DWrapper::setFunctionAndParameters(Function1D func, const std::vector<double> &params)
+bool Function1DWrapper::setFormAndParameters(Functions1D::Form form, const std::vector<double> &params)
 {
-    type_ = func;
-    function_ = functions1D_.at(type_);
+    form_ = form;
+    function_ = functions1D_.at(form_);
 
     if (params.size() != function_.nParameters())
-        return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n", function1D().keyword(type_),
-                                function_.nParameters(), params.size());
+        return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n",
+                                Functions1D::function1D().keyword(form_), function_.nParameters(), params.size());
 
     parameters_ = params;
     calculateInternalParameters();
@@ -264,23 +263,23 @@ bool Function1DWrapper::setFunctionAndParameters(Function1D func, const std::vec
     return true;
 }
 
-// Set current function type
-void Function1DWrapper::setFunction(Function1D func)
+// Set current functional form
+void Function1DWrapper::setForm(Functions1D::Form form)
 {
-    type_ = func;
-    function_ = functions1D_.at(type_);
+    form_ = form;
+    function_ = functions1D_.at(form_);
     calculateInternalParameters();
 }
 
-// Return function type
-Function1D Function1DWrapper::type() const { return type_; }
+// Return functional form
+Functions1D::Form Function1DWrapper::form() const { return form_; }
 
 // Set current function parameters
 bool Function1DWrapper::setParameters(const std::vector<double> &params)
 {
     if (params.size() != function_.nParameters())
-        return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n", function1D().keyword(type_),
-                                function_.nParameters(), params.size());
+        return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n",
+                                Functions1D::function1D().keyword(form_), function_.nParameters(), params.size());
 
     parameters_ = params;
     calculateInternalParameters();
@@ -320,4 +319,3 @@ double Function1DWrapper::normalisation(double omega) const
 {
     return function_.normalisation() ? function_.normalisation()(omega, internalParameters_) : 1.0;
 }
-} // namespace Functions

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -221,7 +221,7 @@ Function1DDefinition Functions1D::functionDefinition1D(Functions1D::Form form) {
 bool Functions1D::validFunction1DProperties(Functions1D::Form form,
                                             const Flags<FunctionProperties::FunctionProperty> &properties)
 {
-    return properties == FunctionProperties::None || (functions1D_.at(form).properties() & properties) == properties;
+    return (functions1D_.at(form).properties() & properties) == properties;
 }
 
 // Return all available functions with properties matching those provided

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -73,7 +73,8 @@ class Functions1D
         Gaussian,
         ScaledGaussian,
         OmegaDependentGaussian,
-        GaussianC2
+        GaussianC2,
+        LennardJones126
     };
     // Return enum options for form
     static EnumOptions<Form> forms();

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -20,23 +20,21 @@ enum FunctionProperty
 };
 };
 
-namespace Functions
-{
 // Function Types
 // -- Setup function parameters, returning vector augmented with any precalculated additional parameters
-using FunctionSetup = std::function<std::vector<double>(std::vector<double> parameters)>;
+using Function1DSetup = std::function<std::vector<double>(std::vector<double> parameters)>;
 // -- Function taking x and omega arguments and returning a value
 using Function1DXOmega = std::function<double(double x, double omega, const std::vector<double> &parameters)>;
 // -- Function taking omega argument and returning a value
 using Function1DOmega = std::function<double(double omega, const std::vector<double> &parameters)>;
 
 // One-Dimensional Function Definition
-class FunctionDefinition1D
+class Function1DDefinition
 {
     public:
-    FunctionDefinition1D(const std::vector<std::string> &parameterNames,
-                         const Flags<FunctionProperties::FunctionProperty> &properties, FunctionSetup setup, Function1DXOmega y,
-                         Function1DXOmega yFT = {}, Function1DOmega norm = {});
+    Function1DDefinition(const std::vector<std::string> &parameterNames,
+                         const Flags<FunctionProperties::FunctionProperty> &properties, Function1DSetup setup,
+                         Function1DXOmega y, Function1DXOmega yFT = {}, Function1DOmega norm = {});
 
     private:
     // Names of parameters defining the function
@@ -44,7 +42,7 @@ class FunctionDefinition1D
     // Properties of the function
     Flags<FunctionProperties::FunctionProperty> properties_;
     // Functions
-    FunctionSetup setup_;
+    Function1DSetup setup_;
     Function1DXOmega y_, yFT_;
     Function1DOmega normaliser_;
 
@@ -56,7 +54,7 @@ class FunctionDefinition1D
     // Return properties of the function
     const Flags<FunctionProperties::FunctionProperty> &properties() const;
     // Return function for setup
-    FunctionSetup setup() const;
+    Function1DSetup setup() const;
     // Return function for y value
     Function1DXOmega y() const;
     // Return function for FT of y value
@@ -65,38 +63,43 @@ class FunctionDefinition1D
     Function1DOmega normalisation() const;
 };
 
-// Function Types
-enum Function1D
+// One-Dimensional Functional Forms
+class Functions1D
 {
-    None,
-    Gaussian,
-    ScaledGaussian,
-    OmegaDependentGaussian,
-    GaussianC2
+    public:
+    // Functional Forms
+    enum Form
+    {
+        None,
+        Gaussian,
+        ScaledGaussian,
+        OmegaDependentGaussian,
+        GaussianC2
+    };
+    // Return enum options for form
+    static EnumOptions<Form> function1D();
+    // Return base function requested
+    static Function1DDefinition functionDefinition1D(Form func);
+    // Check function properties against those supplied, returning truth if the function meets all requirements
+    static bool validFunction1DProperties(Form func, const Flags<FunctionProperties::FunctionProperty> &properties);
+    // Return all available functions with properties matching those provided
+    static std::vector<Form> matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties);
 };
-// Return enum options for Function1D
-EnumOptions<Functions::Function1D> function1D();
-// Return base function requested
-FunctionDefinition1D functionDefinition1D(Functions::Function1D func);
-// Check function properties against those supplied, returning truth if the function meets all requirements
-bool validFunction1DProperties(Functions::Function1D func, const Flags<FunctionProperties::FunctionProperty> &properties);
-// Return all available functions with properties matching those provided
-std::vector<Functions::Function1D> matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties);
 
 // Function 1D Wrapper
 class Function1DWrapper
 {
     public:
-    Function1DWrapper(Function1D func = Function1D::None, const std::vector<double> &params = {});
+    Function1DWrapper(Functions1D::Form form = Functions1D::Form::None, const std::vector<double> &params = {});
 
     /*
      * Function
      */
     private:
-    // Function type
-    Function1D type_;
+    // Functional form
+    Functions1D::Form form_;
     // Function definition
-    FunctionDefinition1D function_;
+    Function1DDefinition function_;
     // Input arguments to function
     std::vector<double> parameters_;
     // Internal function parameters (input params followed by any calculated parameters)
@@ -108,11 +111,11 @@ class Function1DWrapper
 
     public:
     // Set function type and parameters
-    bool setFunctionAndParameters(Function1D func, const std::vector<double> &params);
-    // Set current function type
-    void setFunction(Function1D func);
-    // Return function type
-    Function1D type() const;
+    bool setFormAndParameters(Functions1D::Form form, const std::vector<double> &params);
+    // Set current functional form
+    void setForm(Functions1D::Form form);
+    // Return functional form
+    Functions1D::Form form() const;
     // Return number of parameters for current function
     int nParameters() const;
     // Set current function parameters
@@ -130,4 +133,3 @@ class Function1DWrapper
     // Return normalisation factor at specified omega
     double normalisation(double omega = 0.0) const;
 };
-} // namespace Functions

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -14,7 +14,6 @@ namespace FunctionProperties
 {
 enum FunctionProperty
 {
-    None,
     FourierTransform,
     Normalisation
 };

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -66,7 +66,7 @@ class FunctionDefinition1D
 };
 
 // Function Types
-enum class Function1D
+enum Function1D
 {
     None,
     Gaussian,

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -79,9 +79,9 @@ EnumOptions<Functions::Function1D> function1D();
 // Return base function requested
 FunctionDefinition1D functionDefinition1D(Functions::Function1D func);
 // Check function properties against those supplied, returning truth if the function meets all requirements
-bool validFunction1DProperties(Function1D func, int properties);
+bool validFunction1DProperties(Functions::Function1D func, const Flags<FunctionProperties::FunctionProperty> &properties);
 // Return all available functions with properties matching those provided
-std::vector<Function1D> matchingFunction1D(int properties);
+std::vector<Functions::Function1D> matchingFunction1D(const Flags<FunctionProperties::FunctionProperty> &properties);
 
 // Function 1D Wrapper
 class Function1DWrapper

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -76,7 +76,13 @@ class Functions1D
         GaussianC2
     };
     // Return enum options for form
-    static EnumOptions<Form> function1D();
+    static EnumOptions<Form> forms();
+    // Return parameters for specified form
+    static const std::vector<std::string> &parameters(Form form);
+    // Return nth parameter for the given form
+    static std::string parameter(Form form, int n);
+    // Return index of parameter in the given form
+    static std::optional<int> parameterIndex(Form form, std::string_view name);
     // Return base function requested
     static Function1DDefinition functionDefinition1D(Form func);
     // Check function properties against those supplied, returning truth if the function meets all requirements

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -15,7 +15,8 @@ namespace FunctionProperties
 enum FunctionProperty
 {
     FourierTransform,
-    Normalisation
+    Normalisation,
+    FirstDerivative
 };
 };
 
@@ -33,7 +34,7 @@ class Function1DDefinition
     public:
     Function1DDefinition(const std::vector<std::string> &parameterNames,
                          const Flags<FunctionProperties::FunctionProperty> &properties, Function1DSetup setup,
-                         Function1DXOmega y, Function1DXOmega yFT = {}, Function1DOmega norm = {});
+                         Function1DXOmega y, Function1DXOmega dYdX = {}, Function1DXOmega yFT = {}, Function1DOmega norm = {});
 
     private:
     // Names of parameters defining the function
@@ -42,7 +43,7 @@ class Function1DDefinition
     Flags<FunctionProperties::FunctionProperty> properties_;
     // Functions
     Function1DSetup setup_;
-    Function1DXOmega y_, yFT_;
+    Function1DXOmega y_, dYdX_, yFT_;
     Function1DOmega normaliser_;
 
     public:
@@ -56,6 +57,8 @@ class Function1DDefinition
     Function1DSetup setup() const;
     // Return function for y value
     Function1DXOmega y() const;
+    // Return function for first derivative
+    Function1DXOmega dYdX() const;
     // Return function for FT of y value
     Function1DXOmega yFT() const;
     // Return normalisation function
@@ -134,6 +137,8 @@ class Function1DWrapper
     std::string parameterSummary() const;
     // Return y value at specified x, omega
     double y(double x, double omega = 0.0) const;
+    // Return first derivative of y at specified x, omega
+    double dYdX(double x, double omega = 0.0) const;
     // Return Fourier transformed y value at specified x, omega
     double yFT(double x, double omega = 0.0) const;
     // Return normalisation factor at specified omega

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -445,8 +445,7 @@ bool GRModule::calculateGR(GenericList &processingData, const ProcessPool &procP
 
 // Calculate smoothed/broadened partial g(r) from supplied partials
 bool GRModule::calculateUnweightedGR(const ProcessPool &procPool, Configuration *cfg, const PartialSet &originalgr,
-                                     PartialSet &unweightedgr, const Functions::Function1DWrapper intraBroadening,
-                                     int smoothing)
+                                     PartialSet &unweightedgr, const Function1DWrapper intraBroadening, int smoothing)
 {
     // If the unweightedgr is not yet initialised, copy the originalgr. Otherwise, just copy the values (in order to
     // maintain the incremental versioning of the data)

--- a/src/modules/gr/gr.h
+++ b/src/modules/gr/gr.h
@@ -48,7 +48,7 @@ class GRModule : public Module
     // Perform internal check of calculated partials against a set calculated by a simple unoptimised double-loop
     bool internalTest_{false};
     // Type of broadening to apply to intramolecular g(r)
-    Functions::Function1DWrapper intraBroadening_{Functions::Function1D::Gaussian, {0.18}};
+    Function1DWrapper intraBroadening_{Functions1D::Form::Gaussian, {0.18}};
     // Degree of smoothing to apply
     std::optional<int> nSmooths_;
     // Calculation method for partials
@@ -81,8 +81,7 @@ class GRModule : public Module
                      GRModule::PartialsMethod method, const double rdfRange, const double rdfBinWidth, bool &alreadyUpToDate);
     // Calculate smoothed/broadened partial g(r) from supplied partials
     static bool calculateUnweightedGR(const ProcessPool &procPool, Configuration *cfg, const PartialSet &originalgr,
-                                      PartialSet &weightedgr, const Functions::Function1DWrapper intraBroadening,
-                                      int smoothing);
+                                      PartialSet &weightedgr, const Function1DWrapper intraBroadening, int smoothing);
     // Sum unweighted g(r) over the supplied Module's target Configurations
     static bool sumUnweightedGR(GenericList &processingData, const ProcessPool &procPool, std::string_view targetPrefix,
                                 std::string_view parentPrefix, const std::vector<Configuration *> &parentCfgs,

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -36,11 +36,11 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
                          Averaging::averagingSchemes().keyword(averagingScheme_));
     else
         Messenger::print("RDF: No averaging of partials will be performed.\n");
-    if (intraBroadening_.type() == Functions::Function1D::None)
+    if (intraBroadening_.form() == Functions1D::Form::None)
         Messenger::print("RDF: No broadening will be applied to intramolecular g(r).");
     else
         Messenger::print("RDF: Broadening to be applied to intramolecular g(r) is {} ({}).",
-                         Functions::function1D().keyword(intraBroadening_.type()), intraBroadening_.parameterSummary());
+                         Functions1D::function1D().keyword(intraBroadening_.form()), intraBroadening_.parameterSummary());
     Messenger::print("RDF: Calculation method is '{}'.\n", partialsMethods().keyword(partialsMethod_));
     Messenger::print("RDF: Save data is {}.\n", DissolveSys::onOff(save_));
     Messenger::print("RDF: Save original (unbroadened) g(r) is {}.\n", DissolveSys::onOff(saveOriginal_));

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -40,7 +40,7 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
         Messenger::print("RDF: No broadening will be applied to intramolecular g(r).");
     else
         Messenger::print("RDF: Broadening to be applied to intramolecular g(r) is {} ({}).",
-                         Functions1D::function1D().keyword(intraBroadening_.form()), intraBroadening_.parameterSummary());
+                         Functions1D::forms().keyword(intraBroadening_.form()), intraBroadening_.parameterSummary());
     Messenger::print("RDF: Calculation method is '{}'.\n", partialsMethods().keyword(partialsMethod_));
     Messenger::print("RDF: Save data is {}.\n", DissolveSys::onOff(save_));
     Messenger::print("RDF: Save original (unbroadened) g(r) is {}.\n", DissolveSys::onOff(saveOriginal_));

--- a/src/modules/sq/functions.cpp
+++ b/src/modules/sq/functions.cpp
@@ -14,7 +14,7 @@
 // Generate S(Q) from supplied g(r)
 bool SQModule::calculateUnweightedSQ(const ProcessPool &procPool, const PartialSet &unweightedgr, PartialSet &unweightedsq,
                                      double qMin, double qDelta, double qMax, double rho, const WindowFunction &windowFunction,
-                                     Functions::Function1DWrapper broadening)
+                                     Function1DWrapper broadening)
 {
     // Copy partial g(r) into our new S(Q) object - it should have been initialised already, so we will just check its size
     if (unweightedgr.nAtomTypes() != unweightedsq.nAtomTypes())

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -53,7 +53,7 @@ Module::ExecutionResult SQModule::process(ModuleContext &moduleContext)
         Messenger::print("SQ: No broadening will be applied to calculated S(Q).");
     else
         Messenger::print("SQ: Broadening to be applied in calculated S(Q) is {} ({}).",
-                         Functions1D::function1D().keyword(qBroadening_.form()), qBroadening_.parameterSummary());
+                         Functions1D::forms().keyword(qBroadening_.form()), qBroadening_.parameterSummary());
     if (sourceBragg_)
     {
         Messenger::print("SQ: Bragg scattering from module '{}' will be included.\n", sourceBragg_->name());
@@ -61,7 +61,7 @@ Module::ExecutionResult SQModule::process(ModuleContext &moduleContext)
             Messenger::print("SQ: No additional broadening will be applied to calculated Bragg S(Q).");
         else
             Messenger::print("SQ: Broadening to be applied in calculated Bragg S(Q) is {} ({}).",
-                             Functions1D::function1D().keyword(braggQBroadening_.form()), braggQBroadening_.parameterSummary());
+                             Functions1D::forms().keyword(braggQBroadening_.form()), braggQBroadening_.parameterSummary());
     }
     Messenger::print("SQ: Save data is {}.\n", DissolveSys::onOff(save_));
     Messenger::print("\n");

--- a/src/modules/sq/process.cpp
+++ b/src/modules/sq/process.cpp
@@ -49,19 +49,19 @@ Module::ExecutionResult SQModule::process(ModuleContext &moduleContext)
                          Averaging::averagingSchemes().keyword(averagingScheme_));
     else
         Messenger::print("SQ: No averaging of partials will be performed.\n");
-    if (qBroadening_.type() == Functions::Function1D::None)
+    if (qBroadening_.form() == Functions1D::Form::None)
         Messenger::print("SQ: No broadening will be applied to calculated S(Q).");
     else
         Messenger::print("SQ: Broadening to be applied in calculated S(Q) is {} ({}).",
-                         Functions::function1D().keyword(qBroadening_.type()), qBroadening_.parameterSummary());
+                         Functions1D::function1D().keyword(qBroadening_.form()), qBroadening_.parameterSummary());
     if (sourceBragg_)
     {
         Messenger::print("SQ: Bragg scattering from module '{}' will be included.\n", sourceBragg_->name());
-        if (braggQBroadening_.type() == Functions::Function1D::None)
+        if (braggQBroadening_.form() == Functions1D::Form::None)
             Messenger::print("SQ: No additional broadening will be applied to calculated Bragg S(Q).");
         else
             Messenger::print("SQ: Broadening to be applied in calculated Bragg S(Q) is {} ({}).",
-                             Functions::function1D().keyword(braggQBroadening_.type()), braggQBroadening_.parameterSummary());
+                             Functions1D::function1D().keyword(braggQBroadening_.form()), braggQBroadening_.parameterSummary());
     }
     Messenger::print("SQ: Save data is {}.\n", DissolveSys::onOff(save_));
     Messenger::print("\n");

--- a/src/modules/sq/sq.h
+++ b/src/modules/sq/sq.h
@@ -30,9 +30,9 @@ class SQModule : public Module
     // Weighting scheme to use when averaging partials
     Averaging::AveragingScheme averagingScheme_{Averaging::LinearAveraging};
     // Broadening function to apply to Bragg S(Q)
-    Functions::Function1DWrapper braggQBroadening_{Functions::Function1D::GaussianC2, {0.0, 0.02}};
+    Function1DWrapper braggQBroadening_{Functions1D::Form::GaussianC2, {0.0, 0.02}};
     // Broadening function to apply to S(Q)
-    Functions::Function1DWrapper qBroadening_;
+    Function1DWrapper qBroadening_;
     // Step size in Q for S(Q) calculation
     double qDelta_{0.05};
     // Maximum Q for calculated S(Q)
@@ -59,7 +59,7 @@ class SQModule : public Module
     // Calculate unweighted S(Q) from unweighted g(r)
     static bool calculateUnweightedSQ(const ProcessPool &procPool, const PartialSet &unweightedgr, PartialSet &unweightedsq,
                                       double qMin, double qDelta, double qMax, double rho, const WindowFunction &windowFunction,
-                                      Functions::Function1DWrapper broadening);
+                                      Function1DWrapper broadening);
 
     /*
      * Processing

--- a/src/templates/flags.h
+++ b/src/templates/flags.h
@@ -12,7 +12,7 @@ template <class EnumClass> class Flags
     Flags() : flags_{0} {};
     ~Flags() = default;
     explicit Flags(int flagMask) : flags_(flagMask) {}
-    Flags(EnumClass flag) : flags_{0} { flags_.set(flag); }
+    explicit Flags(EnumClass flag) : flags_{0} { flags_.set(flag); }
     Flags(const std::initializer_list<EnumClass> flags) : flags_{0}
     {
         for (auto &flag : flags)

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -33,11 +33,11 @@ TEST(CellsTest, Basic)
     oType->setName("OW");
     oType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
-    dissolve.addPairPotential(arType, arType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
-    dissolve.addPairPotential(hType, hType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
-    dissolve.addPairPotential(oType, oType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
-    dissolve.addPairPotential(hType, oType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
-    dissolve.addPairPotential(arType, hType)->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    dissolve.addPairPotential(arType, arType)->interactionPotential().setForm(Functions1D::Form::None);
+    dissolve.addPairPotential(hType, hType)->interactionPotential().setForm(Functions1D::Form::None);
+    dissolve.addPairPotential(oType, oType)->interactionPotential().setForm(Functions1D::Form::None);
+    dissolve.addPairPotential(hType, oType)->interactionPotential().setForm(Functions1D::Form::None);
+    dissolve.addPairPotential(arType, hType)->interactionPotential().setForm(Functions1D::Form::None);
 
     // Set up pseudo-species
     auto *argon = coreData.addSpecies();
@@ -69,7 +69,7 @@ TEST(CellsTest, Basic)
     // Prepare the main simulation, and update our specific Ar-OW potential
     EXPECT_TRUE(dissolve.prepare());
     auto *pp = dissolve.pairPotential(arType, oType);
-    pp->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.35 sigma=2.166");
+    pp->interactionPotential().setFormAndParameters(Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166");
     pp->tabulate(dissolve.pairPotentialRange(), dissolve.pairPotentialDelta());
 
     // Test consistency of energy calculation with DL_POLY reference energies

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -25,13 +25,13 @@ TEST(CellsTest, Basic)
     // Add atom types and LJ pair potentials (only one real one - between Ar and OW
     auto arType = coreData.addAtomType(Elements::Ar);
     arType->setName("Ar");
-    arType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
+    arType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     auto hType = coreData.addAtomType(Elements::H);
     hType->setName("HW");
-    hType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
+    hType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
     auto oType = coreData.addAtomType(Elements::O);
     oType->setName("OW");
-    oType->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
+    oType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
 
     dissolve.addPairPotential(arType, arType)->interactionPotential().setForm(Functions1D::Form::None);
     dissolve.addPairPotential(hType, hType)->interactionPotential().setForm(Functions1D::Form::None);
@@ -66,11 +66,12 @@ TEST(CellsTest, Basic)
         i.setCoordinates(r);
     cfg->updateObjectRelationships();
 
-    // Prepare the main simulation, and update our specific Ar-OW potential
+    // Create an override potential to describe the Ar-OW interaction
+    dissolve.coreData().addPairPotentialOverride("Ar", "OW", PairPotentialOverride::PairPotentialOverrideType::Replace,
+                                                 {Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166"});
+
+    // Prepare the main simulation
     EXPECT_TRUE(dissolve.prepare());
-    auto *pp = dissolve.pairPotential(arType, oType);
-    pp->interactionPotential().setFormAndParameters(Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166");
-    pp->tabulate(dissolve.pairPotentialRange(), dissolve.pairPotentialDelta());
 
     // Test consistency of energy calculation with DL_POLY reference energies
 

--- a/tests/data/dissolve/input/energyForce-water3000-overrides.txt
+++ b/tests/data/dissolve/input/energyForce-water3000-overrides.txt
@@ -51,7 +51,7 @@ PairPotentials
   Delta  0.0001
   Parameters  'OW'  O  0.0   LJGeometric   0.0       0.0
   Parameters  'HW'  H  0.0    LJGeometric  0.0       0.0
-  Override  'OW'  'OW'  Replace  LJ   0.6503    3.165492
+  Override  'OW'  'OW'  Replace  LennardJones126   0.6503    3.165492
   ManualChargeSource  True
   ForceChargeSource  True
   IncludeCoulomb  Off

--- a/tests/gui/forcefieldTab.cpp
+++ b/tests/gui/forcefieldTab.cpp
@@ -43,14 +43,14 @@ TEST_F(ForcefieldTabTest, PairPotentials)
 
     EXPECT_EQ(pairs.data(pairs.index(0, 0)).toString().toStdString(), "CA");
     EXPECT_EQ(pairs.data(pairs.index(0, 1)).toString().toStdString(), "CA");
-    EXPECT_EQ(pairs.data(pairs.index(0, 2)).toString().toStdString(), "LJGeometric");
+    EXPECT_EQ(pairs.data(pairs.index(0, 2)).toString().toStdString(), "LennardJones126");
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 3)).toDouble(), -0.115);
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 4)).toDouble(), -0.115);
     EXPECT_EQ(pairs.data(pairs.index(0, 5)).toString().toStdString(), "epsilon=0.29288 sigma=3.55");
 
     EXPECT_EQ(pairs.data(pairs.index(2, 0)).toString().toStdString(), "HA");
     EXPECT_EQ(pairs.data(pairs.index(2, 1)).toString().toStdString(), "HA");
-    EXPECT_EQ(pairs.data(pairs.index(2, 2)).toString().toStdString(), "LJGeometric");
+    EXPECT_EQ(pairs.data(pairs.index(2, 2)).toString().toStdString(), "LennardJones126");
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 3)).toDouble(), 0.115);
     EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 4)).toDouble(), 0.115);
     EXPECT_EQ(pairs.data(pairs.index(2, 5)).toString().toStdString(), "epsilon=0.12552 sigma=2.42");

--- a/tests/math/function1D.cpp
+++ b/tests/math/function1D.cpp
@@ -16,8 +16,7 @@ class Function1DTest : public ::testing::Test
     public:
     Function1DTest() = default;
 
-    Data1D generate(Functions::Function1DWrapper f, double omega = 0.0, double xBegin = -5.0, double xEnd = 5.0,
-                    double xDelta = binWidth)
+    Data1D generate(Function1DWrapper f, double omega = 0.0, double xBegin = -5.0, double xEnd = 5.0, double xDelta = binWidth)
     {
         Data1D d;
         auto x = xBegin;
@@ -33,7 +32,7 @@ class Function1DTest : public ::testing::Test
 TEST_F(Function1DTest, Basic)
 {
     // Basic Gaussian, testing class behaviour
-    auto basicGaussian = generate(Functions::Function1DWrapper(Functions::Function1D::Gaussian, {0.2}));
+    auto basicGaussian = generate(Function1DWrapper(Functions1D::Form::Gaussian, {0.2}));
     auto c = 0.2 / (2.0 * sqrt(2.0 * log(2.0)));
     for (auto &&[x, y] : zip(basicGaussian.xAxis(), basicGaussian.values()))
         EXPECT_NEAR(y, exp(-(x * x) / (2 * c * c)), 1.0e-10);
@@ -44,21 +43,21 @@ TEST_F(Function1DTest, UnitIntegral)
     // Some random omega values for Q-dependency testing
     std::vector<double> omegas = {0.189, 0.78, 1.102, 3.22, 4.8};
 
-    Functions::Function1DWrapper f;
+    Function1DWrapper f;
     Data1D xy;
 
     // Gaussian
-    f.setFunctionAndParameters(Functions::Function1D::Gaussian, {0.2});
+    f.setFormAndParameters(Functions1D::Form::Gaussian, {0.2});
     xy = generate(f);
     EXPECT_NEAR(1.0 / binWidth, f.normalisation() * std::accumulate(xy.values().begin(), xy.values().end(), 0.0), 1.0e-10);
 
     // Scaled Gaussian
-    f.setFunctionAndParameters(Functions::Function1D::ScaledGaussian, {4.325215, 0.38});
+    f.setFormAndParameters(Functions1D::Form::ScaledGaussian, {4.325215, 0.38});
     xy = generate(f);
     EXPECT_NEAR(1.0 / binWidth, f.normalisation() * std::accumulate(xy.values().begin(), xy.values().end(), 0.0), 1.0e-10);
 
     // Omega-Dependent Gaussian
-    f.setFunctionAndParameters(Functions::Function1D::OmegaDependentGaussian, {0.189});
+    f.setFormAndParameters(Functions1D::Form::OmegaDependentGaussian, {0.189});
     for (auto omega : omegas)
     {
         xy = generate(f, omega);
@@ -74,7 +73,7 @@ TEST_F(Function1DTest, UnitIntegral)
     }
 
     // Scaled Gaussian
-    f.setFunctionAndParameters(Functions::Function1D::GaussianC2, {0.1, 0.3});
+    f.setFormAndParameters(Functions1D::Form::GaussianC2, {0.1, 0.3});
     for (auto omega : omegas)
     {
         xy = generate(f, omega);

--- a/tests/modules/broadening.cpp
+++ b/tests/modules/broadening.cpp
@@ -32,7 +32,7 @@ TEST_F(BroadeningModuleTest, Dep2Indep1)
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
     ASSERT_NO_THROW_VERBOSE(
-        sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::GaussianC2, {0.1, 0.2})));
+        sqModule->keywords().set("QBroadening", Function1DWrapper(Functions1D::Form::GaussianC2, {0.1, 0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -46,8 +46,8 @@ TEST_F(BroadeningModuleTest, Dep1)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set(
-        "QBroadening", Functions::Function1DWrapper(Functions::Function1D::OmegaDependentGaussian, {0.1})));
+    ASSERT_NO_THROW_VERBOSE(
+        sqModule->keywords().set("QBroadening", Function1DWrapper(Functions1D::Form::OmegaDependentGaussian, {0.1})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -61,8 +61,8 @@ TEST_F(BroadeningModuleTest, Dep2)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set(
-        "QBroadening", Functions::Function1DWrapper(Functions::Function1D::OmegaDependentGaussian, {0.2})));
+    ASSERT_NO_THROW_VERBOSE(
+        sqModule->keywords().set("QBroadening", Function1DWrapper(Functions1D::Form::OmegaDependentGaussian, {0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -76,8 +76,7 @@ TEST_F(BroadeningModuleTest, Indep1)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW_VERBOSE(
-        sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::Gaussian, {0.1})));
+    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set("QBroadening", Function1DWrapper(Functions1D::Form::Gaussian, {0.1})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 
@@ -91,8 +90,7 @@ TEST_F(BroadeningModuleTest, Indep2)
     // Set QBroadening
     auto *sqModule = systemTest.coreData().findModule("SQ01");
     ASSERT_TRUE(sqModule);
-    ASSERT_NO_THROW_VERBOSE(
-        sqModule->keywords().set("QBroadening", Functions::Function1DWrapper(Functions::Function1D::Gaussian, {0.2})));
+    ASSERT_NO_THROW_VERBOSE(sqModule->keywords().set("QBroadening", Function1DWrapper(Functions1D::Form::Gaussian, {0.2})));
 
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 

--- a/tests/pairPotentials/analytic.cpp
+++ b/tests/pairPotentials/analytic.cpp
@@ -35,8 +35,8 @@ class PairPotentialsTest : public ::testing::Test
     static constexpr double testRDelta_{0.00173};
 
     private:
-    void test(ShortRangeFunctions::Form form, std::string_view parameters, double rStart,
-              const std::function<double(double)> &analytic, const std::function<double(double)> &tabulated)
+    void test(Functions1D::Form form, std::string_view parameters, double rStart, const std::function<double(double)> &analytic,
+              const std::function<double(double)> &tabulated)
     {
         // Set up and tabulate pair potential
         pairPotential_->interactionPotential().setFormAndParameters(form, parameters);
@@ -58,14 +58,14 @@ class PairPotentialsTest : public ::testing::Test
 
     public:
     // Test analytic vs tabulated energy for specified form and parameters
-    void testEnergy(ShortRangeFunctions::Form form, std::string_view parameters, double rStart = testRDelta_)
+    void testEnergy(Functions1D::Form form, std::string_view parameters, double rStart = testRDelta_)
     {
         test(
             form, parameters, rStart, [=](double r) { return pairPotential_->analyticEnergy(r); },
             [=](double r) { return pairPotential_->energy(r); });
     }
     // Test analytic vs tabulated force for specified form and parameters
-    void testForce(ShortRangeFunctions::Form form, std::string_view parameters, double rStart = testRDelta_)
+    void testForce(Functions1D::Form form, std::string_view parameters, double rStart = testRDelta_)
     {
         test(
             form, parameters, rStart, [=](double r) { return pairPotential_->analyticForce(r); },
@@ -75,15 +75,15 @@ class PairPotentialsTest : public ::testing::Test
 
 TEST_F(PairPotentialsTest, NoneForm)
 {
-    testEnergy(ShortRangeFunctions::Form::None, "");
-    testForce(ShortRangeFunctions::Form::None, "");
+    testEnergy(Functions1D::Form::None, "");
+    testForce(Functions1D::Form::None, "");
 }
 
 TEST_F(PairPotentialsTest, LennardJonesForm)
 {
     // Lennard-Jones is super steep at r -> 0 so start a little after that
-    testEnergy(ShortRangeFunctions::Form::LennardJones, "epsilon=0.35 sigma=2.166", testRDelta_ * 5);
-    testForce(ShortRangeFunctions::Form::LennardJones, "epsilon=0.35 sigma=2.166", testRDelta_ * 5);
+    testEnergy(Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166", testRDelta_ * 5);
+    testForce(Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166", testRDelta_ * 5);
 }
 
 } // namespace UnitTest

--- a/tests/pairPotentials/overrides.cpp
+++ b/tests/pairPotentials/overrides.cpp
@@ -48,9 +48,9 @@ TEST_F(PairPotentialOverridesTest, Water3000)
     EXPECT_TRUE(systemTest.checkDouble("zeroed van der Waals energy", interEnergy.values().back(), 0.0, 6.0e-2));
 
     // Reinstate our only potential (OW-OW) with an override ("Off" to begin with)
-    auto *owOverride = systemTest.coreData().addPairPotentialOverride(
-        "OW", "OW", PairPotentialOverride::PairPotentialOverrideType::Off,
-        {ShortRangeFunctions::Form::LennardJones, "epsilon=0.6503 sigma=3.165492"});
+    auto *owOverride =
+        systemTest.coreData().addPairPotentialOverride("OW", "OW", PairPotentialOverride::PairPotentialOverrideType::Off,
+                                                       {Functions1D::Form::LennardJones126, "epsilon=0.6503 sigma=3.165492"});
     EXPECT_TRUE(systemTest.dissolve().regeneratePairPotentials());
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkDouble("overridden (Off) van der Waals energy", interEnergy.values().back(), 0.0, 6.0e-2));


### PR DESCRIPTION
This PR refactors and repurposes the `Function1D` class into a more usable form, and allows it to be used as the primary source for pairpotential function implementation, moving that responsibility out of the `PairPotential` class itself.