### PR TITLE
build: Get OSX Antlr4 Java from official website

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -74,7 +74,7 @@ runs:
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos
 
       # Find ANTLR4
-      ANTLR_EXE="${RUNNER_TEMP}\antlr-${{ env.antlrVersion }}-complete.jar"
+      ANTLR_EXE="${RUNNER_TEMP}/antlr-${{ env.antlrVersion }}-complete.jar"
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
 
       # Make sure we have a Java binary path - $JAVA_HOME_21_X64 does not appear to work on Silicon

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -22,7 +22,6 @@ runs:
     run: |
       set -ex
       brew update-reset
-      ln -s $(which python3)/ $(brew --prefix)/Cellar/python3
       brew install ftgl ninja
       brew install antlr 
 

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -23,7 +23,12 @@ runs:
       set -ex
       brew update-reset
       brew install ftgl ninja
-      brew install antlr 
+
+  - name: Get ANTLR
+    shell: bash
+    run: |
+      set -ex
+      wget https://www.antlr.org/download/antlr-${{ env.antlrVersion }}-complete.jar -Oantlr-${{ env.antlrVersion }}-complete.jar
 
   - name: Install Python Dependencies
     shell: bash
@@ -69,8 +74,7 @@ runs:
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos
 
       # Find ANTLR4
-      brew --prefix antlr
-      ANTLR_EXE=$(brew --prefix antlr)/antlr-${{ env.antlrVersion }}-complete.jar
+      ANTLR_EXE="${RUNNER_TEMP}\antlr-${{ env.antlrVersion }}-complete.jar"
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
 
       # Make sure we have a Java binary path - $JAVA_HOME_21_X64 does not appear to work on Silicon

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -25,6 +25,7 @@ runs:
       brew install ftgl ninja
 
   - name: Get ANTLR
+    working-directory: ${{ runner.temp }}
     shell: bash
     run: |
       set -ex
@@ -74,7 +75,7 @@ runs:
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ env.qtVersion }}/macos
 
       # Find ANTLR4
-      ANTLR_EXE="${RUNNER_TEMP}/antlr-${{ env.antlrVersion }}-complete.jar"
+      ANTLR_EXE="${{ runner.temp }}/antlr-${{ env.antlrVersion }}-complete.jar"
       echo "Detected ANTLR exe as [$ANTLR_EXE]"
 
       # Make sure we have a Java binary path - $JAVA_HOME_21_X64 does not appear to work on Silicon

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -20,7 +20,6 @@ runs:
     if: ${{ inputs.cacheOnly == 'false' }}
     shell: bash
     run: |
-
       set -ex
       brew update-reset
       ln -s $(which python3)/ $(brew --prefix)/Cellar/python3


### PR DESCRIPTION
This PR stops the OSX builds installing the ANTLR4 Java binary from Homebrew, since the dependency chain associated with that is a hot, variable mess, and consistently breaks our builds.