### PR TITLE
build: Naively remove custom Qt

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,22 +68,6 @@
         "type": "indirect"
       }
     },
-    "next": {
-      "locked": {
-        "lastModified": 1709961763,
-        "narHash": "sha256-6H95HGJHhEZtyYA3rIQpvamMKAGoa8Yh2rFV29QnuGw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "3030f185ba6a4bf4f18b87f345f104e6a6961f34",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nix-bundle": {
       "inputs": {
         "nixpkgs": "nixpkgs"
@@ -228,26 +212,6 @@
         "type": "github"
       }
     },
-    "qt-idaaas": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1686232008,
-        "narHash": "sha256-Z//2vkJYSU1/iCTnAnBeg4tOXWtsx5tsEnnS3y/qSM0=",
-        "owner": "disorderedmaterials",
-        "repo": "qt-idaaas",
-        "rev": "99e40b7906cc1944d222a7f81c93280a4beb499d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "disorderedmaterials",
-        "repo": "qt-idaaas",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "bundlers": "bundlers",
@@ -255,8 +219,7 @@
         "home-manager": "home-manager",
         "nixGL-src": "nixGL-src",
         "nixpkgs": "nixpkgs_5",
-        "outdated": "outdated",
-        "qt-idaaas": "qt-idaaas"
+        "outdated": "outdated"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,15 +4,19 @@
     outdated.url = "github:NixOS/nixpkgs/nixos-21.05";
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
-    qt-idaaas.url = "github:disorderedmaterials/qt-idaaas";
-    qt-idaaas.inputs.nixpkgs.follows = "nixpkgs";
+    # qt-idaaas.url = "github:disorderedmaterials/qt-idaaas";
+    # qt-idaaas.inputs.nixpkgs.follows = "nixpkgs";
   };
-  outputs = { self, nixpkgs, outdated, home-manager, flake-utils, bundlers, nixGL-src
-    , qt-idaaas}:
+  outputs =
+    { self, nixpkgs, outdated, home-manager, flake-utils, bundlers, nixGL-src }:
     let
 
       toml = pkgs: ((import ./nix/toml11.nix) { inherit pkgs; });
-      onedpl = pkgs: ((import ./nix/onedpl.nix) { inherit (pkgs) lib stdenv fetchFromGitHub fetchpatch cmake; tbb=pkgs.tbb_2021_8;});
+      onedpl = pkgs:
+        ((import ./nix/onedpl.nix) {
+          inherit (pkgs) lib stdenv fetchFromGitHub fetchpatch cmake;
+          tbb = pkgs.tbb_2021_8;
+        });
       exe-name = mpi: gui:
         if mpi then
           "dissolve-mpi"
@@ -39,7 +43,8 @@
           (toml pkgs)
         ];
       gui_libs = system: pkgs:
-        let q = qt-idaaas.packages.${system};
+        # let q = qt-idaaas.packages.${system};
+        let q = pkgs.qt6;
         in with pkgs; [
           glib
           freetype
@@ -79,7 +84,11 @@
             buildInputs = base_libs pkgs ++ pkgs.lib.optional mpi pkgs.openmpi
               ++ pkgs.lib.optionals gui (gui_libs system pkgs)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
-              ++ pkgs.lib.optionals threading [pkgs.tbb_2021_8 (onedpl pkgs) (onedpl pkgs).dev];
+              ++ pkgs.lib.optionals threading [
+                pkgs.tbb_2021_8
+                (onedpl pkgs)
+                (onedpl pkgs).dev
+              ];
             nativeBuildInputs = pkgs.lib.optionals gui [ pkgs.wrapGAppsHook ];
 
             CTEST_OUTPUT_ON_FAILURE = "ON";
@@ -142,8 +151,8 @@
 
         devShells.default = pkgs.mkShell {
           name = "dissolve-shell";
-          buildInputs = base_libs pkgs ++ gui_libs system pkgs ++ check_libs pkgs
-            ++ (with pkgs; [
+          buildInputs = base_libs pkgs ++ gui_libs system pkgs
+            ++ check_libs pkgs ++ (with pkgs; [
               (pkgs.clang-tools.override {
                 llvmPackages = pkgs.llvmPackages_13;
               })
@@ -162,26 +171,42 @@
               gtk3
               nixGL.nixGLIntel
               openmpi
-              qt-idaaas.packages.${system}.qttools
+              # qt-idaaas.packages.${system}.qttools
+              pkgs.qt6.qttools
               tbb_2021_8
               valgrind
             ]);
           shellHook = ''
             export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS
-            export LIBGL_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "lib" "lib/dri" [pkgs.mesa.drivers]}
-            export LIBVA_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "out" "lib/dri" [pkgs.mesa.drivers]}
+            export LIBGL_DRIVERS_PATH=${
+              pkgs.lib.makeSearchPathOutput "lib" "lib/dri"
+              [ pkgs.mesa.drivers ]
+            }
+            export LIBVA_DRIVERS_PATH=${
+              pkgs.lib.makeSearchPathOutput "out" "lib/dri"
+              [ pkgs.mesa.drivers ]
+            }
             export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
-            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [pkgs.mesa.drivers]}:${pkgs.lib.makeSearchPathOutput "lib" "lib/vdpau" [pkgs.libvdpau]}:${pkgs.lib.makeLibraryPath [pkgs.libglvnd]}"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            export QT_PLUGIN_PATH="${qt-idaaas.packages.${system}.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
+            export LD_LIBRARY_PATH=${
+              pkgs.lib.makeLibraryPath [ pkgs.mesa.drivers ]
+            }:${
+              pkgs.lib.makeSearchPathOutput "lib" "lib/vdpau" [ pkgs.libvdpau ]
+            }:${
+              pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]
+            }"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            export QT_PLUGIN_PATH="${pkgs.qt6.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
           '';
 
-
-          CMAKE_CXX_COMPILER_LAUNCHER = "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
-          CMAKE_C_COMPILER_LAUNCHER = "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
+          CMAKE_CXX_COMPILER_LAUNCHER =
+            "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
+          CMAKE_C_COMPILER_LAUNCHER =
+            "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
           CMAKE_CXX_FLAGS_DEBUG = "-g -O0";
           CXXL = "${pkgs.stdenv.cc.cc.lib}";
-          QML_IMPORT_PATH = "${qt-idaaas.packages.${system}.qtdeclarative}/lib/qt-6/qml/";
-          QML2_IMPORT_PATH = "${qt-idaaas.packages.${system}.qtdeclarative}/lib/qt-6/qml/";
+          # QML_IMPORT_PATH = "${qt-idaaas.packages.${system}.qtdeclarative}/lib/qt-6/qml/";
+          # QML2_IMPORT_PATH = "${qt-idaaas.packages.${system}.qtdeclarative}/lib/qt-6/qml/";
+          QML_IMPORT_PATH = "${pkgs.qt6.qtdeclarative}/lib/qt-6/qml/";
+          QML2_IMPORT_PATH = "${pkgs.qt6.qtdeclarative}/lib/qt-6/qml/";
         };
 
         apps = {
@@ -261,14 +286,10 @@
         homeConfigurations = {
           "dissolve" = home-manager.lib.homeManagerConfiguration {
             inherit pkgs;
-            modules = with self.homeManagerModules; [
-              user-env
-            ];
+            modules = with self.homeManagerModules; [ user-env ];
           };
         };
 
-        homeManagerModule = {
-          user-env = import ./nix/user-env.nix;
-        };
+        homeManagerModule = { user-env = import ./nix/user-env.nix; };
       });
 }


### PR DESCRIPTION
This PR will remove our custom Qt and just use the default one.  This should simplify our builds and development environment.