### PR TITLE
build: Update release publishing workflow

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -92,8 +92,7 @@ jobs:
       - name: Publish
         uses: "./.github/workflows/publish"
         with:
-          isRelease: false
-          publish: true
+          releaseType: 'continuous'
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -96,3 +96,24 @@ jobs:
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}
+
+  Web:
+    needs: [ Package, BuildLinux ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: "./.github/workflows/setup"
+      - name: Build Website
+        uses: "./.github/workflows/website"
+        with:
+          publishType: 'continuous'
+        env:
+          SERVER_ID: ${{ secrets.SERVER_ID }}
+          SERVER_KEY: ${{ secrets.SERVER_KEY }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SERVER_IP: ${{ secrets.SERVER_IP }}
+          SERVER_DOCS_DIR: ${{ secrets.SERVER_DOCS_DIR }}
+          SERVER_MAIN_DIR: ${{ secrets.SERVER_MAIN_DIR }}
+          SERVER_PORT: ${{ secrets.SERVER_PORT }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Publish
         uses: "./.github/workflows/publish"
         with:
-          releaseType: 'continuous'
+          publishType: 'continuous'
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -45,8 +45,8 @@ runs:
     shell: bash
     run: |
       echo "Release tag/name will be: ${{ env.dissolveVersion }}"
-      #export GITHUB_TOKEN=${{ github.token }}
-      #./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
+      export GITHUB_TOKEN=${{ github.token }}
+      ./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
 
   - name: Publish on GitHub (Continuous)
     if: ${{ inputs.publishType == 'continuous' }}
@@ -54,13 +54,13 @@ runs:
     run: |
       echo "Release tag will be: continuous"
       echo "Release name will be: 'Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})'"
-      #export GITHUB_TOKEN=${{ github.token }}
-      #./update-release -r disorderedmaterials/dissolve -t continuous -p -e -u -n "Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})" -b "Continuous release from \`develop\` branch @ ${{ env.dissolveShortHash }}. Built $(date)." packages/*
+      export GITHUB_TOKEN=${{ github.token }}
+      ./update-release -r disorderedmaterials/dissolve -t continuous -p -e -u -n "Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})" -b "Continuous release from \`develop\` branch @ ${{ env.dissolveShortHash }}. Built $(date)." packages/*
 
   - name: Publish on Harbor
     if: ${{ inputs.publishType != 'none' }}
     shell: bash
     run: |
       echo "Publishing to Harbor, tagged as [${{ inputs.publishType }}]..."
-      #apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      #apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.publishType }}
+      apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+      apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.publishType }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -2,12 +2,14 @@ name: Publish
 description: Publish artifacts online
 
 inputs:
-  isRelease:
-    type: boolean
-    default: false
-  publish:
-    type: boolean
-    default: true
+  releaseType:
+    type: choice
+    default: 'none'
+    options:
+      - none
+      - continuous
+      - release
+      - legacy
 
 runs:
   using: "composite"
@@ -39,35 +41,26 @@ runs:
       ./package-examples -v ${{ env.dissolveVersion }}
 
   - name: Publish on GitHub (Release)
-    if: ${{ inputs.publish == 'true' && inputs.isRelease == 'true' }}
+    if: ${{ inputs.releaseType != 'release' }}
     shell: bash
     run: |
-      echo "Release tag will be: ${{ env.dissolveVersion }}"
-      echo "Release name will be: ${{ env.dissolveVersion }}"
-      export GITHUB_TOKEN=${{ github.token }}
-      ./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
+      echo "Release tag/name will be: ${{ env.dissolveVersion }}"
+      #export GITHUB_TOKEN=${{ github.token }}
+      #./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
 
   - name: Publish on GitHub (Continuous)
-    if: ${{ inputs.publish == 'true' && inputs.isRelease == 'false' }}
+    if: ${{ inputs.releaseType != 'continuous' }}
     shell: bash
     run: |
       echo "Release tag will be: continuous"
       echo "Release name will be: 'Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})'"
-      export GITHUB_TOKEN=${{ github.token }}
-      ./update-release -r disorderedmaterials/dissolve -t continuous -p -e -u -n "Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})" -b "Continuous release from \`develop\` branch @ ${{ env.dissolveShortHash }}. Built $(date)." packages/*
+      #export GITHUB_TOKEN=${{ github.token }}
+      #./update-release -r disorderedmaterials/dissolve -t continuous -p -e -u -n "Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})" -b "Continuous release from \`develop\` branch @ ${{ env.dissolveShortHash }}. Built $(date)." packages/*
 
-  - name: Publish on Harbor (Release)
-    if: ${{ inputs.publish == 'true' && inputs.isRelease == 'true' }}
+  - name: Publish on Harbor
+    if: ${{ inputs.releaseType != 'none' }}
     shell: bash
     run: |
-      echo "Release tag will be: latest"
-      apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:latest
-
-  - name: Publish on Harbor (Continuous)
-    if: ${{ inputs.publish == 'true' && inputs.isRelease == 'false' }}
-    shell: bash
-    run: |
-      echo "Release tag will be: continuous"
-      apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:continuous
+      echo "Publishing to Harbor, tagged as [${{ inputs.releaseType }}]..."
+      #apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
+      #apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.releaseType }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -2,7 +2,7 @@ name: Publish
 description: Publish artifacts online
 
 inputs:
-  releaseType:
+  publishType:
     type: choice
     default: 'none'
     options:
@@ -41,7 +41,7 @@ runs:
       ./package-examples -v ${{ env.dissolveVersion }}
 
   - name: Publish on GitHub (Release)
-    if: ${{ inputs.releaseType == 'release' }}
+    if: ${{ inputs.publishType == 'release' }}
     shell: bash
     run: |
       echo "Release tag/name will be: ${{ env.dissolveVersion }}"
@@ -49,7 +49,7 @@ runs:
       #./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
 
   - name: Publish on GitHub (Continuous)
-    if: ${{ inputs.releaseType == 'continuous' }}
+    if: ${{ inputs.publishType == 'continuous' }}
     shell: bash
     run: |
       echo "Release tag will be: continuous"
@@ -58,9 +58,9 @@ runs:
       #./update-release -r disorderedmaterials/dissolve -t continuous -p -e -u -n "Continuous (${{ env.dissolveVersion }} @ ${{ env.dissolveShortHash }})" -b "Continuous release from \`develop\` branch @ ${{ env.dissolveShortHash }}. Built $(date)." packages/*
 
   - name: Publish on Harbor
-    if: ${{ inputs.releaseType != 'none' }}
+    if: ${{ inputs.publishType != 'none' }}
     shell: bash
     run: |
-      echo "Publishing to Harbor, tagged as [${{ inputs.releaseType }}]..."
+      echo "Publishing to Harbor, tagged as [${{ inputs.publishType }}]..."
       #apptainer remote login --username ${HARBOR_USER} --password ${HARBOR_SECRET} docker://harbor.stfc.ac.uk
-      #apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.releaseType }}
+      #apptainer push packages/dissolve-gui-${{ env.dissolveVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.publishType }}

--- a/.github/workflows/publish/action.yml
+++ b/.github/workflows/publish/action.yml
@@ -41,7 +41,7 @@ runs:
       ./package-examples -v ${{ env.dissolveVersion }}
 
   - name: Publish on GitHub (Release)
-    if: ${{ inputs.releaseType != 'release' }}
+    if: ${{ inputs.releaseType == 'release' }}
     shell: bash
     run: |
       echo "Release tag/name will be: ${{ env.dissolveVersion }}"
@@ -49,7 +49,7 @@ runs:
       #./update-release -r disorderedmaterials/dissolve -t ${{ env.dissolveVersion }} -n "${{ env.dissolveVersion }}" -f ReleaseNotes.md packages/* examples/*.zip examples/*.tar.gz
 
   - name: Publish on GitHub (Continuous)
-    if: ${{ inputs.releaseType != 'continuous' }}
+    if: ${{ inputs.releaseType == 'continuous' }}
     shell: bash
     run: |
       echo "Release tag will be: continuous"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,8 +90,7 @@ jobs:
       - name: Publish
         uses: "./.github/workflows/publish"
         with:
-          isRelease: true
-          publish: ${{ ! endsWith(github.ref, 'pre') }}
+          releaseType: 'release'
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,3 +99,24 @@ jobs:
         with:
           createPR: ${{ ! endsWith(github.ref, 'pre') }}
           releaseVersion: ${{ env.dissolveVersion }}
+
+  Web:
+    needs: [ Package, BuildLinux ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: "./.github/workflows/setup"
+      - name: Build Website
+        uses: "./.github/workflows/website"
+        with:
+          publishType: 'release'
+        env:
+          SERVER_ID: ${{ secrets.SERVER_ID }}
+          SERVER_KEY: ${{ secrets.SERVER_KEY }}
+          SERVER_USER: ${{ secrets.SERVER_USER }}
+          SERVER_IP: ${{ secrets.SERVER_IP }}
+          SERVER_DOCS_DIR: ${{ secrets.SERVER_DOCS_DIR }}
+          SERVER_MAIN_DIR: ${{ secrets.SERVER_MAIN_DIR }}
+          SERVER_PORT: ${{ secrets.SERVER_PORT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Publish
         uses: "./.github/workflows/publish"
         with:
-          releaseType: 'release'
+          publishType: 'release'
         env:
           HARBOR_USER: ${{ secrets.HARBOR_USER }}
           HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -1,4 +1,4 @@
-name: Website Build
+name: Test Website Build
 
 on:
   pull_request:
@@ -28,17 +28,4 @@ jobs:
     - name: Build Website
       uses: "./.github/workflows/website"
       with:
-        isDevelopment: ${{ github.ref_name == 'develop' || github.event_name == 'pull_request' }}
-        isRelease: ${{ startsWith(github.ref_name, 'release') }}
-        isLegacy: false
-        deploy: ${{ github.ref_name == 'develop' || (startsWith(github.ref_name, 'release') && ! endsWith(github.ref_name, 'pre')) }}
-      env:
-        HARBOR_USER: ${{ secrets.HARBOR_USER }}
-        HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}
-        SERVER_ID: ${{ secrets.SERVER_ID }}
-        SERVER_KEY: ${{ secrets.SERVER_KEY }}
-        SERVER_USER: ${{ secrets.SERVER_USER }}
-        SERVER_IP: ${{ secrets.SERVER_IP }}
-        SERVER_DOCS_DIR: ${{ secrets.SERVER_DOCS_DIR }}
-        SERVER_MAIN_DIR: ${{ secrets.SERVER_MAIN_DIR }}
-        SERVER_PORT: ${{ secrets.SERVER_PORT }}
+        publishType: 'none'

--- a/.github/workflows/website/action.yml
+++ b/.github/workflows/website/action.yml
@@ -2,18 +2,14 @@ name: Website
 description: Build and publish website
 
 inputs:
-  isRelease:
-    type: boolean
-    default: false
-  isDevelopment:
-    type: boolean
-    default: false
-  isLegacy:
-    type: boolean
-    default: false
-  deploy:
-    type: boolean
-    default: false
+  publishType:
+    type: choice
+    default: 'none'
+    options:
+      - none
+      - continuous
+      - release
+      - legacy
   pdfExamples:
     type: boolean
     default: false
@@ -27,7 +23,7 @@ runs:
     run: sed -i "s/MAJOR.MINOR/${{ env.dissolveMajorVersion }}.${{ env.dissolveMinorVersion }}/g" web/docs.toml
 
   - name: 'Apply Main Release Styling'
-    if: ${{ inputs.isRelease == 'true' && inputs.isLegacy == 'false' }}
+    if: ${{ inputs.publishType == 'release' }}
     shell: bash
     run: |
       # Set version and tip visibility in docs index
@@ -36,7 +32,7 @@ runs:
       head -n 10 web/docs/_index.md
 
   - name: 'Apply Development Release Styling'
-    if: ${{ inputs.isDevelopment == 'true' }}
+    if: ${{ inputs.publishType == 'continuous' }}
     shell: bash
     run: |
       # Set version and tip visibility in docs index
@@ -53,7 +49,7 @@ runs:
       grep navbar-background-color web/assets/scss/_content.scss
 
   - name: 'Apply Legacy Release Styling'
-    if: ${{ inputs.isLegacy == 'true' }}
+    if: ${{ inputs.publishType == 'legacy' }}
     shell: bash
     run: |
       # Set version and tip visibility in docs index
@@ -131,7 +127,7 @@ runs:
       done
 
   - name: 'SSH Deploy to Server (Release) (Docs only)'
-    if: ${{ inputs.deploy == 'true' && inputs.isRelease == 'true' && inputs.isLegacy == 'false' }}
+    if: ${{ inputs.publishType == 'release' }}
     shell: bash
     run: |
       echo "${SERVER_ID}" > ./serverId
@@ -140,7 +136,7 @@ runs:
       rsync -avz --delete --exclude=dev --exclude=legacy -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public-docs/ ${SERVER_IP}:${SERVER_DOCS_DIR}
 
   - name: 'SSH Deploy to Server (Legacy) (Docs only)'
-    if: ${{ inputs.deploy == 'true' && inputs.isLegacy == 'true' }}
+    if: ${{ inputs.publishType == 'legacy' }}
     shell: bash
     run: |
       echo "${SERVER_ID}" > ./serverId
@@ -149,7 +145,7 @@ runs:
       rsync -avz --delete -e "ssh -o UserKnownHostsFile=./serverId -i ./serverKey -p ${SERVER_PORT} -l ${SERVER_USER}" web/public-docs/ ${SERVER_IP}:${SERVER_DOCS_DIR}/legacy
 
   - name: 'SSH Deploy to Server (Development)'
-    if: ${{ inputs.deploy == 'true' && inputs.isDevelopment == 'true' }}
+    if: ${{ inputs.publishType == 'continuous' }}
     shell: bash
     run: |
       echo "${SERVER_ID}" > ./serverId


### PR DESCRIPTION
This PR modifies the `publish.yml` workflow, simplifying it and making it easier to publish our various flavours of release version. 

Some important things to note, or that I have learned during this escapade:
1) Moving to a workflow `input` variable of (new) type `choice`, rather than having three or four `bool`s define what happens for the various release types was a glorious discovery.
2) A less-than-glorious discovery was that there is precisely zero error checking on the GitHub Actions side for whether you have supplied a valid value to a `choice`-type input.  Which more-or-less makes the whole thing pointless and you might as well use a plain old `string`.
3) The `web.yml` top-level workflow previously was responsible for the actual publishing of the website to our server. I have changed this so that it just builds and sanity-checks the website, but does not push anything.  The `release.yml` and `continuous.yml` workflows now include their call to the website-building workflow with the necessary release type. While this does mean that the website does get built twice for every release and push to `develop`, taking this approach did mean that the web workflow itself could be cleaned up pretty nicely.

Please, see what you think!  One question remains on how we actually flag that a build is a legacy build, or at least how we integrate this into the way we work.