### PR TITLE
feat: Add Derivative namespace.

### DIFF
--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -3,7 +3,6 @@
 
 #include "classes/pairPotential.h"
 #include "base/lineParser.h"
-#include "base/messenger.h"
 #include "base/sysFunc.h"
 #include "classes/atomType.h"
 #include "math/constants.h"

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -7,6 +7,7 @@
 #include "base/sysFunc.h"
 #include "classes/atomType.h"
 #include "math/constants.h"
+#include "math/derivative.h"
 #include <cmath>
 
 // Static members
@@ -174,35 +175,7 @@ void PairPotential::updateTotals()
     totalPotentialInterpolation_.interpolate(Interpolator::ThreePointInterpolation);
 
     // Calculate derivative of total potential
-    const auto nPoints = derivative_.nValues();
-    double fprime;
-    for (auto n = 1; n < nPoints - 1; ++n)
-    {
-        /* Calculate numerical derivative with five-point stencil if possible. Otherwise use three-point stencil.
-         * Assumes data are regularly-spaced (they should be, with gap of delta_)
-         *            -f(x+2) + 8 f(x+1) - 8 f(x-1) + f(x-2)
-         *    f'(x) = --------------------------------------
-         *                           12 h
-         */
-        if ((n == 1) || (n == (nPoints - 2)))
-        {
-            // Three-point
-            derivative_.value(n) = -(totalPotential_.value(n - 1) - totalPotential_.value(n + 1)) / (2 * delta_);
-        }
-        else
-        {
-            // Five-point stencil
-            fprime = -totalPotential_.value(n + 2) + 8 * totalPotential_.value(n + 1) - 8 * totalPotential_.value(n - 1) +
-                     totalPotential_.value(n - 2);
-            fprime /= 12 * delta_;
-            derivative_.value(n) = fprime;
-        }
-    }
-
-    // Set first and last points
-    derivative_.value(0) = 10.0 * derivative_.value(1);
-    derivative_.value(nPoints - 1) =
-        derivative_.value(nPoints - 2) + (derivative_.value(nPoints - 2) - derivative_.value(nPoints - 3));
+    derivative_ = Derivative::derivative(totalPotential_);
 
     // Update interpolation
     derivativeInterpolation_.interpolate(Interpolator::ThreePointInterpolation);

--- a/src/math/CMakeLists.txt
+++ b/src/math/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(
   data1D.cpp
   data2D.cpp
   data3D.cpp
+  derivative.cpp
   doubleExp.cpp
   error.cpp
   filters.cpp
@@ -45,6 +46,7 @@ add_library(
   data3D.h
   data3DBase.h
   dataBase.h
+  derivative.h
   doubleExp.h
   error.h
   filters.h

--- a/src/math/derivative.cpp
+++ b/src/math/derivative.cpp
@@ -22,7 +22,8 @@ Data1D derivative(const Data1D &source)
     for (auto n = 1; n < nValues - 1; ++n)
     {
         /* Calculate numerical derivative with five-point stencil if possible. Otherwise use three-point stencil.
-         * Assumes data are regularly-spaced (they should be, with gap of delta_)
+         * Assumes data are regularly-spaced.
+         *
          *            -f(x+2) + 8 f(x+1) - 8 f(x-1) + f(x-2)
          *    f'(x) = --------------------------------------
          *                           12 h

--- a/src/math/derivative.cpp
+++ b/src/math/derivative.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "math/derivative.h"
+#include "math/data1D.h"
+
+namespace Derivative
+{
+// Return derivative of supplied Data1D
+Data1D derivative(const Data1D &source)
+{
+    Data1D dYdX{source};
+    std::fill(dYdX.values().begin(), dYdX.values().end(), 0.0);
+
+    const auto nValues = source.nValues();
+    if (nValues < 3)
+        return dYdX;
+
+    // Get spacing between points - we're assuming a constant spacing
+    const auto delta = source.xAxis(1) - source.xAxis(0);
+
+    for (auto n = 1; n < nValues - 1; ++n)
+    {
+        /* Calculate numerical derivative with five-point stencil if possible. Otherwise use three-point stencil.
+         * Assumes data are regularly-spaced (they should be, with gap of delta_)
+         *            -f(x+2) + 8 f(x+1) - 8 f(x-1) + f(x-2)
+         *    f'(x) = --------------------------------------
+         *                           12 h
+         */
+        if ((n == 1) || (n == (nValues - 2)))
+        {
+            // Three-point
+            dYdX.value(n) = -(source.value(n - 1) - source.value(n + 1)) / (2 * delta);
+        }
+        else
+        {
+            // Five-point stencil
+            dYdX.value(n) =
+                (-source.value(n + 2) + 8 * source.value(n + 1) - 8 * source.value(n - 1) + source.value(n - 2)) / (12 * delta);
+        }
+    }
+
+    // Handle extreme points with a simple extrapolation
+    dYdX.value(0) = dYdX.value(1) - (dYdX.value(1) - dYdX.value(2));
+    dYdX.value(nValues - 1) = dYdX.value(nValues - 2) + (dYdX.value(nValues - 2) - dYdX.value(nValues - 3));
+
+    return dYdX;
+}
+}; // namespace Derivative

--- a/src/math/derivative.h
+++ b/src/math/derivative.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+#include <vector>
+
+// Forward Declarations
+class Data1D;
+
+// Derivative
+namespace Derivative
+{
+// Return derivative of supplied Data1D
+Data1D derivative(const Data1D &source);
+}; // namespace Derivative

--- a/src/math/derivative.h
+++ b/src/math/derivative.h
@@ -3,8 +3,6 @@
 
 #pragma once
 
-#include <vector>
-
 // Forward Declarations
 class Data1D;
 


### PR DESCRIPTION
Represents "Part 3.5" in the `PairPotential` refactoring work.

This PR sits in-between #1906 and #1908, and moves code for calculation of derivatives for `Data1D` from the `PairPotential` class into a separate reusable namespaced function.

Works towards #1900.