### PR TITLE
refactor: Add full pair iterator and for_each_full_pair

### DIFF
--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(
   coreData.cpp
   distributor.cpp
   empiricalFormula.cpp
+  fullPairIterator.cpp
   isotopeData.cpp
   isotopologue.cpp
   isotopologues.cpp

--- a/src/classes/fullPairIterator.cpp
+++ b/src/classes/fullPairIterator.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "classes/fullPairIterator.h"
+#include <cmath>
+
+FullPairIterator::FullPairIterator(int size, int index) : size_(size)
+{
+    if (index == 0)
+        x_ = y_ = 0;
+    else
+        fromIndex(index);
+}
+
+void FullPairIterator::fromIndex(int index)
+{
+    x_ = index / size_;
+    y_ = index % size_;
+}
+
+int FullPairIterator::toIndex() const { return x_ * size_ + y_; }
+
+bool FullPairIterator::operator<(const FullPairIterator &other) const
+{
+    if (x_ != other.x_)
+        return x_ < other.x_;
+    return y_ < other.y_;
+}
+
+bool FullPairIterator::operator==(const FullPairIterator &other) const { return x_ == other.x_ && y_ == other.y_; }
+
+bool FullPairIterator::operator!=(const FullPairIterator &other) const { return x_ != other.x_ || y_ != other.y_; }
+
+FullPairIterator::value_type FullPairIterator::operator*() { return {x_, y_}; }
+
+FullPairIterator &FullPairIterator::operator++()
+{
+    y_++;
+    if (y_ >= size_)
+    {
+        x_ += 1;
+        y_ = 0;
+    }
+    return *this;
+}
+
+FullPairIterator::difference_type FullPairIterator::operator-(const FullPairIterator &other) const
+{
+    return toIndex() - other.toIndex();
+}
+
+FullPairIterator FullPairIterator::operator+(FullPairIterator::difference_type diff) const
+{
+    return FullPairIterator(size_, diff + toIndex());
+}
+
+FullPairIterator &FullPairIterator::operator+=(difference_type forward)
+{
+    fromIndex(forward + toIndex());
+    return *this;
+}
+
+FullPairIterator::value_type FullPairIterator::operator[](difference_type i) const { return *(*this + i); }
+
+FullPairIterator FullPairIterator::begin() const { return FullPairIterator(size_, 0); }
+FullPairIterator FullPairIterator::end() const { return FullPairIterator(size_, size_ * size_); }

--- a/src/classes/fullPairIterator.cpp
+++ b/src/classes/fullPairIterator.cpp
@@ -35,8 +35,7 @@ FullPairIterator::value_type FullPairIterator::operator*() { return {x_, y_}; }
 
 FullPairIterator &FullPairIterator::operator++()
 {
-    y_++;
-    if (y_ >= size_)
+    if (++y_ >= size_)
     {
         x_ += 1;
         y_ = 0;

--- a/src/classes/fullPairIterator.h
+++ b/src/classes/fullPairIterator.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+#pragma once
+
+#include <iterator>
+#include <tuple>
+
+// Iterate over every ordered pair of values (i.e. (2, 3) and (3, 2)
+// are both visited)
+class FullPairIterator
+{
+    private:
+    int size_;
+    int x_;
+    int y_;
+    int toIndex() const;
+    void fromIndex(int);
+
+    public:
+    using value = std::tuple<int, int>;
+    using value_type = std::tuple<int, int>;
+    using difference_type = int;
+    using reference = std::tuple<int, int> &;
+    using pointer = std::tuple<int, int> *;
+    using iterator_category = std::random_access_iterator_tag;
+
+    FullPairIterator(int size = 0, int index = 0);
+
+    FullPairIterator begin() const;
+    FullPairIterator end() const;
+    value_type operator*();
+    value_type operator[](difference_type i) const;
+
+    difference_type operator-(const FullPairIterator &it) const;
+    FullPairIterator &operator+=(difference_type forward);
+
+    FullPairIterator &operator-=(difference_type backward);
+
+    // Operators : arithmetic
+    FullPairIterator &operator++();
+
+    FullPairIterator &operator--();
+
+    FullPairIterator operator++(int);
+
+    FullPairIterator operator--(int);
+
+    FullPairIterator operator+(difference_type forward) const;
+    FullPairIterator operator-(difference_type backward) const;
+
+    // Operators : comparison
+    bool operator==(const FullPairIterator &other) const;
+    bool operator!=(const FullPairIterator &other) const;
+    bool operator<(const FullPairIterator &other) const;
+    bool operator>(const FullPairIterator &other) const;
+    bool operator<=(const FullPairIterator &other) const;
+    bool operator>=(const FullPairIterator &other) const;
+};

--- a/src/classes/pairIterator.h
+++ b/src/classes/pairIterator.h
@@ -5,6 +5,8 @@
 #include <iterator>
 #include <tuple>
 
+// Iterate over every unordered pair of values (i.e. (2, 3) and (3, 2)
+// are considered the same value and only one is visited)
 class PairIterator
 {
     private:

--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -3,8 +3,11 @@
 
 #include "classes/pairIterator.h"
 #include "classes/fullPairIterator.h"
+#include "templates/array2D.h"
 
 #include <gtest/gtest.h>
+#include <numeric>
+#include <random>
 
 namespace UnitTest
 {
@@ -27,17 +30,25 @@ TEST(PairIterTest, Pairs)
 
 TEST(PairIterTest, FullPairs)
 {
-    int x, y, size = 100;
-    FullPairIterator it(100);
-    for (x = 0; x < size; ++x)
+    const int size = 100;
+    FullPairIterator it(size);
+
+    Array2D<int> store(size, size, false);
+
+    std::random_device rd;                           // a seed source for the random number engine
+    std::mt19937 gen(rd());                          // mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<> distrib(1, 100); // Generate a random number in [1, 100]
+
+    int total = 0;
+    for (auto &item : store)
     {
-        for (y = 0; y < size; ++y)
-        {
-            auto [i, j] = *it;
-            EXPECT_EQ(i, x);
-            EXPECT_EQ(j, y);
-            ++it;
-        }
+        item = distrib(gen);
+        total += item;
     }
+
+    auto sum =
+        std::accumulate(it.begin(), it.end(), 0, [&store](const auto acc, const auto index) { return acc + store[index]; });
+
+    EXPECT_EQ(total, sum);
 }
 } // namespace UnitTest

--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "classes/pairIterator.h"
+#include "classes/fullPairIterator.h"
 
 #include <gtest/gtest.h>
 
@@ -15,6 +16,22 @@ TEST(PairIterTest, Pairs)
     for (x = 0; x < size; ++x)
     {
         for (y = x; y < size; ++y)
+        {
+            auto [i, j] = *it;
+            EXPECT_EQ(i, x);
+            EXPECT_EQ(j, y);
+            ++it;
+        }
+    }
+}
+
+TEST(PairIterTest, FullPairs)
+{
+    int x, y, size = 100;
+    FullPairIterator it(100);
+    for (x = 0; x < size; ++x)
+    {
+        for (y = 0; y < size; ++y)
         {
             auto [i, j] = *it;
             EXPECT_EQ(i, x);

--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -14,18 +14,26 @@ namespace UnitTest
 
 TEST(PairIterTest, Pairs)
 {
-    int x, y, size = 100;
-    PairIterator it(100);
-    for (x = 0; x < size; ++x)
+    const int size = 100;
+    PairIterator it(size);
+
+    Array2D<int> store(size, size, true);
+
+    std::random_device rd;                           // a seed source for the random number engine
+    std::mt19937 gen(rd());                          // mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<> distrib(1, 100); // Generate a random number in [1, 100]
+
+    int total = 0;
+    for (auto &item : store)
     {
-        for (y = x; y < size; ++y)
-        {
-            auto [i, j] = *it;
-            EXPECT_EQ(i, x);
-            EXPECT_EQ(j, y);
-            ++it;
-        }
+        item = distrib(gen);
+        total += item;
     }
+
+    auto sum =
+        std::accumulate(it.begin(), it.end(), 0, [&store](const auto acc, const auto index) { return acc + store[index]; });
+
+    EXPECT_EQ(total, sum);
 }
 
 TEST(PairIterTest, FullPairs)


### PR DESCRIPTION
This adds a `FullPairIterator` class and a `for_each_full_pair` algorithm that examines each ordered pair (as opposed to `for_each_pair`, which only examines unique unordered pairs).