### PR TITLE
refactor: unify for_each_pair and for_each_full_pair

### DIFF
--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -3,6 +3,7 @@
 
 #include "classes/pairIterator.h"
 #include "classes/fullPairIterator.h"
+#include "templates/algorithms.h"
 #include "templates/array2D.h"
 
 #include <gtest/gtest.h>
@@ -11,6 +12,30 @@
 
 namespace UnitTest
 {
+
+void for_each_test(bool unordered)
+{
+    const int size = 100;
+
+    Array2D<int> store(size, size, unordered);
+
+    std::random_device rd;                           // a seed source for the random number engine
+    std::mt19937 gen(rd());                          // mersenne_twister_engine seeded with rd()
+    std::uniform_int_distribution<> distrib(1, 100); // Generate a random number in [1, 100]
+
+    int total = 0;
+    for (auto &item : store)
+    {
+        item = distrib(gen);
+        total += item;
+    }
+
+    int sum = 0;
+    dissolve::for_each_pair(
+        ParallelPolicies::seq, 0, size, [&sum, &store](const auto i, const auto j) { sum += store[i, j]; }, unordered);
+
+    EXPECT_EQ(total, sum);
+}
 
 TEST(PairIterTest, Pairs)
 {
@@ -36,6 +61,8 @@ TEST(PairIterTest, Pairs)
     EXPECT_EQ(total, sum);
 }
 
+TEST(PairIterTest, for_each_pair) { for_each_test(true); }
+
 TEST(PairIterTest, FullPairs)
 {
     const int size = 100;
@@ -59,4 +86,6 @@ TEST(PairIterTest, FullPairs)
 
     EXPECT_EQ(total, sum);
 }
+
+TEST(PairIterTest, for_each_full_pair) { for_each_test(false); }
 } // namespace UnitTest

--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -32,7 +32,11 @@ void for_each_test(bool unordered)
 
     int sum = 0;
     dissolve::for_each_pair(
-        ParallelPolicies::seq, 0, size, [&sum, &store](const auto i, const auto j) { sum += store[i, j]; }, unordered);
+        ParallelPolicies::seq, 0, size,
+        [&sum, &store](const auto i, const auto j) {
+            sum += store[{i, j}];
+        },
+        unordered);
 
     EXPECT_EQ(total, sum);
 }


### PR DESCRIPTION
This unifies `for_each_pair` and `for_each_full_pair`  behind a boolean flag that matches the flag on Array2D.