### PR TITLE
fix: SizeFactor icon

### DIFF
--- a/src/gui/configurationTab.ui
+++ b/src/gui/configurationTab.ui
@@ -386,18 +386,20 @@
            <number>2</number>
           </property>
           <item>
-           <widget class="QToolButton" name="CurrentBoxToolButton">
-            <property name="enabled">
-             <bool>false</bool>
+           <widget class="QLabel" name="SizeFactorIcon_5">
+            <property name="maximumSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
             <property name="text">
-             <string>...</string>
+             <string/>
             </property>
-            <property name="icon">
-             <iconset resource="main.qrc">
-              <normaloff>:/general/icons/configuration.svg</normaloff>:/general/icons/configuration.svg</iconset>
+            <property name="pixmap">
+             <pixmap resource="main.qrc">:/general/icons/configuration.svg</pixmap>
             </property>
-            <property name="autoRaise">
+            <property name="scaledContents">
              <bool>true</bool>
             </property>
            </widget>
@@ -452,24 +454,20 @@
            <number>2</number>
           </property>
           <item>
-           <widget class="QToolButton" name="DensityToolButton">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>...</string>
-            </property>
-            <property name="icon">
-             <iconset resource="main.qrc">
-              <normaloff>:/general/icons/density.svg</normaloff>:/general/icons/density.svg</iconset>
-            </property>
-            <property name="iconSize">
+           <widget class="QLabel" name="SizeFactorIcon_4">
+            <property name="maximumSize">
              <size>
               <width>14</width>
               <height>14</height>
              </size>
             </property>
-            <property name="autoRaise">
+            <property name="text">
+             <string/>
+            </property>
+            <property name="pixmap">
+             <pixmap resource="main.qrc">:/general/icons/density.svg</pixmap>
+            </property>
+            <property name="scaledContents">
              <bool>true</bool>
             </property>
            </widget>
@@ -504,6 +502,12 @@
        </item>
        <item>
         <widget class="QFrame" name="SizeFactorFrame">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="toolTip">
           <string>Applied size factor</string>
          </property>
@@ -527,18 +531,20 @@
            <number>4</number>
           </property>
           <item>
-           <widget class="QToolButton" name="SizeFactorToolButton">
-            <property name="enabled">
-             <bool>false</bool>
+           <widget class="QLabel" name="SizeFactorIcon">
+            <property name="maximumSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
             <property name="text">
-             <string>...</string>
+             <string/>
             </property>
-            <property name="icon">
-             <iconset resource="main.qrc">
-              <normaloff>:/nodes/icons/nodes/sizeFactor.svg</normaloff>:/nodes/icons/nodes/sizeFactor.svg</iconset>
+            <property name="pixmap">
+             <pixmap resource="main.qrc">:/nodes/icons/nodes/SizeFactor.svg</pixmap>
             </property>
-            <property name="autoRaise">
+            <property name="scaledContents">
              <bool>true</bool>
             </property>
            </widget>
@@ -603,18 +609,20 @@
            <number>2</number>
           </property>
           <item>
-           <widget class="QToolButton" name="MoleculePopulationToolButton">
-            <property name="enabled">
-             <bool>false</bool>
+           <widget class="QLabel" name="SizeFactorIcon_2">
+            <property name="maximumSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
             <property name="text">
-             <string>...</string>
+             <string/>
             </property>
-            <property name="icon">
-             <iconset resource="main.qrc">
-              <normaloff>:/general/icons/species.svg</normaloff>:/general/icons/species.svg</iconset>
+            <property name="pixmap">
+             <pixmap resource="main.qrc">:/general/icons/species.svg</pixmap>
             </property>
-            <property name="autoRaise">
+            <property name="scaledContents">
              <bool>true</bool>
             </property>
            </widget>
@@ -663,18 +671,20 @@
            <number>2</number>
           </property>
           <item>
-           <widget class="QToolButton" name="AtomPopulationToolButton">
-            <property name="enabled">
-             <bool>false</bool>
+           <widget class="QLabel" name="SizeFactorIcon_3">
+            <property name="maximumSize">
+             <size>
+              <width>16</width>
+              <height>16</height>
+             </size>
             </property>
             <property name="text">
-             <string>...</string>
+             <string/>
             </property>
-            <property name="icon">
-             <iconset resource="main.qrc">
-              <normaloff>:/general/icons/spheres_on.svg</normaloff>:/general/icons/spheres_on.svg</iconset>
+            <property name="pixmap">
+             <pixmap resource="main.qrc">:/general/icons/spheres_on.svg</pixmap>
             </property>
-            <property name="autoRaise">
+            <property name="scaledContents">
              <bool>true</bool>
             </property>
            </widget>

--- a/src/gui/icons/nodes/SizeFactor.svg
+++ b/src/gui/icons/nodes/SizeFactor.svg
@@ -12,7 +12,7 @@
    height="100"
    id="svg2"
    inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
-   sodipodi:docname="sizeFactor.svg">
+   sodipodi:docname="SizeFactor.svg">
   <metadata
      id="metadata3050">
     <rdf:RDF>


### PR DESCRIPTION
Simple fix and slight rejig of `ConfigurationTab` to display icons correctly / more nicely.

Closes #1985.