### PR TITLE
refactor: Single site class

### DIFF
--- a/src/classes/site.cpp
+++ b/src/classes/site.cpp
@@ -38,7 +38,7 @@ const Vec3<double> &Site::origin() const { return origin_; }
 std::shared_ptr<const Molecule> Site::molecule() const { return molecule_; }
 
 // Return whether local axes are present
-bool Site::hasAxes() const { return false; }
+bool Site::hasAxes() const { return hasAxes_; }
 
 // Return local axes
 const Matrix3 &Site::axes() const { return axes_; }

--- a/src/classes/site.cpp
+++ b/src/classes/site.cpp
@@ -6,17 +6,23 @@
 #include "base/messenger.h"
 #include <utility>
 
-/*
- * Site
- */
-
 Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
            const Vec3<double> &origin)
+    : parent_(parent), uniqueSiteIndex_(uniqueSiteIndex), molecule_(std::move(molecule)), origin_(origin)
 {
-    parent_ = parent;
-    uniqueSiteIndex_ = uniqueSiteIndex;
-    molecule_ = std::move(molecule);
-    origin_ = origin;
+}
+
+Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
+           const Matrix3 &axes, const Vec3<double> &origin)
+    : parent_(parent), uniqueSiteIndex_(uniqueSiteIndex), molecule_(std::move(molecule)), origin_(origin), axes_(axes),
+      hasAxes_(true)
+{
+}
+
+// Return enum options for SiteAxis
+EnumOptions<Site::SiteAxis> Site::siteAxis()
+{
+    return EnumOptions<Site::SiteAxis>("SiteAxis", {{Site::XAxis, "X"}, {Site::YAxis, "Y"}, {Site::ZAxis, "Z"}});
 }
 
 // Return the parent
@@ -35,36 +41,4 @@ std::shared_ptr<const Molecule> Site::molecule() const { return molecule_; }
 bool Site::hasAxes() const { return false; }
 
 // Return local axes
-const Matrix3 &Site::axes() const
-{
-    static Matrix3 dummy;
-    Messenger::warn("Returning empty axes for this Site, since it doesn't have any.\n");
-    return dummy;
-}
-
-/*
- * Oriented Site
- */
-
-OrientedSite::OrientedSite(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex,
-                           std::shared_ptr<const Molecule> molecule, const Vec3<double> &origin, const Vec3<double> &xAxis,
-                           const Vec3<double> &yAxis, const Vec3<double> &zAxis)
-    : Site(parent, uniqueSiteIndex, std::move(molecule), origin)
-{
-    axes_.setColumn(0, xAxis);
-    axes_.setColumn(1, yAxis);
-    axes_.setColumn(2, zAxis);
-}
-
-// Return whether local axes are present
-bool OrientedSite::hasAxes() const { return true; }
-
-// Return enum options for SiteAxis
-EnumOptions<OrientedSite::SiteAxis> OrientedSite::siteAxis()
-{
-    return EnumOptions<OrientedSite::SiteAxis>(
-        "SiteAxis", {{OrientedSite::XAxis, "X"}, {OrientedSite::YAxis, "Y"}, {OrientedSite::ZAxis, "Z"}});
-}
-
-// Return local axes
-const Matrix3 &OrientedSite::axes() const { return axes_; }
+const Matrix3 &Site::axes() const { return axes_; }

--- a/src/classes/site.cpp
+++ b/src/classes/site.cpp
@@ -11,7 +11,7 @@
  */
 
 Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
-           Vec3<double> origin)
+           const Vec3<double> &origin)
 {
     parent_ = parent;
     uniqueSiteIndex_ = uniqueSiteIndex;
@@ -47,8 +47,8 @@ const Matrix3 &Site::axes() const
  */
 
 OrientedSite::OrientedSite(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex,
-                           std::shared_ptr<const Molecule> molecule, Vec3<double> origin, Vec3<double> xAxis,
-                           Vec3<double> yAxis, Vec3<double> zAxis)
+                           std::shared_ptr<const Molecule> molecule, const Vec3<double> &origin, const Vec3<double> &xAxis,
+                           const Vec3<double> &yAxis, const Vec3<double> &zAxis)
     : Site(parent, uniqueSiteIndex, std::move(molecule), origin)
 {
     axes_.setColumn(0, xAxis);

--- a/src/classes/site.h
+++ b/src/classes/site.h
@@ -17,7 +17,7 @@ class Site
 {
     public:
     Site(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
-         std::shared_ptr<const Molecule> molecule = nullptr, Vec3<double> origin = Vec3<double>());
+         std::shared_ptr<const Molecule> molecule = {}, const Vec3<double> &origin = {});
     ~Site() = default;
     Site &operator=(const Site &source) = default;
     Site(const Site &source) = default;
@@ -56,8 +56,8 @@ class OrientedSite : public Site
 {
     public:
     OrientedSite(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
-                 std::shared_ptr<const Molecule> molecule = nullptr, Vec3<double> origin = Vec3<double>(),
-                 Vec3<double> xAxis = Vec3<double>(), Vec3<double> yAxis = Vec3<double>(), Vec3<double> zAxis = Vec3<double>());
+                 std::shared_ptr<const Molecule> molecule = {}, const Vec3<double> &origin = {}, const Vec3<double> &xAxis = {},
+                 const Vec3<double> &yAxis = {}, const Vec3<double> &zAxis = {});
     OrientedSite &operator=(const OrientedSite &source) = default;
     OrientedSite(const OrientedSite &source) = default;
     OrientedSite(OrientedSite &&source) = default;

--- a/src/classes/site.h
+++ b/src/classes/site.h
@@ -18,6 +18,8 @@ class Site
     public:
     Site(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
          std::shared_ptr<const Molecule> molecule = {}, const Vec3<double> &origin = {});
+    Site(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
+         std::shared_ptr<const Molecule> molecule = {}, const Matrix3 &axes = {}, const Vec3<double> &origin = {});
     ~Site() = default;
     Site &operator=(const Site &source) = default;
     Site(const Site &source) = default;
@@ -31,10 +33,25 @@ class Site
     const SpeciesSite *parent_;
     // Unique site index in the parent
     std::optional<int> uniqueSiteIndex_;
-    // Site origin
-    Vec3<double> origin_;
     // Molecule to which site is related (if relevant)
     std::shared_ptr<const Molecule> molecule_;
+    // Site origin
+    Vec3<double> origin_;
+    // Local axes
+    Matrix3 axes_;
+    // Whether local axes have been set / defined
+    bool hasAxes_{false};
+
+    public:
+    // Axis Enum
+    enum SiteAxis
+    {
+        XAxis = 0,
+        YAxis = 1,
+        ZAxis = 2
+    };
+    // Return enum options for SiteAxis
+    static EnumOptions<Site::SiteAxis> siteAxis();
 
     public:
     // Return the parent
@@ -46,43 +63,9 @@ class Site
     // Return Molecule to which site is related (if relevant)
     std::shared_ptr<const Molecule> molecule() const;
     // Return whether local axes are present
-    virtual bool hasAxes() const;
+    bool hasAxes() const;
     // Return local axes
-    virtual const Matrix3 &axes() const;
-};
-
-// Oriented Site Definition
-class OrientedSite : public Site
-{
-    public:
-    OrientedSite(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
-                 std::shared_ptr<const Molecule> molecule = {}, const Vec3<double> &origin = {}, const Vec3<double> &xAxis = {},
-                 const Vec3<double> &yAxis = {}, const Vec3<double> &zAxis = {});
-    OrientedSite &operator=(const OrientedSite &source) = default;
-    OrientedSite(const OrientedSite &source) = default;
-    OrientedSite(OrientedSite &&source) = default;
-
-    /*
-     * Site Definition
-     */
-    private:
-    // Local axes
-    Matrix3 axes_;
-
-    public:
-    // Axis Enum
-    enum SiteAxis
-    {
-        XAxis = 0,
-        YAxis = 1,
-        ZAxis = 2
-    };
-    // Return enum options for SiteAxis
-    static EnumOptions<OrientedSite::SiteAxis> siteAxis();
-    // Return whether local axes are present
-    bool hasAxes() const override;
-    // Return local axes
-    const Matrix3 &axes() const override;
+    const Matrix3 &axes() const;
     // Rotate about axis
-    void rotate(double angle, OrientedSite::SiteAxis axis);
+    void rotate(double angle, Site::SiteAxis axis);
 };

--- a/src/classes/siteStack.cpp
+++ b/src/classes/siteStack.cpp
@@ -74,7 +74,6 @@ bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)
     // Set new index and clear old arrays
     configurationIndex_ = configuration_->contentsVersion();
     sites_.clear();
-    orientedSites_.clear();
 
     const auto &instances = site->instances();
     auto *targetSpecies = site->parent();
@@ -83,10 +82,7 @@ bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)
     if (sPop == 0)
         return true;
 
-    if (sitesHaveOrientation_)
-        orientedSites_.reserve(instances.size() * sPop);
-    else
-        sites_.reserve(instances.size() * sPop);
+    sites_.reserve(instances.size() * sPop);
 
     Vec3<double> origin, x, y;
     const auto *box = configuration_->box();
@@ -113,7 +109,7 @@ bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)
                 y.orthogonalise(x);
                 y.normalise();
 
-                orientedSites_.emplace_back(speciesSite_, index, molecule, origin, x, y, x * y);
+                sites_.emplace_back(speciesSite_, index, molecule, Matrix3(x, y, x * y), origin);
             }
             else
                 sites_.emplace_back(speciesSite_, index, molecule, origin);
@@ -129,7 +125,7 @@ bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)
  */
 
 // Return number of sites in the stack
-int SiteStack::nSites() const { return (sitesHaveOrientation_ ? orientedSites_.size() : sites_.size()); }
+int SiteStack::nSites() const { return sites_.size(); }
 
 // Return site with index specified
-const Site &SiteStack::site(int index) const { return (sitesHaveOrientation_ ? orientedSites_.at(index) : sites_.at(index)); }
+const Site &SiteStack::site(int index) const { return sites_.at(index); }

--- a/src/classes/siteStack.h
+++ b/src/classes/siteStack.h
@@ -56,10 +56,8 @@ class SiteStack
     bool sitesInMolecules_;
     // Whether the current stack contains local axes information
     bool sitesHaveOrientation_;
-    // Basic site array (if no local axes are defined)
+    // Site array
     std::vector<Site> sites_;
-    // Oriented site array (if local axes are defined)
-    std::vector<OrientedSite> orientedSites_;
 
     public:
     // Return number of sites in the stack

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -492,7 +492,7 @@ std::vector<std::shared_ptr<Site>> SpeciesSite::createFromParent() const
             y.orthogonalise(x);
             y.normalise();
 
-            sites.push_back(std::make_shared<OrientedSite>(this, index, nullptr, origin, x, y, x * y));
+            sites.push_back(std::make_shared<Site>(this, index, nullptr, Matrix3(x, y, x * y), origin));
         }
         else
             sites.push_back(std::make_shared<Site>(this, index, nullptr, origin));

--- a/src/generator/rotateFragment.cpp
+++ b/src/generator/rotateFragment.cpp
@@ -21,7 +21,7 @@ RotateFragmentGeneratorNode::RotateFragmentGeneratorNode(std::shared_ptr<SelectG
     keywords_.add<NodeKeyword<SelectGeneratorNode>>("Site", "Site to be rotated", site_, this,
                                                     NodeTypeVector{NodeType::Select});
     keywords_.add<NodeValueKeyword>("Rotation", "Rotation to perform", rotation_, this);
-    keywords_.add<EnumOptionsKeyword<OrientedSite::SiteAxis>>("Axis", "Axis for rotation", axis_, OrientedSite::siteAxis());
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("Axis", "Axis for rotation", axis_, Site::siteAxis());
 }
 
 /*
@@ -63,13 +63,13 @@ bool RotateFragmentGeneratorNode::execute(const GeneratorContext &generatorConte
     Matrix3 rotationMatrix;
     switch (axis_)
     {
-        case (OrientedSite::SiteAxis::XAxis):
+        case (Site::SiteAxis::XAxis):
             rotationMatrix.createRotationAxis(site.axes().columnAsVec3(0), rotation_.asDouble(), false);
             break;
-        case (OrientedSite::SiteAxis::YAxis):
+        case (Site::SiteAxis::YAxis):
             rotationMatrix.createRotationAxis(site.axes().columnAsVec3(1), rotation_.asDouble(), false);
             break;
-        case (OrientedSite::SiteAxis::ZAxis):
+        case (Site::SiteAxis::ZAxis):
             rotationMatrix.createRotationAxis(site.axes().columnAsVec3(2), rotation_.asDouble(), false);
             break;
     }

--- a/src/generator/rotateFragment.h
+++ b/src/generator/rotateFragment.h
@@ -28,7 +28,7 @@ class RotateFragmentGeneratorNode : public GeneratorNode
     // Rotation
     NodeValue rotation_{90.0};
     // Axis
-    OrientedSite::SiteAxis axis_{OrientedSite::SiteAxis::XAxis};
+    Site::SiteAxis axis_{Site::SiteAxis::XAxis};
 
     /*
      * Execute

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -7,6 +7,19 @@
 
 Matrix3::Matrix3() { setIdentity(); }
 
+Matrix3::Matrix3(const Vec3<double> &x, const Vec3<double> &y, const Vec3<double> &z)
+{
+    matrix_[0] = x.x;
+    matrix_[1] = x.y;
+    matrix_[2] = x.z;
+    matrix_[3] = y.x;
+    matrix_[4] = y.y;
+    matrix_[5] = y.z;
+    matrix_[6] = z.x;
+    matrix_[7] = z.y;
+    matrix_[8] = z.z;
+}
+
 /*
  * Operators
  */

--- a/src/math/matrix3.h
+++ b/src/math/matrix3.h
@@ -11,6 +11,7 @@ class Matrix3
 {
     public:
     Matrix3();
+    Matrix3(const Vec3<double> &x, const Vec3<double> &y, const Vec3<double> &z);
 
     private:
     // Matrix

--- a/src/modules/axisAngle/axisAngle.cpp
+++ b/src/modules/axisAngle/axisAngle.cpp
@@ -20,12 +20,10 @@ AxisAngleModule::AxisAngleModule() : Module(ModuleTypes::AxisAngle)
     keywords_.setOrganisation("Options", "Sites", "Specify sites defining the axis angle interaction A-B...C.");
     keywords_.add<SpeciesSiteVectorKeyword>("SiteA", "Specify site(s) which represent 'A' in the interaction A-B...C", a_,
                                             true);
-    keywords_.add<EnumOptionsKeyword<OrientedSite::SiteAxis>>("AxisA", "Axis to use from site A", axisA_,
-                                                              OrientedSite::siteAxis());
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("AxisA", "Axis to use from site A", axisA_, Site::siteAxis());
     keywords_.add<SpeciesSiteVectorKeyword>("SiteB", "Specify site(s) which represent 'B' in the interaction A-B...C", b_,
                                             true);
-    keywords_.add<EnumOptionsKeyword<OrientedSite::SiteAxis>>("AxisB", "Axis to use from site B", axisB_,
-                                                              OrientedSite::siteAxis());
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("AxisB", "Axis to use from site B", axisB_, Site::siteAxis());
 
     keywords_.setOrganisation("Options", "Ranges", "Ranges over which to bin quantities from the calculation.");
     keywords_.add<Vec3DoubleKeyword>("DistanceRange", "Range (min, max, binwidth) of distance binning", distanceRange_,

--- a/src/modules/axisAngle/axisAngle.h
+++ b/src/modules/axisAngle/axisAngle.h
@@ -35,7 +35,7 @@ class AxisAngleModule : public Module
     // Target SpeciesSite definitions
     std::vector<const SpeciesSite *> a_, b_;
     // Axes to use for sites
-    OrientedSite::SiteAxis axisA_{OrientedSite::SiteAxis::XAxis}, axisB_{OrientedSite::SiteAxis::XAxis};
+    Site::SiteAxis axisA_{Site::SiteAxis::XAxis}, axisB_{Site::SiteAxis::XAxis};
     // Export file and format for RDF
     Data1DExportFileFormat exportFileAndFormatRDF_;
     // Export file and format for AxisAngle

--- a/src/modules/orientedSDF/orientedSDF.cpp
+++ b/src/modules/orientedSDF/orientedSDF.cpp
@@ -21,12 +21,10 @@ OrientedSDFModule::OrientedSDFModule() : Module(ModuleTypes::OrientedSDF)
     keywords_.setOrganisation("Options", "Sites", "Specify the central (A) and surrounding sites (B).");
     keywords_.add<SpeciesSiteVectorKeyword>("SiteA", "Set the site(s) 'A' which are to represent the origin of the SDF", a_,
                                             true);
-    keywords_.add<EnumOptionsKeyword<OrientedSite::SiteAxis>>("AxisA", "Axis to use from site A", axisA_,
-                                                              OrientedSite::siteAxis());
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("AxisA", "Axis to use from site A", axisA_, Site::siteAxis());
     keywords_.add<SpeciesSiteVectorKeyword>(
         "SiteB", "Set the site(s) 'B' for which the distribution around the origin site(s) 'A' should be calculated", b_);
-    keywords_.add<EnumOptionsKeyword<OrientedSite::SiteAxis>>("AxisB", "Axis to use from site B", axisB_,
-                                                              OrientedSite::siteAxis());
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("AxisB", "Axis to use from site B", axisB_, Site::siteAxis());
 
     keywords_.setOrganisation("Options", "Ranges", "Ranges over which to bin quantities from the calculation.");
     keywords_.add<RangeKeyword>("AngleRange", "Axis angle range required to permit a site to be binned in the SDF",

--- a/src/modules/orientedSDF/orientedSDF.h
+++ b/src/modules/orientedSDF/orientedSDF.h
@@ -23,7 +23,7 @@ class OrientedSDFModule : public Module
     // Target SpeciesSite definitions
     std::vector<const SpeciesSite *> a_, b_;
     // Axes to use for sites
-    OrientedSite::SiteAxis axisA_{OrientedSite::SiteAxis::XAxis}, axisB_{OrientedSite::SiteAxis::XAxis};
+    Site::SiteAxis axisA_{Site::SiteAxis::XAxis}, axisB_{Site::SiteAxis::XAxis};
     // Whether to exclude correlations between sites on the same molecule
     bool excludeSameMolecule_{true};
     // Range along X axis

--- a/tests/procedure/rotateFragment.cpp
+++ b/tests/procedure/rotateFragment.cpp
@@ -61,7 +61,7 @@ TEST(RotateFragmentGeneratorNodeTest, Benzene)
     // Rotate Benzene around the Z-Axis of the site (which is defined at the COG, which is at the origin)
     auto &forEachB = select->branch()->get();
     auto rotate = forEachB.create<RotateFragmentGeneratorNode>("RotateBenzene", select);
-    rotate->keywords().setEnumeration("Axis", OrientedSite::SiteAxis::ZAxis);
+    rotate->keywords().setEnumeration("Axis", Site::SiteAxis::ZAxis);
 
     for (auto x = 90.0; x <= 360.0; x += 90.0)
     {


### PR DESCRIPTION
This PR merges the `OrientedSite` class into `Site`, giving a single site class with a larger memory footprint (since it _always_ contains an axis matrix, even if the origin site does not specify axes) but which simplifies the rest of the code somewhat and allows future useful functions to be introduced in future PRs.