### PR TITLE
fix: Output newlines again

### DIFF
--- a/src/base/messenger.cpp
+++ b/src/base/messenger.cpp
@@ -24,24 +24,9 @@ std::string Messenger::outputPrefix_;
 // Split supplied text into lines (delimited by '\n') and send for output
 void Messenger::splitAndPrint(std::string_view s)
 {
-
-    // Remove final newline if there is one
-    // The outputText function will add the newlines for us
-    if (s.back() == '\n')
-        s.remove_suffix(1);
-
-    // The created text may be over multiple lines (separated by '\n') so split it, prepending the prefix and/or process id to
-    // each line as necessary
-    size_t pos;
-    do
-    {
-        pos = s.find('\n');
-        // Output the current line (up to the next newline delimiter)
-        outputText(s.substr(0, pos));
-
-        // Adjust our view of the working string and find the next newline (if any)
-        s = s.substr(pos + 1);
-    } while (pos != std::string::npos);
+    auto lines = DissolveSys::splitString(s, "\n");
+    for (const auto line : lines)
+        outputText(line);
 }
 
 /*

--- a/src/base/sysFunc.cpp
+++ b/src/base/sysFunc.cpp
@@ -318,10 +318,10 @@ std::string DissolveSys::replace(const std::string_view source, const std::strin
     return result;
 }
 
-// Split a string over a delimiter, returning a vector of elements
-std::vector<std::string> DissolveSys::splitString(std::string_view str, std::string_view delim)
+// Split a string over a delimiter, returning a vector of string view elements
+std::vector<std::string_view> DissolveSys::splitString(std::string_view str, std::string_view delim)
 {
-    std::vector<std::string> parts;
+    std::vector<std::string_view> parts;
     auto index = 0;
     while (true)
     {
@@ -341,16 +341,6 @@ std::vector<std::string> DissolveSys::splitString(std::string_view str, std::str
         index = found + delim.size();
     }
     return parts;
-}
-
-// Split a string over a delimiter, returning a vector of converted double values
-std::vector<double> DissolveSys::splitStringToDoubles(std::string_view str, std::string_view delim)
-{
-    std::vector<double> values;
-    std::vector<string> terms{splitString(str, delim)};
-    values.resize(terms.size());
-    std::transform(terms.begin(), terms.end(), values.begin(), [](const auto &term) { return std::stod(term); });
-    return values;
 }
 
 // Double any of the supplied characters in the string

--- a/src/base/sysFunc.h
+++ b/src/base/sysFunc.h
@@ -67,9 +67,7 @@ class DissolveSys
     // Replace all occurrences of search string with replace string
     static std::string replace(const std::string_view source, const std::string_view search, const std::string_view replace);
     // Split a string over a delimiter, returning a vector of elements
-    static std::vector<std::string> splitString(std::string_view str, std::string_view delim = " ");
-    // Split a string over a delimiter, returning a vector of converted double values
-    static std::vector<double> splitStringToDoubles(std::string_view str, std::string_view delim = ", ");
+    static std::vector<std::string_view> splitString(std::string_view str, std::string_view delim = " ");
     // Double any of the supplied characters in the string
     static std::string doubleChars(const std::string_view s, const std::string_view charsToDouble);
     // Return unique name for object

--- a/src/classes/interactionPotential.h
+++ b/src/classes/interactionPotential.h
@@ -71,7 +71,7 @@ template <class Functions> class InteractionPotential
     // Return functional form of interaction
     typename Functions::Form form() const { return *form_; }
     // Parse supplied vector of terms
-    bool parseParameters(std::vector<std::string> terms)
+    bool parseParameters(std::vector<std::string_view> terms)
     {
         // Do we have a suitable number of parameters
         if (!Functions::forms().validNArgs(form(), terms.size()))
@@ -84,7 +84,8 @@ template <class Functions> class InteractionPotential
         {
             // Plain values
             parameters_.resize(terms.size(), 0.0);
-            std::transform(terms.begin(), terms.end(), parameters_.begin(), [](const auto &term) { return std::stod(term); });
+            std::transform(terms.begin(), terms.end(), parameters_.begin(),
+                           [](const auto &term) { return std::stod(std::string(term)); });
         }
         else if (nAssigned == terms.size())
         {
@@ -125,9 +126,9 @@ template <class Functions> class InteractionPotential
     bool parseParameters(const LineParser &parser, int startArg)
     {
         // Construct a vector of all remaining arguments on the line, starting from the argument offset
-        std::vector<std::string> terms;
+        std::vector<std::string_view> terms;
         for (auto n = startArg; n < parser.nArgs(); ++n)
-            terms.emplace_back(parser.args(n));
+            terms.emplace_back(parser.argsv(n));
         return parseParameters(terms);
     }
     // Set form and parameters

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -72,7 +72,7 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
         if (masterTerm_)
             return Messenger::error("Refused to set intramolecular parameters since master parameters are referenced.\n");
 
-        std::vector<std::string> terms{DissolveSys::splitString(params)};
+        std::vector<std::string_view> terms{DissolveSys::splitString(params)};
         return interactionPotential_.parseParameters(terms);
     }
     bool setInteractionParameters(LineParser &parser, int startArg)

--- a/tests/algorithms/sysFunc.cpp
+++ b/tests/algorithms/sysFunc.cpp
@@ -93,8 +93,8 @@ TEST(SysFunc, StringManipulation)
     EXPECT_TRUE(DissolveSys::replace("Swap the AaA's", "A", "bee") == "Swap the beeabee's");
 
     // String splitting / joining
-    std::vector<std::string> v;
-    const std::vector<std::string> expected = {"arma", "dillo", "is", "in", "pieces"};
+    std::vector<std::string_view> v;
+    const std::vector<std::string_view> expected = {"arma", "dillo", "is", "in", "pieces"};
     // -- Empty string
     v = DissolveSys::splitString("", " ");
     EXPECT_EQ(v.size(), 0);


### PR DESCRIPTION
Another small PR to fix the newlines issue - it seems that we were appending an additional newline after every line.

This PR uses a slightly refactored `DissolveSys::splitString()` to achieve the expected result.