### PR TITLE
build: Add CLion cmake support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,5 @@ RUN /root/.nix-profile/bin/nix build github:disorderedmaterials/dissolve#devShel
 VOLUME /dissolve
 WORKDIR /dissolve
 
-CMD "/root/.nix-profile/bin/nix" "develop" "--extra-experimental-features" "nix-command" "--extra-experimental-features" "flakes" "/dissolve#"
+ARG DEV_SHELL="default"
+CMD "/root/.nix-profile/bin/nix" "develop" ".#$DEV_SHELL" "--extra-experimental-features" "nix-command" "--extra-experimental-features" "flakes" "/dissolve#"


### PR DESCRIPTION
CLion is a bit behind on which versions of CMake it supports.  I've added a new dev shell to the nix flake that uses cmake 3.19 to handle this situation.  The new dev shell is accessible via

```shell
nix develop .#windows_docker
```

I've also added an argument to the docker file to use this dev shell.  It's accessible by adding the following flag to the docker invocation:

```shell
--build-arg=windows_docker
```
