### PR TITLE
feat: Add on sphere

### DIFF
--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -6,6 +6,7 @@
 #include "classes/box.h"
 #include "classes/species.h"
 #include "classes/speciesBond.h"
+#include "data/atomicMasses.h"
 #include "templates/algorithms.h"
 
 /*
@@ -167,6 +168,30 @@ Vec3<double> Molecule::centreOfGeometry(const Box *box) const
     traverseLocal(box, [&cog](auto *j, auto rJ) { cog += rJ; });
 
     return cog / nAtoms();
+}
+
+// Calculate and return centre of geometry over supplied atom indices
+Vec3<double> Molecule::centreOfGeometry(const Box *box, const std::vector<int> &indices) const
+{
+    const auto ref = atoms_[indices.front()]->r();
+    return std::accumulate(std::next(indices.begin()), indices.end(), ref,
+                           [&](const auto &acc, const auto idx) { return acc + box->minimumImage(atoms_[idx]->r(), ref); }) /
+           indices.size();
+}
+
+// Calculate and return centre of mass over supplied atom indices
+Vec3<double> Molecule::centreOfMass(const Box *box, const std::vector<int> &indices) const
+{
+    auto mass = AtomicMass::mass(atoms_[indices.front()]->speciesAtom()->Z());
+    const auto ref = atoms_[indices.front()]->r();
+    auto sums = std::accumulate(std::next(indices.begin()), indices.end(), std::pair<Vec3<double>, double>(ref * mass, mass),
+                                [&](const auto &acc, const auto idx)
+                                {
+                                    auto mass = AtomicMass::mass(atoms_[idx]->speciesAtom()->Z());
+                                    return std::pair<Vec3<double>, double>(
+                                        acc.first + box->minimumImage(atoms_[idx]->r(), ref) * mass, acc.second + mass);
+                                });
+    return sums.first / sums.second;
 }
 
 // Transform molecule with supplied matrix, using centre of geometry as the origin

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -144,7 +144,7 @@ Vec3<double> Molecule::unFold(const Box *box)
 }
 
 // Set centre of geometry of molecule
-void Molecule::setCentreOfGeometry(const Box *box, const Vec3<double> newCentre)
+void Molecule::setCentreOfGeometry(const Box *box, const Vec3<double> &newCentre)
 {
     // Calculate Molecule centre of geometry
     Vec3<double> newR;
@@ -232,7 +232,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 }
 
 // Translate whole molecule by the delta specified
-void Molecule::translate(const Vec3<double> delta)
+void Molecule::translate(const Vec3<double> &delta)
 {
     for (auto n = 0; n < nAtoms(); ++n)
         atom(n)->translateCoordinates(delta);

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -76,6 +76,10 @@ class Molecule : public std::enable_shared_from_this<Molecule>
     void setCentreOfGeometry(const Box *box, const Vec3<double> newCentre);
     // Calculate and return centre of geometry
     Vec3<double> centreOfGeometry(const Box *box) const;
+    // Calculate and return centre of geometry over supplied atom indices
+    Vec3<double> centreOfGeometry(const Box *box, const std::vector<int> &indices) const;
+    // Calculate and return centre of mass over supplied atom indices
+    Vec3<double> centreOfMass(const Box *box, const std::vector<int> &indices) const;
     // Transform molecule with supplied matrix, using centre of geometry as the origin
     void transform(const Box *box, const Matrix3 &transformationMatrix);
     // Transform molecule with supplied matrix about specified origin

--- a/src/classes/molecule.h
+++ b/src/classes/molecule.h
@@ -73,7 +73,7 @@ class Molecule : public std::enable_shared_from_this<Molecule>
     // Un-fold molecule so it is not cut by box boundaries, returning the centre of geometry
     Vec3<double> unFold(const Box *box);
     // Set centre of geometry
-    void setCentreOfGeometry(const Box *box, const Vec3<double> newCentre);
+    void setCentreOfGeometry(const Box *box, const Vec3<double> &newCentre);
     // Calculate and return centre of geometry
     Vec3<double> centreOfGeometry(const Box *box) const;
     // Calculate and return centre of geometry over supplied atom indices
@@ -88,7 +88,7 @@ class Molecule : public std::enable_shared_from_this<Molecule>
     void transform(const Box *box, const Matrix3 &transformationMatrix, const Vec3<double> &origin,
                    const std::vector<int> &targetAtoms);
     // Translate whole molecule by the delta specified
-    void translate(const Vec3<double> delta);
+    void translate(const Vec3<double> &delta);
     // Translate specified atoms by the delta specified
     void translate(const Vec3<double> &delta, const std::vector<int> &targetAtoms);
 };

--- a/src/classes/site.cpp
+++ b/src/classes/site.cpp
@@ -2,8 +2,11 @@
 // Copyright (c) 2024 Team Dissolve and contributors
 
 #include "classes/site.h"
-
 #include "base/messenger.h"
+#include "classes/box.h"
+#include "classes/molecule.h"
+#include "classes/speciesSite.h"
+#include "classes/speciesSiteInstance.h"
 #include <utility>
 
 Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
@@ -17,6 +20,34 @@ Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::s
     : parent_(parent), uniqueSiteIndex_(uniqueSiteIndex), molecule_(std::move(molecule)), origin_(origin), axes_(axes),
       hasAxes_(true)
 {
+}
+
+Site::Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
+           const SpeciesSiteInstance &instance, const Box *box)
+    : parent_(parent), molecule_(std::move(molecule))
+{
+    origin_ = parent_->originMassWeighted() ? molecule_->centreOfMass(box, instance.originIndices())
+                                            : molecule_->centreOfGeometry(box, instance.originIndices());
+
+    if (parent_->hasAxes())
+    {
+        // Get vector from site origin to x-axis reference point and normalise it
+        auto x = box->minimumVector(origin_, molecule_->centreOfGeometry(box, instance.xAxisIndices()));
+        x.normalise();
+
+        axes_.setColumn(0, x);
+
+        // Get vector from site origin to y-axis reference point, normalise it, and orthogonalise
+        auto y = box->minimumVector(origin_, molecule_->centreOfGeometry(box, instance.yAxisIndices()));
+        y.orthogonalise(x);
+        y.normalise();
+
+        axes_.setColumn(1, y);
+
+        axes_.setColumn(2, x * y);
+
+        hasAxes_ = true;
+    }
 }
 
 // Return enum options for SiteAxis

--- a/src/classes/site.h
+++ b/src/classes/site.h
@@ -9,8 +9,10 @@
 #include <optional>
 
 // Forward Declarations
+class Box;
 class Molecule;
 class SpeciesSite;
+class SpeciesSiteInstance;
 
 // Site Definition
 class Site
@@ -20,6 +22,8 @@ class Site
          std::shared_ptr<const Molecule> molecule = {}, const Vec3<double> &origin = {});
     Site(const SpeciesSite *parent = nullptr, std::optional<int> uniqueSiteIndex = {},
          std::shared_ptr<const Molecule> molecule = {}, const Matrix3 &axes = {}, const Vec3<double> &origin = {});
+    Site(const SpeciesSite *parent, std::optional<int> uniqueSiteIndex, std::shared_ptr<const Molecule> molecule,
+         const SpeciesSiteInstance &instance, const Box *box);
     ~Site() = default;
     Site &operator=(const Site &source) = default;
     Site(const Site &source) = default;

--- a/src/classes/site.h
+++ b/src/classes/site.h
@@ -70,6 +70,4 @@ class Site
     bool hasAxes() const;
     // Return local axes
     const Matrix3 &axes() const;
-    // Rotate about axis
-    void rotate(double angle, Site::SiteAxis axis);
 };

--- a/src/classes/siteStack.cpp
+++ b/src/classes/siteStack.cpp
@@ -6,7 +6,6 @@
 #include "classes/configuration.h"
 #include "classes/species.h"
 #include "classes/speciesSite.h"
-#include "data/atomicMasses.h"
 #include <algorithm>
 #include <numeric>
 
@@ -32,31 +31,6 @@ const SpeciesSite *SiteStack::speciesSite() const { return speciesSite_; }
 /*
  * Generation
  */
-
-// Calculate geometric centre of atoms in the given molecule
-Vec3<double> SiteStack::centreOfGeometry(const Molecule &mol, const Box *box, const std::vector<int> &indices)
-{
-    const auto ref = mol.atom(indices.front())->r();
-    return std::accumulate(std::next(indices.begin()), indices.end(), ref,
-                           [&ref, &mol, box](const auto &acc, const auto idx)
-                           { return acc + box->minimumImage(mol.atom(idx)->r(), ref); }) /
-           indices.size();
-}
-
-// Calculate (mass-weighted) coordinate centre of atoms in the given molecule
-Vec3<double> SiteStack::centreOfMass(const Molecule &mol, const Box *box, const std::vector<int> &indices)
-{
-    auto mass = AtomicMass::mass(mol.atom(indices.front())->speciesAtom()->Z());
-    const auto ref = mol.atom(indices.front())->r();
-    auto sums = std::accumulate(std::next(indices.begin()), indices.end(), std::pair<Vec3<double>, double>(ref * mass, mass),
-                                [&ref, &mol, box](const auto &acc, const auto idx)
-                                {
-                                    auto mass = AtomicMass::mass(mol.atom(idx)->speciesAtom()->Z());
-                                    return std::pair<Vec3<double>, double>(
-                                        acc.first + box->minimumImage(mol.atom(idx)->r(), ref) * mass, acc.second + mass);
-                                });
-    return sums.first / sums.second;
-}
 
 // Create stack for specified Configuration and site
 bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)

--- a/src/classes/siteStack.cpp
+++ b/src/classes/siteStack.cpp
@@ -69,26 +69,7 @@ bool SiteStack::create(Configuration *cfg, const SpeciesSite *site)
         auto index = 0;
         for (const auto &instance : instances)
         {
-            origin = speciesSite_->originMassWeighted() ? centreOfMass(*molecule, box, instance.originIndices())
-                                                        : centreOfGeometry(*molecule, box, instance.originIndices());
-
-            if (sitesHaveOrientation_)
-            {
-                // Get vector from site origin to x-axis reference point and normalise it
-                x = box->minimumVector(origin, centreOfGeometry(*molecule, box, instance.xAxisIndices()));
-                x.normalise();
-
-                // Get vector from site origin to y-axis reference point, normalise it, and orthogonalise
-                y = box->minimumVector(origin, centreOfGeometry(*molecule, box, instance.yAxisIndices()));
-                y.orthogonalise(x);
-                y.normalise();
-
-                sites_.emplace_back(speciesSite_, index, molecule, Matrix3(x, y, x * y), origin);
-            }
-            else
-                sites_.emplace_back(speciesSite_, index, molecule, origin);
-
-            ++index;
+            sites_.emplace_back(speciesSite_, index++, molecule, instance, box);
         }
     }
     return true;

--- a/src/classes/siteStack.h
+++ b/src/classes/siteStack.h
@@ -38,12 +38,6 @@ class SiteStack
     /*
      * Creation
      */
-    private:
-    // Calculate geometric centre of atoms in the given molecule
-    Vec3<double> centreOfGeometry(const Molecule &mol, const Box *box, const std::vector<int> &indices);
-    // Calculate (mass-weighted) coordinate centre of atoms in the given molecule
-    Vec3<double> centreOfMass(const Molecule &mol, const Box *box, const std::vector<int> &indices);
-
     public:
     // Create stack for specified Configuration and site
     bool create(Configuration *cfg, const SpeciesSite *site);

--- a/src/generator/CMakeLists.txt
+++ b/src/generator/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(
   add.h
   addBase.cpp
   addBase.h
+  addOnSphere.cpp
+  addOnSphere.h
   addPair.cpp
   addPair.h
   box.cpp

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -27,6 +27,7 @@ void AddOnSphereGeneratorNode::setUpKeywords()
     keywords_.add<EnumOptionsKeyword<AddOnSphereGeneratorNode::PointDistributionStyle>>(
         "Distribution", "Method for distributing points on the underlying sphere", pointDistributionStyle_,
         pointDistributionStyles());
+    keywords_.add<NodeValueKeyword>("Variance", "Random variance to add to distributed points on the sphere", variance_, this);
 
     setUpBaseKeywords();
 }
@@ -133,6 +134,7 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
     Vec3<double> rLocal;
     const auto psi = 0.5 * (1.0 + sqrt(5.0));
     const auto r = radius_.asDouble();
+    const auto variance = variance_.asDouble();
     for (auto n = 0; n < ipop; ++n)
     {
         // Add the Molecule
@@ -153,6 +155,13 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
                 break;
             default:
                 throw(std::runtime_error("PointDistributionStyle not handled in switch.\n"));
+        }
+
+        // Apply variance
+        if (variance > 0.0)
+        {
+            theta += randomBuffer.randomPlusMinusOne() * variance;
+            phi += randomBuffer.randomPlusMinusOne() * 2.0 * variance;
         }
 
         // Calculate cartesian coordinates

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -54,6 +54,10 @@ bool AddOnSphereGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (!speciesSite_)
         return Messenger::error("No target species site specified in AddOnSphere node.\n");
 
+    // Check site multiplicity
+    if (speciesSite_->instances().size() > 1)
+        return Messenger::error("Site must have a single instance - i.e. be unique in the parent species.\n");
+
     // If positioningType_ type is 'Region', must have a suitable node defined
     if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
         return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
@@ -130,6 +134,9 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
     // Add space for the new molecules
     cfg->atoms().reserve(cfg->atoms().size() + ipop * sp->nAtoms());
 
+    // Get the first (only) instance details for the site
+    auto siteInstance = speciesSite_->instances().front();
+
     // Now we add the molecules at points on the sphere
     Vec3<double> rLocal;
     const auto psi = 0.5 * (1.0 + sqrt(5.0));
@@ -167,6 +174,10 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
         // Calculate cartesian coordinates
         rLocal.set(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
         rLocal *= r;
+
+        // Generate a working site from the molecule
+        Site site(speciesSite_, {}, mol, Vec3<double>());
+        site.createFromInstance(siteInstance, box);
 
         mol->setCentreOfGeometry(box, sphereCentre + rLocal);
 

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -6,12 +6,9 @@
 #include "classes/box.h"
 #include "classes/configuration.h"
 #include "classes/species.h"
-#include "generator/coordinateSets.h"
 #include "generator/regionBase.h"
-#include "keywords/bool.h"
 #include "keywords/node.h"
 #include "keywords/nodeValue.h"
-#include "keywords/nodeValueEnumOptions.h"
 #include "keywords/speciesSite.h"
 
 AddOnSphereGeneratorNode::AddOnSphereGeneratorNode(const SpeciesSite *site, const NodeValue &population,
@@ -26,8 +23,24 @@ void AddOnSphereGeneratorNode::setUpKeywords()
 {
     keywords_.setOrganisation("Options", "Target");
     keywords_.add<SpeciesSiteKeyword>("Site", "Target species site to use as anchor point", speciesSite_, false);
+    keywords_.add<NodeValueKeyword>("Radius", "Radius of the sphere upon which molecules will be placed", radius_, this);
+    keywords_.add<EnumOptionsKeyword<AddOnSphereGeneratorNode::PointDistributionStyle>>(
+        "Distribution", "Method for distributing points on the underlying sphere", pointDistributionStyle_,
+        pointDistributionStyles());
 
     setUpBaseKeywords();
+}
+
+/*
+ * Node Data
+ */
+
+// Return enum option info for PointDistributionStyle
+EnumOptions<AddOnSphereGeneratorNode::PointDistributionStyle> AddOnSphereGeneratorNode::pointDistributionStyles()
+{
+    return EnumOptions<AddOnSphereGeneratorNode::PointDistributionStyle>(
+        "BoxAction", {{AddOnSphereGeneratorNode::PointDistributionStyle::Random, "Random"},
+                      {AddOnSphereGeneratorNode::PointDistributionStyle::Fibonacci, "Fibonacci"}});
 }
 
 /*
@@ -117,23 +130,36 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
     cfg->atoms().reserve(cfg->atoms().size() + ipop * sp->nAtoms());
 
     // Now we add the molecules at points on the sphere
-    auto sphereRadius = 5.0;
     Vec3<double> rLocal;
+    const auto psi = 0.5 * (1.0 + sqrt(5.0));
+    const auto r = radius_.asDouble();
     for (auto n = 0; n < ipop; ++n)
     {
         // Add the Molecule
         auto mol = cfg->addMolecule(sp);
 
-        // Generate a point on the sphere
-        if (true)
+        // Calculate spherical coordinates of point in radians
+        auto theta = 0.0, phi = 0.0;
+        switch (pointDistributionStyle_)
         {
-            auto theta = randomBuffer.random() * M_PI;
-            auto psi = randomBuffer.random() * 2.0 * M_PI;
-            rLocal.set(sin(theta) * cos(psi), sin(theta) * sin(psi), cos(theta));
-            rLocal *= sphereRadius;
-
-            mol->setCentreOfGeometry(box, sphereCentre + rLocal);
+            case (PointDistributionStyle::Random):
+                theta = randomBuffer.random() * M_PI;
+                phi = randomBuffer.random() * 2.0 * M_PI;
+                break;
+            case (PointDistributionStyle::Fibonacci):
+                // Map theta as (i+1)/(N+1) to avoid point at pole and give better distribution
+                theta = asin(2.0 * (double(n + 1.0) / (ipop + 1.0)) - 1.0) + M_PI_2;
+                phi = 2.0 * M_PI * n / psi;
+                break;
+            default:
+                throw(std::runtime_error("PointDistributionStyle not handled in switch.\n"));
         }
+
+        // Calculate cartesian coordinates
+        rLocal.set(sin(theta) * cos(phi), sin(theta) * sin(phi), cos(theta));
+        rLocal *= r;
+
+        mol->setCentreOfGeometry(box, sphereCentre + rLocal);
 
         //        // Generate and apply a random rotation matrix
         //        if (rotate_)

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#include "generator/addOnSphere.h"
+#include "base/randomBuffer.h"
+#include "classes/box.h"
+#include "classes/configuration.h"
+#include "classes/species.h"
+#include "generator/coordinateSets.h"
+#include "generator/regionBase.h"
+#include "keywords/bool.h"
+#include "keywords/node.h"
+#include "keywords/nodeValue.h"
+#include "keywords/nodeValueEnumOptions.h"
+#include "keywords/speciesSite.h"
+
+AddOnSphereGeneratorNode::AddOnSphereGeneratorNode(const SpeciesSite *site, const NodeValue &population,
+                                                   const NodeValue &density, Units::DensityUnits densityUnits)
+    : AddGeneratorNodeBase(NodeType::AddOnSphere, population, density, densityUnits), speciesSite_(site)
+{
+    setUpKeywords();
+}
+
+// Set up keywords for node
+void AddOnSphereGeneratorNode::setUpKeywords()
+{
+    keywords_.setOrganisation("Options", "Target");
+    keywords_.add<SpeciesSiteKeyword>("Site", "Target species site to use as anchor point", speciesSite_, false);
+
+    setUpBaseKeywords();
+}
+
+/*
+ * Execute
+ */
+
+// Prepare any necessary data, ready for execution
+bool AddOnSphereGeneratorNode::prepare(const GeneratorContext &generatorContext)
+{
+    if (!speciesSite_)
+        return Messenger::error("No target species site specified in AddOnSphere node.\n");
+
+    // If positioningType_ type is 'Region', must have a suitable node defined
+    if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
+        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
+    else if (positioningType_ != AddGeneratorNode::PositioningType::Region && region_)
+        Messenger::warn(
+            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
+            region_->name(), AddGeneratorNode::positioningTypes().keyword(positioningType_));
+
+    // Check scalable axes definitions
+    if (!scaleA_ && !scaleB_ && !scaleC_)
+        return Messenger::error("Must have at least one scalable box axis!\n");
+
+    return true;
+}
+
+// Execute node
+bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
+{
+    // Get target species
+    auto *sp = speciesSite_->parent();
+
+    auto ipop = population_.asInteger();
+    if (ipop > 0)
+        Messenger::print("[AddOnSphere] Adding species '{}' - population is {}.\n", sp->name(), ipop);
+    else
+    {
+        Messenger::print("[AddOnSphere] Population of species '{}' is zero so it will not be added.\n", sp->name());
+        return true;
+    }
+
+    auto *cfg = generatorContext.configuration();
+    const auto *box = cfg->box();
+
+    // Set / adjust target box volume
+    adjustBoxVolume(cfg, ipop, sp->nAtoms(SpeciesAtom::Presence::Physical) + sp->nAtoms(SpeciesAtom::Presence::Physical),
+                    sp->mass() + sp->mass());
+
+    // Get the positioningType_ type and rotation flag
+    Messenger::print("[AddOnSphere] Positioning type is '{}'.\n",
+                     AddOnSphereGeneratorNode::positioningTypes().keyword(positioningType_));
+
+    // Checks for regional positioning
+    if (positioningType_ == AddGeneratorNode::PositioningType::Region)
+    {
+        if (!region_->region().isValid())
+            return Messenger::error("Region '{}' is invalid, probably because it contains no free space.\n", region_->name());
+
+        Messenger::print("[AddOnSphere] Target region ('{}') covers {:.2f}% of the box volume.\n", region_->name(),
+                         region_->region().freeVoxelFraction() * 100.0);
+    }
+
+    RandomBuffer randomBuffer(generatorContext.processPool(), ProcessPool::PoolProcessesCommunicator);
+
+    // Set / generate position of sphere centre
+    Vec3<double> sphereCentre, fr;
+    switch (positioningType_)
+    {
+        case (AddGeneratorNode::PositioningType::Random):
+            sphereCentre = box->getReal({randomBuffer.random(), randomBuffer.random(), randomBuffer.random()});
+            break;
+        case (AddGeneratorNode::PositioningType::Region):
+            sphereCentre = region_->region().randomCoordinate();
+            break;
+        case (AddGeneratorNode::PositioningType::Central):
+            sphereCentre = box->getReal({0.5, 0.5, 0.5});
+            break;
+        case (AddGeneratorNode::PositioningType::Current):
+            break;
+        default:
+            throw(std::runtime_error(
+                fmt::format("Positioning type {} not handled.\n", positioningTypes().keyword(positioningType_))));
+    }
+
+    // Add space for the new molecules
+    cfg->atoms().reserve(cfg->atoms().size() + ipop * sp->nAtoms());
+
+    // Now we add the molecules at points on the sphere
+    auto sphereRadius = 5.0;
+    Vec3<double> rLocal;
+    for (auto n = 0; n < ipop; ++n)
+    {
+        // Add the Molecule
+        auto mol = cfg->addMolecule(sp);
+
+        // Generate a point on the sphere
+        if (true)
+        {
+            auto theta = randomBuffer.random() * M_PI;
+            auto psi = randomBuffer.random() * 2.0 * M_PI;
+            rLocal.set(sin(theta) * cos(psi), sin(theta) * sin(psi), cos(theta));
+            rLocal *= sphereRadius;
+
+            mol->setCentreOfGeometry(box, sphereCentre + rLocal);
+        }
+
+        //        // Generate and apply a random rotation matrix
+        //        if (rotate_)
+        //        {
+        //            transform.createRotationXY(randomBuffer.randomPlusMinusOne() * 180.0, randomBuffer.randomPlusMinusOne() *
+        //            180.0); mol->transform(box, transform);
+        //        }
+    }
+
+    Messenger::print("[AddOnSphere] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n",
+                     cfg->atomicDensity().value_or(0.0), cfg->chemicalDensity().value_or(0.0));
+
+    // We've added new content to the box, so need to update our object relationships
+    cfg->updateObjectRelationships();
+
+    return true;
+}

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -58,18 +58,6 @@ bool AddOnSphereGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (speciesSite_->instances().size() > 1)
         return Messenger::error("Site must have a single instance - i.e. be unique in the parent species.\n");
 
-    // If positioningType_ type is 'Region', must have a suitable node defined
-    if (positioningType_ == AddGeneratorNode::PositioningType::Region && !region_)
-        return Messenger::error("A valid region must be specified with the 'Region' keyword.\n");
-    else if (positioningType_ != AddGeneratorNode::PositioningType::Region && region_)
-        Messenger::warn(
-            "A region has been specified ({}) but the positioning type is set to '{}' (rather than targetting the region).\n",
-            region_->name(), AddGeneratorNode::positioningTypes().keyword(positioningType_));
-
-    // Check scalable axes definitions
-    if (!scaleA_ && !scaleB_ && !scaleC_)
-        return Messenger::error("Must have at least one scalable box axis!\n");
-
     return true;
 }
 

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -7,6 +7,7 @@
 #include "classes/configuration.h"
 #include "classes/species.h"
 #include "generator/regionBase.h"
+#include "keywords/bool.h"
 #include "keywords/node.h"
 #include "keywords/nodeValue.h"
 #include "keywords/speciesSite.h"
@@ -27,6 +28,9 @@ void AddOnSphereGeneratorNode::setUpKeywords()
     keywords_.add<EnumOptionsKeyword<AddOnSphereGeneratorNode::PointDistributionStyle>>(
         "Distribution", "Method for distributing points on the underlying sphere", pointDistributionStyle_,
         pointDistributionStyles());
+    keywords_.add<BoolKeyword>("Orient", "Whether to orient the site on the surface", orient_);
+    keywords_.add<EnumOptionsKeyword<Site::SiteAxis>>("Axis", "Site axis to orient along surface tangent", axis_,
+                                                      Site::siteAxis());
     keywords_.add<NodeValueKeyword>("Variance", "Random variance to add to distributed points on the sphere", variance_, this);
 
     setUpBaseKeywords();
@@ -57,6 +61,10 @@ bool AddOnSphereGeneratorNode::prepare(const GeneratorContext &generatorContext)
     // Check site multiplicity
     if (speciesSite_->instances().size() > 1)
         return Messenger::error("Site must have a single instance - i.e. be unique in the parent species.\n");
+
+    // Check for axes on the site if orientation was requested
+    if (orient_ && !speciesSite_->hasAxes())
+        return Messenger::error("Orientation requested, but the selected site has no defined axes.\n");
 
     return true;
 }
@@ -164,17 +172,24 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
         rLocal *= r;
 
         // Generate a working site from the molecule
-        Site site(speciesSite_, {}, mol, Vec3<double>());
-        site.createFromInstance(siteInstance, box);
+        Site site(speciesSite_, {}, mol, siteInstance, box);
 
-        mol->setCentreOfGeometry(box, sphereCentre + rLocal);
+        // Locate the site on the sphere
+        mol->translate((sphereCentre + rLocal) - site.origin());
 
-        //        // Generate and apply a random rotation matrix
-        //        if (rotate_)
-        //        {
-        //            transform.createRotationXY(randomBuffer.randomPlusMinusOne() * 180.0, randomBuffer.randomPlusMinusOne() *
-        //            180.0); mol->transform(box, transform);
-        //        }
+        // Orient the site?
+        if (orient_)
+        {
+            // Set up the target matrix
+            Matrix3 target;
+            target.createFromVector(rLocal.normalised(), axis_);
+
+            // Copy the site matrix and invert it
+            Matrix3 source = site.axes();
+            source.invert();
+
+            mol->transform(box, target * source, sphereCentre + rLocal);
+        }
     }
 
     Messenger::print("[AddOnSphere] New box density is {:e} atoms/Angstrom**3 ({} g/cm3).\n",

--- a/src/generator/addOnSphere.h
+++ b/src/generator/addOnSphere.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/units.h"
+#include "generator/add.h"
+#include "generator/node.h"
+#include "generator/nodeValue.h"
+
+// Forward Declarations
+class CoordinateSetsGeneratorNode;
+class Species;
+class RegionGeneratorNodeBase;
+
+// Add Node
+class AddOnSphereGeneratorNode : public AddGeneratorNodeBase
+{
+    public:
+    explicit AddOnSphereGeneratorNode(const SpeciesSite *site = nullptr, const NodeValue &population = 0,
+                                      const NodeValue &density = 0.1,
+                                      Units::DensityUnits densityUnits = Units::AtomsPerAngstromUnits);
+    ~AddOnSphereGeneratorNode() override = default;
+
+    private:
+    // Set up keywords for node
+    void setUpKeywords();
+
+    /*
+     * Node Data
+     */
+    private:
+    // The default scaling settings
+    static constexpr bool defaultScale_{true};
+    // iFlags controlling box axis scaling
+    bool scaleA_{defaultScale_}, scaleB_{defaultScale_}, scaleC_{defaultScale_};
+    // Site representing anchor point (and implicitly the target species)
+    const SpeciesSite *speciesSite_{nullptr};
+
+    /*
+     * Execute
+     */
+    public:
+    // Prepare any necessary data, ready for execution
+    bool prepare(const GeneratorContext &generatorContext) override;
+    // Execute node
+    bool execute(const GeneratorContext &generatorContext) override;
+};

--- a/src/generator/addOnSphere.h
+++ b/src/generator/addOnSphere.h
@@ -44,6 +44,8 @@ class AddOnSphereGeneratorNode : public AddGeneratorNodeBase
     const SpeciesSite *speciesSite_{nullptr};
     // Radius of the underlying sphere
     NodeValue radius_{5.0};
+    // Random variance to apply to distributed points on the sphere
+    NodeValue variance_{0.0};
     // Distribution style for points on the sphere
     PointDistributionStyle pointDistributionStyle_{PointDistributionStyle::Fibonacci};
 

--- a/src/generator/addOnSphere.h
+++ b/src/generator/addOnSphere.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/units.h"
+#include "classes/site.h"
 #include "generator/add.h"
 #include "generator/node.h"
 #include "generator/nodeValue.h"
@@ -48,6 +49,10 @@ class AddOnSphereGeneratorNode : public AddGeneratorNodeBase
     NodeValue variance_{0.0};
     // Distribution style for points on the sphere
     PointDistributionStyle pointDistributionStyle_{PointDistributionStyle::Fibonacci};
+    // Whether to orient sites on the sphere
+    bool orient_{false};
+    // Axis on site to orient along sphere tangent
+    Site::SiteAxis axis_{Site::SiteAxis::XAxis};
 
     /*
      * Execute

--- a/src/generator/addOnSphere.h
+++ b/src/generator/addOnSphere.h
@@ -29,13 +29,23 @@ class AddOnSphereGeneratorNode : public AddGeneratorNodeBase
     /*
      * Node Data
      */
+    public:
+    // Point Distribution Style
+    enum class PointDistributionStyle
+    {
+        Random,   /* Points are generated randomly */
+        Fibonacci /* Points are generated on a Fibonacci lattice */
+    };
+    // Return enum option info for PointDistributionStyle
+    static EnumOptions<PointDistributionStyle> pointDistributionStyles();
+
     private:
-    // The default scaling settings
-    static constexpr bool defaultScale_{true};
-    // iFlags controlling box axis scaling
-    bool scaleA_{defaultScale_}, scaleB_{defaultScale_}, scaleC_{defaultScale_};
     // Site representing anchor point (and implicitly the target species)
     const SpeciesSite *speciesSite_{nullptr};
+    // Radius of the underlying sphere
+    NodeValue radius_{5.0};
+    // Distribution style for points on the sphere
+    PointDistributionStyle pointDistributionStyle_{PointDistributionStyle::Fibonacci};
 
     /*
      * Execute

--- a/src/generator/node.cpp
+++ b/src/generator/node.cpp
@@ -16,6 +16,7 @@ EnumOptions<GeneratorNode::NodeType> GeneratorNode::nodeTypes()
 {
     return EnumOptions<GeneratorNode::NodeType>(
         "NodeType", {{GeneratorNode::NodeType::Add, "Add"},
+                     {GeneratorNode::NodeType::AddOnSphere, "AddOnSphere"},
                      {GeneratorNode::NodeType::AddPair, "AddPair"},
                      {GeneratorNode::NodeType::Box, "Box"},
                      {GeneratorNode::NodeType::CoordinateSets, "CoordinateSets"},

--- a/src/generator/node.h
+++ b/src/generator/node.h
@@ -21,6 +21,7 @@ class GeneratorNode : public std::enable_shared_from_this<GeneratorNode>, public
     enum class NodeType
     {
         Add,
+        AddOnSphere,
         AddPair,
         Box,
         CoordinateSets,

--- a/src/generator/registry.cpp
+++ b/src/generator/registry.cpp
@@ -3,6 +3,7 @@
 
 #include "generator/registry.h"
 #include "generator/add.h"
+#include "generator/addOnSphere.h"
 #include "generator/addPair.h"
 #include "generator/box.h"
 #include "generator/coordinateSets.h"
@@ -30,6 +31,9 @@ GeneratorNodeRegistry::GeneratorNodeRegistry()
 {
     // Build
     registerProducer<AddGeneratorNode>(GeneratorNode::NodeType::Add, "Add molecules to a configuration", "Build");
+    registerProducer<AddOnSphereGeneratorNode>(GeneratorNode::NodeType::AddOnSphere,
+                                               "Add molecules to a configuration, placing them on the surface of a sphere",
+                                               "Build");
     registerProducer<AddPairGeneratorNode>(GeneratorNode::NodeType::AddPair,
                                            "Add a correlated molecule pair to a configuration", "Build");
     registerProducer<BoxGeneratorNode>(GeneratorNode::NodeType::Box, "Define containing box for a configuration", "Build");

--- a/src/gui/icons/nodes/AddOnSphere.svg
+++ b/src/gui/icons/nodes/AddOnSphere.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="100"
+   height="100"
+   id="svg2"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="AddOnSphere.svg">
+  <metadata
+     id="metadata3050">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1531"
+     id="namedview3048"
+     showgrid="false"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="-34.451311"
+     inkscape:cy="84.91121"
+     inkscape:window-x="0"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0" />
+  <defs
+     id="defs4" />
+  <g
+     id="g1511">
+    <g
+       id="g840"
+       transform="matrix(1.0185749,0,0,1.0185749,-0.92847301,-0.928745)"
+       style="fill:none;stroke:#723380;stroke-width:2.30224;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <circle
+         r="33.749939"
+         cy="50"
+         cx="49.999733"
+         id="path4181-3"
+         style="fill:none;fill-opacity:1;stroke:#723380;stroke-width:2.30224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    </g>
+    <g
+       id="g840-3"
+       transform="matrix(1.0178125,0,0,0.41932121,-0.89035321,29.033939)"
+       style="fill:none;stroke:#723380;stroke-width:2.29606;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
+      <path
+         id="path4181-3-6"
+         style="fill:none;fill-opacity:1;stroke:#723380;stroke-width:2.29606;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 83.749672,50 c 0,18.639577 -15.110362,33.749939 -33.749939,33.749939 C 31.360156,83.749939 16.249794,68.639577 16.249794,50"
+         sodipodi:nodetypes="csc" />
+    </g>
+    <g
+       id="g840-3-7"
+       transform="matrix(1.0178125,0,0,0.41932121,-0.89035321,29.033939)"
+       style="fill:none;stroke:#723380;stroke-width:2.30224;stroke-miterlimit:4;stroke-dasharray:2.30224, 9.20896;stroke-dashoffset:0;stroke-opacity:1">
+      <path
+         id="path4181-3-6-5"
+         style="fill:none;fill-opacity:1;stroke:#723380;stroke-width:2.30224;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:2.30224, 9.20896;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 16.249794,50 c 0,-18.639577 15.110362,-33.749939 33.749939,-33.749939 18.639577,0 33.749939,15.110362 33.749939,33.749939"
+         sodipodi:nodetypes="csc" />
+    </g>
+  </g>
+  <g
+     id="g1410"
+     transform="matrix(0.51445191,0,0,0.51445191,-1.0757443,-1.5858542)">
+    <ellipse
+       cy="75.703072"
+       cx="20.962532"
+       id="path4256-6"
+       style="fill:#00004a;fill-opacity:1;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       rx="16.871483"
+       ry="16.862698" />
+    <ellipse
+       cy="57.952869"
+       cx="46.713757"
+       id="path4260"
+       style="fill:#00004a;fill-opacity:1;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       rx="32.093868"
+       ry="32.077156" />
+    <ellipse
+       cy="21.945307"
+       cx="44.937809"
+       id="path4256"
+       style="fill:#00004a;fill-opacity:1;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       rx="16.871483"
+       ry="16.862698" />
+    <ellipse
+       cy="77.731667"
+       cx="79.315041"
+       id="path4256-3"
+       style="fill:#00004a;fill-opacity:1;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       rx="16.871483"
+       ry="16.862698" />
+  </g>
+</svg>

--- a/src/gui/main.qrc
+++ b/src/gui/main.qrc
@@ -9,6 +9,7 @@
     <file>icons/nodes/CustomRegion.svg</file>
     <file>icons/nodes/CoordinateSets.svg</file>
     <file>icons/nodes/AddPair.svg</file>
+    <file>icons/nodes/AddOnSphere.svg</file>
     <file>icons/nodes/CylindricalRegion.svg</file>
     <file>icons/nodes/Copy.svg</file>
     <file>icons/nodes/GeneralRegion.svg</file>
@@ -69,7 +70,7 @@
     <file>icons/modules/Compare.svg</file>
     <file>icons/modules/TemperatureSchedule.svg</file>
     <file>icons/modules/VoxelDensity.svg</file>
-    <file>icons/modules/TR.svg</file>    
+    <file>icons/modules/TR.svg</file>
   </qresource>
   <qresource prefix="general">
     <file>icons/ff.svg</file>

--- a/src/math/matrix3.cpp
+++ b/src/math/matrix3.cpp
@@ -127,6 +127,30 @@ void Matrix3::print() const
 // Set zero matrix
 void Matrix3::zero() { std::fill(matrix_.begin(), matrix_.end(), 0.0); }
 
+// Create orthogonal matrix around supplied single column vector
+void Matrix3::createFromVector(const Vec3<double> &v, int columnIndex)
+{
+    setColumn(columnIndex, v);
+    const auto v2 = v.orthogonal();
+    switch (columnIndex)
+    {
+        case 0:
+            setColumn(1, v2);
+            setColumn(2, v * v2);
+            break;
+        case 1:
+            setColumn(0, v2);
+            setColumn(2, v * v2);
+            break;
+        case 2:
+            setColumn(0, v2);
+            setColumn(1, v * v2);
+            break;
+        default:
+            throw(std::runtime_error("Invalid column index.\n"));
+    }
+}
+
 // Return transpose of current matrix
 Matrix3 &Matrix3::transpose() const
 {

--- a/src/math/matrix3.h
+++ b/src/math/matrix3.h
@@ -42,6 +42,8 @@ class Matrix3
     void print() const;
     // Set the zero matrix
     void zero();
+    // Create orthogonal matrix around supplied single column vector
+    void createFromVector(const Vec3<double> &v, int columnIndex);
     // Return transpose of current matrix
     Matrix3 &transpose() const;
     // Transform the supplied vector by the transpose of the current matrix

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -310,7 +310,7 @@ template <class T> class Vec3 : public Serialisable<typename SerialisableContext
     // Normalise the vector to unity
     void normalise()
     {
-        double mag = sqrt(x * x + y * y + z * z);
+        auto mag = sqrt(x * x + y * y + z * z);
         if (mag < 1.0E-8)
             zero();
         else

--- a/src/templates/vector3.h
+++ b/src/templates/vector3.h
@@ -320,6 +320,12 @@ template <class T> class Vec3 : public Serialisable<typename SerialisableContext
             z /= mag;
         }
     }
+    // Return the normalised vector
+    Vec3<double> normalised()
+    {
+        auto mag = sqrt(x * x + y * y + z * z);
+        return {x / mag, y / mag, z / mag};
+    }
     // Returns an orthogonal, normalised unit vector
     Vec3<T> orthogonal() const
     {

--- a/web/docs/userguide/generators/nodes/addonspherenode.md
+++ b/web/docs/userguide/generators/nodes/addonspherenode.md
@@ -1,0 +1,37 @@
+---
+title: AddOnSphere (Node)
+linkTitle: AddOnSphere
+description: Add molecules to a box, positioning them on the surface of a sphere
+---
+
+{{< htable >}}
+| | |
+|--------|----------|
+|Context|Generation|
+|Name Required?|No|
+|Branches|--|
+{{< /htable >}}
+
+## Overview
+
+The `AddOnSphere` node creates molecule copies of a target species in a box, placing them on the surface of a sphere of specified size. It is therefore useful in the creation of assembled structures such as micelles.
+
+Periodic species cannot be used by this node, nor can {{< node "CoordinateSets" >}}.
+
+## Description
+
+Aside from the geometric constraints placed on the positioning of the molecules the behaviour of the node is similar to the {{> node "Add" >}}. Options specific to this node are detailed below. Otherwise the behaviour is identical to the {{< node "Add" >}} node (see its documentation for explanations of other parameters).
+
+## Options
+
+### Target
+
+|Keyword|Arguments|Default|Description|
+|:------|:--:|:-----:|-----------|
+|`SpeciesSite`|`name`|--|{{< required-label >}} Target species to add along with the reference site for positional purposes. Note that the site must be unique in the parent species (i.e. it cannot represent a number of dynamic sites) and if orientation is required it must also have axes defined.|
+|`Radius`|[`expr`]({{< ref "expressions" >}})|`5.0`|Radius of the sphere upon which to place molecules.|
+|`Distributions`|[`PointDistributionStyle`]({{< ref "pointdistributionstyle" >}})|`Fibonacci`|Method of point distribution on the sphere.|
+|`Variance`|[`expr`]({{< ref "expressions" >}})|`0.0`|Random variance to apply to generated positions.|
+|`Orient`|`bool`|`false`|Whether to orient placed molecules along the surface tangent, using a site axis as a reference.|
+|`Axis`|`Axis`|`X`|Axis to use if orienting site.|
+

--- a/web/docs/userguide/generators/nodes/addpairnode.md
+++ b/web/docs/userguide/generators/nodes/addpairnode.md
@@ -20,7 +20,7 @@ Periodic species cannot be used by this node, nor can {{< node "CoordinateSets" 
 
 ## Description
 
-For full details on the possible options, see the {{< node "Add" >}} node.
+Options specific to this node are detailed below. Otherwise the behaviour is identical to the {{< node "Add" >}} node (see its documentation for explanations of other parameters).
 
 ## Options
 
@@ -30,22 +30,4 @@ For full details on the possible options, see the {{< node "Add" >}} node.
 |:------|:--:|:-----:|-----------|
 |`SpeciesA`|`name`|--|{{< required-label >}} Target species A of the pair to add.|
 |`SpeciesB`|`name`|--|{{< required-label >}} Target species B of the pair to add.|
-|`Density`|[`expr`]({{< ref "expressions" >}})<br/>[`DensityUnit`]({{< ref "densityunit" >}})|`0.1 atoms/A3`|Density at which to add the target species. Note that the use of this value differs according to the selected `BoxAction` (see above).|
-|`Population`|[`expr`]({{< ref "expressions" >}})|`0`|Population of the pairs to add.|
 
-### Box Modification
-
-|Keyword|Arguments|Default|Description|
-|:------|:--:|:-----:|-----------|
-|`BoxAction`|[`BoxActionStyle`]({{< ref "boxactionstyle" >}})|`AddVolume`|Action to take on the Box geometry / volume on addition of the species|
-|`ScaleA`|`bool`|`true`|Whether to scale the A cell axis when changing the cell volume.|
-|`ScaleB`|`bool`|`true`|Whether to scale the B cell axis when changing the cell volume.|
-|`ScaleC`|`bool`|`true`|Whether to scale the C cell axis when changing the cell volume.|
-
-### Positioning
-
-|Keyword|Arguments|Default|Description|
-|:------|:--:|:-----:|-----------|
-|`Positioning`|[`PositioningType`]({{< ref "positioningtype" >}})|`Random`|Positioning type for the pair.|
-|`Region`|`name`|--|Region node controlling the location of inserted species into the configuration.|
-|`Rotate`|`bool`|`true`|Whether to randomly rotate the molecule pair on insertion.|

--- a/web/docs/userguide/reference/pointdistributionstyle.md
+++ b/web/docs/userguide/reference/pointdistributionstyle.md
@@ -1,0 +1,9 @@
+---
+title: Point Distribution Style
+description: Style for distribution of points on spherical surfaces
+---
+
+|Keyword|Parameters|Description|
+|:---:|:--------:|-----------|
+|`Random`|--|Fully random distribution.|
+|`Fibonacci`|--|Regularised distribution generated from a Fibonacci lattice.|


### PR DESCRIPTION
This PR implements a new Add-style node which places a number of molecules on the surface of a sphere through a reference site on the Species, with the optional ability to orient one site axis along the surface tangent. Two positioning methods are implemented - fully random and one based on a Fibonacci lattice, with the latter giving eye-pleasing results like this:

![image](https://github.com/user-attachments/assets/606ad0d1-9180-435a-8900-b5ae98afb2cf)

And for a molecule with a large tail:

![image](https://github.com/user-attachments/assets/991c9696-1186-4a35-9e55-683859734b6f)

### TODO
- [x] Node icon
- [x] Documentation