### PR TITLE
perf: Combinable histograms for angle module parallel execution

### DIFF
--- a/src/math/histogram2D.cpp
+++ b/src/math/histogram2D.cpp
@@ -195,6 +195,22 @@ void Histogram2D::operator=(const Histogram2D &source)
     averages_ = source.averages_;
 }
 
+Histogram2D Histogram2D::operator+(const Histogram2D &other) const
+{
+    assert(nBins_ == other.nBins_ && nXBins_ == other.nYBins_);
+
+    Histogram2D ret = *this;
+
+    std::transform(other.bins_.begin(), other.bins_.end(), ret.bins_.begin(), ret.bins_.begin(), std::plus<>());
+
+    ret.nBinned_ = this->nBinned_ + other.nBinned_;
+    ret.nMissed_ = this->nMissed_ + other.nMissed_;
+    ret.nXBins_ = this->nXBins_;
+    ret.nYBins_ = this->nYBins_;
+
+    return ret;
+}
+
 /*
  * Serialisation
  */

--- a/src/math/histogram2D.cpp
+++ b/src/math/histogram2D.cpp
@@ -197,7 +197,7 @@ void Histogram2D::operator=(const Histogram2D &source)
 
 Histogram2D Histogram2D::operator+(const Histogram2D &other) const
 {
-    assert(nBins_ == other.nBins_ && nXBins_ == other.nYBins_);
+    assert(nXBins_ == other.nXBins_ && nYBins_ == other.nYBins_);
 
     Histogram2D ret = *this;
 

--- a/src/math/histogram2D.h
+++ b/src/math/histogram2D.h
@@ -95,6 +95,7 @@ class Histogram2D
      */
     public:
     void operator=(const Histogram2D &source);
+    Histogram2D operator+(const Histogram2D &other) const;
 
     /*
      * Serialisation

--- a/src/math/histogram3D.cpp
+++ b/src/math/histogram3D.cpp
@@ -232,6 +232,23 @@ void Histogram3D::operator=(const Histogram3D &source)
     averages_ = source.averages_;
 }
 
+Histogram3D Histogram3D::operator+(const Histogram3D &other) const
+{
+    assert(nXBins_ == other.nXBins_ && nYBins_ == other.nYBins_ && nZBins_ == other.nZBins_);
+
+    Histogram3D ret = *this;
+
+    std::transform(other.bins_.begin(), other.bins_.end(), ret.bins_.begin(), ret.bins_.begin(), std::plus<>());
+
+    ret.nBinned_ = this->nBinned_ + other.nBinned_;
+    ret.nMissed_ = this->nMissed_ + other.nMissed_;
+    ret.nXBins_ = this->nXBins_;
+    ret.nYBins_ = this->nYBins_;
+    ret.nZBins_ = this->nZBins_;
+
+    return ret;
+}
+
 /*
  * Serialisation
  */

--- a/src/math/histogram3D.h
+++ b/src/math/histogram3D.h
@@ -122,6 +122,7 @@ class Histogram3D
      */
     public:
     void operator=(const Histogram3D &source);
+    Histogram3D operator+(const Histogram3D &other) const;
 
     /*
      * Serialisation

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -88,26 +88,9 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     auto nBAvailable = 0, nBCumulative = 0, nBSelections = 0;
     auto nCAvailable = 0, nCCumulative = 0, nCSelections = 0;
 
-    auto unaryOp = [
-        this,
-        &b,
-        &c,
-        &nAAvailable,
-        &nACumulative,
-        &nASelections,
-        &nBAvailable,
-        &nBCumulative,
-        &nBSelections,
-        &nCAvailable,
-        &nCCumulative,
-        &nCSelections,
-        &combinableRAB,
-        &combinableRBC,
-        &combinableAABC,
-        &combinableDAngleAB,
-        &combinableDAngleBC,
-        &combinableDAngleABC
-    ](const auto &pair)
+    auto unaryOp = [this, &b, &c, &nAAvailable, &nACumulative, &nASelections, &nBAvailable, &nBCumulative, &nBSelections,
+                    &nCAvailable, &nCCumulative, &nCSelections, &combinableRAB, &combinableRBC, &combinableAABC,
+                    &combinableDAngleAB, &combinableDAngleBC, &combinableDAngleABC](const auto &pair)
     {
         const auto &[siteA, indexA] = pair;
 
@@ -116,7 +99,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
         auto &aABC = combinableAABC.local();
         auto &dAngleAB = combinableDAngleAB.local();
         auto &dAngleBC = combinableDAngleBC.local();
-        auto &dAngleABC = combinableDAngleABC.local(); 
+        auto &dAngleABC = combinableDAngleABC.local();
 
         ++nBSelections;
         for (const auto &[siteB, indexB] : b.sites())
@@ -176,7 +159,7 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     aABC = combinableAABC.finalize();
     dAngleAB = combinableDAngleAB.finalize();
     dAngleBC = combinableDAngleBC.finalize();
-    dAngleABC = combinableDAngleABC.finalize(); 
+    dAngleABC = combinableDAngleABC.finalize();
 
     // Accumulate histograms
     rAB.accumulate();

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -13,6 +13,8 @@
 #include "math/range.h"
 #include "module/context.h"
 #include "modules/angle/angle.h"
+#include "templates/algorithms.h"
+#include "templates/combinable.h"
 
 // Run main processing
 Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
@@ -74,13 +76,48 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
     dAngleBC.zeroBins();
     dAngleABC.zeroBins();
 
+    auto combinableRAB = dissolve::CombinableValue<Histogram1D>(rAB);
+    auto combinableRBC = dissolve::CombinableValue<Histogram1D>(rBC);
+    auto combinableAABC = dissolve::CombinableValue<Histogram1D>(aABC);
+    auto combinableDAngleAB = dissolve::CombinableValue<Histogram2D>(dAngleAB);
+    auto combinableDAngleBC = dissolve::CombinableValue<Histogram2D>(dAngleBC);
+    auto combinableDAngleABC = dissolve::CombinableValue<Histogram3D>(dAngleABC);
+
     auto nAAvailable = a.sites().size(), nACumulative = a.sites().size();
     auto nASelections = 1;
     auto nBAvailable = 0, nBCumulative = 0, nBSelections = 0;
     auto nCAvailable = 0, nCCumulative = 0, nCSelections = 0;
 
-    for (const auto &[siteA, indexA] : a.sites())
+    auto unaryOp = [
+        this,
+        &b,
+        &c,
+        &nAAvailable,
+        &nACumulative,
+        &nASelections,
+        &nBAvailable,
+        &nBCumulative,
+        &nBSelections,
+        &nCAvailable,
+        &nCCumulative,
+        &nCSelections,
+        &combinableRAB,
+        &combinableRBC,
+        &combinableAABC,
+        &combinableDAngleAB,
+        &combinableDAngleBC,
+        &combinableDAngleABC
+    ](const auto &pair)
     {
+        const auto &[siteA, indexA] = pair;
+
+        auto &rAB = combinableRAB.local();
+        auto &rBC = combinableRBC.local();
+        auto &aABC = combinableAABC.local();
+        auto &dAngleAB = combinableDAngleAB.local();
+        auto &dAngleBC = combinableDAngleBC.local();
+        auto &dAngleABC = combinableDAngleABC.local(); 
+
         ++nBSelections;
         for (const auto &[siteB, indexB] : b.sites())
         {
@@ -129,7 +166,17 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
                 dAngleABC.bin(distAB, distBC, angle);
             }
         }
-    }
+    };
+
+    dissolve::for_each(std::execution::par, a.sites().begin(), a.sites().end(), unaryOp);
+
+    // Finalize combinable histograms
+    rAB = combinableRAB.finalize();
+    rBC = combinableRBC.finalize();
+    aABC = combinableAABC.finalize();
+    dAngleAB = combinableDAngleAB.finalize();
+    dAngleBC = combinableDAngleBC.finalize();
+    dAngleABC = combinableDAngleABC.finalize(); 
 
     // Accumulate histograms
     rAB.accumulate();


### PR DESCRIPTION
I've worked on parallelising the module using a similar approach to the previous multithreading work on #1882 (SiteRDF).
Running into a snag where `Angle` tests are failing *only* when `execution_policy` is `par` (but passing when running sequentially!).
I'm guessing this is due to a part of the histogram binning process being non-thread safe, and I believe I have narrowed it down to the `Histogram3D`, since the output from the 1D and 2d histograms looks correct in `gdb`. Surprising, as the histogram classes seem to all effectively be wrappers to a linear array, so I am still trying to figure out where this is going wrong in parallel 3D binning.

