### PR TITLE
fix: AtomType Indexing

### DIFF
--- a/src/classes/atomTypeData.cpp
+++ b/src/classes/atomTypeData.cpp
@@ -11,7 +11,8 @@
 #include "classes/isotopeData.h"
 #include "data/isotopes.h"
 
-AtomTypeData::AtomTypeData(const std::shared_ptr<AtomType> &type, double population, double fraction, double boundCoherent, int nIso)
+AtomTypeData::AtomTypeData(const std::shared_ptr<AtomType> &type, double population, double fraction, double boundCoherent,
+                           int nIso)
     : atomType_(type), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
     isotopes_.resize(nIso, IsotopeData());

--- a/src/classes/atomTypeData.cpp
+++ b/src/classes/atomTypeData.cpp
@@ -12,8 +12,7 @@
 #include "data/isotopes.h"
 
 AtomTypeData::AtomTypeData(std::shared_ptr<AtomType> type, double population, double fraction, double boundCoherent, int nIso)
-    : atomType_(std::move(type)), exchangeable_(false), population_(population), fraction_(fraction),
-      boundCoherent_(boundCoherent)
+    : atomType_(std::move(type)), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
     isotopes_.resize(nIso, IsotopeData());
 }
@@ -24,8 +23,7 @@ AtomTypeData::AtomTypeData(const AtomTypeData &source) : listIndex_(source.listI
 }
 
 AtomTypeData::AtomTypeData(int listIndex, std::shared_ptr<AtomType> type, double population)
-    : listIndex_(listIndex), atomType_(std::move(type)), exchangeable_(false), population_(population), fraction_(0.0),
-      boundCoherent_(0.0)
+    : listIndex_(listIndex), atomType_(std::move(type)), population_(population)
 {
 }
 

--- a/src/classes/atomTypeData.cpp
+++ b/src/classes/atomTypeData.cpp
@@ -11,30 +11,10 @@
 #include "classes/isotopeData.h"
 #include "data/isotopes.h"
 
-AtomTypeData::AtomTypeData(std::shared_ptr<AtomType> type, double population, double fraction, double boundCoherent, int nIso)
-    : atomType_(std::move(type)), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
+AtomTypeData::AtomTypeData(const std::shared_ptr<AtomType> &type, double population, double fraction, double boundCoherent, int nIso)
+    : atomType_(type), population_(population), fraction_(fraction), boundCoherent_(boundCoherent)
 {
     isotopes_.resize(nIso, IsotopeData());
-}
-
-AtomTypeData::AtomTypeData(const AtomTypeData &source) : listIndex_(source.listIndex()), atomType_(source.atomType_)
-{
-    (*this) = source;
-}
-
-AtomTypeData::AtomTypeData(int listIndex, std::shared_ptr<AtomType> type, double population)
-    : listIndex_(listIndex), atomType_(std::move(type)), population_(population)
-{
-}
-
-void AtomTypeData::operator=(const AtomTypeData &source)
-{
-    atomType_ = source.atomType_;
-    exchangeable_ = source.exchangeable_;
-    isotopes_ = source.isotopes_;
-    population_ = source.population_;
-    fraction_ = source.fraction_;
-    boundCoherent_ = source.boundCoherent_;
 }
 
 /*
@@ -84,9 +64,6 @@ void AtomTypeData::zeroPopulations()
     population_ = 0.0;
     fraction_ = 0.0;
 }
-
-// Return list index of AtomTypeData in AtomTypeList
-int AtomTypeData::listIndex() const { return listIndex_; }
 
 // Return reference AtomType
 std::shared_ptr<AtomType> AtomTypeData::atomType() const { return atomType_; }

--- a/src/classes/atomTypeData.h
+++ b/src/classes/atomTypeData.h
@@ -29,15 +29,15 @@ class AtomTypeData
     // Reference AtomType
     std::shared_ptr<AtomType> atomType_;
     // Whether the AtomType has been marked as exchangeable
-    bool exchangeable_;
+    bool exchangeable_{false};
     // Isotopes information (if any)
     std::vector<IsotopeData> isotopes_;
     // Total population
-    double population_;
+    double population_{0.0};
     // World fractional population over all Isotopes
-    double fraction_;
+    double fraction_{0.0};
     // Calculated bound coherent scattering over all Isotopes
-    double boundCoherent_;
+    double boundCoherent_{0.0};
 
     public:
     // Add to population

--- a/src/classes/atomTypeData.h
+++ b/src/classes/atomTypeData.h
@@ -8,24 +8,19 @@
 
 // Forward Declarations
 class AtomType;
-class CoreData;
+class AtomTypeMix;
 
 // AtomTypeData Definition
 class AtomTypeData
 {
     public:
-    AtomTypeData(std::shared_ptr<AtomType> type, double population = 0, double fraction = 0, double boundCoherent = 0,
+    AtomTypeData(const std::shared_ptr<AtomType> &type, double population = 0, double fraction = 0, double boundCoherent = 0,
                  int nIso = 0);
-    AtomTypeData(const AtomTypeData &source);
-    AtomTypeData(int listIndex, std::shared_ptr<AtomType> atomType, double population);
-    void operator=(const AtomTypeData &source);
 
     /*
      * Properties
      */
     private:
-    // List index of AtomTypeData in AtomTypeList
-    int listIndex_;
     // Reference AtomType
     std::shared_ptr<AtomType> atomType_;
     // Whether the AtomType has been marked as exchangeable
@@ -48,8 +43,6 @@ class AtomTypeData
     void setIsotope(Sears91::Isotope tope, double pop, double fraction);
     // Zero populations
     void zeroPopulations();
-    // Return list index of AtomTypeData in AtomTypeList
-    int listIndex() const;
     // Return reference AtomType
     std::shared_ptr<AtomType> atomType() const;
     // Set exchangeable flag

--- a/src/classes/atomTypeMix.cpp
+++ b/src/classes/atomTypeMix.cpp
@@ -47,7 +47,8 @@ std::pair<AtomTypeData &, int> AtomTypeMix::add(std::shared_ptr<AtomType> atomTy
         return {*atd, atd - types_.begin()};
     }
 
-    return {types_.emplace_back(atomType, population), types_.size()};
+    auto &newAtomTypeData = types_.emplace_back(atomType, population);
+    return {newAtomTypeData, types_.size() - 1};
 }
 
 // Add the AtomTypes in the supplied list into this one, increasing populations etc.

--- a/src/classes/atomTypeMix.cpp
+++ b/src/classes/atomTypeMix.cpp
@@ -57,7 +57,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
     // Loop over AtomTypes in the source list
     for (auto &otherType : source)
     {
-        auto &&[atd, std::ignore] = add(otherType.atomType());
+        auto &atd = std::get<0>(add(otherType.atomType()));
 
         // If no Isotope data are present, add the population now. Otherwise, add it via the isotopes...
         if (otherType.nIsotopes() == 0)
@@ -71,7 +71,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
 // Add/increase this AtomType/Isotope pair
 void AtomTypeMix::addIsotope(std::shared_ptr<AtomType> atomType, Sears91::Isotope tope, double popAdd)
 {
-    auto &&[atd, std::ignore] = add(std::move(atomType));
+    auto &atd = std::get<0>(add(std::move(atomType)));
     atd.add(tope, popAdd);
 }
 

--- a/src/classes/atomTypeMix.cpp
+++ b/src/classes/atomTypeMix.cpp
@@ -33,8 +33,8 @@ void AtomTypeMix::zero()
         atd.zeroPopulations();
 }
 
-// Add the specified AtomType to the list, returning the index of the AtomType in the list
-AtomTypeData &AtomTypeMix::add(std::shared_ptr<AtomType> atomType, double population)
+// Add the specified AtomType to the list, returning data object and its index in the vector
+std::pair<AtomTypeData &, int> AtomTypeMix::add(std::shared_ptr<AtomType> atomType, double population)
 {
     // Search the list for the AtomType provided.
     auto atd =
@@ -44,10 +44,10 @@ AtomTypeData &AtomTypeMix::add(std::shared_ptr<AtomType> atomType, double popula
     if (atd != types_.end())
     {
         atd->add(population);
-        return *atd;
+        return {*atd, atd - types_.begin()};
     }
 
-    return types_.emplace_back(atomType, population);
+    return {types_.emplace_back(atomType, population), types_.size()};
 }
 
 // Add the AtomTypes in the supplied list into this one, increasing populations etc.
@@ -56,7 +56,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
     // Loop over AtomTypes in the source list
     for (auto &otherType : source)
     {
-        AtomTypeData &atd = add(otherType.atomType());
+        auto &&[atd, atdIndex] = add(otherType.atomType());
 
         // If no Isotope data are present, add the population now. Otherwise, add it via the isotopes...
         if (otherType.nIsotopes() == 0)
@@ -70,7 +70,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
 // Add/increase this AtomType/Isotope pair
 void AtomTypeMix::addIsotope(std::shared_ptr<AtomType> atomType, Sears91::Isotope tope, double popAdd)
 {
-    auto &atd = add(std::move(atomType));
+    auto &&[atd, atdIndex] = add(std::move(atomType));
     atd.add(tope, popAdd);
 }
 

--- a/src/classes/atomTypeMix.cpp
+++ b/src/classes/atomTypeMix.cpp
@@ -47,7 +47,7 @@ AtomTypeData &AtomTypeMix::add(std::shared_ptr<AtomType> atomType, double popula
         return *atd;
     }
 
-    return types_.emplace_back(types_.size(), atomType, population);
+    return types_.emplace_back(atomType, population);
 }
 
 // Add the AtomTypes in the supplied list into this one, increasing populations etc.
@@ -65,13 +65,6 @@ void AtomTypeMix::add(const AtomTypeMix &source)
             for (auto &topeData : otherType.isotopeData())
                 atd.add(topeData.isotope(), topeData.population());
     }
-}
-
-// Remove specified AtomType from the list
-void AtomTypeMix::remove(std::shared_ptr<AtomType> atomType)
-{
-    types_.erase(
-        std::remove_if(types_.begin(), types_.end(), [&atomType](const auto &atd) { return atd.atomType() == atomType; }));
 }
 
 // Add/increase this AtomType/Isotope pair

--- a/src/classes/atomTypeMix.cpp
+++ b/src/classes/atomTypeMix.cpp
@@ -57,7 +57,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
     // Loop over AtomTypes in the source list
     for (auto &otherType : source)
     {
-        auto &&[atd, atdIndex] = add(otherType.atomType());
+        auto &&[atd, std::ignore] = add(otherType.atomType());
 
         // If no Isotope data are present, add the population now. Otherwise, add it via the isotopes...
         if (otherType.nIsotopes() == 0)
@@ -71,7 +71,7 @@ void AtomTypeMix::add(const AtomTypeMix &source)
 // Add/increase this AtomType/Isotope pair
 void AtomTypeMix::addIsotope(std::shared_ptr<AtomType> atomType, Sears91::Isotope tope, double popAdd)
 {
-    auto &&[atd, atdIndex] = add(std::move(atomType));
+    auto &&[atd, std::ignore] = add(std::move(atomType));
     atd.add(tope, popAdd);
 }
 

--- a/src/classes/atomTypeMix.h
+++ b/src/classes/atomTypeMix.h
@@ -40,8 +40,6 @@ class AtomTypeMix
     AtomTypeData &add(std::shared_ptr<AtomType> atomType, double popAdd = 0);
     // Add the AtomTypes in the supplied object into this one, increasing populations etc.
     void add(const AtomTypeMix &source);
-    // Remove specified AtomType
-    void remove(std::shared_ptr<AtomType> atomType);
     // Add/increase this AtomType/Isotope pair, returning the index of the AtomType
     void addIsotope(std::shared_ptr<AtomType> atomType, Sears91::Isotope tope, double popAdd = 0);
     // Finalise, calculating fractional populations etc.

--- a/src/classes/atomTypeMix.h
+++ b/src/classes/atomTypeMix.h
@@ -36,8 +36,8 @@ class AtomTypeMix
     void clear();
     // Zero populations of all types
     void zero();
-    // Add the specified AtomType, returning the AtomTypeData
-    AtomTypeData &add(std::shared_ptr<AtomType> atomType, double popAdd = 0);
+    // Add the specified AtomType to the list, returning data object and its index in the vector
+    std::pair<AtomTypeData &, int> add(std::shared_ptr<AtomType> atomType, double popAdd = 0);
     // Add the AtomTypes in the supplied object into this one, increasing populations etc.
     void add(const AtomTypeMix &source);
     // Add/increase this AtomType/Isotope pair, returning the index of the AtomType

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -236,8 +236,8 @@ Atom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const std::shared_pt
     // Update our typeIndex (non-isotopic) and set local and master type indices
     if (sourceAtom->atomType() != nullptr)
     {
-        AtomTypeData &atd = atomTypes_.add(sourceAtom->atomType(), 1);
-        newAtom.setLocalTypeIndex(atd.listIndex());
+        auto &&[atd, atdIndex] = atomTypes_.add(sourceAtom->atomType(), 1);
+        newAtom.setLocalTypeIndex(atdIndex);
         newAtom.setMasterTypeIndex(sourceAtom->atomType()->index());
     }
 

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -55,6 +55,11 @@ void CoreData::removeAtomType(std::shared_ptr<AtomType> &at)
     removeReferencesTo(at);
 
     atomTypes_.erase(std::remove(atomTypes_.begin(), atomTypes_.end(), at), atomTypes_.end());
+
+    // Reassign AtomType indices
+    auto count = 0;
+    for (const auto &at : atomTypes_)
+        at->setIndex(count++);
 }
 
 // Return number of AtomTypes in list

--- a/src/io/export/coordinates.cpp
+++ b/src/io/export/coordinates.cpp
@@ -79,12 +79,10 @@ bool CoordinateExportFileFormat::exportDLPOLY(LineParser &parser, Configuration 
     }
 
     // Export Atoms
-    const auto &atomTypes = cfg->atomTypes();
     auto n = 0;
     for (const auto &i : cfg->atoms())
-        if (!parser.writeLineF("{:<6}{:10d}{:20.10f}\n{:20.12f}{:20.12f}{:20.12f}\n",
-                               atomTypes[i.localTypeIndex()].atomTypeName(), n++ + 1, AtomicMass::mass(i.speciesAtom()->Z()),
-                               i.r().x, i.r().y, i.r().z))
+        if (!parser.writeLineF("{:<6}{:10d}{:20.10f}\n{:20.12f}{:20.12f}{:20.12f}\n", i.speciesAtom()->atomType()->name(),
+                               n++ + 1, AtomicMass::mass(i.speciesAtom()->Z()), i.r().x, i.r().y, i.r().z))
             return false;
 
     return true;

--- a/src/io/export/trajectory.cpp
+++ b/src/io/export/trajectory.cpp
@@ -31,10 +31,12 @@ bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
 
     // Write Atoms
     for (const auto &i : cfg->atoms())
+    {
         if (extended)
         {
             if (!parser.writeLineF("{:<3}   {:15.9f}  {:15.9f}  {:15.9f}  {:<6d}  {}\n", Elements::symbol(i.speciesAtom()->Z()),
-                                   i.r().x, i.r().y, i.r().z, i.localTypeIndex(), i.speciesAtom()->atomType()->name()))
+                                   i.r().x, i.r().y, i.r().z, i.speciesAtom()->index() + 1,
+                                   i.speciesAtom()->atomType()->name()))
                 return false;
         }
         else
@@ -43,6 +45,7 @@ bool TrajectoryExportFileFormat::exportXYZ(LineParser &parser, Configuration *cf
                                    i.r().y, i.r().z))
                 return false;
         }
+    }
 
     return true;
 }

--- a/tests/classes/CMakeLists.txt
+++ b/tests/classes/CMakeLists.txt
@@ -1,3 +1,4 @@
+dissolve_add_test(SRC atomTypeMix.cpp)
 dissolve_add_test(SRC box.cpp)
 dissolve_add_test(SRC cells.cpp)
 dissolve_add_test(SRC elements.cpp)

--- a/tests/classes/atomTypeMix.cpp
+++ b/tests/classes/atomTypeMix.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "classes/atomType.h"
+#include "classes/configuration.h"
+#include "tests/testData.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+
+TEST(AtomTypeMixTest, Basic)
+{
+    SmallMolecules molecules_;
+    AtomTypeMix mix_;
+
+    // Add atom types to our mix
+    mix_.add(molecules_.atN(), 1);
+    mix_.add(molecules_.atOW(), 2);
+    mix_.add(molecules_.atHW(), 3);
+    mix_.finalise();
+
+    // Check basic data
+    EXPECT_EQ(mix_.nItems(), 3);
+    EXPECT_TRUE(mix_.contains(molecules_.atN()));
+    EXPECT_FALSE(mix_.contains(molecules_.atH1()));
+
+    // Retrieve atom type data
+    auto optAtdN = mix_.atomTypeData(molecules_.atN());
+    EXPECT_TRUE(optAtdN);
+    auto optAtdHW = mix_.atomTypeData(molecules_.atHW());
+    EXPECT_TRUE(optAtdHW);
+    auto optAtdOW = mix_.atomTypeData(molecules_.atOW());
+    EXPECT_TRUE(optAtdOW);
+    auto optAtdH1 = mix_.atomTypeData(molecules_.atH1());
+    EXPECT_FALSE(optAtdH1);
+
+    // Check detailed data
+    EXPECT_TRUE(optAtdN->get().atomType() == molecules_.atN());
+    EXPECT_EQ(optAtdN->get().atomTypeName(), molecules_.atN()->name());
+    EXPECT_DOUBLE_EQ(optAtdN->get().fraction(), 1.0 / 6.0);
+    EXPECT_DOUBLE_EQ(optAtdOW->get().fraction(), 1.0 / 3.0);
+    EXPECT_DOUBLE_EQ(optAtdHW->get().fraction(), 1.0 / 2.0);
+}
+
+TEST(AtomTypeMixTest, Indexing)
+{
+    SmallMolecules molecules_;
+    AtomTypeMix mix_;
+
+    // Add atom types to our mix
+    std::vector<AtomTypeData> orderedData;
+    orderedData.push_back(mix_.add(molecules_.atN(), 1));
+    orderedData.push_back(mix_.add(molecules_.atOW(), 2));
+    orderedData.push_back(mix_.add(molecules_.atHW(), 3));
+    orderedData.push_back(mix_.add(molecules_.atH1(), 3));
+    mix_.finalise();
+
+    EXPECT_EQ(orderedData.size(), mix_.nItems());
+
+    // Check indexed ordering
+    auto index = 0;
+    for (const auto &atomTypeData : orderedData)
+    {
+        EXPECT_EQ(atomTypeData.listIndex(), index);
+        ++index;
+    }
+
+    // Remove one and check indexing again
+    mix_.remove(molecules_.atOW());
+    mix_.finalise();
+    orderedData.erase(std::remove_if(orderedData.begin(), orderedData.end(),
+                                     [&](const auto &atd) { return atd.atomType() == molecules_.atOW(); }),
+                      orderedData.end());
+    EXPECT_EQ(mix_.nItems(), 3);
+    EXPECT_EQ(orderedData.size(), mix_.nItems());
+    index = 0;
+    for (const auto &atomTypeData : orderedData)
+    {
+        EXPECT_EQ(atomTypeData.listIndex(), index);
+        ++index;
+    }
+}
+
+} // namespace UnitTest

--- a/tests/classes/atomTypeMix.cpp
+++ b/tests/classes/atomTypeMix.cpp
@@ -49,35 +49,20 @@ TEST(AtomTypeMixTest, Indexing)
     AtomTypeMix mix_;
 
     // Add atom types to our mix
-    std::vector<AtomTypeData> orderedData;
-    orderedData.push_back(mix_.add(molecules_.atN(), 1));
-    orderedData.push_back(mix_.add(molecules_.atOW(), 2));
-    orderedData.push_back(mix_.add(molecules_.atHW(), 3));
-    orderedData.push_back(mix_.add(molecules_.atH1(), 3));
+    std::vector<std::pair<AtomTypeData, int>> orderedData;
+    orderedData.emplace_back(mix_.add(molecules_.atN(), 1));
+    orderedData.emplace_back(mix_.add(molecules_.atOW(), 2));
+    orderedData.emplace_back(mix_.add(molecules_.atHW(), 3));
+    orderedData.emplace_back(mix_.add(molecules_.atH1(), 3));
     mix_.finalise();
 
     EXPECT_EQ(orderedData.size(), mix_.nItems());
 
     // Check indexed ordering
     auto index = 0;
-    for (const auto &atomTypeData : orderedData)
+    for (const auto &[atomTypeData, atomTypeDataIndex] : orderedData)
     {
-        EXPECT_EQ(atomTypeData.listIndex(), index);
-        ++index;
-    }
-
-    // Remove one and check indexing again
-    mix_.remove(molecules_.atOW());
-    mix_.finalise();
-    orderedData.erase(std::remove_if(orderedData.begin(), orderedData.end(),
-                                     [&](const auto &atd) { return atd.atomType() == molecules_.atOW(); }),
-                      orderedData.end());
-    EXPECT_EQ(mix_.nItems(), 3);
-    EXPECT_EQ(orderedData.size(), mix_.nItems());
-    index = 0;
-    for (const auto &atomTypeData : orderedData)
-    {
-        EXPECT_EQ(atomTypeData.listIndex(), index);
+        EXPECT_EQ(atomTypeDataIndex, index);
         ++index;
     }
 }

--- a/tests/classes/neutronWeights.cpp
+++ b/tests/classes/neutronWeights.cpp
@@ -2,144 +2,100 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "classes/neutronWeights.h"
-#include "classes/atomType.h"
-#include "classes/configuration.h"
-#include "classes/isotopologue.h"
-#include "classes/species.h"
+#include "tests/testData.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
 {
-class NeutronWeightsTest : public ::testing::Test
+TEST(NeutronWeightsTest, Simple)
 {
-    public:
-    NeutronWeightsTest()
-    {
-        // Set up core data
-        atO_ = std::make_shared<AtomType>(Elements::O);
-        atO_->setName("O");
-        atN_ = std::make_shared<AtomType>(Elements::N);
-        atN_->setName("N");
-        atH1_ = std::make_shared<AtomType>(Elements::H);
-        atH1_->setName("H1");
-        atH2_ = std::make_shared<AtomType>(Elements::H);
-        atH2_->setName("H2");
-
-        // Set up N2 species
-        n2_.addAtom(Elements::N, {});
-        n2_.addAtom(Elements::N, {1.2, 0.0, 0.0});
-        n2_.atom(0).setAtomType(atN_);
-        n2_.atom(1).setAtomType(atN_);
-        n2_.addBond(0, 1);
-        n2A15_ = n2_.addIsotopologue("N15");
-        n2A15_->setAtomTypeIsotope(atN_, Sears91::N_15);
-
-        // Set up H2 species
-        h2_.addAtom(Elements::H, {});
-        h2_.addAtom(Elements::H, {0.7, 0.0, 0.0});
-        h2_.atom(0).setAtomType(atH1_);
-        h2_.atom(1).setAtomType(atH1_);
-        h2_.addBond(0, 1);
-        h2A2_ = h2_.addIsotopologue("H2");
-        h2A2_->setAtomTypeIsotope(atH1_, Sears91::H_2);
-
-        // Set up H2O species
-        h2o_.addAtom(Elements::H, {1.0, 0.0, 0.0});
-        h2o_.addAtom(Elements::O, {});
-        h2o_.addAtom(Elements::H, {cos(107.4 / DEGRAD), sin(107.4 / DEGRAD), 0.0});
-        h2o_.atom(0).setAtomType(atH2_);
-        h2o_.atom(1).setAtomType(atO_);
-        h2o_.atom(2).setAtomType(atH2_);
-        h2o_.addBond(0, 1);
-        h2o_.addBond(1, 2);
-        h2o_.addAngle(0, 1, 2);
-        d2o_ = h2o_.addIsotopologue("D2O");
-        d2o_->setAtomTypeIsotope(atH2_, Sears91::H_2);
-    }
-
-    protected:
-    std::shared_ptr<AtomType> atO_, atN_, atH1_, atH2_;
-    Species n2_, h2_, h2o_;
-    Isotopologue *n2A15_, *h2A2_, *d2o_;
-};
-
-TEST_F(NeutronWeightsTest, Simple)
-{
+    SmallMolecules molecules;
     NeutronWeights nwts;
+
     // Basic population of ten molecules with two atoms of the same type (N2)
-    nwts.addIsotopologue(&n2_, 10, n2_.naturalIsotopologue(), 1.0);
+    nwts.addIsotopologue(&molecules.N2(), 10, molecules.N2().naturalIsotopologue(), 1.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(20, nwts.atomTypes().atomTypeData(atN_)->get().population());
-    EXPECT_NEAR(1.0, nwts.atomTypes().atomTypeData(atN_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(20, nwts.atomTypes().atomTypeData(molecules.atN())->get().population());
+    EXPECT_NEAR(1.0, nwts.atomTypes().atomTypeData(molecules.atN())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::N_Natural), 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
-    // -- Adding more N2 natural isotopologue shouldn't make any difference - the species already exists, so just the
+
+    // Adding more N2 natural isotopologue shouldn't make any difference - the species already exists, so just the
     // relative weight of the isotopologue will be updated, and this will be normalised back to 1.0.
-    nwts.addIsotopologue(&n2_, 10, n2_.naturalIsotopologue(), 50.0);
+    nwts.addIsotopologue(&molecules.N2(), 10, molecules.N2().naturalIsotopologue(), 50.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(20, nwts.atomTypes().atomTypeData(atN_)->get().population());
-    EXPECT_NEAR(1.0, nwts.atomTypes().atomTypeData(atN_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(20, nwts.atomTypes().atomTypeData(molecules.atN())->get().population());
+    EXPECT_NEAR(1.0, nwts.atomTypes().atomTypeData(molecules.atN())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::N_Natural), 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
 }
 
-TEST_F(NeutronWeightsTest, Water)
+TEST(NeutronWeightsTest, Water)
 {
+    SmallMolecules molecules;
     NeutronWeights nwts;
-    nwts.addIsotopologue(&h2o_, 1, h2o_.naturalIsotopologue(), 1.0);
+
+    nwts.addIsotopologue(&molecules.H2O(), 1, molecules.H2O().naturalIsotopologue(), 1.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(atO_)->get().population());
-    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(atH2_)->get().population());
-    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(atO_)->get().fraction(), 1.0e-6);
-    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(atH2_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(molecules.atOW())->get().population());
+    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(molecules.atHW())->get().population());
+    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atOW())->get().fraction(), 1.0e-6);
+    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atHW())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(
         pow((Sears91::boundCoherent(Sears91::O_Natural) / 3.0) + (Sears91::boundCoherent(Sears91::H_Natural) * 2.0 / 3.0), 2) /
             100.0,
         nwts.boundCoherentSquareOfAverage(), 1.0e-6);
 }
 
-TEST_F(NeutronWeightsTest, D2O)
+TEST(NeutronWeightsTest, D2O)
 {
+    SmallMolecules molecules;
     NeutronWeights nwts;
-    nwts.addIsotopologue(&h2o_, 1, d2o_, 1.0);
+
+    nwts.addIsotopologue(&molecules.H2O(), 1, molecules.D2O(), 1.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(atO_)->get().population());
-    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(atH2_)->get().population());
-    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(atO_)->get().fraction(), 1.0e-6);
-    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(atH2_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(molecules.atOW())->get().population());
+    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(molecules.atHW())->get().population());
+    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atOW())->get().fraction(), 1.0e-6);
+    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atHW())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(
         pow((Sears91::boundCoherent(Sears91::O_Natural) / 3.0) + (Sears91::boundCoherent(Sears91::H_2) * 2.0 / 3.0), 2) / 100.0,
         nwts.boundCoherentSquareOfAverage(), 1.0e-6);
 }
 
-TEST_F(NeutronWeightsTest, NullWater)
+TEST(NeutronWeightsTest, NullWater)
 {
+    SmallMolecules molecules;
     NeutronWeights nwts;
+
     auto ratio = fabs(Sears91::boundCoherent(Sears91::H_2) / Sears91::boundCoherent(Sears91::H_Natural));
-    nwts.addIsotopologue(&h2o_, 1000, h2o_.naturalIsotopologue(), ratio);
-    nwts.addIsotopologue(&h2o_, 0, d2o_, 1.0);
+    nwts.addIsotopologue(&molecules.H2O(), 1000, molecules.H2O().naturalIsotopologue(), ratio);
+    nwts.addIsotopologue(&molecules.H2O(), 0, molecules.D2O(), 1.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(1000, nwts.atomTypes().atomTypeData(atO_)->get().population());
-    EXPECT_EQ(2000, nwts.atomTypes().atomTypeData(atH2_)->get().population());
-    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(atO_)->get().fraction(), 1.0e-6);
-    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(atH2_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(1000, nwts.atomTypes().atomTypeData(molecules.atOW())->get().population());
+    EXPECT_EQ(2000, nwts.atomTypes().atomTypeData(molecules.atHW())->get().population());
+    EXPECT_NEAR(1.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atOW())->get().fraction(), 1.0e-6);
+    EXPECT_NEAR(2.0 / 3.0, nwts.atomTypes().atomTypeData(molecules.atHW())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::O_Natural) / 3.0, 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
+
     // Making the H atomtype exchangeable should make no difference
-    nwts.createFromIsotopologues({atH2_});
+    nwts.createFromIsotopologues({molecules.atHW()});
     EXPECT_NEAR(pow(Sears91::boundCoherent(Sears91::O_Natural) / 3.0, 2) / 100.0, nwts.boundCoherentSquareOfAverage(), 1.0e-6);
 }
 
-TEST_F(NeutronWeightsTest, Mix)
+TEST(NeutronWeightsTest, Mix)
 {
+    SmallMolecules molecules;
     NeutronWeights nwts;
-    nwts.addIsotopologue(&h2o_, 1, h2o_.naturalIsotopologue(), 1.0);
-    nwts.addIsotopologue(&n2_, 1, n2_.naturalIsotopologue(), 1.0);
-    nwts.addIsotopologue(&n2_, 1, n2A15_, 1.0);
+
+    nwts.addIsotopologue(&molecules.H2O(), 1, molecules.H2O().naturalIsotopologue(), 1.0);
+    nwts.addIsotopologue(&molecules.N2(), 1, molecules.N2().naturalIsotopologue(), 1.0);
+    nwts.addIsotopologue(&molecules.N2(), 1, molecules.N2A15(), 1.0);
     nwts.createFromIsotopologues({});
-    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(atO_)->get().population());
-    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(atH2_)->get().population());
-    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(atN_)->get().population());
-    EXPECT_NEAR(1.0 / 5.0, nwts.atomTypes().atomTypeData(atO_)->get().fraction(), 1.0e-6);
-    EXPECT_NEAR(2.0 / 5.0, nwts.atomTypes().atomTypeData(atH2_)->get().fraction(), 1.0e-6);
-    EXPECT_NEAR(2.0 / 5.0, nwts.atomTypes().atomTypeData(atN_)->get().fraction(), 1.0e-6);
+    EXPECT_EQ(1, nwts.atomTypes().atomTypeData(molecules.atOW())->get().population());
+    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(molecules.atHW())->get().population());
+    EXPECT_EQ(2, nwts.atomTypes().atomTypeData(molecules.atN())->get().population());
+    EXPECT_NEAR(1.0 / 5.0, nwts.atomTypes().atomTypeData(molecules.atOW())->get().fraction(), 1.0e-6);
+    EXPECT_NEAR(2.0 / 5.0, nwts.atomTypes().atomTypeData(molecules.atHW())->get().fraction(), 1.0e-6);
+    EXPECT_NEAR(2.0 / 5.0, nwts.atomTypes().atomTypeData(molecules.atN())->get().fraction(), 1.0e-6);
     EXPECT_NEAR(pow((Sears91::boundCoherent(Sears91::O_Natural) / 5.0) +
                         (Sears91::boundCoherent(Sears91::H_Natural) * 2.0 / 5.0) +
                         (Sears91::boundCoherent(Sears91::N_Natural) / 5.0) + (Sears91::boundCoherent(Sears91::N_15) / 5.0),

--- a/tests/io/exportTrajectory.cpp
+++ b/tests/io/exportTrajectory.cpp
@@ -57,16 +57,15 @@ TEST_F(ExportTrajectoryTest, XYZ)
     EXPECT_EQ(version, cfg->contentsVersion());
 
     // Line by line analysis
+    std::string elem;
+    double x, y, z;
     for (auto atom : cfg->atoms())
     {
-        std::string elem;
-        double x, y, z;
         result >> elem >> x >> y >> z;
         EXPECT_EQ(elem, Elements::symbol(atom.speciesAtom()->Z()));
         EXPECT_NEAR(atom.x(), x, 1e-9);
         EXPECT_NEAR(atom.y(), y, 1e-9);
         EXPECT_NEAR(atom.z(), z, 1e-9);
-        break;
     }
 }
 
@@ -93,19 +92,20 @@ TEST_F(ExportTrajectoryTest, XYZExport)
     EXPECT_EQ(version, cfg->contentsVersion());
 
     // Line by line analysis
+    auto humanIndex = 0;
+    std::string elem, atomType;
+    double x, y, z;
+    int index;
     for (auto atom : cfg->atoms())
     {
-        std::string elem, atomType;
-        double x, y, z;
-        int index;
         result >> elem >> x >> y >> z >> index >> atomType;
         EXPECT_EQ(elem, Elements::symbol(atom.speciesAtom()->Z()));
         EXPECT_NEAR(atom.x(), x, 1e-9);
         EXPECT_NEAR(atom.y(), y, 1e-9);
         EXPECT_NEAR(atom.z(), z, 1e-9);
         EXPECT_EQ(atomType, atom.speciesAtom()->atomType()->name());
-        EXPECT_EQ(index, atom.localTypeIndex());
-        break;
+        EXPECT_EQ(index, humanIndex % 3 + 1);
+        ++humanIndex;
     }
 }
 

--- a/tests/testData.h
+++ b/tests/testData.h
@@ -665,4 +665,72 @@ const Species &benzeneSpecies()
     return benzene_;
 }
 
+// Return small molecules data
+class SmallMolecules
+{
+    public:
+    SmallMolecules()
+    {
+        // Set up atom types
+        atHW_ = std::make_shared<AtomType>(Elements::H, "HW");
+        atOW_ = std::make_shared<AtomType>(Elements::O, "OW");
+        atN_ = std::make_shared<AtomType>(Elements::N, "N");
+        atH1_ = std::make_shared<AtomType>(Elements::H, "H1");
+
+        // Set up N2 species
+        n2_.addAtom(Elements::N, {});
+        n2_.addAtom(Elements::N, {1.2, 0.0, 0.0});
+        n2_.atom(0).setAtomType(atN_);
+        n2_.atom(1).setAtomType(atN_);
+        n2_.addBond(0, 1);
+        n2A15_ = n2_.addIsotopologue("N15");
+        n2A15_->setAtomTypeIsotope(atN_, Sears91::N_15);
+
+        // Set up H2 species
+        h2_.addAtom(Elements::H, {});
+        h2_.addAtom(Elements::H, {0.7, 0.0, 0.0});
+        h2_.atom(0).setAtomType(atH1_);
+        h2_.atom(1).setAtomType(atH1_);
+        h2_.addBond(0, 1);
+        d2_ = h2_.addIsotopologue("D2");
+        d2_->setAtomTypeIsotope(atH1_, Sears91::H_2);
+
+        // Set up H2O species
+        h2o_.addAtom(Elements::H, {1.0, 0.0, 0.0});
+        h2o_.addAtom(Elements::O, {});
+        h2o_.addAtom(Elements::H, {cos(107.4 / DEGRAD), sin(107.4 / DEGRAD), 0.0});
+        h2o_.atom(0).setAtomType(atHW_);
+        h2o_.atom(1).setAtomType(atOW_);
+        h2o_.atom(2).setAtomType(atHW_);
+        h2o_.addBond(0, 1);
+        h2o_.addBond(1, 2);
+        h2o_.addAngle(0, 1, 2);
+        d2o_ = h2o_.addIsotopologue("D2O");
+        d2o_->setAtomTypeIsotope(atHW_, Sears91::H_2);
+    }
+
+    private:
+    // Atom Types
+    std::shared_ptr<AtomType> atHW_, atOW_, atN_, atH1_;
+    // Species
+    Species n2_, h2_, h2o_;
+    // Isotopologues
+    Isotopologue *n2A15_{nullptr}, *d2_{nullptr}, *d2o_{nullptr};
+
+    public:
+    // Atom Types
+    std::shared_ptr<AtomType> atHW() { return atHW_; }
+    std::shared_ptr<AtomType> atOW() { return atOW_; }
+    std::shared_ptr<AtomType> atN() { return atN_; }
+    std::shared_ptr<AtomType> atH1() { return atH1_; }
+    // Species
+    Species &N2() { return n2_; }
+    Species &H2() { return h2_; }
+    Species &H2O() { return h2o_; }
+    // Isotopologues
+    Isotopologue *N2A15() { return n2A15_; }
+    Isotopologue *D2() { return d2_; }
+    Isotopologue *D2O() { return d2o_; }
+};
+
 } // namespace UnitTest


### PR DESCRIPTION
This PR starts to touch on the painful world of indices associated to our `AtomType`s, relating to #289 and #508.

Here we begin by removing the local index storage from the `AtomTypeData` class and modify `AtomTypeMix` to only allow `add()`ing atom types, prohibiting `remove()` operations. This indexing is _still_copied over to `Atom`s making up a `Configuration` since there is no faster way of accessing the 2D array when computing forces and energies between atoms, but at least we remove one piece of easily-broken storage in a class.

Works towards #289.