### PR TITLE
fix: Copy atom type charge

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -453,6 +453,7 @@ void CoreData::copyAtomType(const SpeciesAtom &sourceAtom, SpeciesAtom &destAtom
         at = addAtomType(sourceAtom.Z());
         at->setName(sourceAtom.atomType()->name());
         at->interactionPotential() = sourceAtom.atomType()->interactionPotential();
+        at->setCharge(sourceAtom.atomType()->charge());
     }
 
     destAtom.setAtomType(at);


### PR DESCRIPTION
When importing a species from an existing simulation input file, atom type charges were not copied.  This is a one-line fix to remedy that.

Closes #852.