### PR TITLE
refactor: Add generator node base

### DIFF
--- a/src/generator/CMakeLists.txt
+++ b/src/generator/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(
   generator
   add.cpp
   add.h
+  addBase.cpp
+  addBase.h
   addPair.cpp
   addPair.h
   box.cpp

--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -41,13 +41,6 @@ void AddGeneratorNode::setUpKeywords()
 }
 
 /*
- * Identity
- */
-
-// Return whether a name for the node must be provided
-bool AddGeneratorNode::mustBeNamed() const { return false; }
-
-/*
  * Execute
  */
 

--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -16,14 +16,14 @@
 
 AddGeneratorNode::AddGeneratorNode(const Species *sp, const NodeValue &population, const NodeValue &density,
                                    Units::DensityUnits densityUnits)
-    : GeneratorNode(NodeType::Add), density_{density, densityUnits}, population_(population), species_(sp)
+    : AddGeneratorNodeBase(NodeType::Add, population, density, densityUnits), species_(sp)
 {
     setUpKeywords();
 }
 
 AddGeneratorNode::AddGeneratorNode(std::shared_ptr<const CoordinateSetsGeneratorNode> sets, const NodeValue &population,
                                    const NodeValue &density, Units::DensityUnits densityUnits)
-    : GeneratorNode(NodeType::Add), coordinateSets_(std::move(sets)), density_{density, densityUnits}, population_(population)
+    : AddGeneratorNodeBase(NodeType::Add, population, density, densityUnits), coordinateSets_(std::move(sets))
 {
     setUpKeywords();
 }
@@ -35,24 +35,9 @@ void AddGeneratorNode::setUpKeywords()
     keywords_.add<SpeciesKeyword>("Species", "Target species to add", species_);
     keywords_.add<NodeKeyword<CoordinateSetsGeneratorNode>>("CoordinateSets", "Target coordinate sets to add", coordinateSets_,
                                                             this, NodeTypeVector{NodeType::CoordinateSets});
-    keywords_.add<NodeValueKeyword>("Population", "Population of the target species to add", population_, this);
-    keywords_.add<NodeValueEnumOptionsKeyword<Units::DensityUnits>>("Density", "Density at which to add the target species",
-                                                                    density_, this, Units::densityUnits());
-
-    keywords_.setOrganisation("Options", "Box Modification");
-    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::BoxActionStyle>>(
-        "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_, boxActionStyles());
-    keywords_.add<BoolKeyword>("ScaleA", "Scale box length A when modifying volume", scaleA_);
-    keywords_.add<BoolKeyword>("ScaleB", "Scale box length B when modifying volume", scaleB_);
-    keywords_.add<BoolKeyword>("ScaleC", "Scale box length C when modifying volume", scaleC_);
-
-    keywords_.setOrganisation("Options", "Target");
-    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::PositioningType>>(
-        "Positioning", "Positioning type for individual molecules", positioningType_, positioningTypes());
-    keywords_.add<NodeKeyword<RegionGeneratorNodeBase>>(
-        "Region", "Region into which to add the species", region_, this,
-        NodeTypeVector{NodeType::CustomRegion, NodeType::CylindricalRegion, NodeType::GeneralRegion});
     keywords_.add<BoolKeyword>("Rotate", "Whether to randomly rotate molecules on insertion", rotate_);
+
+    setUpBaseKeywords();
 }
 
 /*
@@ -61,30 +46,6 @@ void AddGeneratorNode::setUpKeywords()
 
 // Return whether a name for the node must be provided
 bool AddGeneratorNode::mustBeNamed() const { return false; }
-
-/*
- * Node Data
- */
-
-// Return enum option info for PositioningType
-EnumOptions<AddGeneratorNode::BoxActionStyle> AddGeneratorNode::boxActionStyles()
-{
-    return EnumOptions<AddGeneratorNode::BoxActionStyle>("BoxAction",
-                                                         {{AddGeneratorNode::BoxActionStyle::None, "None"},
-                                                          {AddGeneratorNode::BoxActionStyle::AddVolume, "AddVolume"},
-                                                          {AddGeneratorNode::BoxActionStyle::ScaleVolume, "ScaleVolume"},
-                                                          {AddGeneratorNode::BoxActionStyle::Set, "Set"}});
-}
-
-// Return enum option info for PositioningType
-EnumOptions<AddGeneratorNode::PositioningType> AddGeneratorNode::positioningTypes()
-{
-    return EnumOptions<AddGeneratorNode::PositioningType>("PositioningType",
-                                                          {{AddGeneratorNode::PositioningType::Central, "Central"},
-                                                           {AddGeneratorNode::PositioningType::Current, "Current"},
-                                                           {AddGeneratorNode::PositioningType::Random, "Random"},
-                                                           {AddGeneratorNode::PositioningType::Region, "Region"}});
-}
 
 /*
  * Execute
@@ -100,19 +61,19 @@ bool AddGeneratorNode::prepare(const GeneratorContext &generatorContext)
         return Messenger::error("Specify either target Species or target coordinate sets, but not both.\n");
 
     // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddGeneratorNode::PositioningType::Region && region_)
+    else if (positioningType_ != AddGeneratorNodeBase::PositioningType::Region && region_)
         Messenger::warn(
             "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddGeneratorNode::positioningTypes().keyword(positioningType_));
+            region_->name(), AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
 
     // Check scalable axes definitions
     if (!scaleA_ && !scaleB_ && !scaleC_)
         return Messenger::error("Must have at least one scalable box axis!\n");
 
     // If the positioning type is 'Central', don't allow more than one molecule to be added
-    if (positioningType_ == AddGeneratorNode::PositioningType::Central && population_.asInteger() > 1)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Central && population_.asInteger() > 1)
         return Messenger::error(
             "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
             population_.asInteger());
@@ -141,9 +102,9 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // If a density was not given, just add new molecules to the current box without adjusting its size
     Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
-    if (boxAction_ == AddGeneratorNode::BoxActionStyle::None)
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::None)
         Messenger::print("[Add] Current box geometry / volume will remain as-is.\n");
-    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::AddVolume)
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::AddVolume)
     {
         Messenger::print("[Add] Current box volume will be increased to accommodate volume of new species.\n");
 
@@ -178,7 +139,7 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
         Messenger::print("[Add] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
                          cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
     }
-    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::ScaleVolume)
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::ScaleVolume)
     {
         Messenger::print("[Add] Box volume will be set to give supplied density.\n");
 
@@ -215,7 +176,7 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
         Messenger::print("[Add] Current box scaled by ({},{},{}) - new volume is {:e} cubic Angstroms.\n", scaleFactors.x,
                          scaleFactors.y, scaleFactors.z, cfg->box()->volume());
     }
-    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::Set)
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
     {
         Messenger::print("[Add] Box geometry will be set from the species box definition.\n");
         if (sp->box()->type() == Box::BoxType::NonPeriodic)
@@ -239,14 +200,14 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[Add] Positioning type is '{}' and rotation is {}.\n",
-                     AddGeneratorNode::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
+                     AddGeneratorNodeBase::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
 
     // Checks for regional positioning
-    if (positioningType_ == AddGeneratorNode::PositioningType::Region)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region)
     {
         if (!region_)
             return Messenger::error("Positioning type set to '{}' but no region was given.\n",
-                                    AddGeneratorNode::positioningTypes().keyword(positioningType_));
+                                    AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
 
         if (!region_->region().isValid())
             return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
@@ -289,20 +250,20 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
         // Set / generate position of Molecule
         switch (positioningType_)
         {
-            case (AddGeneratorNode::PositioningType::Random):
+            case (AddGeneratorNodeBase::PositioningType::Random):
                 fr.set(randomBuffer.random(), randomBuffer.random(), randomBuffer.random());
                 newCentre = box->getReal(fr);
                 mol->setCentreOfGeometry(box, newCentre);
                 break;
-            case (AddGeneratorNode::PositioningType::Region):
+            case (AddGeneratorNodeBase::PositioningType::Region):
                 mol->setCentreOfGeometry(box, region_->region().randomCoordinate());
                 break;
-            case (AddGeneratorNode::PositioningType::Central):
+            case (AddGeneratorNodeBase::PositioningType::Central):
                 fr.set(0.5, 0.5, 0.5);
                 newCentre = box->getReal(fr);
                 mol->setCentreOfGeometry(box, newCentre);
                 break;
-            case (AddGeneratorNode::PositioningType::Current):
+            case (AddGeneratorNodeBase::PositioningType::Current):
                 break;
             default:
                 throw(std::runtime_error(

--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -60,25 +60,17 @@ bool AddGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (species_ && coordinateSets_)
         return Messenger::error("Specify either target Species or target coordinate sets, but not both.\n");
 
-    // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region && !region_)
-        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddGeneratorNodeBase::PositioningType::Region && region_)
-        Messenger::warn(
-            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
+    // Check for a periodic species in the case of boxAction_ == Set
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
+    {
+        if (species_->box()->type() == Box::BoxType::NonPeriodic)
+            return Messenger::error("Target species '{}' is not periodic!.\n", species_->name());
 
-    // Check scalable axes definitions
-    if (!scaleA_ && !scaleB_ && !scaleC_)
-        return Messenger::error("Must have at least one scalable box axis!\n");
+        if (population_.asInteger() != 1)
+            return Messenger::error("Target population must be set to 1.\n");
+    }
 
-    // If the positioning type is 'Central', don't allow more than one molecule to be added
-    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Central && population_.asInteger() > 1)
-        return Messenger::error(
-            "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
-            population_.asInteger());
-
-    return true;
+    return prepareBase(generatorContext);
 }
 
 // Execute node
@@ -97,90 +89,11 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
     }
 
     auto *cfg = generatorContext.configuration();
-    auto rho = std::get<0>(density_).asDouble();
-    auto rhoUnits = std::get<1>(density_);
 
-    // If a density was not given, just add new molecules to the current box without adjusting its size
-    Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
-    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::None)
-        Messenger::print("[Add] Current box geometry / volume will remain as-is.\n");
-    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::AddVolume)
+    // Set / adjust target box volume
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
     {
-        Messenger::print("[Add] Current box volume will be increased to accommodate volume of new species.\n");
-
-        // Get current cell volume
-        auto currentVolume = cfg->box()->volume();
-
-        // Determine volume required to contain the population of the specified Species at the requested density
-        auto requiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            requiredVolume = (ipop * sp->nAtoms(SpeciesAtom::Presence::Physical)) / rho;
-        else
-            requiredVolume = ((sp->mass() * ipop) / AVOGADRO) / (rho / 1.0E24);
-
-        Messenger::print("[Add] Density for new species is {} {}.\n", rho, Units::densityUnits().keyword(rhoUnits));
-        Messenger::print("[Add] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
-
-        // If the current box has no atoms in it, absorb the current volume rather than adding to it
-        if (cfg->nAtoms() > 0)
-            requiredVolume += currentVolume;
-        else
-            Messenger::print("[Add] Current box is empty, so new volume will be set to exactly {} cubic Angstroms.\n",
-                             requiredVolume);
-
-        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
-
-        // Scale existing contents
-        cfg->scaleContents(scaleFactors);
-
-        // Scale the current Box so there is enough space for our new species
-        cfg->scaleBox(scaleFactors);
-
-        Messenger::print("[Add] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
-                         cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
-    }
-    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::ScaleVolume)
-    {
-        Messenger::print("[Add] Box volume will be set to give supplied density.\n");
-
-        // Get volume required to hold current cell contents at the requested density
-        double existingRequiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            existingRequiredVolume = cfg->nAtoms() / rho;
-        else
-            existingRequiredVolume = cfg->atomicMass() / (rho / 1.0E24);
-        Messenger::print("[Add] Existing contents requires volume of {} cubic Angstroms at specified density.\n",
-                         existingRequiredVolume);
-
-        // Determine volume required to contain the population of the specified Species at the requested density
-        auto requiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            requiredVolume = (ipop * sp->nAtoms(SpeciesAtom::Presence::Physical)) / rho;
-        else
-            requiredVolume = ((sp->mass() * ipop) / AVOGADRO) / (rho / 1.0E24);
-
-        Messenger::print("[Add] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
-
-        // Add on required volume for existing box contents
-        if (cfg->nAtoms() > 0)
-            requiredVolume += existingRequiredVolume;
-
-        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
-
-        // Scale existing contents
-        cfg->scaleContents(scaleFactors);
-
-        // Scale the current Box so there is enough space for our new species
-        cfg->scaleBox(scaleFactors);
-
-        Messenger::print("[Add] Current box scaled by ({},{},{}) - new volume is {:e} cubic Angstroms.\n", scaleFactors.x,
-                         scaleFactors.y, scaleFactors.z, cfg->box()->volume());
-    }
-    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
-    {
-        Messenger::print("[Add] Box geometry will be set from the species box definition.\n");
-        if (sp->box()->type() == Box::BoxType::NonPeriodic)
-            return Messenger::error("Target species '{}' is not periodic!.\n", sp->name());
+        Messenger::print("[Add}] Box geometry will be set from the species box definition.\n");
 
         cfg->createBox(sp->box()->axisLengths(), sp->box()->axisAngles());
         auto *box = cfg->box();
@@ -189,14 +102,9 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
                          "{:10.4e} gamma = {:10.4e}\n",
                          Box::boxTypes().keyword(box->type()), box->axisLengths().x, box->axisLengths().y, box->axisLengths().z,
                          box->axisAngles().x, box->axisAngles().y, box->axisAngles().z);
-
-        // Check on the requestedPopulation - we can have exactly one copy and no more
-        if (ipop > 1)
-        {
-            Messenger::warn("Population for species '{}' reset to 1.\n", sp->name());
-            ipop = 0;
-        }
     }
+    else
+        adjustBoxVolume(cfg, ipop, sp->nAtoms(SpeciesAtom::Presence::Physical), sp->mass());
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[Add] Positioning type is '{}' and rotation is {}.\n",
@@ -205,10 +113,6 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
     // Checks for regional positioning
     if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region)
     {
-        if (!region_)
-            return Messenger::error("Positioning type set to '{}' but no region was given.\n",
-                                    AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
-
         if (!region_->region().isValid())
             return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
 

--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -122,7 +122,7 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Now we add the molecules
     RandomBuffer randomBuffer(generatorContext.processPool(), ProcessPool::PoolProcessesCommunicator);
-    Vec3<double> r, cog, newCentre, fr;
+    Vec3<double> newCentre, fr;
     auto coordinateSetIndex = 0;
     auto hasCoordinateSets = false;
     if (coordinateSets_)

--- a/src/generator/add.h
+++ b/src/generator/add.h
@@ -27,13 +27,6 @@ class AddGeneratorNode : public AddGeneratorNodeBase
     void setUpKeywords();
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether a name for the node must be provided
-    bool mustBeNamed() const override;
-
-    /*
      * Node Data
      */
     private:

--- a/src/generator/add.h
+++ b/src/generator/add.h
@@ -36,7 +36,6 @@ class AddGeneratorNode : public AddGeneratorNodeBase
     /*
      * Node Data
      */
-
     private:
     // Species to be added
     const Species *species_{nullptr};

--- a/src/generator/add.h
+++ b/src/generator/add.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "base/units.h"
-#include "generator/node.h"
+#include "generator/addBase.h"
 #include "generator/nodeValue.h"
 
 // Forward Declarations
@@ -13,7 +13,7 @@ class Species;
 class RegionGeneratorNodeBase;
 
 // Add Node
-class AddGeneratorNode : public GeneratorNode
+class AddGeneratorNode : public AddGeneratorNodeBase
 {
     public:
     explicit AddGeneratorNode(const Species *sp = nullptr, const NodeValue &population = 0, const NodeValue &density = 0.1,
@@ -36,53 +36,14 @@ class AddGeneratorNode : public GeneratorNode
     /*
      * Node Data
      */
-    public:
-    // Box Action Style
-    enum class BoxActionStyle
-    {
-        None,        /* Box geometry / volume will remain unchanged */
-        AddVolume,   /* Increase Box volume to accommodate new species, according to supplied density */
-        ScaleVolume, /* Scale current Box volume to give, after addition of the current species, the supplied density */
-        Set          /* Set the Box geometry to that specified in the Species */
-    };
-    // Return enum option info for BoxActionStyle
-    static EnumOptions<BoxActionStyle> boxActionStyles();
-    // Positioning Type
-    enum class PositioningType
-    {
-        Central, /* Position at the centre of the Box */
-        Current, /* Use current coordinates */
-        Random,  /* Set position randomly */
-        Region   /* Set position randomly within a specified region */
-    };
-    // Return enum option info for PositioningType
-    static EnumOptions<PositioningType> positioningTypes();
 
     private:
-    // The default box action if none is specified
-    static constexpr AddGeneratorNode::BoxActionStyle defaultBoxAction_ = AddGeneratorNode::BoxActionStyle::AddVolume;
-    // Action to take on the Box geometry / volume on addition of the species
-    AddGeneratorNode::BoxActionStyle boxAction_{defaultBoxAction_};
-    // Coordinate set source for Species (if any)
-    std::shared_ptr<const CoordinateSetsGeneratorNode> coordinateSets_{nullptr};
-    // Target density when adding molecules
-    std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
-    // Population of molecules to add
-    NodeValue population_{1.0};
-    // The default positioning if none is specified
-    static constexpr AddGeneratorNode::PositioningType defaultPositioningType_ = AddGeneratorNode::PositioningType::Random;
-    // Positioning type for individual molecules
-    AddGeneratorNode::PositioningType positioningType_{defaultPositioningType_};
-    // Region into which we will add molecules (if any)
-    std::shared_ptr<const RegionGeneratorNodeBase> region_{nullptr};
-    // Whether to rotate molecules on insertion
-    bool rotate_{true};
-    // The default scaling settings
-    static constexpr bool defaultScale_{true};
-    // iFlags controlling box axis scaling
-    bool scaleA_{defaultScale_}, scaleB_{defaultScale_}, scaleC_{defaultScale_};
     // Species to be added
     const Species *species_{nullptr};
+    // Coordinate set source for Species (if any)
+    std::shared_ptr<const CoordinateSetsGeneratorNode> coordinateSets_{nullptr};
+    // Whether to rotate molecules on insertion
+    bool rotate_{true};
 
     /*
      * Execute

--- a/src/generator/add.h
+++ b/src/generator/add.h
@@ -50,8 +50,8 @@ class AddGeneratorNode : public GeneratorNode
     // Positioning Type
     enum class PositioningType
     {
-        Central, /* Position the Species at the centre of the Box */
-        Current, /* Use current Species coordinates */
+        Central, /* Position at the centre of the Box */
+        Current, /* Use current coordinates */
         Random,  /* Set position randomly */
         Region   /* Set position randomly within a specified region */
     };

--- a/src/generator/addBase.cpp
+++ b/src/generator/addBase.cpp
@@ -66,3 +66,122 @@ EnumOptions<AddGeneratorNodeBase::PositioningType> AddGeneratorNodeBase::positio
                                                                {AddGeneratorNodeBase::PositioningType::Random, "Random"},
                                                                {AddGeneratorNodeBase::PositioningType::Region, "Region"}});
 }
+
+/*
+ * DSDSD
+ */
+
+// Adjust or set box volume ready for addition
+void AddGeneratorNodeBase::adjustBoxVolume(Configuration *cfg, int nCopies, int nAtomsPerCopy, double massPerCopy) const
+{
+    auto rho = std::get<0>(density_).asDouble();
+    auto rhoUnits = std::get<1>(density_);
+
+    // Determine volume required to contain the population of the specified Species at the requested density
+    auto requiredVolume = 0.0;
+    if (rhoUnits == Units::AtomsPerAngstromUnits)
+        requiredVolume = (nCopies * nAtomsPerCopy) / rho;
+    else
+        requiredVolume = ((nCopies * massPerCopy) / AVOGADRO) / (rho / 1.0E24);
+
+    // If a density was not given, just add new molecules to the current box without adjusting its size
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::None)
+        Messenger::print("[{}] Current box geometry / volume will remain as-is.\n", GeneratorNode::nodeTypes().keyword(type_));
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::AddVolume)
+    {
+        Messenger::print("[{}] Current box volume will be increased to accommodate volume of new species.\n",
+                         GeneratorNode::nodeTypes().keyword(type_));
+
+        // Get current cell volume
+        auto currentVolume = cfg->box()->volume();
+
+        Messenger::print("[{}] Density for new molecule(s) is {} {}.\n", GeneratorNode::nodeTypes().keyword(type_), rho,
+                         Units::densityUnits().keyword(rhoUnits));
+        Messenger::print("[{}] Required volume for new molecule(s) is {} cubic Angstroms.\n",
+                         GeneratorNode::nodeTypes().keyword(type_), requiredVolume);
+
+        // If the current box has no atoms in it, absorb the current volume rather than adding to it
+        if (cfg->nAtoms() > 0)
+            requiredVolume += currentVolume;
+        else
+            Messenger::print("[{}] Current box is empty, so new volume will be set to exact ly {} cubic Angstroms.\n",
+                             GeneratorNode::nodeTypes().keyword(type_), requiredVolume);
+
+        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, {scaleA_, scaleB_, scaleC_});
+
+        // Scale existing contents
+        cfg->scaleContents(scaleFactors);
+
+        // Scale the current Box so there is enough space for our new species
+        cfg->scaleBox(scaleFactors);
+
+        Messenger::print("[{}] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
+                         GeneratorNode::nodeTypes().keyword(type_), cfg->box()->volume(), scaleFactors.x, scaleFactors.y,
+                         scaleFactors.z);
+    }
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::ScaleVolume)
+    {
+        Messenger::print("[{}] Box volume will be set to give supplied density.\n", GeneratorNode::nodeTypes().keyword(type_));
+
+        // Get volume required to hold current cell contents at the requested density
+        auto existingRequiredVolume = 0.0;
+        if (rhoUnits == Units::AtomsPerAngstromUnits)
+            existingRequiredVolume = cfg->nAtoms() / rho;
+        else
+            existingRequiredVolume = cfg->atomicMass() / (rho / 1.0E24);
+        Messenger::print("[{}] Existing contents requires volume of {} cubic Angstroms at specified density.\n",
+                         GeneratorNode::nodeTypes().keyword(type_), existingRequiredVolume);
+
+        Messenger::print("[{}] Required volume for new species is {} cubic Angstroms.\n",
+                         GeneratorNode::nodeTypes().keyword(type_), requiredVolume);
+
+        // Add on required volume for existing box contents
+        if (cfg->nAtoms() > 0)
+            requiredVolume += existingRequiredVolume;
+
+        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, {scaleA_, scaleB_, scaleC_});
+
+        // Scale existing contents
+        cfg->scaleContents(scaleFactors);
+
+        // Scale the current Box so there is enough space for our new species
+        cfg->scaleBox(scaleFactors);
+
+        Messenger::print("[{}] Current box scaled by ({},{},{}) - new volume is {:e} cubic Angstroms.\n",
+                         GeneratorNode::nodeTypes().keyword(type_), scaleFactors.x, scaleFactors.y, scaleFactors.z,
+                         cfg->box()->volume());
+    }
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
+    {
+        throw(
+            std::runtime_error("A box action of 'Set' must be handled outside of AddGeneratorNodeBase::adjustBoxVolume().\n"));
+    }
+}
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution in the base class
+bool AddGeneratorNodeBase::prepareBase(const GeneratorContext &generatorContext)
+{
+    // If positioningType_ type is 'Region', must have a suitable node defined
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region && !region_)
+        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
+    else if (positioningType_ != AddGeneratorNodeBase::PositioningType::Region && region_)
+        Messenger::warn(
+            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
+            region_->name(), AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
+
+    // Check scalable axes definitions
+    if (!scaleA_ && !scaleB_ && !scaleC_)
+        return Messenger::error("Must have at least one scalable box axis!\n");
+
+    // If the positioning type is 'Central', don't allow more than one molecule to be added
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Central && population_.asInteger() > 1)
+        return Messenger::error(
+            "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
+            population_.asInteger());
+
+    return true;
+}

--- a/src/generator/addBase.cpp
+++ b/src/generator/addBase.cpp
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "generator/addBase.h"
+#include "classes/box.h"
+#include "generator/regionBase.h"
+#include "keywords/bool.h"
+#include "keywords/node.h"
+#include "keywords/nodeValue.h"
+#include "keywords/nodeValueEnumOptions.h"
+
+AddGeneratorNodeBase::AddGeneratorNodeBase(GeneratorNode::NodeType nodeType, const NodeValue &population,
+                                           const NodeValue &density, Units::DensityUnits densityUnits)
+    : GeneratorNode(nodeType), density_{density, densityUnits}, population_(population)
+{
+}
+
+// Set up base keywords
+void AddGeneratorNodeBase::setUpBaseKeywords()
+{
+    keywords_.setOrganisation("Options", "Target");
+    keywords_.add<NodeValueKeyword>("Population", "Population of the target to add", population_, this);
+    keywords_.add<NodeValueEnumOptionsKeyword<Units::DensityUnits>>("Density", "Density at which to add the target", density_,
+                                                                    this, Units::densityUnits());
+    keywords_.add<EnumOptionsKeyword<AddGeneratorNodeBase::PositioningType>>("Positioning", "Positioning type",
+                                                                             positioningType_, positioningTypes());
+    keywords_.add<NodeKeyword<RegionGeneratorNodeBase>>(
+        "Region", "Target region into which to add", region_, this,
+        NodeTypeVector{NodeType::CustomRegion, NodeType::CylindricalRegion, NodeType::GeneralRegion});
+
+    keywords_.setOrganisation("Options", "Box Modification");
+    keywords_.add<EnumOptionsKeyword<AddGeneratorNodeBase::BoxActionStyle>>(
+        "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_, boxActionStyles());
+    keywords_.add<BoolKeyword>("ScaleA", "Scale box length A when modifying volume", scaleA_);
+    keywords_.add<BoolKeyword>("ScaleB", "Scale box length B when modifying volume", scaleB_);
+    keywords_.add<BoolKeyword>("ScaleC", "Scale box length C when modifying volume", scaleC_);
+}
+
+/*
+ * Identity
+ */
+
+// Return whether a name for the node must be provided
+bool AddGeneratorNodeBase::mustBeNamed() const { return false; }
+
+/*
+ * Node Data
+ */
+
+// Return enum option info for PositioningType
+EnumOptions<AddGeneratorNodeBase::BoxActionStyle> AddGeneratorNodeBase::boxActionStyles()
+{
+    return EnumOptions<AddGeneratorNodeBase::BoxActionStyle>(
+        "BoxAction", {{AddGeneratorNodeBase::BoxActionStyle::None, "None"},
+                      {AddGeneratorNodeBase::BoxActionStyle::AddVolume, "AddVolume"},
+                      {AddGeneratorNodeBase::BoxActionStyle::ScaleVolume, "ScaleVolume"},
+                      {AddGeneratorNodeBase::BoxActionStyle::Set, "Set"}});
+}
+
+// Return enum option info for PositioningType
+EnumOptions<AddGeneratorNodeBase::PositioningType> AddGeneratorNodeBase::positioningTypes()
+{
+    return EnumOptions<AddGeneratorNodeBase::PositioningType>("PositioningType",
+                                                              {{AddGeneratorNodeBase::PositioningType::Central, "Central"},
+                                                               {AddGeneratorNodeBase::PositioningType::Current, "Current"},
+                                                               {AddGeneratorNodeBase::PositioningType::Random, "Random"},
+                                                               {AddGeneratorNodeBase::PositioningType::Region, "Region"}});
+}

--- a/src/generator/addBase.h
+++ b/src/generator/addBase.h
@@ -75,4 +75,15 @@ class AddGeneratorNodeBase : public GeneratorNode
     static constexpr bool defaultScale_{true};
     // iFlags controlling box axis scaling
     bool scaleA_{defaultScale_}, scaleB_{defaultScale_}, scaleC_{defaultScale_};
+
+    protected:
+    // Adjust or set box volume ready for addition
+    void adjustBoxVolume(Configuration *cfg, int nCopies, int nAtomsPerCopy, double massPerCopy) const;
+
+    /*
+     * Execute
+     */
+    protected:
+    // Prepare any necessary data, ready for execution in the base class
+    bool prepareBase(const GeneratorContext &generatorContext);
 };

--- a/src/generator/addBase.h
+++ b/src/generator/addBase.h
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/units.h"
+#include "generator/node.h"
+#include "generator/nodeValue.h"
+
+// Forward Declarations
+class RegionGeneratorNodeBase;
+
+// Add Node
+class AddGeneratorNodeBase : public GeneratorNode
+{
+    public:
+    explicit AddGeneratorNodeBase(GeneratorNode::NodeType nodeType, const NodeValue &population = 0,
+                                  const NodeValue &density = 0.1,
+                                  Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
+    ~AddGeneratorNodeBase() override = default;
+
+    protected:
+    // Set up base keywords
+    void setUpBaseKeywords();
+
+    /*
+     * Identity
+     */
+    public:
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
+     * Node Data
+     */
+    public:
+    // Box Action Style
+    enum class BoxActionStyle
+    {
+        None,        /* Box geometry / volume will remain unchanged */
+        AddVolume,   /* Increase Box volume to accommodate new species, according to supplied density */
+        ScaleVolume, /* Scale current Box volume to give, after addition of the current species, the supplied density */
+        Set          /* Set the Box geometry to that specified in the Species */
+    };
+    // Return enum option info for BoxActionStyle
+    static EnumOptions<BoxActionStyle> boxActionStyles();
+    // Positioning Type
+    enum class PositioningType
+    {
+        Central, /* Position at the centre of the Box */
+        Current, /* Use current coordinates */
+        Random,  /* Set position randomly */
+        Region   /* Set position randomly within a specified region */
+    };
+    // Return enum option info for PositioningType
+    static EnumOptions<PositioningType> positioningTypes();
+
+    protected:
+    // The default box action if none is specified
+    static constexpr AddGeneratorNodeBase::BoxActionStyle defaultBoxAction_ = AddGeneratorNodeBase::BoxActionStyle::AddVolume;
+    // Action to take on the Box geometry / volume on addition of the species
+    AddGeneratorNodeBase::BoxActionStyle boxAction_{defaultBoxAction_};
+    // Target density when adding molecules
+    std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
+    // Population of molecules to add
+    NodeValue population_{1.0};
+    // The default positioning if none is specified
+    static constexpr AddGeneratorNodeBase::PositioningType defaultPositioningType_ =
+        AddGeneratorNodeBase::PositioningType::Random;
+    // Positioning type for individual molecules
+    AddGeneratorNodeBase::PositioningType positioningType_{defaultPositioningType_};
+    // Region into which we will add molecules (if any)
+    std::shared_ptr<const RegionGeneratorNodeBase> region_{nullptr};
+    // The default scaling settings
+    static constexpr bool defaultScale_{true};
+    // iFlags controlling box axis scaling
+    bool scaleA_{defaultScale_}, scaleB_{defaultScale_}, scaleC_{defaultScale_};
+};

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -103,7 +103,7 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Now we add the molecules
     RandomBuffer randomBuffer(generatorContext.processPool(), ProcessPool::PoolProcessesCommunicator);
-    Vec3<double> r, cog, newCentre;
+    Vec3<double> newCentre;
     Matrix3 transform;
     const auto *box = cfg->box();
     cfg->atoms().reserve(cfg->atoms().size() + ipop * (speciesA_->nAtoms() + speciesB_->nAtoms()));

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -32,15 +32,16 @@ void AddPairGeneratorNode::setUpKeywords()
                                                                     density_, this, Units::densityUnits());
 
     keywords_.setOrganisation("Options", "Box Modification");
-    keywords_.add<EnumOptionsKeyword<AddPairGeneratorNode::BoxActionStyle>>(
-        "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_, boxActionStyles());
+    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::BoxActionStyle>>(
+        "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_,
+        AddGeneratorNode::boxActionStyles());
     keywords_.add<BoolKeyword>("ScaleA", "Scale box length A when modifying volume", scaleA_);
     keywords_.add<BoolKeyword>("ScaleB", "Scale box length B when modifying volume", scaleB_);
     keywords_.add<BoolKeyword>("ScaleC", "Scale box length C when modifying volume", scaleC_);
 
     keywords_.setOrganisation("Options", "Target");
-    keywords_.add<EnumOptionsKeyword<AddPairGeneratorNode::PositioningType>>(
-        "Positioning", "Positioning type for individual molecules", positioningType_, positioningTypes());
+    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::PositioningType>>(
+        "Positioning", "Positioning type for individual molecules", positioningType_, AddGeneratorNode::positioningTypes());
     keywords_.add<NodeKeyword<RegionGeneratorNodeBase>>(
         "Region", "Region into which to add the species", region_, this,
         NodeTypeVector{NodeType::CustomRegion, NodeType::CylindricalRegion, NodeType::GeneralRegion});
@@ -55,30 +56,6 @@ void AddPairGeneratorNode::setUpKeywords()
 bool AddPairGeneratorNode::mustBeNamed() const { return false; }
 
 /*
- * Node Data
- */
-
-// Return enum option info for PositioningType
-EnumOptions<AddPairGeneratorNode::BoxActionStyle> AddPairGeneratorNode::boxActionStyles()
-{
-    return EnumOptions<AddPairGeneratorNode::BoxActionStyle>(
-        "BoxAction", {{AddPairGeneratorNode::BoxActionStyle::None, "None"},
-                      {AddPairGeneratorNode::BoxActionStyle::AddVolume, "AddVolume"},
-                      {AddPairGeneratorNode::BoxActionStyle::ScaleVolume, "ScaleVolume"},
-                      {AddPairGeneratorNode::BoxActionStyle::Set, "Set"}});
-}
-
-// Return enum option info for PositioningType
-EnumOptions<AddPairGeneratorNode::PositioningType> AddPairGeneratorNode::positioningTypes()
-{
-    return EnumOptions<AddPairGeneratorNode::PositioningType>("PositioningType",
-                                                              {{AddPairGeneratorNode::PositioningType::Central, "Central"},
-                                                               {AddPairGeneratorNode::PositioningType::Current, "Current"},
-                                                               {AddPairGeneratorNode::PositioningType::Random, "Random"},
-                                                               {AddPairGeneratorNode::PositioningType::Region, "Region"}});
-}
-
-/*
  * Execute
  */
 
@@ -89,15 +66,15 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
         return Messenger::error("One or both target species not specified in Add node.\n");
 
     // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddPairGeneratorNode::PositioningType::Region && !region_)
+    if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddPairGeneratorNode::PositioningType::Region && region_)
+    else if (positioningType_ != AddGeneratorNode::PositioningType::Region && region_)
         Messenger::warn(
             "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddPairGeneratorNode::positioningTypes().keyword(positioningType_));
+            region_->name(), AddGeneratorNode::positioningTypes().keyword(positioningType_));
 
     // Can't set box
-    if (boxAction_ == AddPairGeneratorNode::BoxActionStyle::Set)
+    if (boxAction_ == AddGeneratorNode::BoxActionStyle::Set)
         return Messenger::error("Can't set periodic box when using AddPair.\n");
 
     // Can't do this for periodic species
@@ -109,7 +86,7 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
         return Messenger::error("Must have at least one scalable box axis!\n");
 
     // If the positioning type is 'Central', don't allow more than one molecule to be added
-    if (positioningType_ == AddPairGeneratorNode::PositioningType::Central && population_.asInteger() > 1)
+    if (positioningType_ == AddGeneratorNode::PositioningType::Central && population_.asInteger() > 1)
         return Messenger::error(
             "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
             population_.asInteger());
@@ -145,9 +122,9 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // If a density was not given, just add new molecules to the current box without adjusting its size
     Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
-    if (boxAction_ == AddPairGeneratorNode::BoxActionStyle::None)
+    if (boxAction_ == AddGeneratorNode::BoxActionStyle::None)
         Messenger::print("[AddPair] Current box geometry / volume will remain as-is.\n");
-    else if (boxAction_ == AddPairGeneratorNode::BoxActionStyle::AddVolume)
+    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::AddVolume)
     {
         Messenger::print("[AddPair] Current box volume will be increased to accommodate volume of new species.\n");
 
@@ -182,7 +159,7 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
         Messenger::print("[AddPair] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
                          cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
     }
-    else if (boxAction_ == AddPairGeneratorNode::BoxActionStyle::ScaleVolume)
+    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::ScaleVolume)
     {
         Messenger::print("[AddPair] Box volume will be set to give supplied density.\n");
 
@@ -222,14 +199,14 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[AddPair] Positioning type is '{}' and rotation is {}.\n",
-                     AddPairGeneratorNode::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
+                     AddGeneratorNode::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
 
     // Checks for regional positioning
-    if (positioningType_ == AddPairGeneratorNode::PositioningType::Region)
+    if (positioningType_ == AddGeneratorNode::PositioningType::Region)
     {
         if (!region_)
             return Messenger::error("Positioning type set to '{}' but no region was given.\n",
-                                    AddPairGeneratorNode::positioningTypes().keyword(positioningType_));
+                                    AddGeneratorNode::positioningTypes().keyword(positioningType_));
 
         if (!region_->region().isValid())
             return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
@@ -262,20 +239,20 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
         // Set / generate position of pair
         switch (positioningType_)
         {
-            case (AddPairGeneratorNode::PositioningType::Random):
+            case (AddGeneratorNode::PositioningType::Random):
                 newCentre = box->getReal({randomBuffer.random(), randomBuffer.random(), randomBuffer.random()});
                 break;
-            case (AddPairGeneratorNode::PositioningType::Region):
+            case (AddGeneratorNode::PositioningType::Region):
                 newCentre = region_->region().randomCoordinate();
                 break;
-            case (AddPairGeneratorNode::PositioningType::Central):
+            case (AddGeneratorNode::PositioningType::Central):
                 newCentre = box->getReal({0.5, 0.5, 0.5});
                 break;
-            case (AddPairGeneratorNode::PositioningType::Current):
+            case (AddGeneratorNode::PositioningType::Current):
                 break;
             default:
-                throw(std::runtime_error(
-                    fmt::format("Positioning type {} not handled.\n", positioningTypes().keyword(positioningType_))));
+                throw(std::runtime_error(fmt::format("Positioning type {} not handled.\n",
+                                                     AddGeneratorNode::positioningTypes().keyword(positioningType_))));
         }
 
         // Move the molecule pair

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -49,14 +49,6 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (!speciesA_ || !speciesB_)
         return Messenger::error("One or both target species not specified in Add node.\n");
 
-    // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region && !region_)
-        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddGeneratorNodeBase::PositioningType::Region && region_)
-        Messenger::warn(
-            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
-
     // Can't set box
     if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
         return Messenger::error("Can't set periodic box when using AddPair.\n");
@@ -65,17 +57,7 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (speciesA_->box()->type() != Box::BoxType::NonPeriodic || speciesB_->box()->type() != Box::BoxType::NonPeriodic)
         return Messenger::error("Can't use periodic species in AddPair.\n");
 
-    // Check scalable axes definitions
-    if (!scaleA_ && !scaleB_ && !scaleC_)
-        return Messenger::error("Must have at least one scalable box axis!\n");
-
-    // If the positioning type is 'Central', don't allow more than one molecule to be added
-    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Central && population_.asInteger() > 1)
-        return Messenger::error(
-            "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
-            population_.asInteger());
-
-    return true;
+    return prepareBase(generatorContext);
 }
 
 // Execute node
@@ -100,86 +82,10 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     auto *cfg = generatorContext.configuration();
 
-    const auto nAtomsToAdd = ipop * (speciesA_->nAtoms() + speciesB_->nAtoms());
-    auto rho = std::get<0>(density_).asDouble();
-    auto rhoUnits = std::get<1>(density_);
-
-    // If a density was not given, just add new molecules to the current box without adjusting its size
-    Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
-    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::None)
-        Messenger::print("[AddPair] Current box geometry / volume will remain as-is.\n");
-    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::AddVolume)
-    {
-        Messenger::print("[AddPair] Current box volume will be increased to accommodate volume of new species.\n");
-
-        // Get current cell volume
-        auto currentVolume = cfg->box()->volume();
-
-        // Determine volume required to contain the population of the specified Species at the requested density
-        auto requiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            requiredVolume = nAtomsToAdd / rho;
-        else
-            requiredVolume = (((speciesA_->mass() + speciesB_->mass()) * ipop) / AVOGADRO) / (rho / 1.0E24);
-
-        Messenger::print("[AddPair] Density for new species is {} {}.\n", rho, Units::densityUnits().keyword(rhoUnits));
-        Messenger::print("[AddPair] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
-
-        // If the current box has no atoms in it, absorb the current volume rather than adding to it
-        if (cfg->nAtoms() > 0)
-            requiredVolume += currentVolume;
-        else
-            Messenger::print("[AddPair] Current box is empty, so new volume will be set to exactly {} cubic Angstroms.\n",
-                             requiredVolume);
-
-        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
-
-        // Scale existing contents
-        cfg->scaleContents(scaleFactors);
-
-        // Scale the current Box so there is enough space for our new species
-        cfg->scaleBox(scaleFactors);
-
-        Messenger::print("[AddPair] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
-                         cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
-    }
-    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::ScaleVolume)
-    {
-        Messenger::print("[AddPair] Box volume will be set to give supplied density.\n");
-
-        // Get volume required to hold current cell contents at the requested density
-        double existingRequiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            existingRequiredVolume = cfg->nAtoms() / rho;
-        else
-            existingRequiredVolume = cfg->atomicMass() / (rho / 1.0E24);
-        Messenger::print("[AddPair] Existing contents requires volume of {} cubic Angstroms at specified density.\n",
-                         existingRequiredVolume);
-
-        // Determine volume required to contain the population of the specified Species at the requested density
-        auto requiredVolume = 0.0;
-        if (rhoUnits == Units::AtomsPerAngstromUnits)
-            requiredVolume = nAtomsToAdd / rho;
-        else
-            requiredVolume = (((speciesA_->mass() + speciesB_->mass()) * ipop) / AVOGADRO) / (rho / 1.0E24);
-
-        Messenger::print("[AddPair] Required volume for new species is {} cubic Angstroms.\n", requiredVolume);
-
-        // Add on required volume for existing box contents
-        if (cfg->nAtoms() > 0)
-            requiredVolume += existingRequiredVolume;
-
-        auto scaleFactors = cfg->box()->scaleFactors(requiredVolume, scalableAxes);
-
-        // Scale existing contents
-        cfg->scaleContents(scaleFactors);
-
-        // Scale the current Box so there is enough space for our new species
-        cfg->scaleBox(scaleFactors);
-
-        Messenger::print("[AddPair] Current box scaled by ({},{},{}) - new volume is {:e} cubic Angstroms.\n", scaleFactors.x,
-                         scaleFactors.y, scaleFactors.z, cfg->box()->volume());
-    }
+    // Set / adjust target box volume
+    adjustBoxVolume(cfg, ipop,
+                    speciesA_->nAtoms(SpeciesAtom::Presence::Physical) + speciesB_->nAtoms(SpeciesAtom::Presence::Physical),
+                    speciesA_->mass() + speciesB_->mass());
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[AddPair] Positioning type is '{}' and rotation is {}.\n",
@@ -188,10 +94,6 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
     // Checks for regional positioning
     if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region)
     {
-        if (!region_)
-            return Messenger::error("Positioning type set to '{}' but no region was given.\n",
-                                    AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
-
         if (!region_->region().isValid())
             return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
 

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -16,7 +16,7 @@
 
 AddPairGeneratorNode::AddPairGeneratorNode(const Species *spA, const Species *spB, const NodeValue &population,
                                            const NodeValue &density, Units::DensityUnits densityUnits)
-    : GeneratorNode(NodeType::AddPair), density_{density, densityUnits}, population_(population), speciesA_(spA), speciesB_(spB)
+    : AddGeneratorNodeBase(NodeType::AddPair, population, density, densityUnits), speciesA_(spA), speciesB_(spB)
 {
     setUpKeywords();
 }
@@ -27,25 +27,9 @@ void AddPairGeneratorNode::setUpKeywords()
     keywords_.setOrganisation("Options", "Targets");
     keywords_.add<SpeciesKeyword>("SpeciesA", "Target species A to add", speciesA_);
     keywords_.add<SpeciesKeyword>("SpeciesB", "Target species B to add", speciesB_);
-    keywords_.add<NodeValueKeyword>("Population", "Population of the target species to add", population_, this);
-    keywords_.add<NodeValueEnumOptionsKeyword<Units::DensityUnits>>("Density", "Density at which to add the target species",
-                                                                    density_, this, Units::densityUnits());
-
-    keywords_.setOrganisation("Options", "Box Modification");
-    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::BoxActionStyle>>(
-        "BoxAction", "Action to take on the Box geometry / volume on addition of the species", boxAction_,
-        AddGeneratorNode::boxActionStyles());
-    keywords_.add<BoolKeyword>("ScaleA", "Scale box length A when modifying volume", scaleA_);
-    keywords_.add<BoolKeyword>("ScaleB", "Scale box length B when modifying volume", scaleB_);
-    keywords_.add<BoolKeyword>("ScaleC", "Scale box length C when modifying volume", scaleC_);
-
-    keywords_.setOrganisation("Options", "Target");
-    keywords_.add<EnumOptionsKeyword<AddGeneratorNode::PositioningType>>(
-        "Positioning", "Positioning type for individual molecules", positioningType_, AddGeneratorNode::positioningTypes());
-    keywords_.add<NodeKeyword<RegionGeneratorNodeBase>>(
-        "Region", "Region into which to add the species", region_, this,
-        NodeTypeVector{NodeType::CustomRegion, NodeType::CylindricalRegion, NodeType::GeneralRegion});
     keywords_.add<BoolKeyword>("Rotate", "Whether to randomly rotate molecules on insertion", rotate_);
+
+    setUpBaseKeywords();
 }
 
 /*
@@ -66,15 +50,15 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
         return Messenger::error("One or both target species not specified in Add node.\n");
 
     // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddGeneratorNode::PositioningType::Region && region_)
+    else if (positioningType_ != AddGeneratorNodeBase::PositioningType::Region && region_)
         Messenger::warn(
             "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddGeneratorNode::positioningTypes().keyword(positioningType_));
+            region_->name(), AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
 
     // Can't set box
-    if (boxAction_ == AddGeneratorNode::BoxActionStyle::Set)
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
         return Messenger::error("Can't set periodic box when using AddPair.\n");
 
     // Can't do this for periodic species
@@ -86,7 +70,7 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
         return Messenger::error("Must have at least one scalable box axis!\n");
 
     // If the positioning type is 'Central', don't allow more than one molecule to be added
-    if (positioningType_ == AddGeneratorNode::PositioningType::Central && population_.asInteger() > 1)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Central && population_.asInteger() > 1)
         return Messenger::error(
             "Positioning type is set to be the centre of the box, but the requested population is greater than 1 ({}).\n",
             population_.asInteger());
@@ -122,9 +106,9 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // If a density was not given, just add new molecules to the current box without adjusting its size
     Vec3<bool> scalableAxes(scaleA_, scaleB_, scaleC_);
-    if (boxAction_ == AddGeneratorNode::BoxActionStyle::None)
+    if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::None)
         Messenger::print("[AddPair] Current box geometry / volume will remain as-is.\n");
-    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::AddVolume)
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::AddVolume)
     {
         Messenger::print("[AddPair] Current box volume will be increased to accommodate volume of new species.\n");
 
@@ -159,7 +143,7 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
         Messenger::print("[AddPair] New box volume is {:e} cubic Angstroms - scale factors were ({},{},{}).\n",
                          cfg->box()->volume(), scaleFactors.x, scaleFactors.y, scaleFactors.z);
     }
-    else if (boxAction_ == AddGeneratorNode::BoxActionStyle::ScaleVolume)
+    else if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::ScaleVolume)
     {
         Messenger::print("[AddPair] Box volume will be set to give supplied density.\n");
 
@@ -199,14 +183,14 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[AddPair] Positioning type is '{}' and rotation is {}.\n",
-                     AddGeneratorNode::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
+                     AddGeneratorNodeBase::positioningTypes().keyword(positioningType_), rotate_ ? "on" : "off");
 
     // Checks for regional positioning
-    if (positioningType_ == AddGeneratorNode::PositioningType::Region)
+    if (positioningType_ == AddGeneratorNodeBase::PositioningType::Region)
     {
         if (!region_)
             return Messenger::error("Positioning type set to '{}' but no region was given.\n",
-                                    AddGeneratorNode::positioningTypes().keyword(positioningType_));
+                                    AddGeneratorNodeBase::positioningTypes().keyword(positioningType_));
 
         if (!region_->region().isValid())
             return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
@@ -239,20 +223,20 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
         // Set / generate position of pair
         switch (positioningType_)
         {
-            case (AddGeneratorNode::PositioningType::Random):
+            case (AddGeneratorNodeBase::PositioningType::Random):
                 newCentre = box->getReal({randomBuffer.random(), randomBuffer.random(), randomBuffer.random()});
                 break;
-            case (AddGeneratorNode::PositioningType::Region):
+            case (AddGeneratorNodeBase::PositioningType::Region):
                 newCentre = region_->region().randomCoordinate();
                 break;
-            case (AddGeneratorNode::PositioningType::Central):
+            case (AddGeneratorNodeBase::PositioningType::Central):
                 newCentre = box->getReal({0.5, 0.5, 0.5});
                 break;
-            case (AddGeneratorNode::PositioningType::Current):
+            case (AddGeneratorNodeBase::PositioningType::Current):
                 break;
             default:
                 throw(std::runtime_error(fmt::format("Positioning type {} not handled.\n",
-                                                     AddGeneratorNode::positioningTypes().keyword(positioningType_))));
+                                                     AddGeneratorNodeBase::positioningTypes().keyword(positioningType_))));
         }
 
         // Move the molecule pair

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -33,13 +33,6 @@ void AddPairGeneratorNode::setUpKeywords()
 }
 
 /*
- * Identity
- */
-
-// Return whether a name for the node must be provided
-bool AddPairGeneratorNode::mustBeNamed() const { return false; }
-
-/*
  * Execute
  */
 

--- a/src/generator/addPair.h
+++ b/src/generator/addPair.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/units.h"
+#include "generator/add.h"
 #include "generator/node.h"
 #include "generator/nodeValue.h"
 
@@ -34,37 +35,15 @@ class AddPairGeneratorNode : public GeneratorNode
     /*
      * Node Data
      */
-    public:
-    // Box Action Style
-    enum class BoxActionStyle
-    {
-        None,        /* Box geometry / volume will remain unchanged */
-        AddVolume,   /* Increase Box volume to accommodate new species, according to supplied density */
-        ScaleVolume, /* Scale current Box volume to give, after addition of the current species, the supplied density */
-        Set          /* Set the Box geometry to that specified in the Species */
-    };
-    // Return enum option info for BoxActionStyle
-    static EnumOptions<BoxActionStyle> boxActionStyles();
-    // Positioning Type
-    enum class PositioningType
-    {
-        Central, /* Position the Species at the centre of the Box */
-        Current, /* Use current Species coordinates */
-        Random,  /* Set position randomly */
-        Region   /* Set position randomly within a specified region */
-    };
-    // Return enum option info for PositioningType
-    static EnumOptions<PositioningType> positioningTypes();
-
     private:
     // Action to take on the Box geometry / volume on addition of the species
-    AddPairGeneratorNode::BoxActionStyle boxAction_{AddPairGeneratorNode::BoxActionStyle::AddVolume};
+    AddGeneratorNode::BoxActionStyle boxAction_{AddGeneratorNode::BoxActionStyle::AddVolume};
     // Target density when adding molecules
     std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
     // Population of molecules to add
     NodeValue population_{1.0};
     // Positioning type for individual molecules
-    AddPairGeneratorNode::PositioningType positioningType_{AddPairGeneratorNode::PositioningType::Random};
+    AddGeneratorNode::PositioningType positioningType_{AddGeneratorNode::PositioningType::Random};
     // Region into which we will add molecules (if any)
     std::shared_ptr<const RegionGeneratorNodeBase> region_{nullptr};
     // Whether to rotate molecules on insertion

--- a/src/generator/addPair.h
+++ b/src/generator/addPair.h
@@ -26,13 +26,6 @@ class AddPairGeneratorNode : public AddGeneratorNodeBase
     void setUpKeywords();
 
     /*
-     * Identity
-     */
-    public:
-    // Return whether a name for the node must be provided
-    bool mustBeNamed() const override;
-
-    /*
      * Node Data
      */
     private:

--- a/src/generator/addPair.h
+++ b/src/generator/addPair.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "base/units.h"
-#include "generator/add.h"
+#include "generator/addBase.h"
 #include "generator/node.h"
 #include "generator/nodeValue.h"
 
@@ -13,7 +13,7 @@ class Species;
 class RegionGeneratorNodeBase;
 
 // AddPair Node
-class AddPairGeneratorNode : public GeneratorNode
+class AddPairGeneratorNode : public AddGeneratorNodeBase
 {
     public:
     explicit AddPairGeneratorNode(const Species *spA = nullptr, const Species *spB = nullptr, const NodeValue &population = 0,
@@ -36,22 +36,12 @@ class AddPairGeneratorNode : public GeneratorNode
      * Node Data
      */
     private:
-    // Action to take on the Box geometry / volume on addition of the species
-    AddGeneratorNode::BoxActionStyle boxAction_{AddGeneratorNode::BoxActionStyle::AddVolume};
-    // Target density when adding molecules
-    std::pair<NodeValue, Units::DensityUnits> density_{1.0, Units::GramsPerCentimetreCubedUnits};
-    // Population of molecules to add
-    NodeValue population_{1.0};
-    // Positioning type for individual molecules
-    AddGeneratorNode::PositioningType positioningType_{AddGeneratorNode::PositioningType::Random};
-    // Region into which we will add molecules (if any)
-    std::shared_ptr<const RegionGeneratorNodeBase> region_{nullptr};
+    // Species to be added
+    const Species *speciesA_{nullptr}, *speciesB_{nullptr};
     // Whether to rotate molecules on insertion
     bool rotate_{true};
     // Flags controlling box axis scaling
     bool scaleA_{true}, scaleB_{true}, scaleC_{true};
-    // Species to be added
-    const Species *speciesA_{nullptr}, *speciesB_{nullptr};
 
     /*
      * Execute


### PR DESCRIPTION
This PR makes the `AddGeneratorNode` and `AddPairGeneratorNode` classes derive from a common base class `AddGeneratorNodeBase`. This allows us to keep a lot of common variables and functionality in one place, rather than duplicating it everywhere as was done before. Implementation of future `Add*` nodes will now be considerably easier.