### PR TITLE
fix: Correct precedence issue in NeutronSQ Averaging

### DIFF
--- a/src/modules/neutronSQ/process.cpp
+++ b/src/modules/neutronSQ/process.cpp
@@ -55,9 +55,9 @@ bool NeutronSQModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Key
             switch (referenceNormalisedTo_)
             {
                 case (StructureFactors::NoNormalisation):
-                    factor = 1.0 / normaliseTo_ == StructureFactors::SquareOfAverageNormalisation
-                                 ? weights.boundCoherentSquareOfAverage()
-                                 : weights.boundCoherentAverageOfSquares();
+                    factor = 1.0 / (normaliseTo_ == StructureFactors::SquareOfAverageNormalisation
+                                        ? weights.boundCoherentSquareOfAverage()
+                                        : weights.boundCoherentAverageOfSquares());
                     break;
                 case (StructureFactors::SquareOfAverageNormalisation):
                     factor = weights.boundCoherentSquareOfAverage();


### PR DESCRIPTION
I got a warning about this line in NeutronSQ module.  Since divide binds faster than comparison, we're taking the inverse of an enum and comparison *that* to another enum, which I'm pretty sure is not the intended action.

If the original code is correct, it could use some documentation to explain the logic.  As I read it now, it looks like we *always* get the average of squares.