### PR TITLE
fix: Spikes in difference functions

### DIFF
--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -295,6 +295,13 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
         differenceData *= -1.0;
         Interpolator::addInterpolated(originalReferenceData, differenceData);
 
+        // Zero the difference function for points outside of the reference data range
+        auto originalXMin = originalReferenceData.xAxis().front();
+        auto originalXMax = originalReferenceData.xAxis().back();
+        for (auto &&[x, y] : zip(differenceData.xAxis(), differenceData.values()))
+            if (x < originalXMin || x > originalXMax)
+                y = 0.0;
+
         // Calculate r-factor over fit range and store
         auto tempRefData = originalReferenceData;
         Filters::trim(tempRefData, qMin_, qMax_);


### PR DESCRIPTION
This PR fixes an issue where the generated difference data between calculated and reference structure factors in the EPSR module would show a sharp spike at low Q, outside of the range of the supplied reference data. This issue is thought to be purely cosmetic and did not affect the operation of the module.