### PR TITLE
refactor: Master term models

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -148,14 +148,20 @@ const std::vector<std::unique_ptr<PairPotentialOverride>> &CoreData::pairPotenti
  */
 
 // Add new master Bond parameters
-MasterBond &CoreData::addMasterBond(std::string_view name)
+MasterBond &CoreData::addMasterBond(std::string_view name, std::optional<int> insertAtIndex)
 {
     // Check for existence of master Bond already
     if (getMasterBond(name))
         throw(std::runtime_error(
             fmt::format("Refused to add a new master Bond named '{}' since one with the same name already exists.\n", name)));
 
-    return *masters_.bonds.emplace_back(std::make_shared<MasterBond>(name));
+    auto newBond = std::make_shared<MasterBond>(name);
+    if (insertAtIndex)
+        masters_.bonds.insert(masters_.bonds.begin() + *insertAtIndex, newBond);
+    else
+        masters_.bonds.emplace_back(newBond);
+
+    return *newBond;
 }
 
 // Remove specified master Bond

--- a/src/classes/coreData.h
+++ b/src/classes/coreData.h
@@ -113,7 +113,7 @@ class CoreData
     // Read Master values from serialisable value
     void deserialiseMaster(const SerialisedValue &node);
     // Add new master Bond parameters
-    MasterBond &addMasterBond(std::string_view name);
+    MasterBond &addMasterBond(std::string_view name, std::optional<int> insertAtIndex = {});
     // Remove specified master Bond
     void removeMasterBond(const std::shared_ptr<MasterBond> &bond);
     // Return number of master Bond parameters in list

--- a/src/gui/forcefieldTab.cpp
+++ b/src/gui/forcefieldTab.cpp
@@ -530,9 +530,10 @@ void ForcefieldTab::masterImpropersSelectionChanged(const QItemSelection &curren
 
 void ForcefieldTab::on_MasterTermAddBondButton_clicked(bool checked)
 {
-    dissolve_.coreData().addMasterBond(
-        DissolveSys::uniqueName("NewTerm", dissolve_.coreData().masterBonds(), [](const auto &b) { return b->name(); }));
+    masterBondsTableModel_.insertRows(masterBondsTableModel_.rowCount(), 1, {});
+
     ui_.MasterBondsTable->resizeColumnsToContents();
+
     dissolveWindow_->setModified();
 }
 
@@ -557,13 +558,12 @@ void ForcefieldTab::on_MasterTermRemoveBondButton_clicked(bool checked)
     if (!bond)
         return;
 
-    dissolve_.coreData().removeMasterBond(bond);
+    if (masterBondsTableModel_.removeRows(index.row(), 1, {}))
+    {
+        ui_.MasterBondsTable->resizeColumnsToContents();
 
-    Locker refreshLocker(refreshLock_);
-
-    ui_.MasterBondsTable->resizeColumnsToContents();
-
-    dissolveWindow_->setModified();
+        dissolveWindow_->setModified();
+    }
 }
 
 void ForcefieldTab::on_MasterTermAddAngleButton_clicked(bool checked)

--- a/src/gui/forcefieldTab.cpp
+++ b/src/gui/forcefieldTab.cpp
@@ -249,8 +249,7 @@ void ForcefieldTab::on_AtomTypeDuplicateButton_clicked(bool checked)
 
     // Get selected atomtype
     auto at = atomTypesModel_.rawData(index);
-    if (!at)
-        return;
+    assert(at);
 
     // Generate a unique name before we duplicate
     auto newName =
@@ -309,8 +308,7 @@ void ForcefieldTab::on_AtomTypeRemoveButton_clicked(bool checked)
 
     // Get selected atomtype
     auto at = atomTypesModel_.rawData(index);
-    if (!at)
-        return;
+    assert(at);
 
     dissolve_.coreData().removeAtomType(at);
 
@@ -555,8 +553,7 @@ void ForcefieldTab::on_MasterTermRemoveBondButton_clicked(bool checked)
 
     // Get selected master bond
     auto bond = masterBondsTableModel_.rawData(index);
-    if (!bond)
-        return;
+    assert(bond);
 
     if (masterBondsTableModel_.removeRows(index.row(), 1, {}))
     {
@@ -592,8 +589,7 @@ void ForcefieldTab::on_MasterTermRemoveAngleButton_clicked(bool checked)
 
     // Get selected master angle
     auto angle = masterAnglesTableModel_.rawData(index);
-    if (!angle)
-        return;
+    assert(angle);
 
     dissolve_.coreData().removeMasterAngle(angle);
 
@@ -631,8 +627,7 @@ void ForcefieldTab::on_MasterTermRemoveTorsionButton_clicked(bool checked)
 
     // Get selected master torsion
     auto torsion = masterTorsionsTableModel_.rawData(index);
-    if (!torsion)
-        return;
+    assert(torsion);
 
     dissolve_.coreData().removeMasterTorsion(torsion);
 
@@ -670,8 +665,7 @@ void ForcefieldTab::on_MasterTermRemoveImproperButton_clicked(bool checked)
 
     // Get selected master improper
     auto improper = masterImpropersTableModel_.rawData(index);
-    if (!improper)
-        return;
+    assert(improper);
 
     dissolve_.coreData().removeMasterImproper(improper);
 

--- a/src/gui/forcefieldTab.h
+++ b/src/gui/forcefieldTab.h
@@ -35,6 +35,10 @@ class ForcefieldTab : public QWidget, public MainTab
     AtomTypeModel atomTypesModel_;
     PairPotentialModel pairPotentialModel_;
     PairPotentialOverrideModel pairPotentialOverrideModel_;
+    MasterBondModel masterBondsTableModel_;
+    MasterAngleModel masterAnglesTableModel_;
+    MasterTorsionModel masterTorsionsTableModel_;
+    MasterImproperModel masterImpropersTableModel_;
 
     /*
      * MainTab Reimplementations
@@ -48,13 +52,6 @@ class ForcefieldTab : public QWidget, public MainTab
     /*
      * Update
      */
-    private:
-    // Table models
-    MasterBondModel masterBondsTableModel_;
-    MasterAngleModel masterAnglesTableModel_;
-    MasterTorsionModel masterTorsionsTableModel_;
-    MasterImproperModel masterImpropersTableModel_;
-
     private:
     // Update all pair potentials
     void updatePairPotentials();

--- a/src/gui/forcefieldTab.ui
+++ b/src/gui/forcefieldTab.ui
@@ -37,7 +37,7 @@
    <item>
     <widget class="QTabWidget" name="Tabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="AtomTypesTab">
       <attribute name="title">
@@ -900,6 +900,12 @@
              <pointsize>10</pointsize>
             </font>
            </property>
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SingleSelection</enum>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
           </widget>
          </item>
         </layout>
@@ -1006,6 +1012,12 @@
             <font>
              <pointsize>10</pointsize>
             </font>
+           </property>
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SingleSelection</enum>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
            </property>
           </widget>
          </item>
@@ -1114,6 +1126,12 @@
              <pointsize>10</pointsize>
             </font>
            </property>
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SingleSelection</enum>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
+           </property>
           </widget>
          </item>
         </layout>
@@ -1220,6 +1238,12 @@
             <font>
              <pointsize>10</pointsize>
             </font>
+           </property>
+           <property name="selectionMode">
+            <enum>QAbstractItemView::SingleSelection</enum>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectRows</enum>
            </property>
           </widget>
          </item>

--- a/src/gui/importSpeciesDialog.cpp
+++ b/src/gui/importSpeciesDialog.cpp
@@ -10,7 +10,7 @@
 #include <QInputDialog>
 
 ImportSpeciesDialog::ImportSpeciesDialog(QWidget *parent, Dissolve &dissolve)
-    : WizardDialog(parent), dissolve_(dissolve), temporaryDissolve_(temporaryCoreData_)
+    : WizardDialog(parent), dissolve_(dissolve), temporaryDissolve_(temporaryCoreData_), masterTermModel_(dissolve.coreData())
 {
     ui_.setupUi(this);
 
@@ -92,8 +92,6 @@ bool ImportSpeciesDialog::prepareForNextPage(int currentIndex)
             speciesModel_.setData(temporaryDissolve_.coreData().species());
 
             updateAtomTypesPage();
-            masterTermModel_.setData(temporaryCoreData_.masterBonds(), temporaryCoreData_.masterAngles(),
-                                     temporaryCoreData_.masterTorsions(), temporaryCoreData_.masterImpropers());
             ui_.MasterTermsTree->expandAll();
             ui_.MasterTermsTree->resizeColumnToContents(0);
             ui_.MasterTermsTree->resizeColumnToContents(1);

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -124,9 +124,8 @@ void AddForcefieldDialogModel::setDissolve(Dissolve &dissolve)
     temporaryDissolve_ = std::make_unique<Dissolve>(temporaryCoreData_);
     auto node = dissolve_->coreData().serialiseMaster();
     temporaryCoreData_.deserialiseMaster(node);
-    masters_ = std::make_unique<MasterTermTreeModel>();
-    masters_->setData(temporaryCoreData_.masterBonds(), temporaryCoreData_.masterAngles(), temporaryCoreData_.masterTorsions(),
-                      temporaryCoreData_.masterImpropers());
+    masters_ = std::make_unique<MasterTermTreeModel>(dissolve_->coreData());
+
     // Set model and signals for the master terms tree
     atomTypes_.setIconFunction([this](const auto type) { return dissolve_->coreData().findAtomType(type->name()) != nullptr; });
     masters_->setBondIconFunction([this](std::string_view name)

--- a/src/gui/models/dissolveModel.cpp
+++ b/src/gui/models/dissolveModel.cpp
@@ -12,9 +12,7 @@ void DissolveModel::setDissolve(Dissolve &dissolve)
 {
     dissolve_ = &dissolve;
     atomTypes_.setData(dissolve_->coreData().atomTypes());
-    masters_ = std::make_unique<MasterTermTreeModel>();
-    masters_->setData(dissolve_->coreData().masterBonds(), dissolve_->coreData().masterAngles(),
-                      dissolve_->coreData().masterTorsions(), dissolve_->coreData().masterImpropers());
+    masters_ = std::make_unique<MasterTermTreeModel>(dissolve_->coreData());
     speciesModel_.setData(dissolve_->coreData().species());
     configurationModel_.setData(dissolve_->coreData().configurations());
     moduleLayersModel_.setData(dissolve_->coreData().processingLayers(), &dissolve_->coreData());

--- a/src/gui/models/masterAngleModel.cpp
+++ b/src/gui/models/masterAngleModel.cpp
@@ -3,14 +3,8 @@
 
 #include "gui/models/masterAngleModel.h"
 
-MasterAngleModel::MasterAngleModel(QObject *parent) : MasterTermModel(parent) {}
-
-void MasterAngleModel::setSourceData(std::vector<std::shared_ptr<MasterAngle>> &terms)
+MasterAngleModel::MasterAngleModel(CoreData &coreData) : MasterTermModel(coreData), sourceData_(coreData.masterAngles())
 {
-    beginResetModel();
-    sourceData_ = terms;
-    endResetModel();
-
     // Set connections
     modelUpdater.setModel(this);
     modelUpdater.connectModelSignals();
@@ -23,22 +17,14 @@ void MasterAngleModel::reset()
     endResetModel();
 }
 
-int MasterAngleModel::rowCount(const QModelIndex &parent) const
-{
-    return parent.isValid() ? 0 : (sourceData_ ? sourceData_->get().size() : 0);
-}
+int MasterAngleModel::rowCount(const QModelIndex &parent) const { return parent.isValid() ? 0 : sourceData_.size(); }
 
 QVariant MasterAngleModel::getTermData(int row, MasterTermModelData::DataType dataType) const
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return {};
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return {};
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
     switch (dataType)
     {
         case (MasterTermModelData::DataType::Name):
@@ -56,15 +42,10 @@ QVariant MasterAngleModel::getTermData(int row, MasterTermModelData::DataType da
 
 bool MasterAngleModel::setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value)
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return false;
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return false;
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
 
     beginResetModel();
     switch (dataType)
@@ -98,5 +79,5 @@ bool MasterAngleModel::setTermData(int row, MasterTermModelData::DataType dataTy
 const std::shared_ptr<MasterAngle> &MasterAngleModel::rawData(const QModelIndex &index) const
 {
     assert(sourceData_);
-    return sourceData_->get()[index.row()];
+    return sourceData_[index.row()];
 }

--- a/src/gui/models/masterAngleModel.h
+++ b/src/gui/models/masterAngleModel.h
@@ -20,15 +20,13 @@ class MasterAngleModel : public MasterTermModel
     void modelsUpdated();
 
     public:
-    MasterAngleModel(QObject *parent = nullptr);
+    explicit MasterAngleModel(CoreData &coreData);
 
     private:
     // Source term data
-    OptionalReferenceWrapper<std::vector<std::shared_ptr<MasterAngle>>> sourceData_;
+    std::vector<std::shared_ptr<MasterAngle>> &sourceData_;
 
     public:
-    // Set source data
-    void setSourceData(std::vector<std::shared_ptr<MasterAngle>> &bonds);
     // Refresh model data
     void reset();
 

--- a/src/gui/models/masterBondModel.cpp
+++ b/src/gui/models/masterBondModel.cpp
@@ -3,14 +3,8 @@
 
 #include "gui/models/masterBondModel.h"
 
-MasterBondModel::MasterBondModel(QObject *parent) : MasterTermModel(parent) {}
-
-void MasterBondModel::setSourceData(std::vector<std::shared_ptr<MasterBond>> &terms)
+MasterBondModel::MasterBondModel(CoreData &coreData) : MasterTermModel(coreData), sourceData_(coreData.masterBonds())
 {
-    beginResetModel();
-    sourceData_ = terms;
-    endResetModel();
-
     // Set connections
     modelUpdater.setModel(this);
     modelUpdater.connectModelSignals();
@@ -23,22 +17,14 @@ void MasterBondModel::reset()
     endResetModel();
 }
 
-int MasterBondModel::rowCount(const QModelIndex &parent) const
-{
-    return parent.isValid() ? 0 : (sourceData_ ? sourceData_->get().size() : 0);
-}
+int MasterBondModel::rowCount(const QModelIndex &parent) const { return parent.isValid() ? 0 : sourceData_.size(); }
 
 QVariant MasterBondModel::getTermData(int row, MasterTermModelData::DataType dataType) const
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return {};
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return {};
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
     switch (dataType)
     {
         case (MasterTermModelData::DataType::Name):
@@ -56,15 +42,10 @@ QVariant MasterBondModel::getTermData(int row, MasterTermModelData::DataType dat
 
 bool MasterBondModel::setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value)
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return false;
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return false;
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
 
     beginResetModel();
     switch (dataType)
@@ -98,5 +79,5 @@ bool MasterBondModel::setTermData(int row, MasterTermModelData::DataType dataTyp
 const std::shared_ptr<MasterBond> &MasterBondModel::rawData(const QModelIndex &index) const
 {
     assert(sourceData_);
-    return sourceData_->get()[index.row()];
+    return sourceData_[index.row()];
 }

--- a/src/gui/models/masterBondModel.cpp
+++ b/src/gui/models/masterBondModel.cpp
@@ -81,3 +81,33 @@ const std::shared_ptr<MasterBond> &MasterBondModel::rawData(const QModelIndex &i
     assert(sourceData_);
     return sourceData_[index.row()];
 }
+
+bool MasterBondModel::insertRows(int row, int count, const QModelIndex &parent)
+{
+    Q_UNUSED(count);
+
+    beginInsertRows(parent, row, row);
+    coreData_.addMasterBond(
+        DissolveSys::uniqueName("NewBond", coreData_.masterBonds(), [](const auto &b) { return b->name(); }), row);
+    endInsertRows();
+
+    return true;
+}
+
+bool MasterBondModel::removeRows(int row, int count, const QModelIndex &parent)
+{
+    Q_UNUSED(count);
+    if (row >= rowCount() || row < 0)
+    {
+        return false;
+    }
+
+    // Need to get the bond at the specified row index in our vector and remove it via CoreData
+    auto &bond = sourceData_[row];
+
+    beginRemoveRows(parent, row, row);
+    coreData_.removeMasterBond(bond);
+    endRemoveRows();
+
+    return true;
+}

--- a/src/gui/models/masterBondModel.cpp
+++ b/src/gui/models/masterBondModel.cpp
@@ -36,8 +36,6 @@ QVariant MasterBondModel::getTermData(int row, MasterTermModelData::DataType dat
         default:
             return {};
     }
-
-    return {};
 }
 
 bool MasterBondModel::setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value)
@@ -47,7 +45,6 @@ bool MasterBondModel::setTermData(int row, MasterTermModelData::DataType dataTyp
 
     auto &t = sourceData_[row];
 
-    beginResetModel();
     switch (dataType)
     {
         case (MasterTermModelData::DataType::Name):
@@ -71,7 +68,8 @@ bool MasterBondModel::setTermData(int row, MasterTermModelData::DataType dataTyp
         default:
             return false;
     }
-    endResetModel();
+
+    Q_EMIT(dataChanged({}, {}));
 
     return true;
 }

--- a/src/gui/models/masterBondModel.h
+++ b/src/gui/models/masterBondModel.h
@@ -38,6 +38,8 @@ class MasterBondModel : public MasterTermModel
     QVariant getTermData(int row, MasterTermModelData::DataType dataType) const override;
     bool setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value) override;
     const std::shared_ptr<MasterBond> &rawData(const QModelIndex &index) const;
+    bool insertRows(int row, int count, const QModelIndex &parent) override;
+    bool removeRows(int row, int count, const QModelIndex &parent) override;
 
     private:
     ModelUpdater modelUpdater;

--- a/src/gui/models/masterBondModel.h
+++ b/src/gui/models/masterBondModel.h
@@ -20,15 +20,13 @@ class MasterBondModel : public MasterTermModel
     void modelsUpdated();
 
     public:
-    MasterBondModel(QObject *parent = nullptr);
+    explicit MasterBondModel(CoreData &coreData);
 
     private:
     // Source term data
-    OptionalReferenceWrapper<std::vector<std::shared_ptr<MasterBond>>> sourceData_;
+    std::vector<std::shared_ptr<MasterBond>> &sourceData_;
 
     public:
-    // Set source data
-    void setSourceData(std::vector<std::shared_ptr<MasterBond>> &bonds);
     // Refresh model data
     void reset();
 

--- a/src/gui/models/masterImproperModel.cpp
+++ b/src/gui/models/masterImproperModel.cpp
@@ -3,14 +3,9 @@
 
 #include "gui/models/masterImproperModel.h"
 
-MasterImproperModel::MasterImproperModel(QObject *parent) : MasterTermModel(parent) {}
-
-void MasterImproperModel::setSourceData(std::vector<std::shared_ptr<MasterImproper>> &terms)
+MasterImproperModel::MasterImproperModel(CoreData &coreData)
+    : MasterTermModel(coreData), sourceData_(coreData.masterImpropers())
 {
-    beginResetModel();
-    sourceData_ = terms;
-    endResetModel();
-
     // Set connections
     modelUpdater.setModel(this);
     modelUpdater.connectModelSignals();
@@ -23,22 +18,14 @@ void MasterImproperModel::reset()
     endResetModel();
 }
 
-int MasterImproperModel::rowCount(const QModelIndex &parent) const
-{
-    return parent.isValid() ? 0 : (sourceData_ ? sourceData_->get().size() : 0);
-}
+int MasterImproperModel::rowCount(const QModelIndex &parent) const { return parent.isValid() ? 0 : sourceData_.size(); }
 
 QVariant MasterImproperModel::getTermData(int row, MasterTermModelData::DataType dataType) const
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return {};
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return {};
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
     switch (dataType)
     {
         case (MasterTermModelData::DataType::Name):
@@ -56,15 +43,10 @@ QVariant MasterImproperModel::getTermData(int row, MasterTermModelData::DataType
 
 bool MasterImproperModel::setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value)
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return false;
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return false;
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
 
     beginResetModel();
     switch (dataType)
@@ -97,6 +79,5 @@ bool MasterImproperModel::setTermData(int row, MasterTermModelData::DataType dat
 
 const std::shared_ptr<MasterImproper> &MasterImproperModel::rawData(const QModelIndex &index) const
 {
-    assert(sourceData_);
-    return sourceData_->get()[index.row()];
+    return sourceData_[index.row()];
 }

--- a/src/gui/models/masterImproperModel.h
+++ b/src/gui/models/masterImproperModel.h
@@ -20,15 +20,13 @@ class MasterImproperModel : public MasterTermModel
     void modelsUpdated();
 
     public:
-    MasterImproperModel(QObject *parent = nullptr);
+    explicit MasterImproperModel(CoreData &coreData);
 
     private:
     // Source term data
-    OptionalReferenceWrapper<std::vector<std::shared_ptr<MasterImproper>>> sourceData_;
+    std::vector<std::shared_ptr<MasterImproper>> &sourceData_;
 
     public:
-    // Set source data
-    void setSourceData(std::vector<std::shared_ptr<MasterImproper>> &bonds);
     // Refresh model data
     void reset();
 

--- a/src/gui/models/masterTermModel.cpp
+++ b/src/gui/models/masterTermModel.cpp
@@ -3,7 +3,7 @@
 
 #include "gui/models/masterTermModel.h"
 
-MasterTermModel::MasterTermModel(QObject *parent) : QAbstractTableModel(parent) {}
+MasterTermModel::MasterTermModel(CoreData &coreData) : QAbstractTableModel(), coreData_(coreData) {}
 
 void MasterTermModel::setIconFunction(std::function<bool(std::string_view termName)> func) { iconFunction_ = std::move(func); }
 

--- a/src/gui/models/masterTermModel.h
+++ b/src/gui/models/masterTermModel.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "classes/coreData.h"
 #include <QAbstractTableModel>
 #include <QIcon>
 #include <QModelIndex>
@@ -35,7 +36,11 @@ class MasterTermModel : public QAbstractTableModel
     Q_OBJECT
 
     public:
-    MasterTermModel(QObject *parent = nullptr);
+    MasterTermModel(CoreData &coreData);
+
+    protected:
+    // CoreData object containing the master terms
+    CoreData &coreData_;
 
     protected:
     // Icon return function

--- a/src/gui/models/masterTermTreeModel.cpp
+++ b/src/gui/models/masterTermTreeModel.cpp
@@ -3,6 +3,11 @@
 
 #include "gui/models/masterTermTreeModel.h"
 
+MasterTermTreeModel::MasterTermTreeModel(CoreData &coreData)
+    : bondModel_(coreData), angleModel_(coreData), torsionModel_(coreData), improperModel_(coreData)
+{
+}
+
 MasterTermModel &MasterTermTreeModel::modelForTopLevelRow(int row)
 {
     switch (row)
@@ -18,19 +23,6 @@ MasterTermModel &MasterTermTreeModel::modelForTopLevelRow(int row)
         default:
             throw(std::runtime_error("Invalid row provided, so can't return top level model.\n"));
     }
-}
-
-void MasterTermTreeModel::setData(std::vector<std::shared_ptr<MasterBond>> &bonds,
-                                  std::vector<std::shared_ptr<MasterAngle>> &angles,
-                                  std::vector<std::shared_ptr<MasterTorsion>> &torsions,
-                                  std::vector<std::shared_ptr<MasterImproper>> &impropers)
-{
-    beginResetModel();
-    bondModel_.setSourceData(bonds);
-    angleModel_.setSourceData(angles);
-    torsionModel_.setSourceData(torsions);
-    improperModel_.setSourceData(impropers);
-    endResetModel();
 }
 
 void MasterTermTreeModel::setBondIconFunction(std::function<bool(std::string_view termName)> func)

--- a/src/gui/models/masterTermTreeModel.h
+++ b/src/gui/models/masterTermTreeModel.h
@@ -20,6 +20,9 @@ class MasterTermTreeModel : public QAbstractItemModel
     Q_OBJECT
 
     public:
+    explicit MasterTermTreeModel(CoreData &coreData);
+
+    public:
     // Term models
     MasterBondModel bondModel_;
     MasterAngleModel angleModel_;
@@ -30,9 +33,6 @@ class MasterTermTreeModel : public QAbstractItemModel
     MasterTermModel &modelForTopLevelRow(int row);
 
     public:
-    void setData(std::vector<std::shared_ptr<MasterBond>> &bonds, std::vector<std::shared_ptr<MasterAngle>> &angles,
-                 std::vector<std::shared_ptr<MasterTorsion>> &torsions,
-                 std::vector<std::shared_ptr<MasterImproper>> &impropers);
     void setBondIconFunction(std::function<bool(std::string_view termName)> func);
     void setAngleIconFunction(std::function<bool(std::string_view termName)> func);
     void setTorsionIconFunction(std::function<bool(std::string_view termName)> func);

--- a/src/gui/models/masterTorsionModel.cpp
+++ b/src/gui/models/masterTorsionModel.cpp
@@ -3,14 +3,8 @@
 
 #include "gui/models/masterTorsionModel.h"
 
-MasterTorsionModel::MasterTorsionModel(QObject *parent) : MasterTermModel(parent) {}
-
-void MasterTorsionModel::setSourceData(std::vector<std::shared_ptr<MasterTorsion>> &terms)
+MasterTorsionModel::MasterTorsionModel(CoreData &coreData) : MasterTermModel(coreData), sourceData_(coreData.masterTorsions())
 {
-    beginResetModel();
-    sourceData_ = terms;
-    endResetModel();
-
     // Set connections
     modelUpdater.setModel(this);
     modelUpdater.connectModelSignals();
@@ -23,24 +17,16 @@ void MasterTorsionModel::reset()
     endResetModel();
 }
 
-int MasterTorsionModel::rowCount(const QModelIndex &parent) const
-{
-    return parent.isValid() ? 0 : (sourceData_ ? sourceData_->get().size() : 0);
-}
+int MasterTorsionModel::rowCount(const QModelIndex &parent) const { return parent.isValid() ? 0 : sourceData_.size(); }
 
 int MasterTorsionModel::columnCount(const QModelIndex &parent) const { return parent.isValid() ? 0 : 5; }
 
 QVariant MasterTorsionModel::getTermData(int row, MasterTermModelData::DataType dataType) const
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return {};
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return {};
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
     switch (dataType)
     {
         case (MasterTermModelData::DataType::Name):
@@ -60,15 +46,10 @@ QVariant MasterTorsionModel::getTermData(int row, MasterTermModelData::DataType 
 
 bool MasterTorsionModel::setTermData(int row, MasterTermModelData::DataType dataType, const QVariant &value)
 {
-    if (!sourceData_)
+    if (row < 0 || row >= sourceData_.size())
         return false;
 
-    auto &terms = sourceData_->get();
-
-    if (row < 0 || row >= terms.size())
-        return false;
-
-    auto &t = terms[row];
+    auto &t = sourceData_[row];
 
     beginResetModel();
     switch (dataType)
@@ -110,5 +91,5 @@ bool MasterTorsionModel::setTermData(int row, MasterTermModelData::DataType data
 const std::shared_ptr<MasterTorsion> &MasterTorsionModel::rawData(const QModelIndex &index) const
 {
     assert(sourceData_);
-    return sourceData_->get()[index.row()];
+    return sourceData_[index.row()];
 }

--- a/src/gui/models/masterTorsionModel.h
+++ b/src/gui/models/masterTorsionModel.h
@@ -20,15 +20,13 @@ class MasterTorsionModel : public MasterTermModel
     void modelsUpdated();
 
     public:
-    MasterTorsionModel(QObject *parent = nullptr);
+    explicit MasterTorsionModel(CoreData &coreData);
 
     private:
     // Source term data
-    OptionalReferenceWrapper<std::vector<std::shared_ptr<MasterTorsion>>> sourceData_;
+    std::vector<std::shared_ptr<MasterTorsion>> &sourceData_;
 
     public:
-    // Set source data
-    void setSourceData(std::vector<std::shared_ptr<MasterTorsion>> &terms);
     // Refresh model data
     void reset();
 

--- a/tests/gui/masterTerms.cpp
+++ b/tests/gui/masterTerms.cpp
@@ -27,14 +27,13 @@ std::vector<Qt::ItemDataRole> roles = {Qt::DisplayRole, Qt::EditRole};
 
 TEST_F(MasterTermsTableModelTest, MasterBonds)
 {
-    std::vector<std::shared_ptr<MasterBond>> masterBonds;
-    auto &b1 = masterBonds.emplace_back(std::make_shared<MasterBond>("CA-CA"));
-    b1->setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3924.590   eq=1.400");
-    auto &b2 = masterBonds.emplace_back(std::make_shared<MasterBond>("CA-HA"));
-    b2->setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3071.060   eq=1.080");
+    CoreData coreData;
+    auto &b1 = coreData.addMasterBond("CA-CA");
+    b1.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3924.590   eq=1.400");
+    auto &b2 = coreData.addMasterBond("CA-HA");
+    b2.setInteractionFormAndParameters(BondFunctions::Form::Harmonic, "k=3071.060   eq=1.080");
 
-    MasterBondModel model;
-    model.setSourceData(masterBonds);
+    MasterBondModel model(coreData);
 
     // test table structure
     EXPECT_EQ(model.columnCount(), 3);
@@ -70,14 +69,13 @@ TEST_F(MasterTermsTableModelTest, MasterBonds)
 
 TEST_F(MasterTermsTableModelTest, MasterAngles)
 {
-    std::vector<std::shared_ptr<MasterAngle>> masterAngles;
-    auto &a1 = masterAngles.emplace_back(std::make_shared<MasterAngle>("CA-CA-CA"));
-    a1->setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=527.184   eq=120.000");
-    auto &a2 = masterAngles.emplace_back(std::make_shared<MasterAngle>("CA-CA-HA"));
-    a2->setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=292.880   eq=120.000");
+    CoreData coreData;
+    auto &a1 = coreData.addMasterAngle("CA-CA-CA");
+    a1.setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=527.184   eq=120.000");
+    auto &a2 = coreData.addMasterAngle("CA-CA-HA");
+    a2.setInteractionFormAndParameters(AngleFunctions::Form::Harmonic, "k=292.880   eq=120.000");
 
-    MasterAngleModel model;
-    model.setSourceData(masterAngles);
+    MasterAngleModel model(coreData);
 
     // test table structure
     EXPECT_EQ(model.columnCount(), 3);
@@ -114,16 +112,15 @@ TEST_F(MasterTermsTableModelTest, MasterAngles)
 
 TEST_F(MasterTermsTableModelTest, MasterTorsions)
 {
-    std::vector<std::shared_ptr<MasterTorsion>> masterTorsions;
-    auto &t1 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("CA-CA-CA-CA"));
-    t1->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     0.000");
-    auto &t2 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("CA-CA-CA-HA"));
-    t2->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     1.000");
-    auto &t3 = masterTorsions.emplace_back(std::make_shared<MasterTorsion>("HA-CA-CA-HA"));
-    t3->setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     2.000");
+    CoreData coreData;
+    auto &t1 = coreData.addMasterTorsion("CA-CA-CA-CA");
+    t1.setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     0.000");
+    auto &t2 = coreData.addMasterTorsion("CA-CA-CA-HA");
+    t2.setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     1.000");
+    auto &t3 = coreData.addMasterTorsion("HA-CA-CA-HA");
+    t3.setInteractionFormAndParameters(TorsionFunctions::Form::Cos3, "0.000    30.334     2.000");
 
-    MasterTorsionModel model;
-    model.setSourceData(masterTorsions);
+    MasterTorsionModel model(coreData);
 
     // test table structure
     EXPECT_EQ(model.columnCount(), 5);


### PR DESCRIPTION
This PR moves the responsibility of adding / removing master terms to the relevant model, rather than leaving this the job of the GUI at the calling point.

A significant change here is the storage of a reference to `CoreData` within the base `MasterTermModel`.  Comments welcome on this, but the allows easy access to the addition / removal of terms, as well as permitting a nice clean up of code throughout all the models.