### PR TITLE
fix: Inversion of custom regions

### DIFF
--- a/benchmark/region/region_benchmark.cpp
+++ b/benchmark/region/region_benchmark.cpp
@@ -21,7 +21,7 @@ template <ProblemType problem, Population population> static void BM_Region_Gene
     for (auto _ : state)
     {
         Region region;
-        region.generate(cfg, 1.0, []() { return std::make_shared<RandomVoxelKernel>(); });
+        region.generate(cfg, 1.0, false, []() { return std::make_shared<RandomVoxelKernel>(); });
     }
 }
 

--- a/src/classes/region.cpp
+++ b/src/classes/region.cpp
@@ -8,7 +8,7 @@
 Region::Region() : box_(nullptr) {}
 
 // Generate region information
-bool Region::generate(const Configuration *cfg, double voxelSize,
+bool Region::generate(const Configuration *cfg, double voxelSize, bool invert,
                       const std::function<std::shared_ptr<VoxelKernel>(void)> &kernelGenerator)
 {
     box_ = cfg->box();
@@ -26,9 +26,9 @@ bool Region::generate(const Configuration *cfg, double voxelSize,
     auto voxelCheckFunction = [&](auto triplet, auto x, auto y, auto z)
     {
         voxelMap_[triplet] = {Vec3<int>(x, y, z),
-                              voxelCombinable.local()->isVoxelValid(
-                                  cfg, box_->getReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
-                                                      (z + 0.5) * voxelSizeFrac_.z}))};
+                              invert != voxelCombinable.local()->isVoxelValid(
+                                            cfg, box_->getReal({(x + 0.5) * voxelSizeFrac_.x, (y + 0.5) * voxelSizeFrac_.y,
+                                                                (z + 0.5) * voxelSizeFrac_.z}))};
     };
 
     // Iterate over voxels

--- a/src/classes/region.h
+++ b/src/classes/region.h
@@ -54,7 +54,7 @@ class Region
 
     public:
     // Generate region information
-    bool generate(const Configuration *cfg, double voxelSize,
+    bool generate(const Configuration *cfg, double voxelSize, bool invert,
                   const std::function<std::shared_ptr<VoxelKernel>(void)> &kernelGenerator);
     // Return whether the region is valid
     bool isValid() const;

--- a/src/procedure/nodes/regionBase.cpp
+++ b/src/procedure/nodes/regionBase.cpp
@@ -35,5 +35,5 @@ const Region &RegionProcedureNodeBase::region() const { return region_; }
 // Execute node
 bool RegionProcedureNodeBase::execute(const ProcedureContext &procedureContext)
 {
-    return region_.generate(procedureContext.configuration(), voxelSize_, [&]() { return createVoxelKernel(); });
+    return region_.generate(procedureContext.configuration(), voxelSize_, invert_, [&]() { return createVoxelKernel(); });
 }


### PR DESCRIPTION
Addresses a failure of `RegionProcedureNodeBase` which did precisely nothing with its `invert_` variable.

Closes #1925.