### PR TITLE
refactor: Refactor PairPotentials - Part 2

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -46,9 +46,6 @@ std::shared_ptr<AtomType> CoreData::addAtomType(Elements::Element Z)
     newAtomType->setZ(Z);
     newAtomType->setIndex(nAtomTypes() - 1);
 
-    // Bump version
-    ++atomTypesVersion_;
-
     return newAtomType;
 }
 
@@ -80,12 +77,6 @@ std::shared_ptr<AtomType> CoreData::findAtomType(std::string_view name) const
         return nullptr;
     return *it;
 }
-
-// Bump AtomTypes version
-void CoreData::bumpAtomTypesVersion() { ++atomTypesVersion_; }
-
-// Return AtomTypes version
-int CoreData::atomTypesVersion() const { return atomTypesVersion_; }
 
 // Remove any atom types that are unused across all species
 int CoreData::removeUnusedAtomTypes()

--- a/src/classes/coreData.h
+++ b/src/classes/coreData.h
@@ -39,8 +39,6 @@ class CoreData
     private:
     // Core AtomTypes list
     std::vector<std::shared_ptr<AtomType>> atomTypes_;
-    // AtomTypes version
-    VersionCounter atomTypesVersion_;
 
     public:
     // Add new AtomType
@@ -56,10 +54,6 @@ class CoreData
     std::shared_ptr<AtomType> atomType(int n);
     // Search for AtomType by name
     std::shared_ptr<AtomType> findAtomType(std::string_view name) const;
-    // Bump AtomTypes version
-    void bumpAtomTypesVersion();
-    // Return AtomTypes version
-    int atomTypesVersion() const;
     // Remove any atom types that are unused across all species
     int removeUnusedAtomTypes();
     // Clear all atom types

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -131,14 +131,8 @@ void PairPotential::setIncludedCharges(double qi, double qj)
 // Set no included charges
 void PairPotential::setNoIncludedCharges() { includeAtomTypeCharges_ = false; }
 
-// Set charge I
-void PairPotential::setChargeI(double value) { chargeI_ = value; }
-
 // Return charge I
 double PairPotential::chargeI() const { return chargeI_; }
-
-// Set charge J
-void PairPotential::setChargeJ(double value) { chargeJ_ = value; }
 
 // Return charge J
 double PairPotential::chargeJ() const { return chargeJ_; }

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -110,6 +110,13 @@ bool PairPotential::setInteractionPotential(const InteractionPotential<Functions
     return potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
 }
 
+// Set form of interaction potential
+void PairPotential::setInteractionPotentialForm(Functions1D::Form form)
+{
+    interactionPotential_.setForm(form);
+    potentialFunction_.setFormAndParameters(interactionPotential_.form(), interactionPotential_.parameters());
+}
+
 // Return interaction potential
 const InteractionPotential<Functions1D> &PairPotential::interactionPotential() const { return interactionPotential_; }
 

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -96,6 +96,8 @@ class PairPotential
     // Set interaction potential
     bool setInteractionPotential(Functions1D::Form form, std::string_view parameters);
     bool setInteractionPotential(const InteractionPotential<Functions1D> &potential);
+    // Set form of interaction potential
+    void setInteractionPotentialForm(Functions1D::Form form);
     // Return interaction potential
     const InteractionPotential<Functions1D> &interactionPotential() const;
     // Set included charges

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -13,7 +13,7 @@
 class AtomType;
 
 // PairPotential Definition
-class PairPotential
+class PairPotential : Serialisable<>
 {
     public:
     PairPotential(std::string_view nameI = {}, std::string_view nameJ = {});
@@ -195,4 +195,13 @@ class PairPotential
     void setUAdditional(Data1D &newUAdditional);
     // Adjust additional potential, and recalculate UFull and dUFull
     void adjustUAdditional(const Data1D &deltaU, double factor = 1.0);
+
+    /*
+     * I/O
+     */
+    public:
+    // Express as a serialisable value
+    SerialisedValue serialise() const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node);
 };

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -104,12 +104,8 @@ class PairPotential
     void setIncludedCharges(double qi, double qj);
     // Set no included charges
     void setNoIncludedCharges();
-    // Set charge I
-    void setChargeI(double value);
     // Return charge I
     double chargeI() const;
-    // Set charge J
-    void setChargeJ(double value);
     // Return charge J
     double chargeJ() const;
 

--- a/src/gui/forcefieldTab.cpp
+++ b/src/gui/forcefieldTab.cpp
@@ -106,7 +106,12 @@ ForcefieldTab::ForcefieldTab(DissolveWindow *dissolveWindow, Dissolve &dissolve,
     // Ensure fonts for table headers are set correctly and the headers themselves are visible
     ui_.PairPotentialsTable->horizontalHeader()->setFont(font());
     ui_.PairPotentialsTable->horizontalHeader()->setVisible(true);
+    ui_.PairPotentialsTable->setItemDelegateForColumn(
+        PairPotentialModel::Columns::ShortRangeFormColumn,
+        new ComboListDelegate(this, new ComboEnumOptionsItems<Functions1D::Form>(Functions1D::forms())));
     ui_.PairPotentialsTable->setModel(&pairPotentialModel_);
+    connect(&pairPotentialModel_, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)), this,
+            SLOT(pairPotentialDataChanged(const QModelIndex &, const QModelIndex &, const QVector<int> &)));
 
     DataViewer *viewer = ui_.PairPotentialsPlotWidget->dataViewer();
     viewer->view().axes().setTitle(0, "\\it{r}, \\sym{angstrom}");
@@ -467,6 +472,7 @@ void ForcefieldTab::on_UseCombinationRulesCheck_clicked(bool checked)
     }
 
     dissolve_.setUseCombinationRules(checked);
+    pairPotentialModel_.setEditable(!checked);
     resetPairPotentialModel();
     dissolveWindow_->setModified();
     updateControls();
@@ -474,6 +480,10 @@ void ForcefieldTab::on_UseCombinationRulesCheck_clicked(bool checked)
 
 void ForcefieldTab::pairPotentialDataChanged(const QModelIndex &current, const QModelIndex &previous, const QVector<int> &)
 {
+    dissolve_.updatePairPotentials();
+
+    updateControls();
+
     dissolveWindow_->setModified();
 }
 

--- a/src/gui/forcefieldTab.cpp
+++ b/src/gui/forcefieldTab.cpp
@@ -472,6 +472,7 @@ void ForcefieldTab::on_UseCombinationRulesCheck_clicked(bool checked)
     }
 
     dissolve_.setUseCombinationRules(checked);
+    dissolve_.updatePairPotentials();
     pairPotentialModel_.setEditable(!checked);
     resetPairPotentialModel();
     dissolveWindow_->setModified();

--- a/src/gui/forcefieldTab.h
+++ b/src/gui/forcefieldTab.h
@@ -83,8 +83,8 @@ class ForcefieldTab : public QWidget, public MainTab
     void atomTypeSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
     void atomTypeDataChanged(const QModelIndex &current, const QModelIndex &previous, const QVector<int> &);
     // Pair Potentials
-    void on_PairPotentialRangeSpin_valueChanged(double value);
-    void on_PairPotentialDeltaSpin_valueChanged(double value);
+    void on_PairPotentialRangeButton_clicked(bool checked);
+    void on_PairPotentialDeltaButton_clicked(bool checked);
     void on_PairPotentialsAtomTypeChargesRadio_clicked(bool checked);
     void on_PairPotentialsSpeciesAtomChargesRadio_clicked(bool checked);
     void on_ShortRangeTruncationCombo_currentIndexChanged(int index);

--- a/src/gui/forcefieldTab.h
+++ b/src/gui/forcefieldTab.h
@@ -71,10 +71,6 @@ class ForcefieldTab : public QWidget, public MainTab
     /*
      * Signals / Slots
      */
-    private:
-    // Signal that some AtomType parameter has been modified, so pair potentials should be regenerated
-    void atomTypeDataModified();
-
     private Q_SLOTS:
     // Atom Types
     void on_AtomTypeDuplicateButton_clicked(bool checked);
@@ -91,8 +87,7 @@ class ForcefieldTab : public QWidget, public MainTab
     void on_CoulombTruncationCombo_currentIndexChanged(int index);
     void on_AutomaticChargeSourceCheck_clicked(bool checked);
     void on_ForceChargeSourceCheck_clicked(bool checked);
-    void on_RegenerateAllPairPotentialsButton_clicked(bool checked);
-    void on_AutoUpdatePairPotentialsCheck_clicked(bool checked);
+    void on_UseCombinationRulesCheck_clicked(bool checked);
     void pairPotentialDataChanged(const QModelIndex &current, const QModelIndex &previous, const QVector<int> &);
     void pairPotentialSelectionChanged(const QItemSelection &current, const QItemSelection &previous);
     // Pair Potential Overrides

--- a/src/gui/forcefieldTab.ui
+++ b/src/gui/forcefieldTab.ui
@@ -224,28 +224,6 @@
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_6">
                <item>
-                <widget class="QToolButton" name="RegenerateAllPairPotentialsButton">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Regenerate All</string>
-                 </property>
-                 <property name="iconSize">
-                  <size>
-                   <width>16</width>
-                   <height>16</height>
-                  </size>
-                 </property>
-                 <property name="toolButtonStyle">
-                  <enum>Qt::ToolButtonTextBesideIcon</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
                 <spacer name="horizontalSpacer_5">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
@@ -259,9 +237,9 @@
                 </spacer>
                </item>
                <item>
-                <widget class="QCheckBox" name="AutoUpdatePairPotentialsCheck">
+                <widget class="QCheckBox" name="UseCombinationRulesCheck">
                  <property name="text">
-                  <string>Auto</string>
+                  <string>Use Combination Rules</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>

--- a/src/gui/forcefieldTab.ui
+++ b/src/gui/forcefieldTab.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>770</width>
-    <height>364</height>
+    <height>591</height>
    </rect>
   </property>
   <property name="font">
@@ -37,7 +37,7 @@
    <item>
     <widget class="QTabWidget" name="Tabs">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="AtomTypesTab">
       <attribute name="title">
@@ -448,6 +448,12 @@
        </item>
        <item>
         <widget class="QWidget" name="PairPotentialRightWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <layout class="QVBoxLayout" name="verticalLayout_3">
           <property name="spacing">
            <number>4</number>
@@ -477,7 +483,7 @@
               <item row="0" column="0">
                <widget class="QGroupBox" name="PairPotentialRangeGroup">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
@@ -511,19 +517,6 @@
                    </property>
                    <property name="text">
                     <string>???</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="PairPotentialRangeLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Å</string>
                    </property>
                   </widget>
                  </item>
@@ -567,19 +560,6 @@
                    </property>
                    <property name="text">
                     <string>???</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLabel" name="PairPotentialDeltaLabel">
-                   <property name="sizePolicy">
-                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                     <horstretch>0</horstretch>
-                     <verstretch>0</verstretch>
-                    </sizepolicy>
-                   </property>
-                   <property name="text">
-                    <string>Å</string>
                    </property>
                   </widget>
                  </item>
@@ -752,7 +732,7 @@
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>20</width>
-                   <height>40</height>
+                   <height>0</height>
                   </size>
                  </property>
                 </spacer>

--- a/src/gui/forcefieldTab.ui
+++ b/src/gui/forcefieldTab.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>825</width>
-    <height>807</height>
+    <width>770</width>
+    <height>364</height>
    </rect>
   </property>
   <property name="font">
@@ -37,7 +37,7 @@
    <item>
     <widget class="QTabWidget" name="Tabs">
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="AtomTypesTab">
       <attribute name="title">
@@ -196,584 +196,617 @@
       <attribute name="title">
        <string>Pair Potentials</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout_9">
-       <property name="spacing">
-        <number>4</number>
-       </property>
-       <property name="leftMargin">
-        <number>4</number>
-       </property>
-       <property name="topMargin">
-        <number>4</number>
-       </property>
-       <property name="rightMargin">
-        <number>4</number>
-       </property>
-       <property name="bottomMargin">
-        <number>4</number>
-       </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_13">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <property name="spacing">
-          <number>4</number>
-         </property>
-         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_6">
-           <item>
-            <widget class="QToolButton" name="RegenerateAllPairPotentialsButton">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+        <widget class="QWidget" name="PairPotentialLeftWidget" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QGroupBox" name="groupBox_2">
+            <property name="title">
+             <string>Main Potentials</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_4">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_6">
+               <item>
+                <widget class="QToolButton" name="RegenerateAllPairPotentialsButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Regenerate All</string>
+                 </property>
+                 <property name="iconSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="toolButtonStyle">
+                  <enum>Qt::ToolButtonTextBesideIcon</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="AutoUpdatePairPotentialsCheck">
+                 <property name="text">
+                  <string>Auto</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QTableView" name="PairPotentialsTable">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="selectionMode">
+                <enum>QAbstractItemView::SingleSelection</enum>
+               </property>
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGroupBox" name="OverridesGroup">
+            <property name="title">
+             <string>Overrides</string>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="spacing">
+              <number>4</number>
              </property>
-             <property name="text">
-              <string>Regenerate All</string>
+             <property name="leftMargin">
+              <number>4</number>
              </property>
-             <property name="iconSize">
-              <size>
-               <width>16</width>
-               <height>16</height>
-              </size>
+             <property name="topMargin">
+              <number>4</number>
              </property>
-             <property name="toolButtonStyle">
-              <enum>Qt::ToolButtonTextBesideIcon</enum>
+             <property name="rightMargin">
+              <number>4</number>
              </property>
-            </widget>
-           </item>
-           <item>
-            <spacer name="horizontalSpacer_5">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
+             <property name="bottomMargin">
+              <number>4</number>
              </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QCheckBox" name="AutoUpdatePairPotentialsCheck">
-             <property name="text">
-              <string>Auto</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QTableView" name="PairPotentialsTable">
-           <property name="font">
-            <font>
-             <pointsize>10</pointsize>
-            </font>
-           </property>
-           <property name="selectionMode">
-            <enum>QAbstractItemView::SingleSelection</enum>
-           </property>
-           <property name="selectionBehavior">
-            <enum>QAbstractItemView::SelectRows</enum>
-           </property>
-           <attribute name="horizontalHeaderVisible">
-            <bool>false</bool>
-           </attribute>
-           <attribute name="verticalHeaderVisible">
-            <bool>false</bool>
-           </attribute>
-          </widget>
-         </item>
-         <item>
-          <widget class="QGroupBox" name="OverridesGroup">
-           <property name="title">
-            <string>Overrides</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_2">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_10">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QToolButton" name="OverrideDuplicateButton">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Duplicate</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="main.qrc">
+                   <normaloff>:/general/icons/copy.svg</normaloff>:/general/icons/copy.svg</iconset>
+                 </property>
+                 <property name="iconSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="toolButtonStyle">
+                  <enum>Qt::ToolButtonTextBesideIcon</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_7">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QToolButton" name="OverrideRemoveButton">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Remove</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="main.qrc">
+                   <normaloff>:/general/icons/remove.svg</normaloff>:/general/icons/remove.svg</iconset>
+                 </property>
+                 <property name="iconSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="toolButtonStyle">
+                  <enum>Qt::ToolButtonTextBesideIcon</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QToolButton" name="OverrideAddButton">
+                 <property name="sizePolicy">
+                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                   <horstretch>0</horstretch>
+                   <verstretch>0</verstretch>
+                  </sizepolicy>
+                 </property>
+                 <property name="text">
+                  <string>Add</string>
+                 </property>
+                 <property name="icon">
+                  <iconset resource="main.qrc">
+                   <normaloff>:/general/icons/add.svg</normaloff>:/general/icons/add.svg</iconset>
+                 </property>
+                 <property name="iconSize">
+                  <size>
+                   <width>16</width>
+                   <height>16</height>
+                  </size>
+                 </property>
+                 <property name="toolButtonStyle">
+                  <enum>Qt::ToolButtonTextBesideIcon</enum>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QTableView" name="OverridesTable">
+               <property name="font">
+                <font>
+                 <pointsize>10</pointsize>
+                </font>
+               </property>
+               <property name="selectionMode">
+                <enum>QAbstractItemView::SingleSelection</enum>
+               </property>
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>true</bool>
+               </attribute>
+               <attribute name="verticalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QWidget" name="PairPotentialRightWidget" native="true">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <property name="spacing">
+           <number>4</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_12">
             <property name="spacing">
              <number>4</number>
             </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout_10">
+             <layout class="QGridLayout" name="gridLayout">
               <property name="spacing">
                <number>4</number>
               </property>
-              <item>
-               <widget class="QToolButton" name="OverrideDuplicateButton">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
+              <item row="0" column="0">
+               <widget class="QGroupBox" name="PairPotentialRangeGroup">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="text">
-                 <string>Duplicate</string>
+                <property name="title">
+                 <string>Range</string>
                 </property>
-                <property name="icon">
-                 <iconset resource="main.qrc">
-                  <normaloff>:/general/icons/copy.svg</normaloff>:/general/icons/copy.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>16</width>
-                  <height>16</height>
-                 </size>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonTextBesideIcon</enum>
-                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_9">
+                 <property name="spacing">
+                  <number>4</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>4</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="PairPotentialRangeButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>???</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="PairPotentialRangeLabel">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Å</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
-              <item>
-               <spacer name="horizontalSpacer_7">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item>
-               <widget class="QToolButton" name="OverrideRemoveButton">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
+              <item row="0" column="1">
+               <widget class="QGroupBox" name="PairPotentialDeltaGroup">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="text">
-                 <string>Remove</string>
+                <property name="title">
+                 <string>Delta</string>
                 </property>
-                <property name="icon">
-                 <iconset resource="main.qrc">
-                  <normaloff>:/general/icons/remove.svg</normaloff>:/general/icons/remove.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>16</width>
-                  <height>16</height>
-                 </size>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonTextBesideIcon</enum>
-                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_11">
+                 <property name="spacing">
+                  <number>4</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>4</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="PairPotentialDeltaButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>???</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="PairPotentialDeltaLabel">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Å</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
-              <item>
-               <widget class="QToolButton" name="OverrideAddButton">
+              <item row="1" column="0" colspan="2">
+               <widget class="QGroupBox" name="ShortRangeTruncationGroup">
                 <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                   <horstretch>0</horstretch>
                   <verstretch>0</verstretch>
                  </sizepolicy>
                 </property>
-                <property name="text">
-                 <string>Add</string>
+                <property name="title">
+                 <string>Truncation</string>
                 </property>
-                <property name="icon">
-                 <iconset resource="main.qrc">
-                  <normaloff>:/general/icons/add.svg</normaloff>:/general/icons/add.svg</iconset>
-                </property>
-                <property name="iconSize">
-                 <size>
-                  <width>16</width>
-                  <height>16</height>
-                 </size>
-                </property>
-                <property name="toolButtonStyle">
-                 <enum>Qt::ToolButtonTextBesideIcon</enum>
-                </property>
+                <layout class="QGridLayout" name="gridLayout_2">
+                 <property name="leftMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="topMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>4</number>
+                 </property>
+                 <property name="spacing">
+                  <number>4</number>
+                 </property>
+                 <item row="0" column="1" colspan="2">
+                  <widget class="QComboBox" name="ShortRangeTruncationCombo">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="QComboBox" name="CoulombTruncationCombo">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="label_890">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>van der Waals</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_891">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Coulomb</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </widget>
               </item>
              </layout>
             </item>
             <item>
-             <widget class="QTableView" name="OverridesTable">
-              <property name="font">
-               <font>
-                <pointsize>10</pointsize>
-               </font>
-              </property>
-              <property name="selectionMode">
-               <enum>QAbstractItemView::SingleSelection</enum>
-              </property>
-              <property name="selectionBehavior">
-               <enum>QAbstractItemView::SelectRows</enum>
-              </property>
-              <attribute name="horizontalHeaderVisible">
-               <bool>true</bool>
-              </attribute>
-              <attribute name="verticalHeaderVisible">
-               <bool>false</bool>
-              </attribute>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="2" column="0" colspan="2">
-          <widget class="QFrame" name="PairPotentialsPlotFrame">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-             <horstretch>0</horstretch>
-             <verstretch>2</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::StyledPanel</enum>
-           </property>
-           <property name="frameShadow">
-            <enum>QFrame::Sunken</enum>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_8">
-            <property name="spacing">
-             <number>4</number>
-            </property>
-            <property name="leftMargin">
-             <number>4</number>
-            </property>
-            <property name="topMargin">
-             <number>4</number>
-            </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="DataWidget" name="PairPotentialsPlotWidget" native="true">
+             <widget class="QGroupBox" name="PairPotentialStyleGroup">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
+              <property name="title">
+               <string>Charge Source</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <property name="spacing">
+                <number>4</number>
+               </property>
+               <property name="leftMargin">
+                <number>4</number>
+               </property>
+               <property name="topMargin">
+                <number>4</number>
+               </property>
+               <property name="rightMargin">
+                <number>4</number>
+               </property>
+               <property name="bottomMargin">
+                <number>4</number>
+               </property>
+               <item>
+                <widget class="QCheckBox" name="AutomaticChargeSourceCheck">
+                 <property name="text">
+                  <string>Choose Automatically</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="Line" name="line">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="PairPotentialsAtomTypeChargesRadio">
+                 <property name="toolTip">
+                  <string>If selected, charges from atom types are included in tabulated pair potentials</string>
+                 </property>
+                 <property name="text">
+                  <string>Atom Types</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QRadioButton" name="PairPotentialsSpeciesAtomChargesRadio">
+                 <property name="toolTip">
+                  <string>If selected, tabulated pair potentials only contain short-range terms, with charges taken from species atoms</string>
+                 </property>
+                 <property name="text">
+                  <string>Species Atoms</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="ForceChargeSourceCheck">
+                 <property name="text">
+                  <string>Force Choice</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
              </widget>
             </item>
            </layout>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QGroupBox" name="PairPotentialStyleGroup">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="title">
-            <string>Charge Source</string>
-           </property>
-           <layout class="QVBoxLayout" name="verticalLayout_5">
-            <property name="spacing">
-             <number>4</number>
+          </item>
+          <item>
+           <widget class="QFrame" name="PairPotentialsPlotFrame">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>2</verstretch>
+             </sizepolicy>
             </property>
-            <property name="leftMargin">
-             <number>4</number>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
             </property>
-            <property name="topMargin">
-             <number>4</number>
+            <property name="frameShadow">
+             <enum>QFrame::Sunken</enum>
             </property>
-            <property name="rightMargin">
-             <number>4</number>
-            </property>
-            <property name="bottomMargin">
-             <number>4</number>
-            </property>
-            <item>
-             <widget class="QCheckBox" name="AutomaticChargeSourceCheck">
-              <property name="text">
-               <string>Choose Automatically</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="Line" name="line">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="PairPotentialsAtomTypeChargesRadio">
-              <property name="toolTip">
-               <string>If selected, charges from atom types are included in tabulated pair potentials</string>
-              </property>
-              <property name="text">
-               <string>Atom Types</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QRadioButton" name="PairPotentialsSpeciesAtomChargesRadio">
-              <property name="toolTip">
-               <string>If selected, tabulated pair potentials only contain short-range terms, with charges taken from species atoms</string>
-              </property>
-              <property name="text">
-               <string>Species Atoms</string>
-              </property>
-              <property name="checked">
-               <bool>false</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QCheckBox" name="ForceChargeSourceCheck">
-              <property name="text">
-               <string>Force Choice</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <layout class="QVBoxLayout" name="verticalLayout_4">
-           <item>
-            <widget class="QGroupBox" name="PairPotentialControlGroup">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+            <layout class="QHBoxLayout" name="horizontalLayout_8">
+             <property name="spacing">
+              <number>4</number>
              </property>
-             <property name="title">
-              <string>Control</string>
+             <property name="leftMargin">
+              <number>4</number>
              </property>
-             <layout class="QGridLayout" name="gridLayout">
-              <property name="leftMargin">
-               <number>4</number>
-              </property>
-              <property name="topMargin">
-               <number>4</number>
-              </property>
-              <property name="rightMargin">
-               <number>4</number>
-              </property>
-              <property name="bottomMargin">
-               <number>4</number>
-              </property>
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_8">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Å</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_888">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Delta</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="ExponentialSpin" name="PairPotentialDeltaSpin">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="decimals">
-                 <number>4</number>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_887">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Range</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1">
-               <widget class="ExponentialSpin" name="PairPotentialRangeSpin">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="decimals">
-                 <number>4</number>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="2">
-               <widget class="QLabel" name="label_7">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Å</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="ShortRangeTruncationGroup">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
+             <property name="topMargin">
+              <number>4</number>
              </property>
-             <property name="title">
-              <string>Potential Truncation</string>
+             <property name="rightMargin">
+              <number>4</number>
              </property>
-             <layout class="QGridLayout" name="gridLayout_2">
-              <property name="leftMargin">
-               <number>4</number>
-              </property>
-              <property name="topMargin">
-               <number>4</number>
-              </property>
-              <property name="rightMargin">
-               <number>4</number>
-              </property>
-              <property name="bottomMargin">
-               <number>4</number>
-              </property>
-              <property name="spacing">
-               <number>4</number>
-              </property>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_890">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>van der Waals</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="1" colspan="2">
-               <widget class="QComboBox" name="ShortRangeTruncationCombo">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_891">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Coulomb</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="1">
-               <widget class="QComboBox" name="CoulombTruncationCombo">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-           </item>
-          </layout>
-         </item>
-        </layout>
+             <property name="bottomMargin">
+              <number>4</number>
+             </property>
+             <item>
+              <widget class="DataWidget" name="PairPotentialsPlotWidget" native="true">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -1256,11 +1289,6 @@
   </layout>
  </widget>
  <customwidgets>
-  <customwidget>
-   <class>ExponentialSpin</class>
-   <extends>QDoubleSpinBox</extends>
-   <header>gui/widgets/exponentialSpin.h</header>
-  </customwidget>
   <customwidget>
    <class>DataWidget</class>
    <extends>QWidget</extends>

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -28,8 +28,8 @@ bool DissolveWindow::clearModuleData(bool queryUser)
         // Set iteration counter to zero
         dissolve_.resetIterationCounter();
 
-        // Revert pair potentials (so that any additional potential is removed)
-        dissolve_.revertPairPotentials();
+        // Clear any additional terms on pair potentials
+        dissolve_.clearAdditionalPotentials();
 
         Renderable::setSourceDataAccessEnabled(true);
 

--- a/src/gui/menu_simulation.cpp
+++ b/src/gui/menu_simulation.cpp
@@ -66,7 +66,7 @@ void DissolveWindow::on_SimulationClearAdditionalPotentialsAction_triggered(bool
                              QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No,
                              QMessageBox::StandardButton::No) == QMessageBox::StandardButton::Yes)
     {
-        dissolve_.revertPairPotentials();
+        dissolve_.clearAdditionalPotentials();
 
         fullUpdate();
     }

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -239,7 +239,6 @@ void AddForcefieldDialogModel::finalise()
         {
             original.atomType()->interactionPotential() = modified.atomType()->interactionPotential();
             original.atomType()->setCharge(modified.atomType()->charge());
-            dissolve_->coreData().bumpAtomTypesVersion();
         }
 
         // Copy charge on species atom

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -77,7 +77,7 @@ QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
 
 bool PairPotentialModel::setData(const QModelIndex &index, const QVariant &value, int role)
 {
-    if (role != Qt::EditRole)
+    if (role != Qt::EditRole || !editable_)
         return false;
 
     auto *pair = rawData(index);

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -56,9 +56,9 @@ QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
             case (Columns::NameJColumn):
                 return QString::fromStdString(std::string(pp->nameJ()));
             case (Columns::ChargeIColumn):
-                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeI()) : QString();
+                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeI()) : QString("--");
             case (Columns::ChargeJColumn):
-                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeJ()) : QString();
+                return pp->includeAtomTypeCharges() ? QString::number(pp->chargeJ()) : QString("--");
             case (Columns::ShortRangeFormColumn):
                 return QString::fromStdString(Functions1D::forms().keyword(pp->interactionPotential().form()));
             case (Columns::ShortRangeParametersColumn):

--- a/src/gui/models/pairPotentialModel.cpp
+++ b/src/gui/models/pairPotentialModel.cpp
@@ -59,10 +59,8 @@ QVariant PairPotentialModel::data(const QModelIndex &index, int role) const
                 return pp->includeAtomTypeCharges() ? QString::number(pp->chargeI()) : QString();
             case (Columns::ChargeJColumn):
                 return pp->includeAtomTypeCharges() ? QString::number(pp->chargeJ()) : QString();
-            // Form
             case (Columns::ShortRangeFormColumn):
                 return QString::fromStdString(Functions1D::forms().keyword(pp->interactionPotential().form()));
-            // Short Range Parameters
             case (Columns::ShortRangeParametersColumn):
                 return QString::fromStdString(pp->interactionPotential().parametersAsString());
             default:
@@ -90,11 +88,9 @@ bool PairPotentialModel::setData(const QModelIndex &index, const QVariant &value
         case (Columns::ChargeIColumn):
         case (Columns::ChargeJColumn):
             return false;
-        // Short-Range Form
         case (Columns::ShortRangeFormColumn):
             pair->setInteractionPotentialForm(Functions1D::forms().enumeration(value.toString().toStdString()));
             break;
-        // Short Range Parameters
         case (Columns::ShortRangeParametersColumn):
             if (!pair->setInteractionPotential(pair->interactionPotential().form(), value.toString().toStdString()))
                 return false;

--- a/src/gui/models/pairPotentialModel.h
+++ b/src/gui/models/pairPotentialModel.h
@@ -14,14 +14,31 @@ class PairPotentialModel : public QAbstractListModel
 {
     Q_OBJECT
 
+    public:
+    PairPotentialModel(const std::vector<PairPotential::Definition> &data);
+    ~PairPotentialModel() = default;
+
+    enum Columns
+    {
+        NameIColumn,
+        NameJColumn,
+        ChargeIColumn,
+        ChargeJColumn,
+        ShortRangeFormColumn,
+        ShortRangeParametersColumn,
+        nDataColumns
+    };
+
     private:
     // Source pair potential data
     const std::vector<PairPotential::Definition> &data_;
+    // Whether the pair potential is editable
+    bool editable_{false};
 
     public:
-    // Set source pair potential data
-    PairPotentialModel(const std::vector<PairPotential::Definition> &data);
-    ~PairPotentialModel() = default;
+    // Set whether the data is editable or not
+    void setEditable(bool b);
+    // Retrieve raw data for model
     const PairPotential *rawData(const QModelIndex index) const;
     PairPotential *rawData(const QModelIndex index);
     // Update the table contents

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -106,8 +106,8 @@ class Dissolve : public Serialisable<>
     const PotentialMap &potentialMap() const;
     // Update all pair potentials
     bool updatePairPotentials(std::optional<bool> useCombinationRulesHint = {});
-    // Revert potentials to reference state, clearing additional potentials
-    void revertPairPotentials();
+    // Clear additional potentials
+    void clearAdditionalPotentials();
 
     /*
      * Processing Module Data

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -65,6 +65,10 @@ class Dissolve : public Serialisable<>
     PotentialMap potentialMap_;
 
     public:
+    // Set whether pair potentials are updated automatically through combination rules
+    void setUseCombinationRules(bool b);
+    // Return whether pair potentials are updated automatically through combination rules
+    bool useCombinationRules() const;
     // Set maximum distance for tabulated PairPotentials
     void setPairPotentialRange(double range);
     // Return maximum distance for tabulated PairPotentials

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -146,15 +146,15 @@ SerialisedValue Dissolve::serialisePairPotentials() const
     if (!useCombinationRules_)
     {
         pairPotentials["useCombinationRules"] = false;
-        SerialisedValue pots = SerialisedValue::array_type{};
-        for (const auto &[at1, at2, pot] : pairPotentials_)
-        {
-            SerialisedValue value = pot->serialise();
-            value["atomTypeI"] = at1->name();
-            value["atomTypeJ"] = at2->name();
-            pots.push_back(value);
-        }
-        pairPotentials["potentials"] = pots;
+        Serialisable::fromVector(pairPotentials_, "potentials", pairPotentials,
+                                 [](const auto &term)
+                                 {
+                                     const auto &[at1, at2, pot] = term;
+                                     auto value = pot->serialise();
+                                     value["atomTypeI"] = at1->name();
+                                     value["atomTypeJ"] = at2->name();
+                                     return value;
+                                 });
     }
     return pairPotentials;
 }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -384,6 +384,22 @@ bool Dissolve::saveInput(std::string_view filename)
                                atomType->interactionPotential().parametersAsString()))
             return false;
 
+    // Pair potentials (if we are not using combination rules)
+    if (!useCombinationRules_)
+    {
+        if (!parser.writeLineF("  # Pair Potentials\n"))
+            return false;
+        if (!parser.writeLineF("  {}  {}\n", PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::UseCombinationRules),
+                               DissolveSys::btoa(false)))
+            return false;
+        for (const auto &[at1, at2, pot] : pairPotentials_)
+            if (!parser.writeLineF("  {}  '{}'  '{}'  {}  {}\n",
+                                   PairPotentialsBlock::keywords().keyword(PairPotentialsBlock::PairPotentialKeyword),
+                                   at1->name(), at2->name(), Functions1D::forms().keyword(pot->interactionPotential().form()),
+                                   pot->interactionPotential().parametersAsString()))
+                return false;
+    }
+
     // Pair potential overrides
     for (const auto &ppOverride : coreData_.pairPotentialOverrides())
         if (!parser.writeLineF("  {}  '{}'  '{}'  {}  {}  {}\n",

--- a/src/main/keywords.h
+++ b/src/main/keywords.h
@@ -135,12 +135,15 @@ enum PairPotentialsKeyword
     ForceChargeSourceKeyword,  /* 'ForceChargeSource' - Force the selected charge scheme for use if choosing manually */
     IncludeCoulombKeyword,     /* 'IncludeCoulomb' - Include Coulomb term in tabulated pair potentials" */
     ManualChargeSourceKeyword, /* 'ManualChargeSource' - Determine whether automatic or manual charge selection is used */
-    OverrideKeyword,           /* 'Override' - Define a pairpotential override between specific atom types */
+    OverrideKeyword,           /* 'Override' - Define a pair potential override between atom types */
+    PairPotentialKeyword,      /* 'PairPotential' - Define a single pair potential between specific atom types */
     ParametersKeyword, /* 'Parameters' - Sets or re-sets the short-range and charge parameters for a specific AtomType */
     RangeKeyword,      /* 'Range' - Specifies the total range (inc. truncation width) over which to generate potentials */
-    ShortRangeTruncationKeyword,     /* 'ShortRangeTruncation' - Truncation scheme to apply to short-range potential */
-    ShortRangeTruncationWidthKeyword /* 'ShortRangeTruncationWidth' - Width of potential tail over which to reduce
+    ShortRangeTruncationKeyword,      /* 'ShortRangeTruncation' - Truncation scheme to apply to short-range potential */
+    ShortRangeTruncationWidthKeyword, /* 'ShortRangeTruncationWidth' - Width of potential tail over which to reduce
                         short-range term to zero */
+    UseCombinationRules /* 'UseCombinationRules' - Whether to use combination rules, and hence automatic pair potential
+                           generation */
 };
 // Return enum option info for PairPotentialsKeyword
 EnumOptions<PairPotentialsBlock::PairPotentialsKeyword> keywords();

--- a/src/main/pairPotentials.cpp
+++ b/src/main/pairPotentials.cpp
@@ -6,6 +6,20 @@
 #include "classes/atomType.h"
 #include "main/dissolve.h"
 
+// Set whether pair potentials are updated automatically through combination rules
+void Dissolve::setUseCombinationRules(bool b)
+{
+    if (b == useCombinationRules_)
+        return;
+
+    useCombinationRules_ = b;
+
+    updatePairPotentials();
+}
+
+// Return whether pair potentials are updated automatically through combination rules
+bool Dissolve::useCombinationRules() const { return useCombinationRules_; }
+
 // Set maximum distance for tabulated PairPotentials
 void Dissolve::setPairPotentialRange(double range) { pairPotentialRange_ = range; }
 

--- a/src/main/pairPotentials.cpp
+++ b/src/main/pairPotentials.cpp
@@ -239,8 +239,8 @@ bool Dissolve::updatePairPotentials(std::optional<bool> useCombinationRulesHint)
     return potentialMap_.initialise(coreData_.atomTypes(), pairPotentials_, pairPotentialRange_);
 }
 
-// Revert potentials to reference state, clearing additional potentials
-void Dissolve::revertPairPotentials()
+// Clear additional potentials
+void Dissolve::clearAdditionalPotentials()
 {
     for (auto &&[at1, at2, pp] : pairPotentials_)
     {

--- a/src/main/pairPotentials.cpp
+++ b/src/main/pairPotentials.cpp
@@ -7,15 +7,7 @@
 #include "main/dissolve.h"
 
 // Set whether pair potentials are updated automatically through combination rules
-void Dissolve::setUseCombinationRules(bool b)
-{
-    if (b == useCombinationRules_)
-        return;
-
-    useCombinationRules_ = b;
-
-    updatePairPotentials();
-}
+void Dissolve::setUseCombinationRules(bool b) { useCombinationRules_ = b; }
 
 // Return whether pair potentials are updated automatically through combination rules
 bool Dissolve::useCombinationRules() const { return useCombinationRules_; }

--- a/tests/data/dissolve/input/energyForce-water3000-defined.txt
+++ b/tests/data/dissolve/input/energyForce-water3000-defined.txt
@@ -49,8 +49,8 @@ PairPotentials
   Range  15.000000
   ShortRangeTruncation  None
   Delta  0.0001
-  Parameters  'OW'  O  0.0   LJGeometric  0.0       0.0
-  Parameters  'HW'  H  0.0   LJGeometric  0.0       0.0
+  Parameters  'OW'  O  0.0   Undefined
+  Parameters  'HW'  H  0.0   Undefined
   UseCombinationRules  False
   PairPotential  'OW'  'OW'  LennardJones126   0.6503    3.165492
   ManualChargeSource  True

--- a/tests/data/dissolve/input/energyForce-water3000-defined.txt
+++ b/tests/data/dissolve/input/energyForce-water3000-defined.txt
@@ -1,0 +1,59 @@
+Master
+  Bond  'HW-OW'  Harmonic  k=4431.53 eq=1.012
+  Angle  'HW-OW-HW'  Harmonic  k=317.566 eq=113.24
+EndMaster
+
+# Define Water Molecule
+Species 'Water'
+  # Atoms
+  Atom    1    O     0.015   -0.009   -0.373   'OW'  -0.82
+  Atom    2    H     0.757    0.013    0.217   'HW'   0.41
+  Atom    3    H    -0.771   -0.003    0.157   'HW'   0.41
+
+  # Intramolecular Terms
+  Bond    1    2    @HW-OW
+  Bond    1    3    @HW-OW
+  Angle    2    1    3    @HW-OW-HW
+EndSpecies
+
+# Define Configuration
+Configuration  'Bulk'
+  Generator
+    Add
+      Density  9.99999642E-02 atoms/A3
+      Population  1000
+      Species  'Water'
+    EndAdd
+    ImportCoordinates  'InputCoordinates01'
+      File  dlpoly  'dlpoly/water3000_energyForce/CONFIG'
+      EndFile
+    EndImportCoordinates
+  EndGenerator
+
+EndConfiguration
+
+Layer  'Processing'
+
+  Module Energy  'Energy01'
+    Configuration  'Bulk'
+  EndModule
+
+  Module Forces  'Forces01'
+    Configuration  'Bulk'
+  EndModule
+
+EndLayer
+
+# Pair Potentials
+PairPotentials
+  Range  15.000000
+  ShortRangeTruncation  None
+  Delta  0.0001
+  Parameters  'OW'  O  0.0   LJGeometric  0.0       0.0
+  Parameters  'HW'  H  0.0   LJGeometric  0.0       0.0
+  UseCombinationRules  False
+  PairPotential  'OW'  'OW'  LennardJones126   0.6503    3.165492
+  ManualChargeSource  True
+  ForceChargeSource  True
+  IncludeCoulomb  Off
+EndPairPotentials

--- a/tests/gui/forcefieldTab.cpp
+++ b/tests/gui/forcefieldTab.cpp
@@ -37,35 +37,58 @@ TEST_F(ForcefieldTabTest, PairPotentials)
     PairPotentialModel pairs(dissolve.pairPotentials());
     ASSERT_EQ(dissolve.nPairPotentials(), 3);
 
-    // Test Pairss
+    // Test Pairs
     EXPECT_EQ(pairs.columnCount(), 6);
     EXPECT_EQ(pairs.rowCount(), 3);
 
-    EXPECT_EQ(pairs.data(pairs.index(0, 0)).toString().toStdString(), "CA");
-    EXPECT_EQ(pairs.data(pairs.index(0, 1)).toString().toStdString(), "CA");
-    EXPECT_EQ(pairs.data(pairs.index(0, 2)).toString().toStdString(), "LennardJones126");
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 3)).toDouble(), -0.115);
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 4)).toDouble(), -0.115);
-    EXPECT_EQ(pairs.data(pairs.index(0, 5)).toString().toStdString(), "epsilon=0.29288 sigma=3.55");
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::NameIColumn)).toString().toStdString(), "CA");
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::NameJColumn)).toString().toStdString(), "CA");
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ChargeIColumn)).toDouble(), -0.115);
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ChargeJColumn)).toDouble(), -0.115);
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeFormColumn)).toString().toStdString(),
+              "LennardJones126");
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeParametersColumn)).toString().toStdString(),
+              "epsilon=0.29288 sigma=3.55");
 
-    EXPECT_EQ(pairs.data(pairs.index(2, 0)).toString().toStdString(), "HA");
-    EXPECT_EQ(pairs.data(pairs.index(2, 1)).toString().toStdString(), "HA");
-    EXPECT_EQ(pairs.data(pairs.index(2, 2)).toString().toStdString(), "LennardJones126");
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 3)).toDouble(), 0.115);
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, 4)).toDouble(), 0.115);
-    EXPECT_EQ(pairs.data(pairs.index(2, 5)).toString().toStdString(), "epsilon=0.12552 sigma=2.42");
+    EXPECT_EQ(pairs.data(pairs.index(1, PairPotentialModel::Columns::NameIColumn)).toString().toStdString(), "CA");
+    EXPECT_EQ(pairs.data(pairs.index(1, PairPotentialModel::Columns::NameJColumn)).toString().toStdString(), "HA");
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(1, PairPotentialModel::Columns::ChargeIColumn)).toDouble(), -0.115);
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(1, PairPotentialModel::Columns::ChargeJColumn)).toDouble(), 0.115);
+    EXPECT_EQ(pairs.data(pairs.index(1, PairPotentialModel::Columns::ShortRangeFormColumn)).toString().toStdString(),
+              "LennardJones126");
 
-    // Currently, we do not support the user changing the values, but
-    // I've added the option for the future
-    EXPECT_FALSE(pairs.setData(pairs.index(0, 0), "HA"));
-    EXPECT_FALSE(pairs.setData(pairs.index(0, 1), "HA"));
-    EXPECT_FALSE(pairs.setData(pairs.index(0, 2), "LJ"));
-    EXPECT_TRUE(pairs.setData(pairs.index(0, 3), 2));
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 3)).toDouble(), 2);
-    EXPECT_TRUE(pairs.setData(pairs.index(0, 4), -3));
-    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(0, 4)).toDouble(), -3);
-    EXPECT_TRUE(pairs.setData(pairs.index(0, 5), "4.0, -5.0"));
-    EXPECT_THAT(pairs.data(pairs.index(0, 5)).toString().toStdString(),
-                testing::AnyOf(testing::Eq("epsilon=4.0 sigma=-5.0"), testing::Eq("epsilon=4 sigma=-5")));
+    EXPECT_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::NameIColumn)).toString().toStdString(), "HA");
+    EXPECT_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::NameJColumn)).toString().toStdString(), "HA");
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::ChargeIColumn)).toDouble(), 0.115);
+    EXPECT_DOUBLE_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::ChargeJColumn)).toDouble(), 0.115);
+    EXPECT_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::ShortRangeFormColumn)).toString().toStdString(),
+              "LennardJones126");
+    EXPECT_EQ(pairs.data(pairs.index(2, PairPotentialModel::Columns::ShortRangeParametersColumn)).toString().toStdString(),
+              "epsilon=0.12552 sigma=2.42");
+
+    // Try to set immutable data
+    EXPECT_FALSE(pairs.setData(pairs.index(0, PairPotentialModel::Columns::NameIColumn), "XX"));
+    EXPECT_FALSE(pairs.setData(pairs.index(1, PairPotentialModel::Columns::NameJColumn), "XX"));
+    EXPECT_FALSE(pairs.setData(pairs.index(2, PairPotentialModel::Columns::ChargeIColumn), 1.0));
+    EXPECT_FALSE(pairs.setData(pairs.index(2, PairPotentialModel::Columns::ChargeJColumn), -0.5));
+
+    // Set data - model is not set to editable yet, so these should also fail
+    EXPECT_FALSE(pairs.setData(pairs.index(0, PairPotentialModel::Columns::ShortRangeFormColumn),
+                               QString::fromStdString(Functions1D::forms().keyword(Functions1D::GaussianPotential))));
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeFormColumn)).toString().toStdString(),
+              "LennardJones126");
+    EXPECT_FALSE(pairs.setData(pairs.index(0, PairPotentialModel::Columns::ShortRangeParametersColumn), "A=4 fwhm=1.0 x0=2.5"));
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeParametersColumn)).toString().toStdString(),
+              "epsilon=0.29288 sigma=3.55");
+
+    // Set model to be editable and repeat
+    pairs.setEditable(true);
+    EXPECT_TRUE(pairs.setData(pairs.index(0, PairPotentialModel::Columns::ShortRangeFormColumn),
+                              QString::fromStdString(Functions1D::forms().keyword(Functions1D::GaussianPotential))));
+    EXPECT_EQ(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeFormColumn)).toString().toStdString(),
+              Functions1D::forms().keyword(Functions1D::GaussianPotential));
+    EXPECT_TRUE(pairs.setData(pairs.index(0, PairPotentialModel::Columns::ShortRangeParametersColumn), "A=4 fwhm=1.0 x0=2.5"));
+    EXPECT_THAT(pairs.data(pairs.index(0, PairPotentialModel::Columns::ShortRangeParametersColumn)).toString().toStdString(),
+                testing::AnyOf(testing::Eq("A=4 fwhm=1 x0=2.5"), testing::Eq("A=4.0 fwhm=1.0 x0=2.5")));
 }
 } // namespace UnitTest

--- a/tests/modules/energy.cpp
+++ b/tests/modules/energy.cpp
@@ -53,14 +53,32 @@ TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaals)
 
 TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaalsOverrides)
 {
-    ASSERT_NO_THROW(systemTest.setUp("dissolve/input/energyForce-water3000-overrides.txt",
-                                     [](Dissolve &D, CoreData &C)
-                                     {
-                                         D.setAtomTypeChargeSource(true);
-                                         D.setAutomaticChargeSource(false);
-                                         C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                         C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
-                                     }));
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000-overrides.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
+    systemTest.setModuleEnabled("Forces01", false);
+    ASSERT_TRUE(systemTest.dissolve().iterate(1));
+
+    auto &interEnergy = systemTest.dissolve().processingModuleData().value<Data1D>("Energy01//Bulk//PairPotential");
+    EXPECT_TRUE(
+        systemTest.checkDouble("interatomic van der Waals energy", interEnergy.values().back(), 1770.1666370083758, 6.0e-2));
+}
+
+TEST_F(EnergyModuleTest, DLPOLYWater3000VanDerWaalsDefined)
+{
+    ASSERT_NO_THROW_VERBOSE(systemTest.setUp("dissolve/input/energyForce-water3000-defined.txt",
+                                             [](Dissolve &D, CoreData &C)
+                                             {
+                                                 D.setAtomTypeChargeSource(true);
+                                                 D.setAutomaticChargeSource(false);
+                                                 C.masterBonds().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                                 C.masterAngles().front()->setInteractionParameters("k=0.0 eq=1.0");
+                                             }));
     systemTest.setModuleEnabled("Forces01", false);
     ASSERT_TRUE(systemTest.dissolve().iterate(1));
 


### PR DESCRIPTION
Following on from #1901 this PR addresses the user-facing elements of pair potential display and editing from the perspective of the new option to use combination rules or not.

Works towards #1900.