### PR TITLE
fix: Restart Load Crash

### DIFF
--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -44,7 +44,8 @@ template <typename T> class EarlyReturn
     std::optional<T> value() const { return value_; }
 };
 
-// Perform an operation on every pair of elements in a container, or the half-matrix only ([i,j] == [j,i])
+// Perform an operation on every pair of elements in a container,
+// or the half-matrix only ([i,j] == [j,i])
 // Please note that this can *not* be transformed to use the
 // FullPairIterator, since it would prevent using `Break` to move to
 // the next loop iteration

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -245,8 +245,8 @@ void for_each_pair(ParallelPolicy policy, Iter begin, Iter end, Lam lambda, bool
     }
 }
 
-template <typename ParalellPolicy, class Iter, class Lam>
-void for_each_triplet(ParalellPolicy policy, Iter begin, Iter end, Lam lambda)
+template <typename ParallelPolicy, class Iter, class Lam>
+void for_each_triplet(ParallelPolicy policy, Iter begin, Iter end, Lam lambda)
 {
     for_each(policy, begin, end,
              [&lambda](const auto triplet)


### PR DESCRIPTION
This PR fixes a bug introduced in #1977 where one of the algorithms used inverted logic when setting the inner loop lower limit.

Closes #1974.