### PR TITLE
build: enable ccache by default under nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -157,7 +157,6 @@
               cmake-format
               cmake-language-server
               conan
-              distcc
               direnv
               gdb
               gtk3
@@ -190,9 +189,9 @@
           '';
 
           CMAKE_CXX_COMPILER_LAUNCHER =
-            "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
+            "${pkgs.ccache}/bin/ccache";
           CMAKE_C_COMPILER_LAUNCHER =
-            "${pkgs.ccache}/bin/ccache;${pkgs.distcc}/bin/distcc";
+            "${pkgs.ccache}/bin/ccache";
           CMAKE_CXX_FLAGS_DEBUG = "-g -O0";
           CXXL = "${pkgs.stdenv.cc.cc.lib}";
           Qt6Quick3D_DIR = "${pkgs.qt6.qtquick3d}/lib/";


### PR DESCRIPTION
This PR enables ccache by default within the nix shell.

To be honest, it re-enables it.  It had always been enabled, but it was being overshadowed by `distcc`, which I don't believe is being used by anyone on the development team.  By entering the `nix develop` in the update flake *and* deleting the build directory and recreating it from the preset, you'll enable ccache.

As a quick benchmark, I managed to recompile the full dissolve GUI build on IDAaaS in 128 seconds.