### PR TITLE
build: Correctly pass CMake build type to conan

### DIFF
--- a/cmake/Modules/conan-dissolve.cmake
+++ b/cmake/Modules/conan-dissolve.cmake
@@ -41,7 +41,7 @@ conan_cmake_configure(
     ${_conan_options}
 )
 
-conan_cmake_autodetect(settings)
+conan_cmake_autodetect(settings BUILD_TYPE ${CMAKE_BUILD_TYPE})
 
 conan_cmake_install(PATH_OR_REFERENCE .
                     BUILD missing


### PR DESCRIPTION
A longstanding issue I have had on my local machine is building the debug version, which would segfault somewhere in the Antlr4 runtime.  Turns out that this was because `conan` was still building `Release` dependencies for a `Debug` build.  Explicitly passing `CMAKE_BUILD_TYPE` when autodetecting appears to clear this all up.

@rprospero this may now allow us to address #1840 without too much hassle.