### PR TITLE
build: Bump dev version to 1.6.0.

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup
       uses: "./.github/workflows/setup"
     - name: Quality Control
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup
         uses: "./.github/workflows/setup"
       - name: Set Short Hash
@@ -53,6 +57,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
     - name: Setup
       uses: "./.github/workflows/setup"
     - name: Set Short Hash
@@ -72,6 +78,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup
         uses: "./.github/workflows/setup"
       - name: "Package (${{ matrix.os }})"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(Dissolve)
 set(DESCRIPTION "Dissolve")
 set(AUTHOR "Team Dissolve")
 set(VERSION_MAJOR "1")
-set(VERSION_MINOR "5")
+set(VERSION_MINOR "6")
 set(VERSION_PATCH "0")
 
 if(NOT CMAKE_BUILD_TYPE)

--- a/ci/windows/dissolve-gui.iss
+++ b/ci/windows/dissolve-gui.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Dissolve-GUI"
-#define MyAppVersion "1.5.0"
+#define MyAppVersion "1.6.0"
 #define MyAppPublisher "Team Dissolve"
 #define MyAppURL "https://www.projectdissolve.com/"
 #define MyAppExeName "Dissolve-GUI.exe"
@@ -31,7 +31,7 @@ DefaultDirName={commonpf}\Dissolve-GUI
 DefaultGroupName={#MyAppName}
 LicenseFile=..\..\LICENSE.txt
 OutputDir=..\..\
-OutputBaseFilename=Dissolve-GUI-1.5.0-Win64
+OutputBaseFilename=Dissolve-GUI-1.6.0-Win64
 SetupIconFile=Dissolve.ico
 Compression=lzma
 SolidCompression=yes

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         else
           (if gui then "dissolve-gui" else "dissolve");
       cmake-bool = x: if x then "ON" else "OFF";
-      version = "1.5.0";
+      version = "1.6.0";
       base_libs = pkgs:
         with pkgs; [
           antlr4

--- a/src/main/version.cpp
+++ b/src/main/version.cpp
@@ -5,7 +5,7 @@
 #include <fmt/format.h>
 #include <iostream>
 
-#define DISSOLVEVERSION "1.5.0"
+#define DISSOLVEVERSION "1.6.0"
 #define DISSOLVESHORTHASH ""
 #define DISSOLVEREPO "https://github.com/disorderedmaterials/dissolve.git"
 


### PR DESCRIPTION
We forgot to change the `develop` version to 1.6.0!

Also modifies the PR workflow to checkout the SHA of the `HEAD` of the PR, rather than sit on the merge commit, since this obscured traceability of the generated artifacts back to "where they were built from".