### PR TITLE
feat: (#1890) Support extended trajectory export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ tests/epsr/H2O-weighted-total.gr.broad
 tests/epsr/H2OX-weighted-total.gr.broad
 tests/epsr/HDO-ReferenceData.q
 tests/epsr/HDO-ReferenceData.r
+tests/data/dissolve/input/TestOutput_*
 
 # Visual Studio
 .vscode/

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -33,7 +33,7 @@ bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
     for (const auto &i : cfg->atoms())
         if (extended)
         {
-            if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f} {:<6d} {}\n", Elements::symbol(i.speciesAtom()->Z()),
+            if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}  {:<6d}  {}\n", Elements::symbol(i.speciesAtom()->Z()),
                                    i.r().x, i.r().y, i.r().z, i.localTypeIndex(), i.speciesAtom()->atomType()->name()))
                 return false;
         }

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -12,7 +12,8 @@ TrajectoryExportFileFormat::TrajectoryExportFileFormat(std::string_view filename
     : FileAndFormat(formats_, filename, (int)format)
 {
     formats_ = EnumOptions<TrajectoryExportFileFormat::TrajectoryExportFormat>(
-        "TrajectoryExportFileFormat", {{TrajectoryExportFormat::XYZ, "xyz", "XYZ Trajectory"}});
+        "TrajectoryExportFileFormat", {{TrajectoryExportFormat::XYZ, "xyz", "XYZ Trajectory"},
+                                       {TrajectoryExportFormat::XYZExtended, "xyzExt", "XYZ Trajectory Extended"}});
 }
 
 /*
@@ -20,7 +21,7 @@ TrajectoryExportFileFormat::TrajectoryExportFileFormat(std::string_view filename
  */
 
 // Append XYZ frame to trajectory
-bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cfg)
+bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cfg, bool extended)
 {
     // Write number of atoms and title
     if (!parser.writeLineF("{}\n", cfg->nAtoms()))
@@ -30,9 +31,18 @@ bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
 
     // Write Atoms
     for (const auto &i : cfg->atoms())
-        if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}\n", Elements::symbol(i.speciesAtom()->Z()), i.r().x,
-                               i.r().y, i.r().z))
-            return false;
+        if (extended)
+        {
+            if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f} {:<6d} {}\n", Elements::symbol(i.speciesAtom()->Z()),
+                                   i.r().x, i.r().y, i.r().z, i.localTypeIndex(), i.speciesAtom()->atomType()->name()))
+                return false;
+        }
+        else
+        {
+            if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}\n", Elements::symbol(i.speciesAtom()->Z()), i.r().x,
+                                   i.r().y, i.r().z))
+                return false;
+        }
 
     return true;
 }
@@ -60,7 +70,7 @@ bool TrajectoryExportFileFormat::exportData(Configuration *cfg)
     {
         auto headerResult = false;
 
-        if (formats_.enumerationByIndex(*formatIndex_) == TrajectoryExportFormat::XYZ)
+        if (*formatIndex_ >= 0 && *formatIndex_ < formats_.nOptions())
             headerResult = true;
         else
             headerResult = Messenger::error("Unrecognised trajectory format so can't write header.\nKnown formats are:\n");
@@ -75,7 +85,10 @@ bool TrajectoryExportFileFormat::exportData(Configuration *cfg)
     switch (formats_.enumerationByIndex(*formatIndex_))
     {
         case (TrajectoryExportFormat::XYZ):
-            frameResult = exportXYZ(parser, cfg);
+            frameResult = exportXYZ(parser, cfg, false);
+            break;
+        case (TrajectoryExportFormat::XYZExtended):
+            frameResult = exportXYZ(parser, cfg, true);
             break;
         default:
             throw(std::runtime_error(fmt::format("Trajectory format '{}' export has not been implemented.\n",

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -15,8 +15,8 @@ class TrajectoryExportFileFormat : public FileAndFormat
     // Trajectory Export Formats
     enum class TrajectoryExportFormat
     {
-      XYZ,
-      XYZExtended
+        XYZ,
+        XYZExtended
     };
     TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = TrajectoryExportFormat::XYZ);
     ~TrajectoryExportFileFormat() override = default;

--- a/src/io/export/trajectory.h
+++ b/src/io/export/trajectory.h
@@ -15,7 +15,8 @@ class TrajectoryExportFileFormat : public FileAndFormat
     // Trajectory Export Formats
     enum class TrajectoryExportFormat
     {
-        XYZ
+      XYZ,
+      XYZExtended
     };
     TrajectoryExportFileFormat(std::string_view filename = "", TrajectoryExportFormat format = TrajectoryExportFormat::XYZ);
     ~TrajectoryExportFileFormat() override = default;
@@ -39,7 +40,7 @@ class TrajectoryExportFileFormat : public FileAndFormat
      */
     private:
     // Append XYZ frame to trajectory
-    bool exportXYZ(LineParser &parser, Configuration *cfg);
+    bool exportXYZ(LineParser &parser, Configuration *cfg, bool extended);
 
     public:
     // Append trajectory using current filename and format

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -1,3 +1,4 @@
 dissolve_add_test(SRC cif.cpp)
+dissolve_add_test(SRC exportTrajectory.cpp)
 dissolve_add_test(SRC intraParameterParse.cpp)
 dissolve_add_test(SRC version.cpp)

--- a/tests/io/exportTrajectory.cpp
+++ b/tests/io/exportTrajectory.cpp
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "base/lineParser.h"
+#include "base/sysFunc.h"
+#include "data/elements.h"
+#include "io/export/trajectory.h"
+#include "tests/testData.h"
+#include <fstream>
+#include <gtest/gtest.h>
+#include <vector>
+
+namespace UnitTest
+{
+class ExportTrajectoryTest : public ::testing::Test
+{
+    protected:
+    DissolveSystemTest systemTest;
+};
+
+std::string exportFile(DissolveSystemTest &systemTest, std::string outfile,
+                       TrajectoryExportFileFormat::TrajectoryExportFormat format)
+{
+    std::string inputFile = "dissolve/input/angle.txt";
+
+    systemTest.setUp(inputFile);
+
+    auto *cfg = systemTest.coreData().configuration(0);
+
+    auto output_path = fmt::format("{}/{}", DissolveSys::beforeLastChar(inputFile, '/'), outfile);
+    TrajectoryExportFileFormat exporter(output_path, format);
+    EXPECT_TRUE(exporter.exportData(cfg));
+
+    return output_path;
+}
+
+TEST_F(ExportTrajectoryTest, XYZ)
+{
+    auto output_path = exportFile(systemTest, "TestOutput_exportTrajectory.basic.xyz",
+                                  TrajectoryExportFileFormat::TrajectoryExportFormat::XYZ);
+    auto *cfg = systemTest.coreData().configuration(0);
+
+    std::ifstream result(output_path);
+    ASSERT_TRUE(result.is_open());
+
+    // Size Header
+    int size;
+    result >> size;
+    EXPECT_EQ(size, cfg->nAtoms());
+
+    // Configuration Header
+    std::string name, at;
+    int version;
+    result >> name >> at >> version;
+    EXPECT_EQ(name, cfg->name());
+    EXPECT_EQ(at, "@");
+    EXPECT_EQ(version, cfg->contentsVersion());
+
+    // Line by line analysis
+    for (auto atom : cfg->atoms())
+    {
+        std::string elem;
+        double x, y, z;
+        result >> elem >> x >> y >> z;
+        EXPECT_EQ(elem, Elements::symbol(atom.speciesAtom()->Z()));
+        EXPECT_NEAR(atom.x(), x, 1e-9);
+        EXPECT_NEAR(atom.y(), y, 1e-9);
+        EXPECT_NEAR(atom.z(), z, 1e-9);
+        break;
+    }
+}
+
+TEST_F(ExportTrajectoryTest, XYZExport)
+{
+    auto output_path = exportFile(systemTest, "TestOutput_exportTrajectory.extended.xyz",
+                                  TrajectoryExportFileFormat::TrajectoryExportFormat::XYZExtended);
+    auto *cfg = systemTest.coreData().configuration(0);
+
+    std::ifstream result(output_path);
+    ASSERT_TRUE(result.is_open());
+
+    // Size Header
+    int size;
+    result >> size;
+    EXPECT_EQ(size, cfg->nAtoms());
+
+    // Configuration Header
+    std::string name, at;
+    int version;
+    result >> name >> at >> version;
+    EXPECT_EQ(name, cfg->name());
+    EXPECT_EQ(at, "@");
+    EXPECT_EQ(version, cfg->contentsVersion());
+
+    // Line by line analysis
+    for (auto atom : cfg->atoms())
+    {
+        std::string elem, atomType;
+        double x, y, z;
+        int index;
+        result >> elem >> x >> y >> z >> index >> atomType;
+        EXPECT_EQ(elem, Elements::symbol(atom.speciesAtom()->Z()));
+        EXPECT_NEAR(atom.x(), x, 1e-9);
+        EXPECT_NEAR(atom.y(), y, 1e-9);
+        EXPECT_NEAR(atom.z(), z, 1e-9);
+        EXPECT_EQ(atomType, atom.speciesAtom()->atomType()->name());
+        EXPECT_EQ(index, atom.localTypeIndex());
+        break;
+    }
+}
+
+} // namespace UnitTest

--- a/web/docs/userguide/reference/fileandformat/trajectoryformat.md
+++ b/web/docs/userguide/reference/fileandformat/trajectoryformat.md
@@ -23,3 +23,4 @@ description: Trajectory import/export
 |Keyword|Description|
 |:---:|-----------|
 |`xyz`|Appended XMol-style xyz coordinates. Line 1 contains the number of atoms N. Line 2 contains a title string. The next N lines contain "element  rx  ry  rz". This format is repeated for each frame.|
+|`xyzExt`|Extended XMol-style xyz coordinates. Mostly identical to `xyz`, but with two additional columns appended to the line for each atom.  These columns contain first the index of the atom within the molecule, followed by the atom type|


### PR DESCRIPTION
As mentioned in #1890, it would be useful to have additional informtation (i.e. atom index and atom type) along side the trajectory information.  I've added an *extended* trajectory format that includes the extra columns.  I have also added a unit test for checking the trajectory export and updated the documention to include this alternate format.

Closes #1890
