### PR TITLE
build: Correctly pass secrets through to publishing workflow.

### DIFF
--- a/.github/workflows/_publishing.yml
+++ b/.github/workflows/_publishing.yml
@@ -6,6 +6,11 @@ on:
       publishType:
         required: true
         type: string
+    secrets:
+      HARBOR_USER:
+        description: "Username for Harbor access"
+      HARBOR_SECRET:
+        description: "Key for Harbor access"
 
 jobs:
 

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -26,3 +26,6 @@ jobs:
     uses: "./.github/workflows/_publishing.yml"
     with:
       publishType: 'continuous'
+    secrets:
+      HARBOR_USER: ${{ secrets.HARBOR_USER }}
+      HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -15,3 +15,6 @@ jobs:
     uses: "./.github/workflows/_publishing.yml"
     with:
       publishType: 'legacy'
+    secrets:
+      HARBOR_USER: ${{ secrets.HARBOR_USER }}
+      HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,6 @@ jobs:
     uses: "./.github/workflows/_publishing.yml"
     with:
       publishType: 'release'
+    secrets:
+      HARBOR_USER: ${{ secrets.HARBOR_USER }}
+      HARBOR_SECRET: ${{ secrets.HARBOR_SECRET }}


### PR DESCRIPTION
Publishing was broken after #2020 since secrets are not directly accessible to reusable workflows. Following the documentation at https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onworkflow_callsecrets this PR implements the necessary changes, but of course can't realistically test the changes until it's merged in.