### PR TITLE
fix: Copy global potentials from source configuration

### DIFF
--- a/src/kernels/potentials/base.cpp
+++ b/src/kernels/potentials/base.cpp
@@ -9,6 +9,12 @@
 
 ExternalPotential::ExternalPotential(ExternalPotentialTypes::ExternalPotentialType type) : type_(type) {}
 
+// Create and return a copy of this potential
+std::unique_ptr<ExternalPotential> ExternalPotential::duplicate() const
+{
+    throw(std::runtime_error(fmt::format("Can't duplicate() an ExternalPotential of this type.\n")));
+}
+
 /*
  * Target Information
  */

--- a/src/kernels/potentials/base.h
+++ b/src/kernels/potentials/base.h
@@ -18,6 +18,8 @@ class ExternalPotential
     public:
     explicit ExternalPotential(ExternalPotentialTypes::ExternalPotentialType type);
     ~ExternalPotential() = default;
+    // Create and return a copy of this potential
+    virtual std::unique_ptr<ExternalPotential> duplicate() const;
 
     /*
      * Type

--- a/src/kernels/potentials/directional.cpp
+++ b/src/kernels/potentials/directional.cpp
@@ -41,14 +41,21 @@ std::optional<int> DirectionalPotentialFunctions::parameterIndex(Form form, std:
     return it - parameters(form).begin();
 }
 
-DirectionalPotential::DirectionalPotential()
+DirectionalPotential::DirectionalPotential(const InteractionPotential<DirectionalPotentialFunctions> &interactionPotential,
+                                           const Vec3<double> &origin, const Vec3<double> &vector)
     : ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Directional),
-      interactionPotential_(DirectionalPotentialFunctions::Form::LJCylinder)
+      interactionPotential_(interactionPotential), origin_(origin), vector_(vector)
 {
     keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
     keywords_.add<InteractionPotentialKeyword<DirectionalPotentialFunctions>>(
         "Form", "Functional form and parameters for the potential", interactionPotential_);
     keywords_.add<Vec3DoubleKeyword>("Vector", "Direction vector", vector_, Vec3Labels::LabelType::XYZLabels);
+}
+
+// Create and return a copy of this potential
+std::unique_ptr<ExternalPotential> DirectionalPotential::duplicate() const
+{
+    return std::make_unique<DirectionalPotential>(interactionPotential_, origin_, vector_);
 }
 
 /*

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -28,8 +28,12 @@ class DirectionalPotentialFunctions
 class DirectionalPotential : public ExternalPotential
 {
     public:
-    DirectionalPotential();
+    DirectionalPotential(const InteractionPotential<DirectionalPotentialFunctions> &interactionPotential =
+                             {DirectionalPotentialFunctions::Form::LJCylinder},
+                         const Vec3<double> &origin = {0.0, 0.0, 0.0}, const Vec3<double> &vector = {0.0, 0.0, 1.0});
     ~DirectionalPotential() = default;
+    // Create and return a copy of this potential
+    std::unique_ptr<ExternalPotential> duplicate() const override;
 
     /*
      * Definition
@@ -40,7 +44,7 @@ class DirectionalPotential : public ExternalPotential
     // Coordinate origin of potential
     Vec3<double> origin_;
     // Direction of potential
-    Vec3<double> vector_{0.0, 0.0, 1.0};
+    Vec3<double> vector_;
 
     public:
     // Set potential form

--- a/src/kernels/potentials/directional.h
+++ b/src/kernels/potentials/directional.h
@@ -34,7 +34,6 @@ class DirectionalPotential : public ExternalPotential
     /*
      * Definition
      */
-
     private:
     // Potential form
     InteractionPotential<DirectionalPotentialFunctions> interactionPotential_;

--- a/src/kernels/potentials/simple.cpp
+++ b/src/kernels/potentials/simple.cpp
@@ -40,13 +40,20 @@ std::optional<int> SimplePotentialFunctions::parameterIndex(Form form, std::stri
     return it - parameters(form).begin();
 }
 
-SimplePotential::SimplePotential()
-    : ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Simple),
-      interactionPotential_(SimplePotentialFunctions::Form::Harmonic)
+SimplePotential::SimplePotential(const InteractionPotential<SimplePotentialFunctions> &interactionPotential,
+                                 const Vec3<double> &origin)
+    : ExternalPotential(ExternalPotentialTypes::ExternalPotentialType::Simple), interactionPotential_(interactionPotential),
+      origin_(origin)
 {
     keywords_.add<Vec3DoubleKeyword>("Origin", "Reference origin point", origin_, Vec3Labels::LabelType::XYZLabels);
     keywords_.add<InteractionPotentialKeyword<SimplePotentialFunctions>>(
         "Form", "Functional form and parameters for the potential", interactionPotential_);
+}
+
+// Create and return a copy of this potential
+std::unique_ptr<ExternalPotential> SimplePotential::duplicate() const
+{
+    return std::make_unique<SimplePotential>(interactionPotential_, origin_);
 }
 
 /*

--- a/src/kernels/potentials/simple.h
+++ b/src/kernels/potentials/simple.h
@@ -29,8 +29,12 @@ class SimplePotentialFunctions
 class SimplePotential : public ExternalPotential
 {
     public:
-    SimplePotential();
+    SimplePotential(
+        const InteractionPotential<SimplePotentialFunctions> &interactionPotential = {SimplePotentialFunctions::Form::Harmonic},
+        const Vec3<double> &origin = {0.0, 0.0, 0.0});
     ~SimplePotential() = default;
+    // Create and return a copy of this potential
+    std::unique_ptr<ExternalPotential> duplicate() const override;
 
     /*
      * Definition

--- a/src/procedure/nodes/copy.h
+++ b/src/procedure/nodes/copy.h
@@ -35,6 +35,8 @@ class CopyProcedureNode : public ProcedureNode
     Configuration *source_{nullptr};
     // Vector of Species to exclude from copy
     std::vector<const Species *> excludedSpecies_;
+    // Whether to copy global potentials
+    bool copyGlobalPotentials_{true};
 
     /*
      * Execute

--- a/web/docs/userguide/procedures/nodes/copy.md
+++ b/web/docs/userguide/procedures/nodes/copy.md
@@ -24,3 +24,4 @@ The `Copy` node copies the box and all molecules from a source configuration int
 |:------|:--:|:-----:|-----------|
 |`Source`|`Configuration`|--|Source configuration to copy.|
 |`Exclude`|`Species ...`|--|Species to exclude from the copy.|
+|`CopyGlobalPotentials`|`bool`|`true`|Whether to copy any defined global potentials from the source configuration.|


### PR DESCRIPTION
This PR adds the missing ability for the `CopyProcedureNode` to also duplicate any defined global-type `ExternalPotentials`, with the exception of the "regional" type since its dependencies on the originating generator procedure are much deeper and so is not feasible to do without a significant refactor.

Likewise, targeted potentials are not copied across at present since there are further dependencies on content, which species are copied across etc.

Closes #1922.