### PR TITLE
build: Fix benchmark data upload and nix integration

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
         if: ${{ github.ref_name == 'develop' }}
         with:
             tool: 'googlecpp'
-            output-file-path: all_benchmark_results.json
+            output-file-path: build/all_benchmark_results.json
             github-token: ${{ secrets.GITHUB_TOKEN }}
             auto-push: true
             comment-on-alert: true

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
           antlr4
           antlr4.runtime.cpp
           antlr4.runtime.cpp.dev
+          gbenchmark
           cmake
           cli11
           fmt_8


### PR DESCRIPTION
Of course, following #1927 I broke the benchmark data upload because the path had changed.

This PR hopefully fixes that.

Also, this PR fixes the `nix` build!

Closes #1957 