### PR TITLE
build: Update SCARF compile scripts

### DIFF
--- a/cmake/Modules/conan-dissolve.cmake
+++ b/cmake/Modules/conan-dissolve.cmake
@@ -19,6 +19,7 @@ set(_conan_options
     fmt:header_only=True
     pugixml:header_only=False
     antlr4-cppruntime:shared=True
+    ${EXTRA_CONAN_OPTIONS}
 )
 
 # Handle platform-specific requirements

--- a/scripts/slurm-compile-mpi.script
+++ b/scripts/slurm-compile-mpi.script
@@ -54,7 +54,7 @@ cd ${BUILD_DIR}
 # Run CMake
 # ---------
 MPI_ROOT=/apps/eb/software/OpenMPI/4.0.3-GCC-9.3.0/bin
-cmake ../../ -DMPI_C=${MPI_ROOT}/mpicc -DMPI_CXX=${MPI_ROOT}/mpic++ -DCMAKE_CXX_FLAGS:string="-std=c++17 -pthread" -DCMAKE_C_FLAGS:string="-pthread" -DPARALLEL:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DANTLR_EXECUTABLE:path=${BASE_DIR}/${ANTLR_JAR} -DBUILD_ANTLR_ZIPFILE:path=${BASE_DIR}/${ANTLR_ZIP}
+cmake ../../ -DMPI_C=${MPI_ROOT}/mpicc -DMPI_CXX=${MPI_ROOT}/mpic++ -DCMAKE_CXX_FLAGS:string="-std=c++17 -pthread" -DCMAKE_C_FLAGS:string="-pthread" -DPARALLEL:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DANTLR_EXECUTABLE:path=${BASE_DIR}/${ANTLR_JAR} -DBUILD_ANTLR_ZIPFILE:path=${BASE_DIR}/${ANTLR_ZIP} -DEXTRA_CONAN_OPTIONS:string="pugixml:header_only=True"
 
 # Make
 # ----

--- a/scripts/slurm-compile-mpi.script
+++ b/scripts/slurm-compile-mpi.script
@@ -18,7 +18,7 @@ echo "Base script dir is ${BASE_DIR}"
 # Check / download ANTLR4
 # -----------------------
 
-ANTLR_VERSION=4.8
+ANTLR_VERSION=4.13.1
 ANTLR_JAR=antlr-${ANTLR_VERSION}-complete.jar
 if [ -f ${ANTLR_JAR} ]
 then
@@ -40,7 +40,9 @@ fi
 # Load Necessary Modules
 # ----------------------
 module load foss
-module load CMake/3.16.4-GCCcore-9.3.0
+module load CMake/3.23.1-GCCcore-11.3.0
+module load Java/13.0.2
+
 
 # Set-up Build Dir
 # ---------------
@@ -48,10 +50,6 @@ BUILD_DIR="${BASE_DIR}/build-$SLURM_JOB_ID"
 echo "Build directory is '${BUILD_DIR}'"
 mkdir ${BUILD_DIR}
 cd ${BUILD_DIR}
-
-# Run Conan
-# ---------
-conan install ../../ -s compiler.libcxx=libstdc++11 -s compiler.version=9 --build=tbb -o tbb:shared=False -o antlr4-cppruntime:shared=False
 
 # Run CMake
 # ---------

--- a/scripts/slurm-compile-threads.script
+++ b/scripts/slurm-compile-threads.script
@@ -18,7 +18,7 @@ echo "Base script dir is ${BASE_DIR}"
 # Check / download ANTLR4
 # -----------------------
 
-ANTLR_VERSION=4.8
+ANTLR_VERSION=4.13.1
 ANTLR_JAR=antlr-${ANTLR_VERSION}-complete.jar
 if [ -f ${ANTLR_JAR} ]
 then
@@ -40,7 +40,9 @@ fi
 # Load Necessary Modules
 # ----------------------
 module load foss
-module load CMake/3.16.4-GCCcore-9.3.0
+module load CMake/3.23.1-GCCcore-11.3.0
+module load Java/13.0.2
+
 
 # Set-up Build Dir
 # ---------------
@@ -48,10 +50,6 @@ BUILD_DIR="${BASE_DIR}/build-$SLURM_JOB_ID"
 echo "Build directory is '${BUILD_DIR}'"
 mkdir ${BUILD_DIR}
 cd ${BUILD_DIR}
-
-# Run Conan
-# ---------
-conan install ../../ -s compiler.libcxx=libstdc++11 -s compiler.version=9 --build=tbb -o tbb:shared=False -o antlr4-cppruntime:shared=False
 
 # Run CMake
 # ---------

--- a/scripts/slurm-compile-threads.script
+++ b/scripts/slurm-compile-threads.script
@@ -53,7 +53,7 @@ cd ${BUILD_DIR}
 
 # Run CMake
 # ---------
-cmake ../../ -DCMAKE_CXX_FLAGS:string="-std=c++17 -pthread" -DCMAKE_C_FLAGS:string="-pthread" -DMULTI_THREADING:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DANTLR_EXECUTABLE:path=${BASE_DIR}/${ANTLR_JAR} -DBUILD_ANTLR_ZIPFILE:path=${BASE_DIR}/${ANTLR_ZIP}
+cmake ../../ -DCMAKE_CXX_FLAGS:string="-std=c++17 -pthread" -DCMAKE_C_FLAGS:string="-pthread" -DMULTI_THREADING:bool=true -DBUILD_ANTLR_RUNTIME:bool=true -DANTLR_EXECUTABLE:path=${BASE_DIR}/${ANTLR_JAR} -DBUILD_ANTLR_ZIPFILE:path=${BASE_DIR}/${ANTLR_ZIP} -DEXTRA_CONAN_OPTIONS:string="pugixml:header_only=True"
 
 # Make
 # ----


### PR DESCRIPTION
Here we just adjust the slurm scripts for compilation on SCARF, following attempts to build 1.5.1 on that platform.