### PR TITLE
refactor: Refactor PairPotentials - Part 1

### DIFF
--- a/examples/water/input.txt
+++ b/examples/water/input.txt
@@ -1,4 +1,4 @@
-# Input file written by Dissolve v1.2.0 at 09:11:59 on 05-04-2023.
+# Input file written by Dissolve v1.5.1 at 16:04:58 on 21-05-2024.
 
 #==============================================================================#
 #                                 Master Terms                                 #
@@ -48,6 +48,9 @@ Species 'Water'
   Site  'H2'
     Origin  3
   EndSite
+  Site  'Blah'
+    Origin  2
+  EndSite
 EndSpecies
 
 #==============================================================================#
@@ -72,8 +75,8 @@ Configuration  'Bulk'
 
   # Generator
   Generator
-    Temperature
-      Temperature  300
+    Temperature  'Temperature01'
+      Temperature  '300'
     EndTemperature
     Parameters  'Parameters01'
       Parameter  rho  0.1
@@ -94,11 +97,14 @@ Configuration  'Bulk'
       CoordinateSets  'Water_Sets'
       Population  '1000'
       Density  'rho'  atoms/A3
-      BoxAction  AddVolume
       Positioning  Random
       Rotate  True
+      BoxAction  AddVolume
     EndAdd
   EndGenerator
+
+  Temperature  300
+
 EndConfiguration
 
 #==============================================================================#
@@ -112,8 +118,6 @@ Layer  'Evolve (Standard)'
     Frequency  1
     Configuration  'Bulk'
     RotationStepSize  37.30483575426232
-    RotationStepSize  37.30483575426232
-    TranslationStepSize  0.4103953050595744
     TranslationStepSize  0.4103953050595744
   EndModule
 
@@ -144,15 +148,21 @@ Layer  'GR / Neutron S(Q)'
   Module  SQ  'SQ01'
     Frequency  1
     SourceGR  'GR01'
+    QBroadening  'None'  
+    WindowFunction  None
+    BraggQBroadening  'GaussianC2'  0  0.02
     Averaging  5
+    AveragingScheme  Linear
   EndModule
 
   Module  NeutronSQ  'H2O'
     Frequency  1
     SourceSQs  'SQ01'
     Isotopologue  'Water'  'Natural'  1
+    NormaliseTo  None
     Reference  mint  'data/SLS18498-H2O.mint01'
     EndReference
+    ReferenceNormalisedTo  None
     ReferenceWindowFunction  Lorch0
   EndModule
 
@@ -160,8 +170,10 @@ Layer  'GR / Neutron S(Q)'
     Frequency  1
     SourceSQs  'SQ01'
     Isotopologue  'Water'  'Deuterated'  1
+    NormaliseTo  None
     Reference  mint  'data/SLS18502-D2O.mint01'
     EndReference
+    ReferenceNormalisedTo  None
     ReferenceWindowFunction  Lorch0
   EndModule
 
@@ -171,8 +183,10 @@ Layer  'GR / Neutron S(Q)'
     Exchangeable  HW
     Isotopologue  'Water'  'Natural'  1
     Isotopologue  'Water'  'Deuterated'  1
+    NormaliseTo  None
     Reference  mint  'data/SLS18500-HDO5050.mint01'
     EndReference
+    ReferenceNormalisedTo  None
     ReferenceWindowFunction  Lorch0
   EndModule
 EndLayer

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -6,10 +6,10 @@
 #include "templates/algorithms.h"
 #include <map>
 
-AtomType::AtomType(Elements::Element Z) : Z_(Z), interactionPotential_(ShortRangeFunctions::Form::None) {}
-AtomType::AtomType(std::string_view name) : name_(name), interactionPotential_(ShortRangeFunctions::Form::None) {}
+AtomType::AtomType(Elements::Element Z) : Z_(Z), interactionPotential_(ShortRangeFunctions::Form::Undefined) {}
+AtomType::AtomType(std::string_view name) : name_(name), interactionPotential_(ShortRangeFunctions::Form::Undefined) {}
 AtomType::AtomType(Elements::Element Z, std::string_view name)
-    : Z_(Z), name_(name), interactionPotential_(ShortRangeFunctions::Form::None)
+    : Z_(Z), name_(name), interactionPotential_(ShortRangeFunctions::Form::Undefined)
 {
 }
 

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -106,11 +106,11 @@ bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::sha
                                 typeJ->name());
 
     // Combine the atom type parameters into potential function parameters
-    interactionPotential_ = ShortRangeFunctions::combine(typeI->interactionPotential(), typeJ->interactionPotential());
-    potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
-
-    if (!interactionPotential_.hasValidForm())
+    auto optPotential = ShortRangeFunctions::combine(typeI->interactionPotential(), typeJ->interactionPotential());
+    if (!optPotential)
         return false;
+    interactionPotential_ = *optPotential;
+    potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
 
     // Set charges
     chargeI_ = includeAtomTypeCharges_ ? typeI->charge() : 0.0;

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -14,21 +14,15 @@ PairPotential::CoulombTruncationScheme PairPotential::coulombTruncationScheme_ =
 PairPotential::ShortRangeTruncationScheme PairPotential::shortRangeTruncationScheme_ =
     PairPotential::ShiftedShortRangeTruncation;
 
-PairPotential::PairPotential()
-    : interactionPotential_(Functions1D::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
+PairPotential::PairPotential(std::string_view nameI, std::string_view nameJ)
+    : nameI_(nameI), nameJ_(nameJ), uFullInterpolation_(uFull_),
+      dUFullInterpolation_(dUFull_), interactionPotential_{Functions1D::Form::None, ""}, potentialFunction_{
+                                                                                             Functions1D::Form::None, {}}
 {
-}
-
-PairPotential::PairPotential(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ,
-                             bool includeCharges)
-    : interactionPotential_(Functions1D::Form::None), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
-{
-    setUp(typeI, typeJ, includeCharges);
 }
 
 PairPotential::PairPotential(std::string_view nameI, std::string_view nameJ, const InteractionPotential<Functions1D> &potential)
-    : includeAtomTypeCharges_(false), nameI_(nameI), nameJ_(nameJ), interactionPotential_(potential),
-      uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
+    : nameI_(nameI), nameJ_(nameJ), interactionPotential_(potential), uFullInterpolation_(uFull_), dUFullInterpolation_(dUFull_)
 {
     potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
 }
@@ -62,9 +56,6 @@ void PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTrunc
 // Return short-ranged truncation scheme
 PairPotential::ShortRangeTruncationScheme PairPotential::shortRangeTruncationScheme() { return shortRangeTruncationScheme_; }
 
-// Set whether atom type charges should be included in the generated potential
-void PairPotential::setIncludeAtomTypeCharges(bool b) { includeAtomTypeCharges_ = b; }
-
 // Return whether atom type charges should be included in the generated potential
 bool PairPotential::includeAtomTypeCharges() const { return includeAtomTypeCharges_; }
 
@@ -81,44 +72,6 @@ PairPotential::CoulombTruncationScheme PairPotential::coulombTruncationScheme() 
  * Source Parameters
  */
 
-// Set up PairPotential parameters from specified AtomTypes
-bool PairPotential::setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges)
-{
-    // Check for NULL pointers
-    if (typeI == nullptr)
-        throw(std::runtime_error("Invalid AtomType pointer (typeI) given to PairPotential::setUp().\n"));
-    if (typeJ == nullptr)
-        throw(std::runtime_error("Invalid AtomType pointer (typeJ) given to PairPotential::setUp().\n"));
-
-    includeAtomTypeCharges_ = includeCharges;
-    interactionPotential_.setFormAndParameters(Functions1D::Form::None, "");
-
-    nameI_ = typeI->name();
-    nameJ_ = typeJ->name();
-    setData1DNames();
-
-    // Sanity check - do both atom types have valid short range functions set?
-    if (!typeI->interactionPotential().hasValidForm())
-        return Messenger::error("Can't set parameters for PairPotential since atom type {} has no valid short range form.\n",
-                                typeI->name());
-    if (!typeJ->interactionPotential().hasValidForm())
-        return Messenger::error("Can't set parameters for PairPotential since atom type {} has no valid short range form.\n",
-                                typeJ->name());
-
-    // Combine the atom type parameters into potential function parameters
-    auto optPotential = ShortRangeFunctions::combine(typeI->interactionPotential(), typeJ->interactionPotential());
-    if (!optPotential)
-        return false;
-    interactionPotential_ = *optPotential;
-    potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
-
-    // Set charges
-    chargeI_ = includeAtomTypeCharges_ ? typeI->charge() : 0.0;
-    chargeJ_ = includeAtomTypeCharges_ ? typeJ->charge() : 0.0;
-
-    return true;
-}
-
 // Set Data1D names from source AtomTypes
 void PairPotential::setData1DNames()
 {
@@ -129,6 +82,14 @@ void PairPotential::setData1DNames()
     uOriginal_.setTag(fmt::format("{}-{} (Orig)", nameI_, nameJ_));
 
     dUFull_.setTag(fmt::format("{}-{} (dU/dr)", nameI_, nameJ_));
+}
+
+// Set names reflecting target atom types for potential
+void PairPotential::setNames(std::string_view nameI, std::string_view nameJ)
+{
+    nameI_ = nameI;
+    nameJ_ = nameJ;
+    setData1DNames();
 }
 
 // Return name for first source parameters
@@ -143,9 +104,25 @@ bool PairPotential::setInteractionPotential(Functions1D::Form form, std::string_
     return interactionPotential_.setFormAndParameters(form, parameters) &&
            potentialFunction_.setFormAndParameters(form, interactionPotential_.parameters());
 }
+bool PairPotential::setInteractionPotential(const InteractionPotential<Functions1D> &potential)
+{
+    interactionPotential_ = potential;
+    return potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
+}
 
 // Return interaction potential
 const InteractionPotential<Functions1D> &PairPotential::interactionPotential() const { return interactionPotential_; }
+
+// Set included charges
+void PairPotential::setIncludedCharges(double qi, double qj)
+{
+    chargeI_ = qi;
+    chargeJ_ = qj;
+    includeAtomTypeCharges_ = true;
+}
+
+// Set no included charges
+void PairPotential::setNoIncludedCharges() { includeAtomTypeCharges_ = false; }
 
 // Set charge I
 void PairPotential::setChargeI(double value) { chargeI_ = value; }

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -16,8 +16,7 @@ class AtomType;
 class PairPotential
 {
     public:
-    PairPotential();
-    PairPotential(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges);
+    PairPotential(std::string_view nameI = {}, std::string_view nameJ = {});
     PairPotential(std::string_view nameI, std::string_view nameJ, const InteractionPotential<Functions1D> &potential);
     // Coulomb Truncation Scheme enum
     enum CoulombTruncationScheme
@@ -49,7 +48,7 @@ class PairPotential
     // Short-range force at cutoff distance (used by truncation scheme)
     double shortRangeForceAtCutoff_{0.0};
     // Whether atom type charges should be included in the generated potential
-    bool includeAtomTypeCharges_{true};
+    bool includeAtomTypeCharges_{false};
     // Truncation scheme to apply to Coulomb part of potential
     static CoulombTruncationScheme coulombTruncationScheme_;
     // Coulomb energy at cutoff distance (used by truncation scheme)
@@ -62,8 +61,6 @@ class PairPotential
     static void setShortRangeTruncationScheme(ShortRangeTruncationScheme scheme);
     // Return short-ranged truncation scheme
     static ShortRangeTruncationScheme shortRangeTruncationScheme();
-    // Set whether atom type charges should be included in the generated potential
-    void setIncludeAtomTypeCharges(bool b);
     // Return whether atom type charges should be included in the generated potential
     bool includeAtomTypeCharges() const;
     // Set Coulomb truncation scheme
@@ -75,7 +72,7 @@ class PairPotential
      * Source Parameters
      */
     private:
-    // Names reflecting source parameters
+    // Names reflecting target atom types for potential
     std::string nameI_, nameJ_;
     // Interaction potential and function
     InteractionPotential<Functions1D> interactionPotential_;
@@ -86,20 +83,25 @@ class PairPotential
     double chargeJ_{0.0};
 
     private:
-    // Set up PairPotential parameters from specified AtomTypes
-    bool setUp(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges);
     // Set Data1D names from source AtomTypes
     void setData1DNames();
 
     public:
-    // Return name for first source parameters
+    // Set names reflecting target atom types for potential
+    void setNames(std::string_view nameI, std::string_view nameJ);
+    // Return name for first target atom type
     std::string_view nameI() const;
-    // Return name for second source parameters
+    // Return name for second target atom type
     std::string_view nameJ() const;
     // Set interaction potential
     bool setInteractionPotential(Functions1D::Form form, std::string_view parameters);
+    bool setInteractionPotential(const InteractionPotential<Functions1D> &potential);
     // Return interaction potential
     const InteractionPotential<Functions1D> &interactionPotential() const;
+    // Set included charges
+    void setIncludedCharges(double qi, double qj);
+    // Set no included charges
+    void setNoIncludedCharges();
     // Set charge I
     void setChargeI(double value);
     // Return charge I

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -15,8 +15,6 @@ class AtomType;
 // PairPotential Definition
 class PairPotential
 {
-    friend class Dissolve;
-
     public:
     PairPotential();
     PairPotential(const std::shared_ptr<AtomType> &typeI, const std::shared_ptr<AtomType> &typeJ, bool includeCharges);
@@ -141,14 +139,14 @@ class PairPotential
     // Return analytic short range force
     double analyticShortRangeForce(
         double r, PairPotential::ShortRangeTruncationScheme truncation = PairPotential::shortRangeTruncationScheme()) const;
-    // Calculate full potential
-    void calculateUFull();
-    // Calculate derivative of potential
-    void calculateDUFull();
 
     public:
     // Generate energy and force tables
     bool tabulate(double maxR, double delta);
+    // Calculate full potential
+    void calculateUFull();
+    // Calculate derivative of potential
+    void calculateDUFull();
     // Return number of tabulated points in potential
     int nPoints() const;
     // Return range of potential

--- a/src/classes/shortRangeFunctions.h
+++ b/src/classes/shortRangeFunctions.h
@@ -14,7 +14,7 @@ class ShortRangeFunctions
     public:
     enum class Form
     {
-        None,                  /* No short-range dispersive forces */
+        Undefined,
         LennardJones,          /* Lennard-Jones 12-6 form with Lorentz-Berthelot combination rules */
         LennardJonesGeometric, /* Lennard-Jones 12-6 form with Geometric combination rules */
         Buckingham             /* Buckingham form */
@@ -33,6 +33,6 @@ class ShortRangeFunctions
      */
     public:
     // Combine parameters for the two atom types using suitable rules
-    static InteractionPotential<Functions1D> combine(const InteractionPotential<ShortRangeFunctions> &srI,
-                                                     const InteractionPotential<ShortRangeFunctions> &srJ);
+    static std::optional<InteractionPotential<Functions1D>> combine(const InteractionPotential<ShortRangeFunctions> &srI,
+                                                                    const InteractionPotential<ShortRangeFunctions> &srJ);
 };

--- a/src/data/ff/atomType.h
+++ b/src/data/ff/atomType.h
@@ -16,7 +16,7 @@ class ForcefieldAtomType
     public:
     ForcefieldAtomType(Elements::Element Z = Elements::Unknown, int index = -1, std::string_view name = "",
                        std::string_view netaDefinition = "", std::string_view description = "", double q = 0.0,
-                       ShortRangeFunctions::Form parametersForm = ShortRangeFunctions::Form::None,
+                       ShortRangeFunctions::Form parametersForm = ShortRangeFunctions::Form::Undefined,
                        std::string_view parameterString = "", std::string_view equivalentName = "");
     ForcefieldAtomType(Elements::Element Z = Elements::Unknown, int index = -1, std::string_view name = "",
                        std::string_view netaDefinition = "", std::string_view description = "", double q = 0.0,

--- a/src/gui/configurationTab.cpp
+++ b/src/gui/configurationTab.cpp
@@ -221,7 +221,7 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     dissolveWindow_->clearMessages();
 
     // Make sure the potential map is up to date
-    dissolve_.regeneratePairPotentials();
+    dissolve_.updatePairPotentials();
 
     // Initialise the content
     configuration_->initialiseContent({dissolve_.worldPool(), dissolve_});

--- a/src/gui/forcefieldTab.cpp
+++ b/src/gui/forcefieldTab.cpp
@@ -159,15 +159,9 @@ bool ForcefieldTab::canClose() const { return false; }
 // Update all pair potentials
 void ForcefieldTab::updatePairPotentials()
 {
-    // Mute output
-    Messenger::mute();
-
-    dissolve_.regeneratePairPotentials();
+    dissolve_.updatePairPotentials();
 
     resetPairPotentialModel();
-
-    // Reinstate output
-    Messenger::unMute();
 }
 
 // Reset pair potential model

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -221,6 +221,9 @@ bool DissolveWindow::loadInputFile(std::string_view inputFile, bool handleRestar
     modified_ = false;
     dissolveIterating_ = false;
 
+    Messenger::banner("Updating Pair Potentials");
+    dissolve_.updatePairPotentials();
+
     Messenger::banner("Setting Up Processing Modules");
 
     if (!dissolve_.coreData().setUpProcessingLayerModules(dissolve_))
@@ -229,9 +232,6 @@ bool DissolveWindow::loadInputFile(std::string_view inputFile, bool handleRestar
     // Handle restart file loading?
     if (handleRestartFile)
     {
-        fullUpdate();
-
-        // Load / handle restart file
         SelectRestartFileDialog selectRestartFileDialog(this);
         auto restartFile = selectRestartFileDialog.getRestartFileName(inputFileInfo.filePath());
         if (!restartFile.isEmpty())
@@ -239,9 +239,9 @@ bool DissolveWindow::loadInputFile(std::string_view inputFile, bool handleRestar
             loadRestartFile(restartFile.toStdString());
             dissolve_.prepare();
         }
-
-        fullUpdate();
     }
+
+    fullUpdate();
 
     // Empty timer text
     elapsedTimer_.zero();

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -28,8 +28,8 @@ bool DissolveWindow::clearModuleData(bool queryUser)
         // Set iteration counter to zero
         dissolve_.resetIterationCounter();
 
-        // Regenerate pair potentials
-        dissolve_.regeneratePairPotentials();
+        // Revert pair potentials (so that any additional potential is removed)
+        dissolve_.revertPairPotentials();
 
         Renderable::setSourceDataAccessEnabled(true);
 

--- a/src/gui/menu_configuration.cpp
+++ b/src/gui/menu_configuration.cpp
@@ -70,11 +70,7 @@ void DissolveWindow::on_ConfigurationCreateAction_triggered(bool checked)
 
     if (addConfigurationDialog.exec() == QDialog::Accepted)
     {
-
         auto newConfig = dissolve_.coreData().configurations().back().get();
-
-        // Make sure the potential map is up to date
-        dissolve_.regeneratePairPotentials();
 
         // Initialise the content
         newConfig->initialiseContent({dissolve_.worldPool(), dissolve_});

--- a/src/gui/speciesEditor.cpp
+++ b/src/gui/speciesEditor.cpp
@@ -234,7 +234,7 @@ void SpeciesEditor::on_ToolsMinimiseButton_clicked(bool checked)
         return;
 
     // Set up interatomic potentials
-    if (!dissolve.regeneratePairPotentials())
+    if (!dissolve.updatePairPotentials(true))
     {
         Messenger::error("Couldn't set up interatomic pair potentials - no optimisation performed!\n");
         return;

--- a/src/gui/speciesWidget.cpp
+++ b/src/gui/speciesWidget.cpp
@@ -142,7 +142,7 @@ void SpeciesWidget::on_ToolsMinimiseButton_clicked(bool checked)
         return;
 
     // Set up interatomic potentials
-    if (!dissolve_->regeneratePairPotentials())
+    if (!dissolve_->updatePairPotentials(true))
     {
         Messenger::error("Couldn't set up interatomic pair potentials - no optimisation performed!\n");
         return;

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -38,6 +38,7 @@ void Dissolve::clear()
 
     // PairPotentials
     Messenger::printVerbose("Clearing Pair Potentials...\n");
+    automaticPairPotentials_ = true;
     pairPotentialDelta_ = 0.005;
     pairPotentialRange_ = 15.0;
     automaticChargeSource_ = true;

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -38,7 +38,7 @@ void Dissolve::clear()
 
     // PairPotentials
     Messenger::printVerbose("Clearing Pair Potentials...\n");
-    autoCombinePairPotentials_ = true;
+    useCombinationRules_ = true;
     pairPotentialDelta_ = 0.005;
     pairPotentialRange_ = 15.0;
     automaticChargeSource_ = true;

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -38,7 +38,7 @@ void Dissolve::clear()
 
     // PairPotentials
     Messenger::printVerbose("Clearing Pair Potentials...\n");
-    automaticPairPotentials_ = true;
+    autoCombinePairPotentials_ = true;
     pairPotentialDelta_ = 0.005;
     pairPotentialRange_ = 15.0;
     automaticChargeSource_ = true;

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -47,8 +47,8 @@ class Dissolve : public Serialisable<>
      * Pair Potentials
      */
     private:
-    // Whether pair potentials are generated automatically through combination rules
-    bool automaticPairPotentials_;
+    // Whether pair potentials are updated automatically through combination rules
+    bool autoCombinePairPotentials_;
     // Maximum distance for tabulated PairPotentials
     double pairPotentialRange_;
     // Delta to use in tabulation

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -47,6 +47,8 @@ class Dissolve : public Serialisable<>
      * Pair Potentials
      */
     private:
+    // Whether pair potentials are generated automatically through combination rules
+    bool automaticPairPotentials_;
     // Maximum distance for tabulated PairPotentials
     double pairPotentialRange_;
     // Delta to use in tabulation
@@ -98,8 +100,8 @@ class Dissolve : public Serialisable<>
     PairPotential *pairPotential(std::string_view at1Name, std::string_view at2Name) const;
     // Return map for PairPotentials
     const PotentialMap &potentialMap() const;
-    // Clear and regenerate all PairPotentials, replacing those currently defined
-    bool regeneratePairPotentials();
+    // Update all pair potentials
+    bool updatePairPotentials(std::optional<bool> autoCombineHint = {});
     // Revert potentials to reference state, clearing additional potentials
     void revertPairPotentials();
 

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -48,7 +48,7 @@ class Dissolve : public Serialisable<>
      */
     private:
     // Whether pair potentials are updated automatically through combination rules
-    bool autoCombinePairPotentials_;
+    bool useCombinationRules_;
     // Maximum distance for tabulated PairPotentials
     double pairPotentialRange_;
     // Delta to use in tabulation
@@ -101,7 +101,7 @@ class Dissolve : public Serialisable<>
     // Return map for PairPotentials
     const PotentialMap &potentialMap() const;
     // Update all pair potentials
-    bool updatePairPotentials(std::optional<bool> autoCombineHint = {});
+    bool updatePairPotentials(std::optional<bool> useCombinationRulesHint = {});
     // Revert potentials to reference state, clearing additional potentials
     void revertPairPotentials();
 

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -135,9 +135,9 @@ SerialisedValue Dissolve::serialisePairPotentials() const
         {"range", pairPotentialRange_},
         {"delta", pairPotentialDelta_},
         {"autoChargeSource", automaticChargeSource_},
-        {"coulombTruncation", PairPotential::coulombTruncationSchemes().serialise(PairPotential::coulombTruncationScheme_)},
+        {"coulombTruncation", PairPotential::coulombTruncationSchemes().serialise(PairPotential::coulombTruncationScheme())},
         {"shortRangeTruncation",
-         PairPotential::shortRangeTruncationSchemes().serialise(PairPotential::shortRangeTruncationScheme_)}};
+         PairPotential::shortRangeTruncationSchemes().serialise(PairPotential::shortRangeTruncationScheme())}};
     if (forceChargeSource_)
         pairPotentials["forceChargeSource"] = true;
     if (atomTypeChargeSource_)
@@ -179,10 +179,10 @@ void Dissolve::deserialisePairPotentials(const SerialisedValue &node)
     forceChargeSource_ = toml::find_or<bool>(node, "forceChargeSource", false);
     automaticChargeSource_ = toml::find_or<bool>(node, "autoChargeSource", true);
 
-    PairPotential::coulombTruncationScheme_ =
-        PairPotential::coulombTruncationSchemes().deserialise(toml::find_or<std::string>(node, "coulombTruncation", "Shifted"));
-    PairPotential::shortRangeTruncationScheme_ = PairPotential::shortRangeTruncationSchemes().deserialise(
-        toml::find_or<std::string>(node, "shortRangeTruncation", "Shifted"));
+    PairPotential::setCoulombTruncationScheme(PairPotential::coulombTruncationSchemes().deserialise(
+        toml::find_or<std::string>(node, "coulombTruncation", "Shifted")));
+    PairPotential::setShortRangeTruncationScheme(PairPotential::shortRangeTruncationSchemes().deserialise(
+        toml::find_or<std::string>(node, "shortRangeTruncation", "Shifted")));
 
     toMap(node, "atomTypes",
           [this](const std::string &name, const auto &data)

--- a/src/main/pairPotentials.cpp
+++ b/src/main/pairPotentials.cpp
@@ -91,12 +91,12 @@ PairPotential *Dissolve::pairPotential(std::string_view at1Name, std::string_vie
 const PotentialMap &Dissolve::potentialMap() const { return potentialMap_; }
 
 // Update all pair potentials
-bool Dissolve::updatePairPotentials(std::optional<bool> autoCombineHint)
+bool Dissolve::updatePairPotentials(std::optional<bool> useCombinationRulesHint)
 {
     Messenger::print("Updating pair potentials...\n");
     potentialMap_.clear();
 
-    auto autoCombine = autoCombineHint.value_or(autoCombinePairPotentials_);
+    auto useCombinationRules = useCombinationRulesHint.value_or(useCombinationRules_);
 
     // First step - add or update tabulated pair potentials defined by the parameters and form of the associated atom types
     if (!for_each_pair_early(coreData_.atomTypes().begin(), coreData_.atomTypes().end(),
@@ -120,8 +120,8 @@ bool Dissolve::updatePairPotentials(std::optional<bool> autoCombineHint)
                                  else
                                      pot->setNoIncludedCharges();
 
-                                 // Auto-update parameters?
-                                 if (autoCombine)
+                                 // Auto-update parameters using combination rules?
+                                 if (useCombinationRules)
                                  {
                                      // Combine the atom type parameters into potential function parameters
                                      auto optPotential =

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -48,7 +48,7 @@ bool Dissolve::prepare()
     }
 
     // Make sure pair potentials are up-to-date
-    if (!regeneratePairPotentials())
+    if (!updatePairPotentials(automaticPairPotentials_))
         return false;
 
     // Check Configurations
@@ -171,7 +171,7 @@ bool Dissolve::prepare()
     }
 
     // Make sure pair potentials are up-to-date
-    if (!regeneratePairPotentials())
+    if (!updatePairPotentials(automaticPairPotentials_))
         return false;
 
     // Generate attached atom lists if IntraShake modules are present and enabled

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -48,7 +48,7 @@ bool Dissolve::prepare()
     }
 
     // Make sure pair potentials are up-to-date
-    if (!updatePairPotentials(automaticPairPotentials_))
+    if (!updatePairPotentials())
         return false;
 
     // Check Configurations
@@ -171,7 +171,7 @@ bool Dissolve::prepare()
     }
 
     // Make sure pair potentials are up-to-date
-    if (!updatePairPotentials(automaticPairPotentials_))
+    if (!updatePairPotentials())
         return false;
 
     // Generate attached atom lists if IntraShake modules are present and enabled

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -25,13 +25,13 @@ TEST(CellsTest, Basic)
     // Add atom types and LJ pair potentials (only one real one - between Ar and OW
     auto arType = coreData.addAtomType(Elements::Ar);
     arType->setName("Ar");
-    arType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    arType->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
     auto hType = coreData.addAtomType(Elements::H);
     hType->setName("HW");
-    hType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    hType->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
     auto oType = coreData.addAtomType(Elements::O);
     oType->setName("OW");
-    oType->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    oType->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
 
     dissolve.addPairPotential(arType, arType)->setInteractionPotential(Functions1D::Form::None, "");
     dissolve.addPairPotential(hType, hType)->setInteractionPotential(Functions1D::Form::None, "");

--- a/tests/gui/forcefieldTab.cpp
+++ b/tests/gui/forcefieldTab.cpp
@@ -32,7 +32,7 @@ TEST_F(ForcefieldTabTest, PairPotentials)
 
     dissolve.clear();
     ASSERT_TRUE(dissolve.loadInput("dissolve/input/full-benzene.txt"));
-    ASSERT_TRUE(dissolve.regeneratePairPotentials());
+    ASSERT_TRUE(dissolve.updatePairPotentials());
 
     PairPotentialModel pairs(dissolve.pairPotentials());
     ASSERT_EQ(dissolve.nPairPotentials(), 3);

--- a/tests/math/geometryMin.cpp
+++ b/tests/math/geometryMin.cpp
@@ -14,13 +14,13 @@ TEST(GeometryMinimisationTest, Water)
     // Set up CoreData
     CoreData coreData;
     auto atO = coreData.addAtomType(Elements::O);
-    atO->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    atO->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
     auto atH = coreData.addAtomType(Elements::H);
-    atH->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+    atH->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
     std::vector<PairPotential::Definition> pairPotentials;
-    pairPotentials.emplace_back(atO, atO, std::make_unique<PairPotential>(atO, atO, false));
-    pairPotentials.emplace_back(atH, atH, std::make_unique<PairPotential>(atH, atH, false));
-    pairPotentials.emplace_back(atO, atH, std::make_unique<PairPotential>(atO, atH, false));
+    pairPotentials.emplace_back(atO, atO, std::make_unique<PairPotential>("O", "O"));
+    pairPotentials.emplace_back(atH, atH, std::make_unique<PairPotential>("H", "H"));
+    pairPotentials.emplace_back(atO, atH, std::make_unique<PairPotential>("O", "H"));
     PotentialMap potMap;
     potMap.initialise(coreData.atomTypes(), pairPotentials, 15.0);
 

--- a/tests/pairPotentials/analytic.cpp
+++ b/tests/pairPotentials/analytic.cpp
@@ -16,12 +16,12 @@ class PairPotentialsTest : public ::testing::Test
 
         A_ = std::make_shared<AtomType>(Elements::H);
         A_->setName("A");
-        A_->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+        A_->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
         B_ = std::make_shared<AtomType>(Elements::H);
         B_->setName("B");
-        B_->interactionPotential().setForm(ShortRangeFunctions::Form::None);
+        B_->interactionPotential().setForm(ShortRangeFunctions::Form::Undefined);
 
-        pairPotential_ = std::make_shared<PairPotential>(A_, B_, false);
+        pairPotential_ = std::make_shared<PairPotential>("A", "B");
     }
 
     protected:

--- a/tests/pairPotentials/overrides.cpp
+++ b/tests/pairPotentials/overrides.cpp
@@ -43,7 +43,7 @@ TEST_F(PairPotentialOverridesTest, Water3000)
 
     // Set the potentials to zero and check that the new energy is zero
     EXPECT_TRUE(ow->interactionPotential().parseParameters("epsilon=0.0 sigma=0.0"));
-    EXPECT_TRUE(systemTest.dissolve().regeneratePairPotentials());
+    EXPECT_TRUE(systemTest.dissolve().updatePairPotentials());
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkDouble("zeroed van der Waals energy", interEnergy.values().back(), 0.0, 6.0e-2));
 
@@ -51,7 +51,7 @@ TEST_F(PairPotentialOverridesTest, Water3000)
     auto *owOverride =
         systemTest.coreData().addPairPotentialOverride("OW", "OW", PairPotentialOverride::PairPotentialOverrideType::Off,
                                                        {Functions1D::Form::LennardJones126, "epsilon=0.6503 sigma=3.165492"});
-    EXPECT_TRUE(systemTest.dissolve().regeneratePairPotentials());
+    EXPECT_TRUE(systemTest.dissolve().updatePairPotentials());
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkDouble("overridden (Off) van der Waals energy", interEnergy.values().back(), 0.0, 6.0e-2));
 
@@ -62,14 +62,14 @@ TEST_F(PairPotentialOverridesTest, Water3000)
 
     // Turn it on to Add
     owOverride->setType(PairPotentialOverride::PairPotentialOverrideType::Add);
-    EXPECT_TRUE(systemTest.dissolve().regeneratePairPotentials());
+    EXPECT_TRUE(systemTest.dissolve().updatePairPotentials());
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkDouble("overridden (Add) van der Waals energy", interEnergy.values().back(),
                                        expectedVanDerWaalsEnergy, 6.0e-2));
 
     // And now to Replace
     owOverride->setType(PairPotentialOverride::PairPotentialOverrideType::Replace);
-    EXPECT_TRUE(systemTest.dissolve().regeneratePairPotentials());
+    EXPECT_TRUE(systemTest.dissolve().updatePairPotentials());
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
     EXPECT_TRUE(systemTest.checkDouble("overridden (Replace) van der Waals energy", interEnergy.values().back(),
                                        expectedVanDerWaalsEnergy, 6.0e-2));


### PR DESCRIPTION
This PR performs some preliminary work on the `PairPotential` class and associated code with a bigger-picture view of implementing #1900.

Herein we tidy the class up a little and improve the update handling of pairpotentials prior to formation of the main `PotentialMap`.

Works towards #1900.