### PR TITLE
fix: Species site display

### DIFF
--- a/src/gui/speciesTab.ui
+++ b/src/gui/speciesTab.ui
@@ -1050,6 +1050,21 @@
                 </widget>
                 <widget class="QWidget" name="FragmentSiteDefinitionPage">
                  <layout class="QVBoxLayout" name="verticalLayout_18">
+                  <property name="spacing">
+                   <number>4</number>
+                  </property>
+                  <property name="leftMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>4</number>
+                  </property>
+                  <property name="bottomMargin">
+                   <number>4</number>
+                  </property>
                   <item>
                    <widget class="QGroupBox" name="FragmentNETAGroup">
                     <property name="sizePolicy">

--- a/src/gui/speciesTab.ui
+++ b/src/gui/speciesTab.ui
@@ -758,13 +758,6 @@
                <number>4</number>
               </property>
               <item>
-               <widget class="QCheckBox" name="SiteOriginMassWeightedCheck">
-                <property name="text">
-                 <string>Weight origin by mass</string>
-                </property>
-               </widget>
-              </item>
-              <item>
                <widget class="QStackedWidget" name="SiteDefinitionStack">
                 <property name="currentIndex">
                  <number>0</number>
@@ -1118,6 +1111,13 @@
                   </item>
                  </layout>
                 </widget>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="SiteOriginMassWeightedCheck">
+                <property name="text">
+                 <string>Weight origin by mass</string>
+                </property>
                </widget>
               </item>
              </layout>

--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -169,6 +169,8 @@ void SpeciesTab::updateSitesTab()
             // Set origin atom indices
             ui_.SiteOriginAtomsEdit->setText(QString::fromStdString(
                 joinStrings(site->staticOriginAtoms(), " ", [](const auto &i) { return siteName(*i); })));
+
+            // Set mass weighted option
             ui_.SiteOriginMassWeightedCheck->setCheckState(site->originMassWeighted() ? Qt::Checked : Qt::Unchecked);
 
             // Set x axis atom indices
@@ -200,9 +202,16 @@ void SpeciesTab::updateSitesTab()
 
             // Determine if description is valid
             ui_.DescriptionValidIndicator->setOK(site->fragment().isValid());
+
+            // Set mass weighted option
+            ui_.SiteOriginMassWeightedCheck->setCheckState(site->originMassWeighted() ? Qt::Checked : Qt::Unchecked);
             break;
     }
 
+    // Set visibility of origin mass weighted check
+    ui_.SiteOriginMassWeightedCheck->setVisible(site->type() != SpeciesSite::SiteType::Dynamic);
+
+    // Update the instance counts
     updateInstanceCountGroup();
 
     // If the current site has changed, also regenerate the SpeciesSite renderable

--- a/src/gui/speciesTab_sites.cpp
+++ b/src/gui/speciesTab_sites.cpp
@@ -25,10 +25,13 @@ void SpeciesTab::updateInstanceCountGroup()
     else if (site->instances().empty())
         ui_.InstanceCountLabel->setText("0 (no instances generated)");
     else
+    {
         ui_.InstanceCountLabel->setText(
-            QString("%1 (%2 atom%3 each)")
-                .arg(QString::number(site->instances().size()), QString::number(site->instances().front().allIndices().size()),
-                     QString::fromStdString(DissolveSys::plural(site->instances().front().allIndices().size()))));
+            QString("%1 (%2 origin atom%3 each)")
+                .arg(QString::number(site->instances().size()),
+                     QString::number(site->instances().front().originIndices().size()),
+                     QString::fromStdString(DissolveSys::plural(site->instances().front().originIndices().size()))));
+    }
 }
 
 /*


### PR DESCRIPTION
This PR fixes some minor issues with the display and editing of species sites in the SpeciesTab.

Closes #1997.
Closes #2001.