### PR TITLE
docs: Move to new website server

### DIFF
--- a/.github/workflows/website/action.yml
+++ b/.github/workflows/website/action.yml
@@ -158,7 +158,7 @@ runs:
       rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public/ ${SERVER_IP}:${SERVER_MAIN_DIR}
       rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public-docs/ ${SERVER_IP}:${SERVER_DOCS_DIR}/dev
 
-  - name: Upload Web Artifacts
+  - name: 'Upload Web Artifacts'
     uses: actions/upload-artifact@v4
     with:
       name: web-artifacts


### PR DESCRIPTION
The existing VPS became unsuitable in the past week or so - it had limited memory (0.5 Gb) which proved to be enough in the past but which is now not feasible. This PR makes little change to the workflow, but is designed to test the new secrets by publishing directly to the new server within the PR to ensure things are working correctly.