### PR TITLE
fix: Update SpeciesSite keywords after data mutation

### DIFF
--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -39,7 +39,7 @@ void SpeciesTab::setCurrentSiteFromViewer()
     ui_.SiteList->setCurrentIndex(sites_.index(index, 0));
     ui_.SitesPushButton->setChecked(true);
 
-    dissolveWindow_->setModified();
+    dissolveWindow_->setModified(DissolveSignals::SpeciesSiteMutated);
 
     dissolveWindow_->fullUpdate();
 }


### PR DESCRIPTION
Previously, the species site vector keyword widget wasn't updating in line with newly added species sites. This is now updating when a site is added (see below)

Closes #1896 

![WaterSites](https://github.com/disorderedmaterials/dissolve/assets/106311829/f6bd3fa5-617e-46ba-bf25-6edfbfce7311)
![WaterSites2](https://github.com/disorderedmaterials/dissolve/assets/106311829/18a0563d-c13e-41e3-9056-6516fcf4b9eb)
