### PR TITLE
chore: benchmark fixes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,9 @@ jobs:
 
           rm result
 
-          nix run .#benchmarks > all_benchmark_results.json
+          touch  all_benchmark_results.json
+
+          nix run -L .#benchmarks
 
           cat all_benchmark_results.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
 
           touch  all_benchmark_results.json
 
-          nix run -L .#benchmarks
+          nix run .#benchmarks
 
           cat all_benchmark_results.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
 
           touch  all_benchmark_results.json
 
-          nix run .#benchmarks
+          nix run -L .#benchmarks
 
           cat all_benchmark_results.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,9 +51,7 @@ jobs:
 
           rm result
 
-          touch  all_benchmark_results.json
-
-          nix run -L .#benchmarks
+          nix run -L .#benchmarks > all_benchmark_results
 
           cat all_benchmark_results.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -49,6 +49,8 @@ jobs:
 
           nix build -L .#benchmarks
 
+          rm result
+
           nix run .#benchmarks > all_benchmark_results.json
 
           cat all_benchmark_results.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,7 +51,7 @@ jobs:
 
           rm result
 
-          nix run -L .#benchmarks > all_benchmark_results
+          nix run -L .#benchmarks > all_benchmark_results.json
 
           cat all_benchmark_results.json
       - name: Store benchmark result

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,9 +48,7 @@ jobs:
           export LD_LIBRARY_PATH=`pwd`/build/onetbb/lib
 
           nix build -L .#benchmarks
-
           rm result
-
           nix run -L .#benchmarks > all_benchmark_results.json
 
           cat all_benchmark_results.json

--- a/flake.nix
+++ b/flake.nix
@@ -211,6 +211,7 @@
               for bm in ${self.packages.${system}.benchmarks}/bin/benchmark_*
               do
                 export BENCHNAME=$(basename ${"$"}{bm})_result.json
+                >&2 echo Running ${"$"}{BENCHNAME}
                 ${"$"}{bm} --benchmark_format=json > $TMP/${"$"}{BENCHNAME}
               done
               ${pkgs.jq}/bin/jq -s '[.[] | to_entries] | flatten | reduce .[] as $dot ({}; .[$dot.key] += $dot.value)' $TMP/benchmark_*.json > $TMP/all_benchmark_results.json

--- a/flake.nix
+++ b/flake.nix
@@ -71,7 +71,10 @@
           pkgs.stdenv.mkDerivation ({
             inherit version;
             pname = exe-name mpi gui;
-            src = ./.;
+            src = builtins.path {
+              path = ./.;
+              name = "dissolve-src";
+            };
             buildInputs = base_libs pkgs ++ pkgs.lib.optional mpi pkgs.openmpi
               ++ pkgs.lib.optionals gui (gui_libs system pkgs)
               ++ pkgs.lib.optionals checks (check_libs pkgs)


### PR DESCRIPTION
What seems to be the most important part of this PR is that the benchmarks now provide status updates on stderr.  These seem to prevent the process from hanging (I've had two consecutive successful benchmarks).  In the worst case, this will still provide diagnostic information if the problem recurs.