### PR TITLE
feat: Permit global potential origins in fractional coordinates

### DIFF
--- a/src/procedure/nodes/directionalGlobalPotential.h
+++ b/src/procedure/nodes/directionalGlobalPotential.h
@@ -23,7 +23,7 @@ class DirectionalGlobalPotentialProcedureNode : public ProcedureNode
     Vec3<NodeValue> origin_;
     bool originIsFractional_{false};
     // Directional vector
-    Vec3<NodeValue> vector_;
+    Vec3<NodeValue> vector_{0.0, 0.0, 1.0};
 
     /*
      * Execute

--- a/src/procedure/nodes/directionalGlobalPotential.h
+++ b/src/procedure/nodes/directionalGlobalPotential.h
@@ -17,9 +17,12 @@ class DirectionalGlobalPotentialProcedureNode : public ProcedureNode
      * Potential Function
      */
     private:
-    // Potential form, origin and directional vector
+    // Potential form
     InteractionPotential<DirectionalPotentialFunctions> potential_;
+    // Origin coordinates
     Vec3<NodeValue> origin_;
+    bool originIsFractional_{false};
+    // Directional vector
     Vec3<NodeValue> vector_;
 
     /*

--- a/src/procedure/nodes/simpleGlobalPotential.h
+++ b/src/procedure/nodes/simpleGlobalPotential.h
@@ -17,9 +17,11 @@ class SimpleGlobalPotentialProcedureNode : public ProcedureNode
      * Potential Function
      */
     private:
-    // Potential form and origin
+    // Potential form
     InteractionPotential<SimplePotentialFunctions> potential_;
+    // Origin coordinates
     Vec3<NodeValue> origin_;
+    bool originIsFractional_{false};
 
     /*
      * Execute

--- a/web/docs/userguide/procedures/nodes/directionalglobalpotential.md
+++ b/web/docs/userguide/procedures/nodes/directionalglobalpotential.md
@@ -23,3 +23,6 @@ The `DirectionalGlobalPotential` node allows an additional, global potential to 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`Potential`|[`DirectionalPotential`]({{< ref directionalpotential >}})|--|Functional form and associated parameters for the potential.|
+|`Origin`|`Vec3<double>`|`0.0 0.0 0.0`|Coordinate origin of the potential.|
+|`Fractional`|`bool`|`false`|Whether the coordinate origin is specified in fractional cell coordinates.|
+|`Vector`|`Vec3<double>`|`0.0 0.0 1.0`|Directional vector along which the potential acts.|

--- a/web/docs/userguide/procedures/nodes/simpleglobalpotential.md
+++ b/web/docs/userguide/procedures/nodes/simpleglobalpotential.md
@@ -23,3 +23,5 @@ The `SimpleGlobalPotential` node allows an additional, global potential to be de
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`Potential`|[`SimplePotential`]({{< ref simplepotential >}})|--|Functional form and associated parameters for the potential.|
+|`Origin`|`Vec3<double>`|`0.0 0.0 0.0`|Coordinate origin of the potential.|
+|`Fractional`|`bool`|`false`|Whether the coordinate origin is specified in fractional cell coordinates.|


### PR DESCRIPTION
This PR adds a simple `bool` option to `SimpleGlobalPotentialProcedureNode` and `DirectionalGlobalPotentialProcedureNode` to allow specification of the origin coordinates in terms of the fractional unit cell.

Closes #1913.