### PR TITLE
refactor: Tidy site generation

### DIFF
--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -69,6 +69,7 @@ add_library(
   speciesImproper.cpp
   speciesRing.cpp
   speciesSite.cpp
+  speciesSiteInstance.cpp
   speciesTorsion.cpp
   torsionFunctions.cpp
   valueStore.cpp
@@ -123,6 +124,7 @@ add_library(
   speciesIntra.h
   speciesRing.h
   speciesSite.h
+  speciesSiteInstance.h
   speciesTorsion.h
   torsionFunctions.h
   valueStore.h

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -338,6 +338,8 @@ const NETADefinition &SpeciesSite::fragment() const { return fragment_; }
 // Update fragment definition
 bool SpeciesSite::setFragmentDefinitionString(std::string_view definitionString)
 {
+    instances_.clear();
+
     return fragment_.create(definitionString) && generateInstances();
 }
 

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -342,6 +342,7 @@ const std::vector<std::shared_ptr<AtomType>> &SpeciesSite::dynamicAtomTypes() co
 
 // Return fragment definition
 const NETADefinition &SpeciesSite::fragment() const { return fragment_; }
+
 // Update fragment definition
 bool SpeciesSite::setFragmentDefinitionString(std::string_view definitionString)
 {

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -167,15 +167,15 @@ class SpeciesSite : public Serialisable<CoreData &>
 
     private:
     // Calculate geometric centre of atoms in the parent Species
-    Vec3<double> centreOfGeometry(std::vector<int> &indices) const;
+    Vec3<double> centreOfGeometry(const std::vector<int> &indices) const;
     // Calculate (mass-weighted) coordinate centre of atoms in the parent Species
-    Vec3<double> centreOfMass(std::vector<int> &indices) const;
+    Vec3<double> centreOfMass(const std::vector<int> &indices) const;
 
     public:
     // Create and return Site description from parent Species
     std::vector<std::shared_ptr<Site>> createFromParent() const;
-    // Generate unique sites
-    bool generateUniqueSites();
+    // Generate instances
+    bool generateInstances();
     // Return site instances
     const std::vector<SpeciesSiteInstance> &instances() const;
 

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -7,10 +7,10 @@
 #include "base/serialiser.h"
 #include "base/version.h"
 #include "classes/atomType.h"
+#include "classes/speciesSiteInstance.h"
 #include "data/elements.h"
 #include "neta/neta.h"
 #include "templates/vector3.h"
-
 #include <map>
 #include <vector>
 
@@ -159,44 +159,25 @@ class SpeciesSite : public Serialisable<CoreData &>
     bool setFragmentDefinitionString(std::string_view definitionString);
 
     /*
-     * Advanced Sites
-     */
-    private:
-    // For each unique site, indices of atoms in the species that correspond to that site
-    std::vector<std::vector<int>> sitesAllAtomsIndices_;
-    // For each unique site, indices of atoms in the species which contribute to the origin of the site
-    std::vector<std::vector<int>> sitesOriginAtomsIndices_;
-    // For each unique site, indices of atoms in the species which indicate the x axis with the origin
-    std::vector<std::vector<int>> sitesXAxisAtomsIndices_;
-    // For each unique site, indices of atoms in the species which indicate the y axis with the origin, after orthogonalisation
-    std::vector<std::vector<int>> sitesYAxisAtomsIndices_;
-
-    public:
-    // Generate unique sites
-    bool generateUniqueSites();
-    // Number of unique sites
-    const int nSites() const;
-    // Return atom indices corresponding to unique sites
-    const std::vector<std::vector<int>> &sitesAllAtomsIndices() const;
-    // Return atom indices contributing to unique site origins
-    const std::vector<std::vector<int>> &sitesOriginAtomsIndices() const;
-    // Return atom indices indicating the x axis with the origins of unique sites.
-    const std::vector<std::vector<int>> &sitesXAxisAtomsIndices() const;
-    // Return atom indices indicating the y axis with the origins of unique sites.
-    const std::vector<std::vector<int>> &sitesYAxisAtomsIndices() const;
-
-    /*
      * Generation
      */
-    public:
-    // Create and return Site description from parent Species
-    std::vector<std::shared_ptr<Site>> createFromParent() const;
+    private:
+    // Instances for this site within the Species
+    std::vector<SpeciesSiteInstance> instances_;
 
     private:
     // Calculate geometric centre of atoms in the parent Species
     Vec3<double> centreOfGeometry(std::vector<int> &indices) const;
     // Calculate (mass-weighted) coordinate centre of atoms in the parent Species
     Vec3<double> centreOfMass(std::vector<int> &indices) const;
+
+    public:
+    // Create and return Site description from parent Species
+    std::vector<std::shared_ptr<Site>> createFromParent() const;
+    // Generate unique sites
+    bool generateUniqueSites();
+    // Return site instances
+    const std::vector<SpeciesSiteInstance> &instances() const;
 
     /*
      * Read / Write

--- a/src/classes/speciesSiteInstance.cpp
+++ b/src/classes/speciesSiteInstance.cpp
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "classes/speciesSiteInstance.h"
+
+SpeciesSiteInstance::SpeciesSiteInstance(const std::vector<int> &allIndices, const std::vector<int> &originIndices,
+                                         const std::vector<int> &xAxisIndices, const std::vector<int> &yAxisIndices)
+    : allIndices_(allIndices), originIndices_(originIndices), xAxisIndices_(xAxisIndices), yAxisIndices_(yAxisIndices)
+{
+}
+
+// Return all atom indices representing the site
+const std::vector<int> &SpeciesSiteInstance::allIndices() const { return allIndices_; }
+
+// Return atom indices contributing to site origin
+const std::vector<int> &SpeciesSiteInstance::originIndices() const { return originIndices_; }
+
+// Return atom indices indicating the x axis with the origin
+const std::vector<int> &SpeciesSiteInstance::xAxisIndices() const { return xAxisIndices_; }
+
+// Return atom indices indicating the y axis with the origin
+const std::vector<int> &SpeciesSiteInstance::yAxisIndices() const { return yAxisIndices_; }

--- a/src/classes/speciesSiteInstance.h
+++ b/src/classes/speciesSiteInstance.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+#include <vector>
+
+// Species Site Instance
+class SpeciesSiteInstance
+{
+    public:
+    SpeciesSiteInstance(const std::vector<int> &allIndices = {}, const std::vector<int> &originIndices = {},
+                        const std::vector<int> &xAxisIndices = {}, const std::vector<int> &yAxisIndices = {});
+    ~SpeciesSiteInstance() = default;
+
+    private:
+    // Indices of all atoms that correspond to the site
+    std::vector<int> allIndices_;
+    // Indices of atoms which contribute to the origin of the site
+    std::vector<int> originIndices_;
+    // Indices of atoms which indicate the x axis with the origin
+    std::vector<int> xAxisIndices_;
+    // Indices of atoms which indicate the y axis with the origin, after orthogonalisation
+    std::vector<int> yAxisIndices_;
+
+    public:
+    // Return all atom indices representing the site
+    const std::vector<int> &allIndices() const;
+    // Return atom indices contributing to site origin
+    const std::vector<int> &originIndices() const;
+    // Return atom indices indicating the x axis with the origin
+    const std::vector<int> &xAxisIndices() const;
+    // Return atom indices indicating the y axis with the origin
+    const std::vector<int> &yAxisIndices() const;
+};

--- a/src/gui/render/renderableSpeciesSite.cpp
+++ b/src/gui/render/renderableSpeciesSite.cpp
@@ -78,6 +78,9 @@ void RenderableSpeciesSite::recreatePrimitives(const View &view, const ColourDef
             }
         }
     }
+
+    // Set the value transform data version here, since we don't use it
+    valuesTransformDataVersion_ = dataVersion();
 }
 
 // Send primitives for rendering

--- a/src/gui/speciesTab.h
+++ b/src/gui/speciesTab.h
@@ -134,6 +134,8 @@ class SpeciesTab : public QWidget, public MainTab
     private:
     // Return currently-selected SpeciesSite
     SpeciesSite *currentSite();
+    // Update instance count group
+    void updateInstanceCountGroup();
 
     private Q_SLOTS:
     void setCurrentSiteFromViewer();

--- a/src/gui/speciesTab.ui
+++ b/src/gui/speciesTab.ui
@@ -1048,10 +1048,10 @@
                   </item>
                  </layout>
                 </widget>
-                <widget class="QWidget" name="page">
+                <widget class="QWidget" name="FragmentSiteDefinitionPage">
                  <layout class="QVBoxLayout" name="verticalLayout_18">
                   <item>
-                   <widget class="QGroupBox" name="SiteElementsGroup_2">
+                   <widget class="QGroupBox" name="FragmentNETAGroup">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
                       <horstretch>0</horstretch>
@@ -1103,6 +1103,31 @@
                   </item>
                  </layout>
                 </widget>
+               </widget>
+              </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="InstanceCountGroup">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="title">
+              <string>Instance Count</string>
+             </property>
+             <layout class="QHBoxLayout" name="horizontalLayout_19">
+              <item>
+               <widget class="QLabel" name="InstanceCountLabel">
+                <property name="text">
+                 <string>0</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
                </widget>
               </item>
              </layout>

--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -16,6 +16,21 @@ SpeciesSite *SpeciesTab::currentSite()
     return sites_.data(ui_.SiteList->selectionModel()->currentIndex(), Qt::UserRole).value<SpeciesSite *>();
 }
 
+// Update instance count group
+void SpeciesTab::updateInstanceCountGroup()
+{
+    auto *site = currentSite();
+    if (!site)
+        ui_.InstanceCountLabel->setText("N/A");
+    else if (site->instances().empty())
+        ui_.InstanceCountLabel->setText("0 (no instances generated)");
+    else
+        ui_.InstanceCountLabel->setText(
+            QString("%1 (%2 atom%3 each)")
+                .arg(QString::number(site->instances().size()), QString::number(site->instances().front().allIndices().size()),
+                     QString::fromStdString(DissolveSys::plural(site->instances().front().allIndices().size()))));
+}
+
 /*
  * Private Slots
  */
@@ -102,6 +117,7 @@ void SpeciesTab::on_SiteFragmentDescriptionEdit_editingFinished()
     site->setFragmentDefinitionString(std::string_view(ui_.SiteFragmentDescriptionEdit->text().toStdString()));
     ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
 
+    updateInstanceCountGroup();
     ui_.ViewerWidget->setSite(site);
     ui_.ViewerWidget->postRedisplay();
 
@@ -186,6 +202,8 @@ void SpeciesTab::updateSitesTab()
             ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
             break;
     }
+
+    updateInstanceCountGroup();
 
     // If the current site has changed, also regenerate the SpeciesSite renderable
     if (ui_.ViewerWidget->speciesViewer()->speciesSite() != site)

--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -186,6 +186,7 @@ void SpeciesTab::updateSitesTab()
             ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
             break;
     }
+
     // If the current site has changed, also regenerate the SpeciesSite renderable
     if (ui_.ViewerWidget->speciesViewer()->speciesSite() != site)
         ui_.ViewerWidget->setSite(site);

--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -102,23 +102,13 @@ void SpeciesTab::on_SiteFragmentDescriptionEdit_editingFinished()
     site->setFragmentDefinitionString(std::string_view(ui_.SiteFragmentDescriptionEdit->text().toStdString()));
     ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
 
+    ui_.ViewerWidget->setSite(site);
     ui_.ViewerWidget->postRedisplay();
 
     dissolveWindow_->setModified();
 }
 
-void SpeciesTab::on_SiteFragmentDescriptionEdit_returnPressed()
-{
-    auto *site = currentSite();
-    if (refreshLock_.isLocked() || (!site))
-        return;
-    site->setFragmentDefinitionString(std::string_view(ui_.SiteFragmentDescriptionEdit->text().toStdString()));
-    ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
-
-    ui_.ViewerWidget->postRedisplay();
-
-    dissolveWindow_->setModified();
-}
+void SpeciesTab::on_SiteFragmentDescriptionEdit_returnPressed() { on_SiteFragmentDescriptionEdit_editingFinished(); }
 
 /*
  * Public Functions

--- a/src/gui/speciesViewer.cpp
+++ b/src/gui/speciesViewer.cpp
@@ -70,7 +70,7 @@ void SpeciesViewer::setSite(SpeciesSite *site)
     siteRenderable_ = nullptr;
 
     // Create a new Renderable for the SpeciesSite
-    if (site_ != nullptr && sitesVisible_)
+    if ((site_ != nullptr) && sitesVisible_)
     {
         siteRenderable_ = std::make_shared<RenderableSpeciesSite>(species_, site_);
         siteRenderable_->setName("Site");

--- a/src/procedure/nodes/rotateFragment.cpp
+++ b/src/procedure/nodes/rotateFragment.cpp
@@ -39,7 +39,8 @@ bool RotateFragmentProcedureNode::mustBeNamed() const { return false; }
 
 bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureContext)
 {
-    assert(site_->currentSite());
+    if (!site_->currentSite())
+        return Messenger::error("No current site to act upon! Did you mean to put this in a loop?");
 
     auto &site = site_->currentSite()->get();
     auto parent = site.parent();

--- a/src/procedure/nodes/rotateFragment.cpp
+++ b/src/procedure/nodes/rotateFragment.cpp
@@ -75,7 +75,7 @@ bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureConte
             break;
     }
 
-    for (auto index : parent->sitesAllAtomsIndices().at(parentIndex))
+    for (auto index : parent->instances()[parentIndex].allIndices())
     {
         auto atom = molecule->atom(index);
         atom->set(rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin());

--- a/src/procedure/nodes/rotateFragment.cpp
+++ b/src/procedure/nodes/rotateFragment.cpp
@@ -57,7 +57,7 @@ bool RotateFragmentProcedureNode::execute(const ProcedureContext &procedureConte
 
     if (!site.hasAxes())
     {
-        Messenger::warn("FragmentSite '{}' has no axes to rotate about.", parent->name());
+        Messenger::warn("Fragment site '{}' has no axes to rotate about.", parent->name());
         return false;
     }
 

--- a/tests/classes/speciesSite.cpp
+++ b/tests/classes/speciesSite.cpp
@@ -181,7 +181,7 @@ TEST_F(SpeciesSiteTest, FragmentBasic)
     {
         // There should be 1 atom in the site overall
         EXPECT_EQ(instance.allIndices().size(), 1);
-        // There should be a single defined origin atoms
+        // There should be a single defined origin atom
         EXPECT_EQ(instance.originIndices().size(), 1);
         // There should be no defined x or y axis atoms
         EXPECT_EQ(instance.xAxisIndices().size(), 0);
@@ -204,7 +204,7 @@ TEST_F(SpeciesSiteTest, FragmentAdvanced)
 
     // There should be 12 atoms in the site overall
     EXPECT_EQ(instance.allIndices().size(), 12);
-    // There should be a single defined origin atoms
+    // There should be a single defined origin atom
     EXPECT_EQ(instance.originIndices().size(), 1);
     // There should be no defined x or y axis atoms
     EXPECT_EQ(instance.xAxisIndices().size(), 0);

--- a/tests/classes/speciesSite.cpp
+++ b/tests/classes/speciesSite.cpp
@@ -166,10 +166,39 @@ TEST_F(SpeciesSiteTest, FragmentBasic)
 
     SpeciesSite site(&benzene, SpeciesSite::SiteType::Fragment);
 
-    // Set the NETA definition string.
+    // Set the NETA definition string - no origin
+    EXPECT_TRUE(site.setFragmentDefinitionString("?C"));
+
+    // No origin specified, so expect no instances
+    EXPECT_EQ(site.instances().size(), 0);
+
+    // Re-set with actual origin on the root match
+    EXPECT_TRUE(site.setFragmentDefinitionString("?C,#origin"));
+
+    // Expect six instances, one for each carbon
+    EXPECT_EQ(site.instances().size(), 6);
+    for (auto &instance : site.instances())
+    {
+        // There should be 1 atom in the site overall
+        EXPECT_EQ(instance.allIndices().size(), 1);
+        // There should be a single defined origin atoms
+        EXPECT_EQ(instance.originIndices().size(), 1);
+        // There should be no defined x or y axis atoms
+        EXPECT_EQ(instance.xAxisIndices().size(), 0);
+        EXPECT_EQ(instance.yAxisIndices().size(), 0);
+    }
+}
+
+TEST_F(SpeciesSiteTest, FragmentAdvanced)
+{
+    auto &benzene = benzeneSpecies();
+
+    SpeciesSite site(&benzene, SpeciesSite::SiteType::Fragment);
+
+    // Set the NETA definition string
     EXPECT_TRUE(site.setFragmentDefinitionString("?C, #origin, ring(C(-H),C(-H),C(-H),C(-H),C(-H),C(-H))"));
 
-    // Expect a single unique site
+    // Expect a single instance
     EXPECT_EQ(site.instances().size(), 1);
     const auto &instance = site.instances().front();
 
@@ -180,6 +209,28 @@ TEST_F(SpeciesSiteTest, FragmentBasic)
     // There should be no defined x or y axis atoms
     EXPECT_EQ(instance.xAxisIndices().size(), 0);
     EXPECT_EQ(instance.yAxisIndices().size(), 0);
+}
+
+TEST_F(SpeciesSiteTest, FragmentAdvancedAxes)
+{
+    auto &benzene = benzeneSpecies();
+
+    SpeciesSite site(&benzene, SpeciesSite::SiteType::Fragment);
+
+    // Set the NETA definition string
+    EXPECT_TRUE(site.setFragmentDefinitionString("?C, #origin, ring(C(-H),C(-H,#x),C(-H,#x),C(-H),C(-H(#y)),C(-H))"));
+
+    // Expect a single instance
+    EXPECT_EQ(site.instances().size(), 1);
+    const auto &instance = site.instances().front();
+
+    // There should be 12 atoms in the site overall
+    EXPECT_EQ(instance.allIndices().size(), 12);
+    // There should be a single defined origin atom
+    EXPECT_EQ(instance.originIndices().size(), 1);
+    // There should be two atoms defined for the x axis and one for the y
+    EXPECT_EQ(instance.xAxisIndices().size(), 2);
+    EXPECT_EQ(instance.yAxisIndices().size(), 1);
 }
 
 } // namespace UnitTest

--- a/tests/classes/speciesSite.cpp
+++ b/tests/classes/speciesSite.cpp
@@ -170,15 +170,16 @@ TEST_F(SpeciesSiteTest, FragmentBasic)
     EXPECT_TRUE(site.setFragmentDefinitionString("?C, #origin, ring(C(-H),C(-H),C(-H),C(-H),C(-H),C(-H))"));
 
     // Expect a single unique site
-    EXPECT_EQ(site.nSites(), 1);
-    EXPECT_EQ(site.sitesAllAtomsIndices().size(), 1);
-    // There should be 12 atoms in the site
-    EXPECT_EQ(site.sitesAllAtomsIndices().front().size(), 12);
+    EXPECT_EQ(site.instances().size(), 1);
+    const auto &instance = site.instances().front();
+
+    // There should be 12 atoms in the site overall
+    EXPECT_EQ(instance.allIndices().size(), 12);
     // There should be a single defined origin atoms
-    EXPECT_EQ(site.sitesOriginAtomsIndices().size(), 1);
+    EXPECT_EQ(instance.originIndices().size(), 1);
     // There should be no defined x or y axis atoms
-    EXPECT_EQ(site.sitesXAxisAtomsIndices().size(), 0);
-    EXPECT_EQ(site.sitesYAxisAtomsIndices().size(), 0);
+    EXPECT_EQ(instance.xAxisIndices().size(), 0);
+    EXPECT_EQ(instance.yAxisIndices().size(), 0);
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR tidies "unique site" generation - these are instances of a `SpeciesSite` description occurring in the same `Species`. These instances are generated from either dynamic element / atom type selection, or via NETA fragment description. Previously, the generated vectors of indices corresponding to the origin, xAxis, yAxis, as well as "all involved atoms" were held in separate `std::vector`s of `std::vector`s which was a bit messy. Here we introduce a `SpeciesSiteInstance` class to knit the information corresponding to individual instances together more tightly.