### PR TITLE
refactor: Function1D definitions

### DIFF
--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -12,12 +12,8 @@
  * One-Dimensional Function Definition
  */
 
-Function1DDefinition::Function1DDefinition(const std::vector<std::string> &parameterNames,
-                                           const Flags<FunctionProperties::FunctionProperty> &properties, Function1DSetup setup,
-                                           Function1DXOmega y, Function1DXOmega dYdX, Function1DXOmega yFT,
-                                           Function1DOmega norm)
-    : parameterNames_(parameterNames), properties_(properties), setup_(std::move(setup)), y_(std::move(y)),
-      dYdX_(std::move(dYdX)), yFT_(std::move(yFT)), normaliser_(std::move(norm))
+Function1DDefinition::Function1DDefinition(const std::vector<std::string> &parameterNames, Function1DXOmega valueFunction)
+    : parameterNames_(parameterNames), y_(std::move(valueFunction))
 {
 }
 
@@ -30,322 +26,321 @@ const std::vector<std::string> &Function1DDefinition::parameterNames() const { r
 // Return properties of the function
 const Flags<FunctionProperties::FunctionProperty> &Function1DDefinition::properties() const { return properties_; }
 
+// Set setup function
+void Function1DDefinition::setSetupFunction(Function1DSetup func) { setup_ = std::move(func); }
+
 // Return function for setup
 Function1DSetup Function1DDefinition::setup() const { return setup_; }
 
 // Return function for y value at specified x, omega
 Function1DXOmega Function1DDefinition::y() const { return y_; }
 
+// Set derivative function
+void Function1DDefinition::setDerivativeFunction(Function1DXOmega func)
+{
+    dYdX_ = std::move(func);
+    properties_.setFlag(FunctionProperties::FirstDerivative);
+}
+
 // Return function for first derivative of y with respect to x (at specified omega)
 Function1DXOmega Function1DDefinition::dYdX() const { return dYdX_; }
 
+// Set FT function
+void Function1DDefinition::setFTFunction(Function1DXOmega func)
+{
+    yFT_ = std::move(func);
+    properties_.setFlag(FunctionProperties::FourierTransform);
+}
+
 // Return function for FT of y value at the specified x, omega
 Function1DXOmega Function1DDefinition::yFT() const { return yFT_; }
+
+// Set normalisation function
+void Function1DDefinition::setNormalisationFunction(Function1DOmega func)
+{
+    normaliser_ = std::move(func);
+    properties_.setFlag(FunctionProperties::Normalisation);
+}
 
 // Return normalisation function
 Function1DOmega Function1DDefinition::normalisation() const { return normaliser_; }
 
 // One-Dimensional Function Definitions
-static std::map<Functions1D::Form, Function1DDefinition> functions1D_ = {
-    // No Function - returns zero
-    {Functions1D::Form::None,
-     {{},
-      {FunctionProperties::FourierTransform, FunctionProperties::Normalisation, FunctionProperties::FirstDerivative},
-      [](std::vector<double> params) { return params; },
-      [](double x, double omega, const std::vector<double> &params) { return 0.0; },
-      [](double x, double omega, const std::vector<double> &params) { return 0.0; },
-      [](double x, double omega, const std::vector<double> &params) { return 0.0; },
-      [](double omega, const std::vector<double> &params) { return 0.0; }}},
-    /*
-     * Gaussian
-     *
-     * Parameters:
-     *  INPUT  0 = fwhm
-     *  CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
-     *  CALC   2 = 1.0 / c
-     */
-    {Functions1D::Form::Gaussian,
-     {{"fwhm"},
-      {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
-      [](std::vector<double> params)
-      {
-          params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(1.0 / params[1]);
-          return params;
-      },
-      /*
-       *            (     x * x   )
-       * f(x) = exp ( - --------- )
-       * 	        (   2 * c * c )
-       */
-      [](double x, double omega, const std::vector<double> &params) { return exp(-(0.5 * x * x * params[2] * params[2])); },
-      {},
-      /*
-       *             (   x * x * c * c )
-       * FT(x) = exp ( - ------------- )
-       *             (         2       )
-       */
-      [](double x, double omega, const std::vector<double> &params) { return exp(-(0.5 * x * x * params[1] * params[1])); },
-      /*
-       *             1
-       * Norm = ------------
-       *        c sqrt(2 pi)
-       */
-      [](double omega, const std::vector<double> &params) { return params[2] / sqrt(2.0 * M_PI); }}},
-    /*
-     * Gaussian with prefactor
-     *
-     * Parameters:
-     *  INPUT  0 = A
-     *  INPUT  1 = fwhm
-     *  CALC   2 = c = fwhm / (2 * sqrt(2 ln 2))
-     *  CALC   3 = 1.0 / c
-     */
-    {Functions1D::Form::ScaledGaussian,
-     {{"A", "fwhm"},
-      {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
-      [](std::vector<double> params)
-      {
-          params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(1.0 / params[2]);
-          return params;
-      },
-      /*
-       *              (     x * x   )
-       * f(x) = A exp ( - --------- )
-       *              (   2 * c * c )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return params[0] * exp(-(0.5 * x * x * params[3] * params[3])); },
-      // First derivative (not defined)
-      {},
-      /*
-       *               (   x * x * c * c )
-       * FT(x) = A exp ( - ------------- )
-       *               (         2       )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return params[0] * exp(-(0.5 * x * x * params[2] * params[2])); },
-      /*
-       *              1
-       * Norm = --------------
-       *        A c sqrt(2 pi)
-       */
-      [](double omega, const std::vector<double> &params) { return params[3] / (params[0] * sqrt(2.0 * M_PI)); }}},
-    /*
-     * Gaussian with omega-dependent fwhm
-     *
-     * Parameters:
-     * INPUT  0 = fwhm
-     * CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
-     * CALC   2 = 1.0 / c
-     */
-    {Functions1D::Form::OmegaDependentGaussian,
-     {{"fwhm(x)"},
-      {FunctionProperties::FourierTransform, FunctionProperties::Normalisation},
-      [](std::vector<double> params)
-      {
-          params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(1.0 / params[1]);
-          return params;
-      },
-      /*
-       *            (         x * x      )
-       * f(x) = exp ( - ---------------- )
-       *            (   2 * (c*omega)**2 )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return exp(-(x * x) / (2.0 * (params[1] * omega) * (params[1] * omega))); },
-      // First derivative (not defined)
-      {},
-      /*
-       *             (   x*x * (c*omega)**2 )
-       * FT(x) = exp ( - ------------------ )
-       *             (            2         )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return exp(-(0.5 * x * x * (params[1] * omega) * (params[1] * omega))); },
-      /*
-       *                1
-       * Norm = ------------------
-       *        c omega sqrt(2 pi)
-       */
-      [](double omega, const std::vector<double> &params) { return 1.0 / (params[1] * omega * sqrt(2.0 * M_PI)); }}},
-    /*
-     * Gaussian with omega-independent and omega-dependent fwhm
-     *
-     * Parameters:
-     *  INPUT  0 = fwhm1
-     *  INPUT  1 = fwhm2  (omega-dependent)
-     *  CALC   2 = c1 = fwhm1 / (2 * sqrt(2 ln 2))
-     *  CALC   3 = c2 = fwhm2 / (2 * sqrt(2 ln 2))
-     *  CALC   4 = 1.0 / c1
-     *  CALC   5 = 1.0 / c2
-     */
-    {Functions1D::Form::GaussianC2,
-     {{"fwhm", "fwhm(x)"},
-      {FunctionProperties::FourierTransform},
-      [](std::vector<double> params)
-      {
-          params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(1.0 / params[2]);
-          params.push_back(1.0 / params[3]);
-          return params;
-      },
-      /*
-       *            (            x * x         )
-       * f(x) = exp ( - ---------------------- )
-       *            (   2 * (c1 + c2*omega)**2 )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return exp(-(x * x) / (2.0 * (params[2] + params[3] * omega) * (params[2] + params[3] * omega))); },
+const std::map<Functions1D::Form, Function1DDefinition> &functions1D()
+{
+    static std::map<Functions1D::Form, Function1DDefinition> functions;
+    if (functions.empty())
+    {
+        /*
+         * No function - returns zero
+         */
+        functions[Functions1D::Form::None] =
+            Function1DDefinition({}, [](double x, double omega, const std::vector<double> &params) { return 0.0; });
+        functions[Functions1D::Form::None].setDerivativeFunction([](double x, double omega, const std::vector<double> &params)
+                                                                 { return 0.0; });
+        functions[Functions1D::Form::None].setFTFunction([](double x, double omega, const std::vector<double> &params)
+                                                         { return 0.0; });
+        functions[Functions1D::Form::None].setNormalisationFunction([](double omega, const std::vector<double> &params)
+                                                                    { return 0.0; });
 
-      {},
-      /*
-       *             (   x * x * (c1 + c2*omega)**2 )
-       * FT(x) = exp ( - -------------------------- )
-       *             (                2             )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return exp(-(0.5 * x * x * (params[2] + params[3] * omega) * (params[2] + params[3] * omega))); },
-      /*
-       *                    1
-       * Norm = --------------------------
-       *        (c1 + c2 omega) sqrt(2 pi)
-       */
-      [](double omega, const std::vector<double> &params)
-      { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); }}},
+        /*
+         * Gaussian
+         *
+         * Parameters:
+         * INPUT  0 = fwhm
+         * CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
+         * CALC   2 = 1.0 / c
+         *
+         *            (     x * x   )               (   x * x * c * c )
+         * f(x) = exp ( - --------- )   FT(x) = exp ( - ------------- )
+         * 	          (   2 * c * c )               (         2       )
+         */
+        functions[Functions1D::Form::Gaussian] =
+            Function1DDefinition({"fwhm"}, [](double x, double omega, const std::vector<double> &params)
+                                 { return exp(-(0.5 * x * x * params[2] * params[2])); });
+        functions[Functions1D::Form::Gaussian].setSetupFunction(
+            [](std::vector<double> params)
+            {
+                params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(1.0 / params[1]);
+                return params;
+            });
+        functions[Functions1D::Form::Gaussian].setFTFunction([](double x, double omega, const std::vector<double> &params)
+                                                             { return exp(-(0.5 * x * x * params[1] * params[1])); });
+        functions[Functions1D::Form::Gaussian].setNormalisationFunction([](double omega, const std::vector<double> &params)
+                                                                        { return params[2] / sqrt(2.0 * M_PI); });
 
-    /*
-     * Lennard-Jones 12-6 Potential
-     *
-     * Parameters:
-     *  INPUT  0 = epsilon
-     *  INPUT  1 = sigma
-     */
-    {Functions1D::Form::LennardJones126,
-     {{"epsilon", "sigma"},
-      {FunctionProperties::FirstDerivative},
-      [](std::vector<double> params) { return params; },
-      /*
-       *                      [ ( sigma )**12   ( sigma )**6 ]
-       * F(x) = 4 * epsilon * [ ( ----- )     - ( ----- )    ]
-       *                      [ (   x   )       (   x   )    ]
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      {
-          auto sigmar = params[1] / x;
-          auto sigmar6 = pow(sigmar, 6.0);
-          auto sigmar12 = sigmar6 * sigmar6;
-          return 4.0 * params[0] * (sigmar12 - sigmar6);
-      },
-      /*
-       *                           [ ( sigma**12 )         ( sigma**6 ) ]
-       * dYdX(x) = -48 * epsilon * [ ( --------- ) - 0.5 * ( -------- ) ]
-       *                           [ (   x**13   )         (   x**7   ) ]
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      {
-          auto sigmar = params[1] / x;
-          auto sigmar6 = pow(sigmar, 6.0);
-          return 48.0 * params[0] * sigmar6 * (-sigmar6 + 0.5) / x;
-      },
-      {},
-      {}}},
-    /*
-     * Buckingham Potential
-     *
-     * Parameters:
-     *  INPUT  0 = A
-     *  INPUT  1 = B
-     *  INPUT  2 = C
-     */
-    {Functions1D::Form::Buckingham,
-     {{"A", "B", "C"},
-      {FunctionProperties::FirstDerivative},
-      [](std::vector<double> params) { return params; },
-      /*                         C
-       *  F(x)=A exp(-B * x) - -----
-       *                       x**6
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      {
-          auto B = exp(-params[1] * x);
-          auto C = params[2] / pow(x, 6.0);
-          return params[0] * B - C;
-      },
-      // dy/dx = -B * A exp(-B * x) + 6 * C * x**-7
-      [](double x, double omega, const std::vector<double> &params)
-      {
-          auto expo = exp(-params[1] * x);
-          auto C = 6 * params[2] * pow(x, -7.0);
-          return -params[1] * params[0] * expo + C;
-      },
-      {},
-      {}}},
-    /*
-     * GaussianPotential with prefactor, located at specific x.
-     * Intended for use as a potential override.
-     *
-     * Parameters:
-     *  INPUT  0 = A
-     *  INPUT  1 = fwhm
-     *  INPUT  2 = x0
-     *  CALC   3 = c = fwhm / (2 * sqrt(2 ln 2))
-     *  CALC   4 = 1.0 / c
-     */
-    {Functions1D::Form::GaussianPotential,
-     {{"A", "fwhm", "x0"},
-      {FunctionProperties::FirstDerivative},
-      [](std::vector<double> params)
-      {
-          params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
-          params.push_back(1.0 / params[3]);
-          return params;
-      },
-      /*
-       *            (     x * x   )
-       * f(x) = exp ( - --------- )
-       * 	        (   2 * c * c )
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      { return params[0] * exp(-(0.5 * (x - params[2]) * (x - params[2]) * params[4] * params[4])); },
-      /*
-       *
-       *             1             (     x * x   )
-       * dy/dx = - ----- * x * exp ( - --------- )
-       *           c**2            (   2 * c * c )
-       *
-       */
-      [](double x, double omega, const std::vector<double> &params)
-      {
-          auto dx = x - params[2];
-          auto c1 = (1 / (params[3] * params[3])) * dx;
-          return -params[0] * c1 * exp(-(0.5 * dx * dx * params[4] * params[4]));
-      },
-      {},
-      {}}},
-    /*
-     * Harmonic Well Potential
-     *
-     * Parameters:
-     *  INPUT  0 = k
-     */
-    {Functions1D::Form::Harmonic,
-     {{"k"},
-      {FunctionProperties::FirstDerivative},
-      [](std::vector<double> params) { return params; },
-      /*
-       * f(x) = 0.5 * k * x^2
-       */
-      [](double x, double omega, const std::vector<double> &params) { return 0.5 * params[0] * x * x; },
-      /*
-       * dy/dx = k * x
-       */
-      [](double x, double omega, const std::vector<double> &params) { return params[0] * x; },
-      {},
-      {}}}};
+        /*
+         * Gaussian with prefactor
+         *
+         * Parameters:
+         * INPUT  0 = A
+         * INPUT  1 = fwhm
+         * CALC   2 = c = fwhm / (2 * sqrt(2 ln 2))
+         * CALC   3 = 1.0 / c
+         *
+         *              (     x * x   )                 (   x * x * c * c )                 1
+         * f(x) = A exp ( - --------- )   FT(x) = A exp ( - ------------- )   Norm = --------------
+         *              (   2 * c * c )                 (         2       )          A c sqrt(2 pi)
+         */
+        functions[Functions1D::Form::ScaledGaussian] =
+            Function1DDefinition({"A", "fwhm"}, [](double x, double omega, const std::vector<double> &params)
+                                 { return params[0] * exp(-(0.5 * x * x * params[3] * params[3])); });
+        functions[Functions1D::Form::ScaledGaussian].setSetupFunction(
+            [](std::vector<double> params)
+            {
+                params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(1.0 / params[2]);
+                return params;
+            });
+        functions[Functions1D::Form::ScaledGaussian].setFTFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            { return params[0] * exp(-(0.5 * x * x * params[2] * params[2])); });
+        functions[Functions1D::Form::ScaledGaussian].setNormalisationFunction(
+            [](double omega, const std::vector<double> &params) { return params[3] / (params[0] * sqrt(2.0 * M_PI)); });
+
+        /*
+         * Gaussian with omega-dependent fwhm
+         *
+         * Parameters:
+         * INPUT  0 = fwhm
+         * CALC   1 = c = fwhm / (2 * sqrt(2 ln 2))
+         * CALC   2 = 1.0 / c
+         *
+         *            (         x * x      )               (   x*x * (c*omega)**2 )                  1
+         * f(x) = exp ( - ---------------- )   FT(x) = exp ( - ------------------ )   Norm = ------------------
+         *            (   2 * (c*omega)**2 )               (            2         )          c omega sqrt(2 pi)
+         */
+        functions[Functions1D::Form::OmegaDependentGaussian] =
+            Function1DDefinition({"fwhm(x)"}, [](double x, double omega, const std::vector<double> &params)
+                                 { return exp(-(x * x) / (2.0 * (params[1] * omega) * (params[1] * omega))); });
+        functions[Functions1D::Form::OmegaDependentGaussian].setSetupFunction(
+            [](std::vector<double> params)
+            {
+                params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(1.0 / params[1]);
+                return params;
+            });
+        /*
+         *             (   x*x * (c*omega)**2 )                  1
+         * FT(x) = exp ( - ------------------ )   Norm = ------------------
+         *             (            2         )          c omega sqrt(2 pi)
+         */
+        functions[Functions1D::Form::OmegaDependentGaussian].setFTFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            { return exp(-(0.5 * x * x * (params[1] * omega) * (params[1] * omega))); });
+        /*
+         *               1
+         * Norm = ------------------
+         *        c omega sqrt(2 pi)
+         */
+        functions[Functions1D::Form::OmegaDependentGaussian].setNormalisationFunction(
+            [](double omega, const std::vector<double> &params) { return 1.0 / (params[1] * omega * sqrt(2.0 * M_PI)); });
+
+        /*
+         * Gaussian with omega-independent and omega-dependent fwhm
+         *
+         * Parameters:
+         * INPUT  0 = fwhm1
+         * INPUT  1 = fwhm2  (omega-dependent)
+         * CALC   2 = c1 = fwhm1 / (2 * sqrt(2 ln 2))
+         * CALC   3 = c2 = fwhm2 / (2 * sqrt(2 ln 2))
+         * CALC   4 = 1.0 / c1
+         * CALC   5 = 1.0 / c2
+         *
+         *            (            x * x         )
+         * f(x) = exp ( - ---------------------- )
+         *            (   2 * (c1 + c2*omega)**2 )
+         */
+        functions[Functions1D::Form::GaussianC2] = Function1DDefinition(
+            {"fwhm", "fwhm(x)"}, [](double x, double omega, const std::vector<double> &params)
+            { return exp(-(x * x) / (2.0 * (params[2] + params[3] * omega) * (params[2] + params[3] * omega))); });
+        functions[Functions1D::Form::GaussianC2].setSetupFunction(
+            [](std::vector<double> params)
+            {
+                params.push_back(params[0] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(1.0 / params[2]);
+                params.push_back(1.0 / params[3]);
+                return params;
+            });
+        /*
+         *             (   x * x * (c1 + c2*omega)**2 )
+         * FT(x) = exp ( - -------------------------- )
+         *             (                2             )
+         */
+        functions[Functions1D::Form::GaussianC2].setFTFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            { return exp(-(0.5 * x * x * (params[2] + params[3] * omega) * (params[2] + params[3] * omega))); });
+        /*
+         *                    1
+         * Norm = --------------------------
+         *        (c1 + c2 omega) sqrt(2 pi)
+         */
+        functions[Functions1D::Form::GaussianC2].setNormalisationFunction(
+            [](double omega, const std::vector<double> &params)
+            { return 1.0 / ((params[2] + params[3] * omega) * sqrt(2.0 * M_PI)); });
+
+        /*
+         * Lennard-Jones 12-6 Potential
+         *
+         * Parameters:
+         * INPUT  0 = epsilon
+         * INPUT  1 = sigma
+         *
+         *                      [ ( sigma )**12   ( sigma )**6 ]
+         * F(x) = 4 * epsilon * [ ( ----- )     - ( ----- )    ]
+         *                      [ (   x   )       (   x   )    ]
+         */
+        functions[Functions1D::Form::LennardJones126] =
+            Function1DDefinition({"epsilon", "sigma"},
+                                 [](double x, double omega, const std::vector<double> &params)
+                                 {
+                                     auto sigmar = params[1] / x;
+                                     auto sigmar6 = pow(sigmar, 6.0);
+                                     auto sigmar12 = sigmar6 * sigmar6;
+                                     return 4.0 * params[0] * (sigmar12 - sigmar6);
+                                 });
+        /*
+         *                           [ ( sigma**12 )         ( sigma**6 ) ]
+         * dYdX(x) = -48 * epsilon * [ ( --------- ) - 0.5 * ( -------- ) ]
+         *                           [ (   x**13   )         (   x**7   ) ]
+         */
+        functions[Functions1D::Form::LennardJones126].setDerivativeFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            {
+                auto sigmar = params[1] / x;
+                auto sigmar6 = pow(sigmar, 6.0);
+                return 48.0 * params[0] * sigmar6 * (-sigmar6 + 0.5) / x;
+            });
+
+        /*
+         * Buckingham Potential
+         *
+         * Parameters:
+         * INPUT  0 = A
+         * INPUT  1 = B
+         * INPUT  2 = C
+         *
+         *                       C
+         * F(x)=A exp(-B * x) - ----
+         *                      x**6
+         */
+        functions[Functions1D::Form::Buckingham] =
+            Function1DDefinition({"A", "B", "C"},
+                                 [](double x, double omega, const std::vector<double> &params)
+                                 {
+                                     auto B = exp(-params[1] * x);
+                                     auto C = params[2] / pow(x, 6.0);
+                                     return params[0] * B - C;
+                                 });
+        /*
+         * dYdX(x) = -B * A exp(-B * x) + 6 * C * x**-7
+         */
+        functions[Functions1D::Form::Buckingham].setDerivativeFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            {
+                auto expo = exp(-params[1] * x);
+                auto C = 6 * params[2] * pow(x, -7.0);
+                return -params[1] * params[0] * expo + C;
+            });
+
+        /*
+         * GaussianPotential with prefactor, located at specific x.
+         * Intended for use as a potential override.
+         *
+         * Parameters:
+         * INPUT  0 = A
+         * INPUT  1 = fwhm
+         * INPUT  2 = x0
+         * CALC   3 = c = fwhm / (2 * sqrt(2 ln 2))
+         * CALC   4 = 1.0 / c
+         *
+         *            (     x * x   )
+         * f(x) = exp ( - --------- )
+         *            (   2 * c * c )
+         */
+
+        functions[Functions1D::Form::GaussianPotential] = Function1DDefinition(
+            {"A", "fwhm", "x0"}, [](double x, double omega, const std::vector<double> &params)
+            { return params[0] * exp(-(0.5 * (x - params[2]) * (x - params[2]) * params[4] * params[4])); });
+        functions[Functions1D::Form::GaussianPotential].setSetupFunction(
+            [](std::vector<double> params)
+            {
+                params.push_back(params[1] / (2.0 * sqrt(2.0 * log(2.0))));
+                params.push_back(1.0 / params[3]);
+                return params;
+            });
+        /*
+         *              1             (     x * x   )
+         * dYdX(x) = - ---- * x * exp ( - --------- )
+         *             c**2           (   2 * c * c )
+         */
+        functions[Functions1D::Form::GaussianPotential].setDerivativeFunction(
+            [](double x, double omega, const std::vector<double> &params)
+            {
+                auto dx = x - params[2];
+                auto c1 = (1 / (params[3] * params[3])) * dx;
+                return -params[0] * c1 * exp(-(0.5 * dx * dx * params[4] * params[4]));
+            });
+
+        /*
+         * Harmonic Well Potential
+         *
+         * Parameters:
+         * INPUT  0 = k
+         */
+        functions[Functions1D::Form::Harmonic] = Function1DDefinition(
+            {"k"}, [](double x, double omega, const std::vector<double> &params) { return 0.5 * params[0] * x * x; });
+        /*
+         * dYdX(x) = k * x
+         */
+        functions[Functions1D::Form::Harmonic].setDerivativeFunction(
+            [](double x, double omega, const std::vector<double> &params) { return params[0] * x; });
+    }
+
+    return functions;
+};
 
 // Return enum option info for forms
 EnumOptions<Functions1D::Form> Functions1D::forms()
@@ -363,28 +358,28 @@ EnumOptions<Functions1D::Form> Functions1D::forms()
 }
 
 // Return parameters for specified form
-const std::vector<std::string> &Functions1D::parameters(Form form) { return functions1D_.at(form).parameterNames(); }
+const std::vector<std::string> &Functions1D::parameters(Form form) { return functions1D().at(form).parameterNames(); }
 
 // Return nth parameter for the given form
-std::string Functions1D::parameter(Form form, int n) { return functions1D_.at(form).parameterNames()[n]; }
+std::string Functions1D::parameter(Form form, int n) { return functions1D().at(form).parameterNames()[n]; }
 
 // Return index of parameter in the given form
 std::optional<int> Functions1D::parameterIndex(Form form, std::string_view name)
 {
-    auto it = std::find(functions1D_.at(form).parameterNames().begin(), functions1D_.at(form).parameterNames().end(), name);
-    if (it == functions1D_.at(form).parameterNames().end())
+    auto it = std::find(functions1D().at(form).parameterNames().begin(), functions1D().at(form).parameterNames().end(), name);
+    if (it == functions1D().at(form).parameterNames().end())
         return {};
-    return it - functions1D_.at(form).parameterNames().begin();
+    return it - functions1D().at(form).parameterNames().begin();
 }
 
 // Return base function requested
-Function1DDefinition Functions1D::functionDefinition1D(Functions1D::Form form) { return functions1D_.at(form); }
+Function1DDefinition Functions1D::functionDefinition1D(Functions1D::Form form) { return functions1D().at(form); }
 
 // Check function properties against those supplied, returning truth if the function meets all requirements
 bool Functions1D::validFunction1DProperties(Functions1D::Form form,
                                             const Flags<FunctionProperties::FunctionProperty> &properties)
 {
-    return (functions1D_.at(form).properties() & properties) == properties;
+    return (functions1D().at(form).properties() & properties) == properties;
 }
 
 // Return all available functions with properties matching those provided
@@ -402,19 +397,22 @@ std::vector<Functions1D::Form> Functions1D::matchingFunction1D(const Flags<Funct
  */
 
 Function1DWrapper::Function1DWrapper(Functions1D::Form form, const std::vector<double> &params)
-    : form_(form), function_(functions1D_.at(form)), parameters_(params)
+    : form_(form), function_(functions1D().at(form)), parameters_(params)
 {
     calculateInternalParameters();
 }
 
 // Initialise internal function parameters from current base parameters
-void Function1DWrapper::calculateInternalParameters() { internalParameters_ = function_.setup()(parameters_); }
+void Function1DWrapper::calculateInternalParameters()
+{
+    internalParameters_ = function_.setup() ? function_.setup()(parameters_) : parameters_;
+}
 
 // Set function type and parameters
 bool Function1DWrapper::setFormAndParameters(Functions1D::Form form, const std::vector<double> &params)
 {
     form_ = form;
-    function_ = functions1D_.at(form_);
+    function_ = functions1D().at(form_);
 
     if (params.size() != function_.nParameters())
         return Messenger::error("1D function '{}' requires {} parameters, but {} were given.\n",
@@ -430,7 +428,7 @@ bool Function1DWrapper::setFormAndParameters(Functions1D::Form form, const std::
 void Function1DWrapper::setForm(Functions1D::Form form)
 {
     form_ = form;
-    function_ = functions1D_.at(form_);
+    function_ = functions1D().at(form_);
     calculateInternalParameters();
 }
 

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -32,9 +32,8 @@ using Function1DOmega = std::function<double(double omega, const std::vector<dou
 class Function1DDefinition
 {
     public:
-    Function1DDefinition(const std::vector<std::string> &parameterNames,
-                         const Flags<FunctionProperties::FunctionProperty> &properties, Function1DSetup setup,
-                         Function1DXOmega y, Function1DXOmega dYdX = {}, Function1DXOmega yFT = {}, Function1DOmega norm = {});
+    Function1DDefinition() = default;
+    Function1DDefinition(const std::vector<std::string> &parameterNames, Function1DXOmega valueFunction);
 
     private:
     // Names of parameters defining the function
@@ -53,14 +52,22 @@ class Function1DDefinition
     const std::vector<std::string> &parameterNames() const;
     // Return properties of the function
     const Flags<FunctionProperties::FunctionProperty> &properties() const;
+    // Set setup function
+    void setSetupFunction(Function1DSetup func);
     // Return function for setup
     Function1DSetup setup() const;
     // Return function for y value
     Function1DXOmega y() const;
+    // Set derivative function
+    void setDerivativeFunction(Function1DXOmega func);
     // Return function for first derivative
     Function1DXOmega dYdX() const;
+    // Set FT function
+    void setFTFunction(Function1DXOmega func);
     // Return function for FT of y value
     Function1DXOmega yFT() const;
+    // Set normalisation function
+    void setNormalisationFunction(Function1DOmega func);
     // Return normalisation function
     Function1DOmega normalisation() const;
 };


### PR DESCRIPTION
This PR changes the way that `Function1DDefinitions` are defined in the code, moving away from the obscure bunch of strictly-ordered initialisers and introducing specific setters.