### PR TITLE
fix: Size factor persisted after node was removed

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -98,6 +98,7 @@ bool Configuration::initialiseContent(const GeneratorContext &generatorContext)
     empty();
 
     appliedSizeFactor_ = std::nullopt;
+    requestedSizeFactor_ = defaultSizeFactor_;
 
     // Run the generator Generator
     if (!generate(generatorContext))

--- a/src/generator/sizeFactor.cpp
+++ b/src/generator/sizeFactor.cpp
@@ -12,6 +12,13 @@ SizeFactorGeneratorNode::SizeFactorGeneratorNode() : GeneratorNode(NodeType::Siz
 }
 
 /*
+ * Identity
+ */
+
+// Return whether a name for the node must be provided
+bool SizeFactorGeneratorNode::mustBeNamed() const { return false; }
+
+/*
  * Execute
  */
 

--- a/src/generator/sizeFactor.h
+++ b/src/generator/sizeFactor.h
@@ -17,6 +17,13 @@ class SizeFactorGeneratorNode : public GeneratorNode
     NodeValue sizeFactor_{10.0};
 
     /*
+     * Identity
+     */
+    public:
+    // Return whether a name for the node must be provided
+    bool mustBeNamed() const override;
+
+    /*
      * Execute
      */
     public:


### PR DESCRIPTION
This PR fixes an issue where the requested size factor on a configuration was not reset when regenerating the content, leading to unwanted "sizefactor history".

Closes #2010.