### PR TITLE
refactor: Establish Graphable Concept

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if(UNIX)
     set(gui_target_name dissolve-gui)
     set(qmlgui_target_name dissolve-gui-qml)
   endif(PARALLEL)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fconcepts-diagnostics-depth=2")
 endif(UNIX)
 
 # -- OSX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ if(UNIX)
     set(gui_target_name dissolve-gui)
     set(qmlgui_target_name dissolve-gui-qml)
   endif(PARALLEL)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fconcepts-diagnostics-depth=2")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif(UNIX)
 
 # -- OSX

--- a/src/gui-qml/qml/DissolveMain.qml
+++ b/src/gui-qml/qml/DissolveMain.qml
@@ -11,6 +11,7 @@ import "../../Dissolve"
 
 ApplicationWindow {
     id: dissolveWindow
+
     property vector3d scale: Qt.vector3d(Math.min(graphView.width / 2.5, graphView.height / 2.5), Math.min(graphView.width / 2.5, graphView.height / 2.5), 200)
 
     height: 743
@@ -18,240 +19,9 @@ ApplicationWindow {
     visible: true
     width: 819
 
-    TabBar {
-        id: tabBar
-        width: parent.width
-
-        // DEFAULT TABS
-        TabButton {
-            text: "Messages"
-            width: implicitWidth
-        }
-        TabButton {
-            text: "Forcefield"
-            width: implicitWidth
-        }
-        TabButton {
-            text: "Example Plot"
-            width: implicitWidth
-        }
-        TabButton {
-            text: "Layer Graph"
-            width: implicitWidth
-        }
-    }
-    StackLayout {
-        anchors.bottom: parent.bottom
-        anchors.top: tabBar.bottom
-        currentIndex: tabBar.currentIndex
-        width: parent.width
-
-        Item {
-            id: messagesTab
-            Text {
-                text: "Messages"
-            }
-        }
-        Item {
-            id: forcefieldTab
-            Text {
-                text: "Forcefields"
-            }
-        }
-        Item {
-            id: examplePlotTab
-            Node {
-                id: standAloneScene
-                DirectionalLight {
-                    ambientColor: Qt.rgba(0.5, 0.5, 0.5, 1.0)
-                    brightness: 1.0
-                    eulerRotation.x: -25
-                }
-                ScatterModel {
-                    id: plotLine
-                    color: "red"
-                    scale: dissolveWindow.scale
-                    thickness: 0.1
-                    xAxis: xAxis
-                    yAxis: yAxis
-                }
-                LineModel {
-                    color: "#006f6f"
-                    scale: dissolveWindow.scale
-                    thickness: 0.1
-                    xAxis: xAxis
-                    xs: [-1.0, -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.0]
-                    yAxis: yAxis
-                    ys: [1.0, 0.64, 0.36, 0.16, 0.04, 0, 0.04, 0.16, 0.36, 0.64, 1.0]
-                }
-                AxisModel {
-                    color: "black"
-                    scl: dissolveWindow.scale
-
-                    axis: Axis {
-                        id: xAxis
-                        direction: true
-                        maximum: 2.0
-                        minimum: -2.0
-                        thickness: 0.01
-                    }
-                }
-                AxisModel {
-                    color: "black"
-                    scl: dissolveWindow.scale
-
-                    axis: Axis {
-                        id: yAxis
-                        direction: false
-                        maximum: 2.0
-                        minimum: -2.0
-                        thickness: 0.01
-                    }
-                }
-            }
-            View3D {
-                id: graphView
-                anchors.fill: parent
-                importScene: standAloneScene
-
-                MouseArea {
-                    anchors.fill: parent
-
-                    onWheel: function (event) {
-                        xAxis.nudge(0.01 * event.pixelDelta.x);
-                        yAxis.nudge(-0.01 * event.pixelDelta.y);
-                    }
-                }
-
-                camera: OrthographicCamera {
-                    id: cameraOrthographicLeft
-                    z: 600
-                }
-            }
-        }
-        Item {
-            id: exampleGraphTab
-            ModuleGraphModel {
-                id: graphModel
-                world: dissolve
-            }
-            Connections {
-                target: dissolve.configurationsModel
-
-                function onModelReset() {
-                    graphModel.handleReset();
-                }
-            }
-            GeneratorDelegate {
-                id: exampleDelegate
-                rootModel: graphModel
-            }
-            Pane {
-                id: toolBar
-                RowLayout {
-                    anchors.left: parent.left
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-
-                    FileDialog {
-                        id: openDialog
-                        onAccepted: {
-                            dissolve.file = selectedFile;
-                        }
-                    }
-                    Button {
-                        icon.source: "qrc:/Dissolve/icons/open.svg"
-
-                        onClicked: openDialog.open()
-                    }
-                    Label {
-                        text: "Nodes: " + graphModel.nodeCount
-                    }
-                    Label {
-                        text: "Edges: " + graphModel.edgeCount
-                    }
-                    SpinBox {
-                        id: nodeValue
-                        from: 0
-                    }
-                    Button {
-                        text: "Add Raw Value"
-
-                        onClicked: {
-                            var px = Math.floor(Math.random() * (graph.width - 50));
-                            var py = Math.floor(Math.random() * (graph.height - 50));
-                            graphModel.emplace_back(px, py, nodeValue.value);
-                        }
-                    }
-                    Button {
-                        text: "Add Pointer"
-
-                        onClicked: {
-                            var px = Math.floor(Math.random() * (graph.width - 50));
-                            var py = Math.floor(Math.random() * (graph.height - 50));
-                            graphModel.emplace_back(px, py, null);
-                        }
-                    }
-                    Label {
-                        text: "Source"
-                    }
-                    SpinBox {
-                        id: conSrc
-                        from: 0
-                        to: graphModel.nodeCount - 1
-                    }
-                    Label {
-                        text: "Destination"
-                    }
-                    SpinBox {
-                        id: conDest
-                        from: 0
-                        to: graphModel.nodeCount - 1
-                    }
-                    Button {
-                        id: connectButton
-                        text: "Connect"
-
-                        onClicked: {
-                            let success = graphModel.connect(conSrc.value, 0, conDest.value, 0);
-                            if (!success) {
-                                text = "Bad Connect";
-                            } else {
-                                text = "Good Connect";
-                            }
-                        }
-                    }
-                    Button {
-                        id: disconnectButton
-                        text: "Disconnect"
-
-                        onClicked: {
-                            let success = graphModel.disconnect(conSrc.value, 0, conDest.value, 0);
-                            if (!success) {
-                                text = "Bad Disconnect";
-                            } else {
-                                text = "Good Disconnect";
-                            }
-                        }
-                    }
-                }
-            }
-            GraphView {
-                id: graph
-                anchors.bottom: parent.bottom
-                anchors.left: parent.left
-                anchors.right: parent.right
-                anchors.top: toolBar.bottom
-                delegate: exampleDelegate.delegate
-                edgeModel: graphModel.edges
-                nodeModel: graphModel.nodes
-                rootModel: graphModel
-            }
-        }
-    }
-
     menuBar: MenuBar {
         id: mainMenu
+
         Menu {
             title: "&File"
 
@@ -287,6 +57,259 @@ ApplicationWindow {
                 text: "&Quit"
 
                 onTriggered: Qt.quit()
+            }
+        }
+    }
+
+    TabBar {
+        id: tabBar
+
+        width: parent.width
+
+        // DEFAULT TABS
+        TabButton {
+            text: "Messages"
+            width: implicitWidth
+        }
+        TabButton {
+            text: "Forcefield"
+            width: implicitWidth
+        }
+        TabButton {
+            text: "Example Plot"
+            width: implicitWidth
+        }
+        TabButton {
+            text: "Layer Graph"
+            width: implicitWidth
+        }
+    }
+    StackLayout {
+        anchors.bottom: parent.bottom
+        anchors.top: tabBar.bottom
+        currentIndex: tabBar.currentIndex
+        width: parent.width
+
+        Item {
+            id: messagesTab
+
+            Text {
+                text: "Messages"
+            }
+        }
+        Item {
+            id: forcefieldTab
+
+            Text {
+                text: "Forcefields"
+            }
+        }
+        Item {
+            id: examplePlotTab
+
+            Node {
+                id: standAloneScene
+
+                DirectionalLight {
+                    ambientColor: Qt.rgba(0.5, 0.5, 0.5, 1.0)
+                    brightness: 1.0
+                    eulerRotation.x: -25
+                }
+                ScatterModel {
+                    id: plotLine
+
+                    color: "red"
+                    scale: dissolveWindow.scale
+                    thickness: 0.1
+                    xAxis: xAxis
+                    yAxis: yAxis
+                }
+                LineModel {
+                    color: "#006f6f"
+                    scale: dissolveWindow.scale
+                    thickness: 0.1
+                    xAxis: xAxis
+                    xs: [-1.0, -0.8, -0.6, -0.4, -0.2, 0, 0.2, 0.4, 0.6, 0.8, 1.0]
+                    yAxis: yAxis
+                    ys: [1.0, 0.64, 0.36, 0.16, 0.04, 0, 0.04, 0.16, 0.36, 0.64, 1.0]
+                }
+                AxisModel {
+                    color: "black"
+                    scl: dissolveWindow.scale
+
+                    axis: Axis {
+                        id: xAxis
+
+                        direction: true
+                        maximum: 2.0
+                        minimum: -2.0
+                        thickness: 0.01
+                    }
+                }
+                AxisModel {
+                    color: "black"
+                    scl: dissolveWindow.scale
+
+                    axis: Axis {
+                        id: yAxis
+
+                        direction: false
+                        maximum: 2.0
+                        minimum: -2.0
+                        thickness: 0.01
+                    }
+                }
+            }
+            View3D {
+                id: graphView
+
+                anchors.fill: parent
+                importScene: standAloneScene
+
+                camera: OrthographicCamera {
+                    id: cameraOrthographicLeft
+
+                    z: 600
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+
+                    onWheel: function (event) {
+                        xAxis.nudge(0.01 * event.pixelDelta.x);
+                        yAxis.nudge(-0.01 * event.pixelDelta.y);
+                    }
+                }
+            }
+        }
+        Item {
+            id: exampleGraphTab
+
+            ModuleGraphModel {
+                id: graphModel
+
+                world: dissolve
+            }
+            Connections {
+                function onModelReset() {
+                    graphModel.handleReset();
+                }
+
+                target: dissolve.configurationsModel
+            }
+            GeneratorDelegate {
+                id: exampleDelegate
+
+                rootModel: graphModel
+            }
+            Pane {
+                id: toolBar
+
+                RowLayout {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+
+                    FileDialog {
+                        id: openDialog
+
+                        onAccepted: {
+                            dissolve.file = selectedFile;
+                        }
+                    }
+                    Button {
+                        icon.source: "qrc:/Dissolve/icons/open.svg"
+
+                        onClicked: openDialog.open()
+                    }
+                    Label {
+                        text: "Nodes: " + graphModel.nodeCount
+                    }
+                    Label {
+                        text: "Edges: " + graphModel.edgeCount
+                    }
+                    SpinBox {
+                        id: nodeValue
+
+                        from: 0
+                    }
+                    Button {
+                        text: "Add Raw Value"
+
+                        onClicked: {
+                            var px = Math.floor(Math.random() * (graph.width - 50));
+                            var py = Math.floor(Math.random() * (graph.height - 50));
+                            graphModel.emplace_back(px, py, nodeValue.value);
+                        }
+                    }
+                    Button {
+                        text: "Add Pointer"
+
+                        onClicked: {
+                            var px = Math.floor(Math.random() * (graph.width - 50));
+                            var py = Math.floor(Math.random() * (graph.height - 50));
+                            graphModel.emplace_back(px, py, null);
+                        }
+                    }
+                    Label {
+                        text: "Source"
+                    }
+                    SpinBox {
+                        id: conSrc
+
+                        from: 0
+                        to: graphModel.nodeCount - 1
+                    }
+                    Label {
+                        text: "Destination"
+                    }
+                    SpinBox {
+                        id: conDest
+
+                        from: 0
+                        to: graphModel.nodeCount - 1
+                    }
+                    Button {
+                        id: connectButton
+
+                        text: "Connect"
+
+                        onClicked: {
+                            let success = graphModel.connect(conSrc.value, 0, conDest.value, 0);
+                            if (!success) {
+                                text = "Bad Connect";
+                            } else {
+                                text = "Good Connect";
+                            }
+                        }
+                    }
+                    Button {
+                        id: disconnectButton
+
+                        text: "Disconnect"
+
+                        onClicked: {
+                            let success = graphModel.disconnect(conSrc.value, 0, conDest.value, 0);
+                            if (!success) {
+                                text = "Bad Disconnect";
+                            } else {
+                                text = "Good Disconnect";
+                            }
+                        }
+                    }
+                }
+            }
+            GraphView {
+                id: graph
+
+                anchors.bottom: parent.bottom
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: toolBar.bottom
+                delegate: exampleDelegate.delegate
+                edgeModel: graphModel.edges
+                nodeModel: graphModel.nodes
+                rootModel: graphModel
             }
         }
     }

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "exampleGraphModel.h"
 #include "nodeWrapper.h"

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -27,7 +27,7 @@ template <> QVariant nodeGetValue<nodeValue>(const nodeValue value)
 };
 
 // The name of the type (for delegate dispatch)
-template <> std::string nodeTypeName<nodeValue>(const nodeValue &value)
+std::string nodeTypeName(const nodeValue &value)
 {
     return std::visit(
         [](auto arg) -> std::string
@@ -45,7 +45,7 @@ template <> std::string nodeTypeName<nodeValue>(const nodeValue &value)
 }
 
 // The path to the icon for the node
-template <> std::string nodeTypeIcon<nodeValue>(const nodeValue &value)
+std::string nodeTypeIcon(const nodeValue &value)
 {
     return std::visit(
         [](auto arg) -> std::string

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -98,7 +98,7 @@ QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteAr
 }
 
 // Get a specific piece of information from a node by index
-template <> QVariant nodeData<nodeValue>(const nodeValue &item, int role)
+QVariant nodeData(const nodeValue &item, int role)
 {
     switch (role)
     {
@@ -110,7 +110,7 @@ template <> QVariant nodeData<nodeValue>(const nodeValue &item, int role)
 }
 
 // Set a specific piece of information from a node by index
-template <> bool nodeSetData<nodeValue>(nodeValue &item, const QVariant &value, int role) { return false; }
+bool nodeSetData(nodeValue &item, const QVariant &value, int role) { return false; }
 
 // Delete the node
 bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context) { return true; }

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -7,7 +7,7 @@
 #include <variant>
 
 // The value of the node
-template <> QVariant nodeGetValue<nodeValue>(const nodeValue value)
+QVariant nodeGetValue(const nodeValue &value)
 {
     return std::visit(
         [](auto arg) -> QVariant
@@ -19,7 +19,7 @@ template <> QVariant nodeGetValue<nodeValue>(const nodeValue value)
             else
             {
                 if (arg)
-                    return nodeGetValue<nodeValue>(*arg);
+                    return nodeGetValue(*arg);
                 return {};
             }
         },
@@ -66,7 +66,7 @@ std::string nodeTypeIcon(const nodeValue &value)
 std::string nodeName(const nodeValue &value) { return value.name; }
 
 // Change the title of the node
-template <> void setNodeName<nodeValue>(nodeValue &value, const std::string name) { value.name = name; }
+void setNodeName(nodeValue &value, const std::string name) { value.name = name; }
 
 // Link an indexed position on the source to an indexed position on the destination
 template <> bool nodeConnect<nodeValue>(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex)

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -90,7 +90,7 @@ bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, 
 }
 
 // Append the roles for the type onto the QHash
-QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles)
+QHash<int, QByteArray> &nodeRoleNames(Phantom<nodeValue> proxy, QHash<int, QByteArray> &roles)
 {
     const auto base = Qt::UserRole + GraphNodeModelBase::ownedRoles;
     roles[base] = "value";
@@ -113,7 +113,7 @@ QVariant nodeData(const nodeValue &item, int role)
 bool nodeSetData(nodeValue &item, const QVariant &value, int role) { return false; }
 
 // Delete the node
-bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context) { return true; }
+bool nodeDelete(nodeValue &value, Phantom<nodeValue> &context) { return true; }
 
 // Create node from variant
 nodeValue::nodeValue(QVariant var)

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -69,21 +69,21 @@ std::string nodeName(const nodeValue &value) { return value.name; }
 void setNodeName(nodeValue &value, const std::string name) { value.name = name; }
 
 // Link an indexed position on the source to an indexed position on the destination
-template <> bool nodeConnect<nodeValue>(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex)
+bool nodeConnect(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex)
 {
     destionation.value = &source;
     return true;
 }
 
 // Confirm that a connection is possible (e.g. types match and index isn't already connected)
-template <>
-bool nodeConnectable<nodeValue>(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex)
+
+bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex)
 {
     return std::holds_alternative<double>(source.value) && std::holds_alternative<nodeValue *>(destination.value);
 }
 
 // Unlink an indexed position on the source to an indexed position on the destination
-template <> bool nodeDisconnect<nodeValue>(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex)
+bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex)
 {
     destination.value = nullptr;
     return true;

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -90,7 +90,7 @@ bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, 
 }
 
 // Append the roles for the type onto the QHash
-template <> QHash<int, QByteArray> &nodeRoleNames<nodeValue>(QHash<int, QByteArray> &roles)
+QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles)
 {
     const auto base = Qt::UserRole + GraphNodeModelBase::ownedRoles;
     roles[base] = "value";

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -63,7 +63,7 @@ template <> std::string nodeTypeIcon<nodeValue>(const nodeValue &value)
 }
 
 // The title of the node
-template <> std::string nodeName<nodeValue>(const nodeValue &value) { return value.name; }
+std::string nodeName(const nodeValue &value) { return value.name; }
 
 // Change the title of the node
 template <> void setNodeName<nodeValue>(nodeValue &value, const std::string name) { value.name = name; }

--- a/src/gui/models/nodeGraph/exampleGraphModel.cpp
+++ b/src/gui/models/nodeGraph/exampleGraphModel.cpp
@@ -113,7 +113,7 @@ template <> QVariant nodeData<nodeValue>(const nodeValue &item, int role)
 template <> bool nodeSetData<nodeValue>(nodeValue &item, const QVariant &value, int role) { return false; }
 
 // Delete the node
-template <> bool nodeDelete<nodeValue>(nodeValue &value, GraphNodeContext<nodeValue>::type &context) { return true; }
+bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context) { return true; }
 
 // Create node from variant
 nodeValue::nodeValue(QVariant var)

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -39,6 +39,8 @@ bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &
 bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex);
 QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles);
 bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context);
+QVariant nodeData(const nodeValue &item, int role);
+bool nodeSetData(nodeValue &item, const QVariant &value, int role);
 
 // The graph model for the example
 typedef GraphModel<nodeValue, Proxy<nodeValue>> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -37,6 +37,7 @@ QVariant nodeGetValue(const nodeValue &value);
 bool nodeConnect(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex);
 bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex);
 bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex);
+QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles);
 
 // The graph model for the example
 typedef GraphModel<nodeValue> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -29,5 +29,7 @@ class nodeValue
     std::variant<double, nodeValue *> value;
 };
 
+std::string nodeName(const nodeValue &value);
+
 // The graph model for the example
 typedef GraphModel<nodeValue> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -30,6 +30,8 @@ class nodeValue
 };
 
 std::string nodeName(const nodeValue &value);
+std::string nodeTypeName(const nodeValue &value);
+std::string nodeTypeIcon(const nodeValue &value);
 
 // The graph model for the example
 typedef GraphModel<nodeValue> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -37,10 +37,10 @@ QVariant nodeGetValue(const nodeValue &value);
 bool nodeConnect(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex);
 bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex);
 bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex);
-QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles);
-bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context);
+QHash<int, QByteArray> &nodeRoleNames(Phantom<nodeValue> proxy, QHash<int, QByteArray> &roles);
+bool nodeDelete(nodeValue &value, Phantom<nodeValue> &context);
 QVariant nodeData(const nodeValue &item, int role);
 bool nodeSetData(nodeValue &item, const QVariant &value, int role);
 
 // The graph model for the example
-typedef GraphModel<nodeValue, Proxy<nodeValue>> ExampleGraphModel;
+typedef GraphModel<nodeValue, Phantom<nodeValue>> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -32,6 +32,8 @@ class nodeValue
 std::string nodeName(const nodeValue &value);
 std::string nodeTypeName(const nodeValue &value);
 std::string nodeTypeIcon(const nodeValue &value);
+void setNodeName(nodeValue &value, std::string);
+QVariant nodeGetValue(const nodeValue &value);
 
 // The graph model for the example
 typedef GraphModel<nodeValue> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -38,6 +38,7 @@ bool nodeConnect(nodeValue &source, int sourceIndex, nodeValue &destionation, in
 bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex);
 bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex);
 QHash<int, QByteArray> &nodeRoleNames(Proxy<nodeValue> proxy, QHash<int, QByteArray> &roles);
+bool nodeDelete(nodeValue &value, Proxy<nodeValue> &context);
 
 // The graph model for the example
-typedef GraphModel<nodeValue> ExampleGraphModel;
+typedef GraphModel<nodeValue, Proxy<nodeValue>> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/exampleGraphModel.h
+++ b/src/gui/models/nodeGraph/exampleGraphModel.h
@@ -34,6 +34,9 @@ std::string nodeTypeName(const nodeValue &value);
 std::string nodeTypeIcon(const nodeValue &value);
 void setNodeName(nodeValue &value, std::string);
 QVariant nodeGetValue(const nodeValue &value);
+bool nodeConnect(nodeValue &source, int sourceIndex, nodeValue &destionation, int destinationIndex);
+bool nodeConnectable(const nodeValue &source, int sourceIndex, const nodeValue &destination, int destinationIndex);
+bool nodeDisconnect(nodeValue &source, int sourceIndex, nodeValue &destination, int destinationIndex);
 
 // The graph model for the example
 typedef GraphModel<nodeValue> ExampleGraphModel;

--- a/src/gui/models/nodeGraph/generatorGraphModel.cpp
+++ b/src/gui/models/nodeGraph/generatorGraphModel.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "generatorGraphModel.h"
 #include "expression/variable.h"

--- a/src/gui/models/nodeGraph/generatorGraphModel.h
+++ b/src/gui/models/nodeGraph/generatorGraphModel.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/generatorGraphModel.h
+++ b/src/gui/models/nodeGraph/generatorGraphModel.h
@@ -10,24 +10,6 @@
 #include "gui/models/nodeGraph/instances/all.h"
 #include "nodeWrapper.h"
 
-// The variant of all of the types that we will examine
-using GeneratorGraphInnerType = std::variant<Configuration *, Generator *, GeneratorNode *>;
-
-// A class to contain the inner type, since we need a constructor that
-// take a QVariant
-class GeneratorGraphNode
-{
-    public:
-    GeneratorGraphNode(QVariant var = {});
-    GeneratorGraphInnerType value;
-};
-
-// All of these types may require access to CoreData
-template <> struct GraphNodeContext<GeneratorGraphNode>
-{
-    using type = CoreData *;
-};
-
 // A graph node model for looking at the generators on a configuration
 class GeneratorGraphModel : public GraphModel<GeneratorGraphNode>
 {

--- a/src/gui/models/nodeGraph/generatorGraphModel.h
+++ b/src/gui/models/nodeGraph/generatorGraphModel.h
@@ -11,7 +11,7 @@
 #include "nodeWrapper.h"
 
 // A graph node model for looking at the generators on a configuration
-class GeneratorGraphModel : public GraphModel<GeneratorGraphNode, CoreData*>
+class GeneratorGraphModel : public GraphModel<GeneratorGraphNode, CoreData *>
 {
     Q_OBJECT
     // The Dissolve Model that contains the Dissolve object instance we

--- a/src/gui/models/nodeGraph/generatorGraphModel.h
+++ b/src/gui/models/nodeGraph/generatorGraphModel.h
@@ -11,7 +11,7 @@
 #include "nodeWrapper.h"
 
 // A graph node model for looking at the generators on a configuration
-class GeneratorGraphModel : public GraphModel<GeneratorGraphNode>
+class GeneratorGraphModel : public GraphModel<GeneratorGraphNode, CoreData*>
 {
     Q_OBJECT
     // The Dissolve Model that contains the Dissolve object instance we

--- a/src/gui/models/nodeGraph/graphEdgeModel.cpp
+++ b/src/gui/models/nodeGraph/graphEdgeModel.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "gui/models/nodeGraph/graphEdgeModel.h"
 

--- a/src/gui/models/nodeGraph/graphEdgeModel.h
+++ b/src/gui/models/nodeGraph/graphEdgeModel.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -37,15 +37,17 @@
 **/
 
 // This is the base class for any node graph type
-template <Graphable T> class GraphModel : public GraphModelBase
+template <typename T, typename Context>
+    requires Graphable<T, Context>
+class GraphModel : public GraphModelBase
 {
     public:
     GraphModel() : nodes_(this) {}
 
     protected:
-    typename GraphNodeContext<T>::type context_;
+    Context context_;
     // The nodes in the model
-    std::vector<NodeWrapper<T>> items_;
+    std::vector<NodeWrapper<T, Context>> items_;
     // Get index of name
     int indexByName(std::string name) override
     {
@@ -55,7 +57,7 @@ template <Graphable T> class GraphModel : public GraphModelBase
 
     public:
     // Access the acutal nodes in the model
-    std::vector<NodeWrapper<T>> &items() { return items_; }
+    std::vector<NodeWrapper<T, Context>> &items() { return items_; }
 
     // Access the GraphNodeModel
     QAbstractListModel *nodes() override { return &nodes_; }
@@ -120,5 +122,5 @@ template <Graphable T> class GraphModel : public GraphModelBase
 
     protected:
     // The abstract data model for the nodes
-    GraphNodeModel<T> nodes_;
+    GraphNodeModel<T, Context> nodes_;
 };

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -37,7 +37,7 @@
 **/
 
 // This is the base class for any node graph type
-template <typename T> class GraphModel : public GraphModelBase
+template <Graphable T> class GraphModel : public GraphModelBase
 {
     public:
     GraphModel() : nodes_(this) {}

--- a/src/gui/models/nodeGraph/graphModelBase.cpp
+++ b/src/gui/models/nodeGraph/graphModelBase.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "graphEdgeModel.h"
 #include "graphModel.h"

--- a/src/gui/models/nodeGraph/graphModelBase.h
+++ b/src/gui/models/nodeGraph/graphModelBase.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/graphNodeContext.h
+++ b/src/gui/models/nodeGraph/graphNodeContext.h
@@ -3,13 +3,6 @@
 
 #pragma once
 
-// A template that we can specialise to associate a a context type
-// with a type.
-template <typename T> struct GraphNodeContext
-{
-    using type = GraphNodeContext<void>;
-};
-
 template <typename T> struct Proxy
 {
 };

--- a/src/gui/models/nodeGraph/graphNodeContext.h
+++ b/src/gui/models/nodeGraph/graphNodeContext.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+// A template that we can specialise to associate a a context type
+// with a type.
+template <typename T> struct GraphNodeContext
+{
+    using type = GraphNodeContext<void>;
+};

--- a/src/gui/models/nodeGraph/graphNodeContext.h
+++ b/src/gui/models/nodeGraph/graphNodeContext.h
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
-
-#pragma once
-
-template <typename T> struct Proxy
-{
-};

--- a/src/gui/models/nodeGraph/graphNodeContext.h
+++ b/src/gui/models/nodeGraph/graphNodeContext.h
@@ -9,3 +9,7 @@ template <typename T> struct GraphNodeContext
 {
     using type = GraphNodeContext<void>;
 };
+
+template <typename T> struct Proxy
+{
+};

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -47,7 +47,7 @@ class GraphNodeModel : public GraphNodeModelBase
     // Labels for QML roles (required by QAbstractListModel)
     QHash<int, QByteArray> roleNames() const override
     {
-        Proxy<T> proxy;
+        Phantom<T> proxy;
         QHash<int, QByteArray> roles;
         roles[Qt::UserRole] = "name";
         roles[Qt::UserRole + 1] = "posX";

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -8,7 +8,7 @@
 #include <qabstractitemmodel.h>
 #include <qvariant.h>
 
-template <typename T> class GraphModel;
+template <Graphable T> class GraphModel;
 
 // A base to add a static terms or properties to GraphNodeModel
 class GraphNodeModelBase : public QAbstractListModel
@@ -22,7 +22,7 @@ class GraphNodeModelBase : public QAbstractListModel
 
 // The model for accessing the node data (which is *held* in the
 // GraphModel class)
-template <typename T> class GraphNodeModel : public GraphNodeModelBase
+template <Graphable T> class GraphNodeModel : public GraphNodeModelBase
 {
     friend GraphModel<T>;
 

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -8,7 +8,9 @@
 #include <qabstractitemmodel.h>
 #include <qvariant.h>
 
-template <Graphable T> class GraphModel;
+template <typename T, typename Context>
+    requires Graphable<T, Context>
+class GraphModel;
 
 // A base to add a static terms or properties to GraphNodeModel
 class GraphNodeModelBase : public QAbstractListModel
@@ -22,20 +24,22 @@ class GraphNodeModelBase : public QAbstractListModel
 
 // The model for accessing the node data (which is *held* in the
 // GraphModel class)
-template <Graphable T> class GraphNodeModel : public GraphNodeModelBase
+template <typename T, typename Context>
+    requires Graphable<T, Context>
+class GraphNodeModel : public GraphNodeModelBase
 {
-    friend GraphModel<T>;
+    friend GraphModel<T, Context>;
 
     public:
-    GraphNodeModel(GraphModel<T> *parent = nullptr) : parent_(parent) {}
-    GraphNodeModel(const GraphNodeModel<T> &other) : parent_(other.parent_) {}
+    GraphNodeModel(GraphModel<T, Context> *parent = nullptr) : parent_(parent) {}
+    GraphNodeModel(const GraphNodeModel<T, Context> &other) : parent_(other.parent_) {}
 
-    GraphNodeModel<T> &operator=(const GraphNodeModel<T> &other)
+    GraphNodeModel<T, Context> &operator=(const GraphNodeModel<T, Context> &other)
     {
         parent_ = other.parent_;
         return *this;
     }
-    bool operator!=(const GraphNodeModel<T> &other) { return &parent_ != &other.parent_; }
+    bool operator!=(const GraphNodeModel<T, Context> &other) { return &parent_ != &other.parent_; }
 
     // Number of nodes (required by QAbstractListModel)
     int rowCount(const QModelIndex &parent = QModelIndex()) const override { return parent_->items().size(); }
@@ -102,5 +106,5 @@ template <Graphable T> class GraphNodeModel : public GraphNodeModelBase
 
     private:
     // The GraphModel that this is part of (which will hold the actual vector of nodes
-    GraphModel<T> *parent_;
+    GraphModel<T, Context> *parent_;
 };

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -47,14 +47,14 @@ class GraphNodeModel : public GraphNodeModelBase
     // Labels for QML roles (required by QAbstractListModel)
     QHash<int, QByteArray> roleNames() const override
     {
-        Phantom<T> proxy;
+        Phantom<T> phantom;
         QHash<int, QByteArray> roles;
         roles[Qt::UserRole] = "name";
         roles[Qt::UserRole + 1] = "posX";
         roles[Qt::UserRole + 2] = "posY";
         roles[Qt::UserRole + 3] = "type";
         roles[Qt::UserRole + 4] = "icon";
-        return nodeRoleNames(proxy, roles);
+        return nodeRoleNames(phantom, roles);
     }
 
     // Data accessor (required by QAbstractListModel)

--- a/src/gui/models/nodeGraph/graphNodeModel.h
+++ b/src/gui/models/nodeGraph/graphNodeModel.h
@@ -43,13 +43,14 @@ template <Graphable T> class GraphNodeModel : public GraphNodeModelBase
     // Labels for QML roles (required by QAbstractListModel)
     QHash<int, QByteArray> roleNames() const override
     {
+        Proxy<T> proxy;
         QHash<int, QByteArray> roles;
         roles[Qt::UserRole] = "name";
         roles[Qt::UserRole + 1] = "posX";
         roles[Qt::UserRole + 2] = "posY";
         roles[Qt::UserRole + 3] = "type";
         roles[Qt::UserRole + 4] = "icon";
-        return nodeRoleNames<T>(roles);
+        return nodeRoleNames(proxy, roles);
     }
 
     // Data accessor (required by QAbstractListModel)

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -35,3 +35,4 @@ bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode
 bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination, int destinationIndex);
 bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);
 QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);
+bool nodeDelete(GeneratorGraphNode &item, CoreData *coreData);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -36,3 +36,5 @@ bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const Ge
 bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);
 QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);
 bool nodeDelete(GeneratorGraphNode &item, CoreData *coreData);
+QVariant nodeData(const GeneratorGraphNode &item, int role);
+bool nodeSetData(GeneratorGraphNode &item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
-#include <QVariant>
 #include "configuration.h"
 #include "generator.h"
 #include "generatorNode.h"
+#include <QVariant>
 
 // The variant of all of the types that we will examine
 using GeneratorGraphInnerType = std::variant<Configuration *, Generator *, GeneratorNode *>;
@@ -26,7 +26,8 @@ std::string nodeTypeIcon(const GeneratorGraphNode &value);
 void setNodeName(GeneratorGraphNode &value, std::string);
 QVariant nodeGetValue(const GeneratorGraphNode &value);
 bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destionation, int destinationIndex);
-bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination, int destinationIndex);
+bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination,
+                     int destinationIndex);
 bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);
 QHash<int, QByteArray> &nodeRoleNames(Phantom<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);
 bool nodeDelete(GeneratorGraphNode &item, CoreData *coreData);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -20,12 +20,6 @@ class GeneratorGraphNode
     GeneratorGraphInnerType value;
 };
 
-// All of these types may require access to CoreData
-template <> struct GraphNodeContext<GeneratorGraphNode>
-{
-    using type = CoreData *;
-};
-
 std::string nodeName(const GeneratorGraphNode &value);
 std::string nodeTypeName(const GeneratorGraphNode &value);
 std::string nodeTypeIcon(const GeneratorGraphNode &value);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -34,3 +34,4 @@ QVariant nodeGetValue(const GeneratorGraphNode &value);
 bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destionation, int destinationIndex);
 bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination, int destinationIndex);
 bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);
+QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -29,3 +29,5 @@ template <> struct GraphNodeContext<GeneratorGraphNode>
 std::string nodeName(const GeneratorGraphNode &value);
 std::string nodeTypeName(const GeneratorGraphNode &value);
 std::string nodeTypeIcon(const GeneratorGraphNode &value);
+void setNodeName(GeneratorGraphNode &value, std::string);
+QVariant nodeGetValue(const GeneratorGraphNode &value);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -26,4 +26,6 @@ template <> struct GraphNodeContext<GeneratorGraphNode>
     using type = CoreData *;
 };
 
-std::string nodeName(GeneratorGraphNode &value);
+std::string nodeName(const GeneratorGraphNode &value);
+std::string nodeTypeName(const GeneratorGraphNode &value);
+std::string nodeTypeIcon(const GeneratorGraphNode &value);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -28,7 +28,7 @@ QVariant nodeGetValue(const GeneratorGraphNode &value);
 bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destionation, int destinationIndex);
 bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination, int destinationIndex);
 bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);
-QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);
+QHash<int, QByteArray> &nodeRoleNames(Phantom<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles);
 bool nodeDelete(GeneratorGraphNode &item, CoreData *coreData);
 QVariant nodeData(const GeneratorGraphNode &item, int role);
 bool nodeSetData(GeneratorGraphNode &item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -3,8 +3,27 @@
 
 #pragma once
 
+#include <QVariant>
 #include "configuration.h"
 #include "generator.h"
 #include "generatorNode.h"
 
-// This file exists to easily include all of the templated methods for all of the types for the Node Graph
+// The variant of all of the types that we will examine
+using GeneratorGraphInnerType = std::variant<Configuration *, Generator *, GeneratorNode *>;
+
+// A class to contain the inner type, since we need a constructor that
+// take a QVariant
+class GeneratorGraphNode
+{
+    public:
+    GeneratorGraphNode(QVariant var = {});
+    GeneratorGraphInnerType value;
+};
+
+// All of these types may require access to CoreData
+template <> struct GraphNodeContext<GeneratorGraphNode>
+{
+    using type = CoreData *;
+};
+
+std::string nodeName(GeneratorGraphNode &value);

--- a/src/gui/models/nodeGraph/instances/all.h
+++ b/src/gui/models/nodeGraph/instances/all.h
@@ -31,3 +31,6 @@ std::string nodeTypeName(const GeneratorGraphNode &value);
 std::string nodeTypeIcon(const GeneratorGraphNode &value);
 void setNodeName(GeneratorGraphNode &value, std::string);
 QVariant nodeGetValue(const GeneratorGraphNode &value);
+bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destionation, int destinationIndex);
+bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination, int destinationIndex);
+bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex);

--- a/src/gui/models/nodeGraph/instances/configuration.cpp
+++ b/src/gui/models/nodeGraph/instances/configuration.cpp
@@ -13,7 +13,7 @@ template <> std::string nodeTypeIcon<Configuration *>(Configuration *const &valu
 }
 
 // The title of the node
-template <> std::string nodeName<Configuration *>(Configuration *const &value)
+std::string nodeName(Configuration *const &value)
 {
 
     if (!value)

--- a/src/gui/models/nodeGraph/instances/configuration.cpp
+++ b/src/gui/models/nodeGraph/instances/configuration.cpp
@@ -23,7 +23,7 @@ std::string nodeName(const Configuration *value)
 }
 
 // Get a specific piece of information from a node by index
-template <> QVariant nodeData(Configuration *const &value, int role)
+QVariant nodeData(const Configuration *value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     if (!value)
@@ -42,7 +42,7 @@ template <> QVariant nodeData(Configuration *const &value, int role)
 }
 
 // Set a specific piece of information from a node by index
-template <> bool nodeSetData(Configuration *&item, const QVariant &value, int role)
+bool nodeSetData(Configuration *item, const QVariant &value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     switch (role)

--- a/src/gui/models/nodeGraph/instances/configuration.cpp
+++ b/src/gui/models/nodeGraph/instances/configuration.cpp
@@ -4,16 +4,16 @@
 #include "gui/models/nodeGraph/nodeWrapper.h"
 
 // The name of the type (for delegate dispatch)
-std::string nodeTypeName(Configuration *const &value) { return "Configuration"; }
+std::string nodeTypeName(const Configuration *value) { return "Configuration"; }
 
 // The path to the icon for the node
-std::string nodeTypeIcon(Configuration *const &value)
+std::string nodeTypeIcon(const Configuration *value)
 {
     return "qrc:/Dissolve/icons/configuration.svg";
 }
 
 // The title of the node
-std::string nodeName(Configuration *const &value)
+std::string nodeName(const Configuration *value)
 {
 
     if (!value)
@@ -56,7 +56,7 @@ template <> bool nodeSetData(Configuration *&item, const QVariant &value, int ro
 }
 
 // Delete the node
-template <> bool nodeDelete(Configuration *&item, typename GraphNodeContext<Configuration *>::type &coreData)
+bool nodeDelete(Configuration *item, CoreData *coreData)
 {
     coreData->removeConfiguration(item);
     return true;

--- a/src/gui/models/nodeGraph/instances/configuration.cpp
+++ b/src/gui/models/nodeGraph/instances/configuration.cpp
@@ -7,10 +7,7 @@
 std::string nodeTypeName(const Configuration *value) { return "Configuration"; }
 
 // The path to the icon for the node
-std::string nodeTypeIcon(const Configuration *value)
-{
-    return "qrc:/Dissolve/icons/configuration.svg";
-}
+std::string nodeTypeIcon(const Configuration *value) { return "qrc:/Dissolve/icons/configuration.svg"; }
 
 // The title of the node
 std::string nodeName(const Configuration *value)

--- a/src/gui/models/nodeGraph/instances/configuration.cpp
+++ b/src/gui/models/nodeGraph/instances/configuration.cpp
@@ -4,10 +4,10 @@
 #include "gui/models/nodeGraph/nodeWrapper.h"
 
 // The name of the type (for delegate dispatch)
-template <> std::string nodeTypeName<Configuration *>(Configuration *const &value) { return "Configuration"; }
+std::string nodeTypeName(Configuration *const &value) { return "Configuration"; }
 
 // The path to the icon for the node
-template <> std::string nodeTypeIcon<Configuration *>(Configuration *const &value)
+std::string nodeTypeIcon(Configuration *const &value)
 {
     return "qrc:/Dissolve/icons/configuration.svg";
 }

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -14,3 +14,5 @@ template <> struct GraphNodeContext<Configuration *>
 };
 
 std::string nodeName(Configuration *const &value);
+std::string nodeTypeName(Configuration *const &value);
+std::string nodeTypeIcon(Configuration *const &value);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -21,3 +21,5 @@ bool nodeConnect(Configuration *source, int sourceIndex, Configuration *destinat
 bool nodeConnectable(const Configuration *source, int sourceIndex, const Configuration *destination, int destinationIndex);
 bool nodeDisconnect(Configuration *source, int sourceIndex, Configuration *destination, int destinationIndex);
 bool nodeDelete(Configuration *item, CoreData *coreData);
+QVariant nodeData(const Configuration *value, int role);
+bool nodeSetData(Configuration *item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -6,13 +6,6 @@
 #include "classes/configuration.h"
 #include "gui/models/nodeGraph/graphNodeContext.h"
 
-// Configurations need access to the CoreData to access all of their
-// children.
-template <> struct GraphNodeContext<Configuration *>
-{
-    using type = CoreData *;
-};
-
 std::string nodeName(const Configuration *value);
 std::string nodeTypeName(const Configuration *value);
 std::string nodeTypeIcon(const Configuration *value);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "classes/configuration.h"
-#include "gui/models/nodeGraph/graphNodeContext.h"
+#include "gui/models/nodeGraph/phantom.h"
 
 std::string nodeName(const Configuration *value);
 std::string nodeTypeName(const Configuration *value);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "classes/configuration.h"
-#include "gui/models/nodeGraph/nodeWrapper.h"
+#include "gui/models/nodeGraph/graphNodeContext.h"
 
 // Configurations need access to the CoreData to access all of their
 // children.
@@ -12,3 +12,5 @@ template <> struct GraphNodeContext<Configuration *>
 {
     using type = CoreData *;
 };
+
+std::string nodeName(Configuration *const &value);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -16,3 +16,7 @@ template <> struct GraphNodeContext<Configuration *>
 std::string nodeName(Configuration *const &value);
 std::string nodeTypeName(Configuration *const &value);
 std::string nodeTypeIcon(Configuration *const &value);
+
+bool nodeConnect(Configuration *&source, int sourceIndex, Configuration *&destionation, int destinationIndex);
+bool nodeConnectable(const Configuration *&source, int sourceIndex, const Configuration *&destination, int destinationIndex);
+bool nodeDisconnect(Configuration *&source, int sourceIndex, Configuration *&destination, int destinationIndex);

--- a/src/gui/models/nodeGraph/instances/configuration.h
+++ b/src/gui/models/nodeGraph/instances/configuration.h
@@ -13,10 +13,11 @@ template <> struct GraphNodeContext<Configuration *>
     using type = CoreData *;
 };
 
-std::string nodeName(Configuration *const &value);
-std::string nodeTypeName(Configuration *const &value);
-std::string nodeTypeIcon(Configuration *const &value);
+std::string nodeName(const Configuration *value);
+std::string nodeTypeName(const Configuration *value);
+std::string nodeTypeIcon(const Configuration *value);
 
-bool nodeConnect(Configuration *&source, int sourceIndex, Configuration *&destionation, int destinationIndex);
-bool nodeConnectable(const Configuration *&source, int sourceIndex, const Configuration *&destination, int destinationIndex);
-bool nodeDisconnect(Configuration *&source, int sourceIndex, Configuration *&destination, int destinationIndex);
+bool nodeConnect(Configuration *source, int sourceIndex, Configuration *destination, int destinationIndex);
+bool nodeConnectable(const Configuration *source, int sourceIndex, const Configuration *destination, int destinationIndex);
+bool nodeDisconnect(Configuration *source, int sourceIndex, Configuration *destination, int destinationIndex);
+bool nodeDelete(Configuration *item, CoreData *coreData);

--- a/src/gui/models/nodeGraph/instances/generator.cpp
+++ b/src/gui/models/nodeGraph/instances/generator.cpp
@@ -13,7 +13,7 @@ std::string nodeTypeIcon(Generator *const &value) { return "qrc:/Dissolve/icons/
 std::string nodeName(Generator *const &value) { return "Generator"; }
 
 // Get a specific piece of information from a node by index
-template <> QVariant nodeData(Generator *const &value, int role)
+QVariant nodeData(const Generator *value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     if (!value)
@@ -30,7 +30,7 @@ template <> QVariant nodeData(Generator *const &value, int role)
 }
 
 // Set a specific piece of information from a node by index
-template <> bool nodeSetData(Generator *&item, const QVariant &value, int role) { return false; }
+bool nodeSetData(Generator *item, const QVariant &value, int role) { return false; }
 
 // Delete the node
 bool nodeDelete(Generator *item, CoreData *coreData) { return false; }

--- a/src/gui/models/nodeGraph/instances/generator.cpp
+++ b/src/gui/models/nodeGraph/instances/generator.cpp
@@ -33,4 +33,4 @@ template <> QVariant nodeData(Generator *const &value, int role)
 template <> bool nodeSetData(Generator *&item, const QVariant &value, int role) { return false; }
 
 // Delete the node
-template <> bool nodeDelete(Generator *&item, typename GraphNodeContext<Generator *>::type &coreData) { return false; }
+bool nodeDelete(Generator *item, CoreData *coreData) { return false; }

--- a/src/gui/models/nodeGraph/instances/generator.cpp
+++ b/src/gui/models/nodeGraph/instances/generator.cpp
@@ -4,10 +4,10 @@
 #include "gui/models/nodeGraph/nodeWrapper.h"
 
 // The name of the type (for delegate dispatch)
-template <> std::string nodeTypeName<Generator *>(Generator *const &value) { return "Generator"; }
+std::string nodeTypeName(Generator *const &value) { return "Generator"; }
 
 // The path to the icon for the node
-template <> std::string nodeTypeIcon<Generator *>(Generator *const &value) { return "qrc:/Dissolve/icons/generator.svg"; }
+std::string nodeTypeIcon(Generator *const &value) { return "qrc:/Dissolve/icons/generator.svg"; }
 
 // The title of the node
 std::string nodeName(Generator *const &value) { return "Generator"; }

--- a/src/gui/models/nodeGraph/instances/generator.cpp
+++ b/src/gui/models/nodeGraph/instances/generator.cpp
@@ -10,7 +10,7 @@ template <> std::string nodeTypeName<Generator *>(Generator *const &value) { ret
 template <> std::string nodeTypeIcon<Generator *>(Generator *const &value) { return "qrc:/Dissolve/icons/generator.svg"; }
 
 // The title of the node
-template <> std::string nodeName<Generator *>(Generator *const &value) { return "Generator"; }
+std::string nodeName(Generator *const &value) { return "Generator"; }
 
 // Get a specific piece of information from a node by index
 template <> QVariant nodeData(Generator *const &value, int role)

--- a/src/gui/models/nodeGraph/instances/generator.cpp
+++ b/src/gui/models/nodeGraph/instances/generator.cpp
@@ -13,7 +13,7 @@ std::string nodeTypeIcon(Generator *const &value) { return "qrc:/Dissolve/icons/
 std::string nodeName(Generator *const &value) { return "Generator"; }
 
 // Get a specific piece of information from a node by index
-QVariant nodeData(const Generator *value, int role)
+QVariant nodeData(Generator *value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     if (!value)

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -14,3 +14,5 @@ template <> struct GraphNodeContext<Generator *>
 };
 
 std::string nodeName(Generator *const &value);
+std::string nodeTypeName(Generator *const &value);
+std::string nodeTypeIcon(Generator *const &value);

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -6,16 +6,9 @@
 #include "generator/generator.h"
 #include "gui/models/nodeGraph/graphNodeContext.h"
 
-// Generators need access to the CoreData to access all of their
-// children.
-template <> struct GraphNodeContext<Generator *>
-{
-    using type = CoreData *;
-};
-
 std::string nodeName(Generator *const &value);
 std::string nodeTypeName(Generator *const &value);
 std::string nodeTypeIcon(Generator *const &value);
 bool nodeDelete(Generator *item, CoreData *coreData);
-QVariant nodeData(const Generator *value, int role);
+QVariant nodeData(Generator *value, int role);
 bool nodeSetData(Generator *item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -17,3 +17,5 @@ std::string nodeName(Generator *const &value);
 std::string nodeTypeName(Generator *const &value);
 std::string nodeTypeIcon(Generator *const &value);
 bool nodeDelete(Generator *item, CoreData *coreData);
+QVariant nodeData(const Generator *value, int role);
+bool nodeSetData(Generator *item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "generator/generator.h"
-#include "gui/models/nodeGraph/graphNodeContext.h"
+#include "gui/models/nodeGraph/phantom.h"
 
 std::string nodeName(Generator *const &value);
 std::string nodeTypeName(Generator *const &value);

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include "generator/generator.h"
-#include "gui/models/nodeGraph/nodeWrapper.h"
+#include "gui/models/nodeGraph/graphNodeContext.h"
 
 // Generators need access to the CoreData to access all of their
 // children.
@@ -12,3 +12,5 @@ template <> struct GraphNodeContext<Generator *>
 {
     using type = CoreData *;
 };
+
+std::string nodeName(Generator *const &value);

--- a/src/gui/models/nodeGraph/instances/generator.h
+++ b/src/gui/models/nodeGraph/instances/generator.h
@@ -16,3 +16,4 @@ template <> struct GraphNodeContext<Generator *>
 std::string nodeName(Generator *const &value);
 std::string nodeTypeName(Generator *const &value);
 std::string nodeTypeIcon(Generator *const &value);
+bool nodeDelete(Generator *item, CoreData *coreData);

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -3,7 +3,7 @@
 #include "gui/models/nodeGraph/generatorGraphModel.h"
 
 // The value of the node
-template <> QVariant nodeGetValue<GeneratorGraphNode>(const GeneratorGraphNode value)
+QVariant nodeGetValue(const GeneratorGraphNode value)
 {
     return std::visit(
         [](auto *arg) -> QVariant
@@ -16,7 +16,7 @@ template <> QVariant nodeGetValue<GeneratorGraphNode>(const GeneratorGraphNode v
 }
 
 // The name of the type (for delegate dispatch)
-template <> std::string nodeTypeName<GeneratorGraphNode>(const GeneratorGraphNode &value)
+std::string nodeTypeName(const GeneratorGraphNode &value)
 {
     return std::visit(
         [](auto *arg) -> std::string
@@ -53,13 +53,13 @@ bool nodeDisconnect<GeneratorGraphNode>(GeneratorGraphNode &source, int sourceIn
 }
 
 // The path to the icon for the node
-template <> std::string nodeTypeIcon<GeneratorGraphNode>(const GeneratorGraphNode &value)
+std::string nodeTypeIcon(const GeneratorGraphNode &value)
 {
     return std::visit([](auto *arg) { return nodeTypeIcon(arg); }, value.value);
 }
 
 // The title of the node
-std::string nodeName(GeneratorGraphNode &value)
+std::string nodeName(const GeneratorGraphNode &value)
 {
     return std::visit([](auto *arg) { return nodeName(arg); }, value.value);
 }

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -29,25 +29,20 @@ std::string nodeTypeName(const GeneratorGraphNode &value)
 }
 
 // Link an indexed position on the source to an indexed position on the destination
-template <>
-bool nodeConnect<GeneratorGraphNode>(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination,
-                                     int destinationIndex)
+bool nodeConnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex)
 {
     return false;
 }
 
 // Confirm that a connection is possible (e.g. types match and index isn't already connected)
-template <>
-bool nodeConnectable<GeneratorGraphNode>(const GeneratorGraphNode &source, int sourceIndex,
-                                         const GeneratorGraphNode &destination, int destinationIndex)
+bool nodeConnectable(const GeneratorGraphNode &source, int sourceIndex, const GeneratorGraphNode &destination,
+                     int destinationIndex)
 {
     return false;
 }
 
 // Unlink an indexed position on the source to an indexed position on the destination
-template <>
-bool nodeDisconnect<GeneratorGraphNode>(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination,
-                                        int destinationIndex)
+bool nodeDisconnect(GeneratorGraphNode &source, int sourceIndex, GeneratorGraphNode &destination, int destinationIndex)
 {
     return true;
 }

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -59,7 +59,7 @@ template <> std::string nodeTypeIcon<GeneratorGraphNode>(const GeneratorGraphNod
 }
 
 // The title of the node
-template <> std::string nodeName<GeneratorGraphNode>(const GeneratorGraphNode &value)
+std::string nodeName(GeneratorGraphNode &value)
 {
     return std::visit([](auto *arg) { return nodeName(arg); }, value.value);
 }

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -65,7 +65,7 @@ std::string nodeName(const GeneratorGraphNode &value)
 }
 
 // Change the title of the node
-template <> void setNodeName<GeneratorGraphNode>(GeneratorGraphNode &value, const std::string name) {}
+void setNodeName(GeneratorGraphNode &value, const std::string name) {}
 
 // Set a specific piece of information from a node by index
 template <> bool nodeSetData<GeneratorGraphNode>(GeneratorGraphNode &item, const QVariant &value, int role)

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -77,7 +77,7 @@ template <> QVariant nodeData(const GeneratorGraphNode &item, int role)
 }
 
 // Append the roles for the type onto the QHash
-template <> QHash<int, QByteArray> &nodeRoleNames<GeneratorGraphNode>(QHash<int, QByteArray> &roles)
+QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles)
 {
     auto base = Qt::UserRole + GraphNodeModelBase::ownedRoles;
     using names = GeneratorGraphModel::PropertyIndex;

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -77,7 +77,7 @@ QVariant nodeData(const GeneratorGraphNode &item, int role)
 }
 
 // Append the roles for the type onto the QHash
-QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles)
+QHash<int, QByteArray> &nodeRoleNames(Phantom<GeneratorGraphNode> proxy, QHash<int, QByteArray> &roles)
 {
     auto base = Qt::UserRole + GraphNodeModelBase::ownedRoles;
     using names = GeneratorGraphModel::PropertyIndex;

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -89,8 +89,7 @@ QHash<int, QByteArray> &nodeRoleNames(Proxy<GeneratorGraphNode> proxy, QHash<int
 }
 
 // Delete the node
-template <>
-bool nodeDelete<GeneratorGraphNode>(GeneratorGraphNode &item, typename GraphNodeContext<GeneratorGraphNode>::type &coreData)
+bool nodeDelete(GeneratorGraphNode &item, CoreData *coreData)
 {
     return std::visit([&](auto *arg) -> bool { return nodeDelete(arg, coreData); }, item.value);
 }

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.cpp
@@ -63,14 +63,14 @@ std::string nodeName(const GeneratorGraphNode &value)
 void setNodeName(GeneratorGraphNode &value, const std::string name) {}
 
 // Set a specific piece of information from a node by index
-template <> bool nodeSetData<GeneratorGraphNode>(GeneratorGraphNode &item, const QVariant &value, int role)
+bool nodeSetData(GeneratorGraphNode &item, const QVariant &value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     return std::visit([&value, role](auto *arg) { return nodeSetData(arg, value, role); }, item.value);
 }
 
 // Get a specific piece of information from a node by index
-template <> QVariant nodeData(const GeneratorGraphNode &item, int role)
+QVariant nodeData(const GeneratorGraphNode &item, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     return std::visit([role](auto *arg) -> QVariant { return nodeData(arg, role); }, item.value);

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/instances/generatorGraphNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorGraphNode.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024 Team Dissolve and contributors
 
-#include "gui/models/nodeGraph/generatorGraphModel.h"
-#include "gui/models/nodeGraph/nodeWrapper.h"
-
 #pragma once
+
+#include "gui/models/nodeGraph/generatorGraphModel.h"

--- a/src/gui/models/nodeGraph/instances/generatorNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorNode.cpp
@@ -53,7 +53,7 @@ template <> QVariant nodeData(GeneratorNode *const &value, int role)
 template <> bool nodeSetData(GeneratorNode *&item, const QVariant &value, int role) { return false; }
 
 // Delete the node
-template <> bool nodeDelete(GeneratorNode *&item, typename GraphNodeContext<GeneratorNode *>::type &coreData)
+bool nodeDelete(GeneratorNode *item, CoreData *coreData)
 {
     for (auto &conf : coreData->configurations())
     {

--- a/src/gui/models/nodeGraph/instances/generatorNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorNode.cpp
@@ -6,10 +6,10 @@
 #include "keywords/nodeValue.h"
 
 // The name of the type (for delegate dispatch)
-template <> std::string nodeTypeName<GeneratorNode *>(GeneratorNode *const &value) { return "GeneratorNode"; }
+std::string nodeTypeName(GeneratorNode *const &value) { return "GeneratorNode"; }
 
 // The path to the icon for the node
-template <> std::string nodeTypeIcon<GeneratorNode *>(GeneratorNode *const &value)
+std::string nodeTypeIcon(GeneratorNode *const &value)
 {
     auto name = GeneratorNode::nodeTypes().keyword(value->type());
     return "qrc:/Dissolve/icons/nodes/" + name + ".svg";

--- a/src/gui/models/nodeGraph/instances/generatorNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorNode.cpp
@@ -23,7 +23,7 @@ std::string nodeName(GeneratorNode *const &value)
 }
 
 // Get a specific piece of information from a node by index
-template <> QVariant nodeData(GeneratorNode *const &value, int role)
+QVariant nodeData(const GeneratorNode *value, int role)
 {
     using names = GeneratorGraphModel::PropertyIndex;
     if (!value)
@@ -50,7 +50,7 @@ template <> QVariant nodeData(GeneratorNode *const &value, int role)
 }
 
 // Set a specific piece of information from a node by index
-template <> bool nodeSetData(GeneratorNode *&item, const QVariant &value, int role) { return false; }
+bool nodeSetData(GeneratorNode *item, const QVariant &value, int role) { return false; }
 
 // Delete the node
 bool nodeDelete(GeneratorNode *item, CoreData *coreData)

--- a/src/gui/models/nodeGraph/instances/generatorNode.cpp
+++ b/src/gui/models/nodeGraph/instances/generatorNode.cpp
@@ -16,7 +16,7 @@ template <> std::string nodeTypeIcon<GeneratorNode *>(GeneratorNode *const &valu
 }
 
 // The title of the node
-template <> std::string nodeName<GeneratorNode *>(GeneratorNode *const &value)
+std::string nodeName(GeneratorNode *const &value)
 {
     std::string result = {value->name().begin(), value->name().end()};
     return result;

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -3,7 +3,11 @@
 
 #pragma once
 
-#include "gui/models/nodeGraph/generatorGraphModel.h"
+#include "gui/models/nodeGraph/graphNodeContext.h"
+#include "classes/coreData.h"
+
+class GeneratorNode;
+
 
 // GeneratorNodes need access to the CoreData to access all of their
 // children.
@@ -11,3 +15,5 @@ template <> struct GraphNodeContext<GeneratorNode *>
 {
     using type = CoreData *;
 };
+
+std::string nodeName(GeneratorNode *const &value);

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -19,3 +19,5 @@ template <> struct GraphNodeContext<GeneratorNode *>
 std::string nodeName(GeneratorNode *const &value);
 std::string nodeTypeName(GeneratorNode *const &value);
 std::string nodeTypeIcon(GeneratorNode *const &value);
+
+bool nodeDelete(GeneratorNode *item, CoreData *coreData);

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -17,3 +17,5 @@ template <> struct GraphNodeContext<GeneratorNode *>
 };
 
 std::string nodeName(GeneratorNode *const &value);
+std::string nodeTypeName(GeneratorNode *const &value);
+std::string nodeTypeIcon(GeneratorNode *const &value);

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-#include <QVariant>
-#include "gui/models/nodeGraph/phantom.h"
 #include "classes/coreData.h"
+#include "gui/models/nodeGraph/phantom.h"
+#include <QVariant>
 
 class GeneratorNode;
 

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -9,14 +9,6 @@
 
 class GeneratorNode;
 
-
-// GeneratorNodes need access to the CoreData to access all of their
-// children.
-template <> struct GraphNodeContext<GeneratorNode *>
-{
-    using type = CoreData *;
-};
-
 std::string nodeName(GeneratorNode *const &value);
 std::string nodeTypeName(GeneratorNode *const &value);
 std::string nodeTypeIcon(GeneratorNode *const &value);

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <QVariant>
 #include "gui/models/nodeGraph/graphNodeContext.h"
 #include "classes/coreData.h"
 
@@ -19,5 +20,6 @@ template <> struct GraphNodeContext<GeneratorNode *>
 std::string nodeName(GeneratorNode *const &value);
 std::string nodeTypeName(GeneratorNode *const &value);
 std::string nodeTypeIcon(GeneratorNode *const &value);
-
 bool nodeDelete(GeneratorNode *item, CoreData *coreData);
+QVariant nodeData(const GeneratorNode *value, int role);
+bool nodeSetData(GeneratorNode *item, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/instances/generatorNode.h
+++ b/src/gui/models/nodeGraph/instances/generatorNode.h
@@ -4,7 +4,7 @@
 #pragma once
 
 #include <QVariant>
-#include "gui/models/nodeGraph/graphNodeContext.h"
+#include "gui/models/nodeGraph/phantom.h"
 #include "classes/coreData.h"
 
 class GeneratorNode;

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -32,7 +32,7 @@
 
 template <typename T, typename Context>
 concept Graphable = requires(T a, Context context, const std::string name, T b, int sourceIndex, int destinationIndex,
-                             Proxy<T> proxy, QHash<int, QByteArray> &baseHash, int role, QVariant value) {
+                             Phantom<T> proxy, QHash<int, QByteArray> &baseHash, int role, QVariant value) {
     {
         nodeDelete(a, context)
     } -> std::same_as<bool>;

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -27,13 +27,15 @@
    suddenly become a dependency of the command line code.
  **/
 
-// Append the roles for the type onto the QHash
-template <typename T> QHash<int, QByteArray> &nodeRoleNames(QHash<int, QByteArray> &base);
 // Delete the node
 template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
 
 template <typename T>
-concept Graphable = requires(T a, const std::string name, T b, int sourceIndex, int destinationIndex) {
+concept Graphable = requires(T a, const std::string name, T b, int sourceIndex, int destinationIndex, Proxy<T> proxy,
+                             QHash<int, QByteArray> &baseHash) {
+    {
+        nodeRoleNames(proxy, baseHash)
+    } -> std::same_as<QHash<int, QByteArray> &>;
     {
         nodeName(a)
     } -> std::same_as<std::string>;

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -3,10 +3,10 @@
 
 #pragma once
 
+#include "gui/models/nodeGraph/instances/all.h"
 #include <QAbstractListModel>
 #include <concepts>
 #include <variant>
-#include "gui/models/nodeGraph/instances/all.h"
 
 /**
    This file contains a series of templates that need to be overloaded
@@ -29,24 +29,35 @@
 
 // Append the roles for the type onto the QHash
 template <typename T> QHash<int, QByteArray> &nodeRoleNames(QHash<int, QByteArray> &base);
-// The path to the icon for the node
-template <typename T> std::string nodeTypeIcon(const T &value);
 // Delete the node
 template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
-// Link an indexed position on the source to an indexed position on the destination
-template <typename T> bool nodeConnect(T &source, int sourceIndex, T &destination, int destinationIndex);
-// Confirm that a connection is possible (e.g. types match and index isn't already connected)
-template <typename T> bool nodeConnectable(const T &source, int sourceIndex, const T &destination, int destinationIndex);
-// Unlink an indexed position on the source to an indexed position on the destination
-template <typename T> bool nodeDisconnect(T &source, int sourceIndex, T &destination, int destinationIndex);
 
 template <typename T>
-concept Graphable = requires(T a, const std::string name) {
-  { nodeName(a) } -> std::same_as<std::string>;
-  { nodeTypeName(a) } -> std::same_as<std::string>;
-  { nodeTypeIcon(a) } -> std::same_as<std::string>;
-  { setNodeName(a, name) };
-  { nodeGetValue(a) } -> std::same_as<QVariant>;
+concept Graphable = requires(T a, const std::string name, T b, int sourceIndex, int destinationIndex) {
+    {
+        nodeName(a)
+    } -> std::same_as<std::string>;
+    {
+        nodeTypeName(a)
+    } -> std::same_as<std::string>;
+    {
+        nodeTypeIcon(a)
+    } -> std::same_as<std::string>;
+    {
+        setNodeName(a, name)
+    };
+    {
+        nodeGetValue(a)
+    } -> std::same_as<QVariant>;
+    {
+        nodeConnect(a, sourceIndex, b, destinationIndex)
+    } -> std::same_as<bool>;
+    {
+        nodeConnectable(a, sourceIndex, b, destinationIndex)
+    } -> std::same_as<bool>;
+    {
+        nodeDisconnect(a, sourceIndex, b, destinationIndex)
+    } -> std::same_as<bool>;
 };
 
 // A wrapper with supplemental information for a node

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -32,7 +32,7 @@
 
 template <typename T, typename Context>
 concept Graphable = requires(T a, Context context, const std::string name, T b, int sourceIndex, int destinationIndex,
-                             Proxy<T> proxy, QHash<int, QByteArray> &baseHash) {
+                             Proxy<T> proxy, QHash<int, QByteArray> &baseHash, int role, QVariant value) {
     {
         nodeDelete(a, context)
     } -> std::same_as<bool>;
@@ -63,6 +63,12 @@ concept Graphable = requires(T a, Context context, const std::string name, T b, 
     {
         nodeDisconnect(a, sourceIndex, b, destinationIndex)
     } -> std::same_as<bool>;
+    {
+        nodeData(a, role)
+    } -> std::convertible_to<QVariant>;
+    {
+        nodeSetData(a, value, role)
+    } -> std::convertible_to<bool>;
 };
 
 // A wrapper with supplemental information for a node
@@ -86,9 +92,3 @@ class NodeWrapper
     // The actual value of the node
     T value_;
 };
-
-// Get a specific piece of information from a node by index
-template <typename T> QVariant nodeData(const T &, int role);
-
-// Set a specific piece of information from a node by index
-template <typename T> bool nodeSetData(T &, const QVariant &value, int role);

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -9,10 +9,12 @@
 #include <variant>
 
 /**
-   This file contains a series of templates that need to be overloaded
-   to allow a type to be displayed as a node.  This is essentially a
-   C++ Concept, but without all the compiler checks and niceties that
-   we will get with C++20.
+   This file contains a C++20 concept which defines whether a type can
+   be shown as a graph.  Any type T which contains implementations for
+   all of the functions listed below can be displayed in a graph.  A
+   second template parameter Context was also necessary to implement
+   deletion as most nodes would need to know *where* they were being
+   deleted from.
 
    A concept was chosen over class methods because:
 
@@ -25,10 +27,13 @@
    part of the class even in the command line version.  As some of the
    methods require Qt types (e.g. QHash, QVariant), then Qt would
    suddenly become a dependency of the command line code.
- **/
 
-// Delete the node
-// template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
+   This code is a direct conversion of the template code that came
+   before.  Truth be told, the connection functions should likely be
+   split out into a separate Concept (allowing us to check for
+   connection correctness as compile time), but that is outside of the
+   scope of this PR.
+ **/
 
 template <typename T, typename Context>
 concept Graphable = requires(T a, Context context, const std::string name, T b, int sourceIndex, int destinationIndex,

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -28,11 +28,14 @@
  **/
 
 // Delete the node
-template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
+// template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
 
-template <typename T>
-concept Graphable = requires(T a, const std::string name, T b, int sourceIndex, int destinationIndex, Proxy<T> proxy,
-                             QHash<int, QByteArray> &baseHash) {
+template <typename T, typename Context>
+concept Graphable = requires(T a, Context context, const std::string name, T b, int sourceIndex, int destinationIndex,
+                             Proxy<T> proxy, QHash<int, QByteArray> &baseHash) {
+    {
+        nodeDelete(a, context)
+    } -> std::same_as<bool>;
     {
         nodeRoleNames(proxy, baseHash)
     } -> std::same_as<QHash<int, QByteArray> &>;
@@ -63,7 +66,9 @@ concept Graphable = requires(T a, const std::string name, T b, int sourceIndex, 
 };
 
 // A wrapper with supplemental information for a node
-template <Graphable T> class NodeWrapper
+template <typename T, typename Context>
+    requires Graphable<T, Context>
+class NodeWrapper
 {
     public:
     NodeWrapper(QVariant value) : value_(value) {}

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -29,8 +29,6 @@
 
 // Append the roles for the type onto the QHash
 template <typename T> QHash<int, QByteArray> &nodeRoleNames(QHash<int, QByteArray> &base);
-// The name of the type (for delegate dispatch)
-template <typename T> std::string nodeTypeName(const T &value);
 // The path to the icon for the node
 template <typename T> std::string nodeTypeIcon(const T &value);
 // Delete the node
@@ -49,6 +47,8 @@ template <typename T> bool nodeDisconnect(T &source, int sourceIndex, T &destina
 template <typename T>
 concept Graphable = requires(T a) {
   { nodeName(a) } -> std::same_as<std::string>;
+  { nodeTypeName(a) } -> std::same_as<std::string>;
+  { nodeTypeIcon(a) } -> std::same_as<std::string>;
 };
 
 // A wrapper with supplemental information for a node

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -4,7 +4,9 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <concepts>
 #include <variant>
+#include "gui/models/nodeGraph/instances/all.h"
 
 /**
    This file contains a series of templates that need to be overloaded
@@ -25,13 +27,6 @@
    suddenly become a dependency of the command line code.
  **/
 
-// A template that we can specialise to associate a a context type
-// with a type.
-template <typename T> struct GraphNodeContext
-{
-    using type = GraphNodeContext<void>;
-};
-
 // Append the roles for the type onto the QHash
 template <typename T> QHash<int, QByteArray> &nodeRoleNames(QHash<int, QByteArray> &base);
 // The name of the type (for delegate dispatch)
@@ -40,8 +35,6 @@ template <typename T> std::string nodeTypeName(const T &value);
 template <typename T> std::string nodeTypeIcon(const T &value);
 // Delete the node
 template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
-// The title of the node
-template <typename T> std::string nodeName(const T &value);
 // Change the title of the node
 template <typename T> void setNodeName(T &value, const std::string);
 // The value of the node
@@ -53,8 +46,13 @@ template <typename T> bool nodeConnectable(const T &source, int sourceIndex, con
 // Unlink an indexed position on the source to an indexed position on the destination
 template <typename T> bool nodeDisconnect(T &source, int sourceIndex, T &destination, int destinationIndex);
 
+template <typename T>
+concept Graphable = requires(T a) {
+  { nodeName(a) } -> std::same_as<std::string>;
+};
+
 // A wrapper with supplemental information for a node
-template <typename T> class NodeWrapper
+template <Graphable T> class NodeWrapper
 {
     public:
     NodeWrapper(QVariant value) : value_(value) {}

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -33,10 +33,6 @@ template <typename T> QHash<int, QByteArray> &nodeRoleNames(QHash<int, QByteArra
 template <typename T> std::string nodeTypeIcon(const T &value);
 // Delete the node
 template <typename T> bool nodeDelete(T &value, typename GraphNodeContext<T>::type &context);
-// Change the title of the node
-template <typename T> void setNodeName(T &value, const std::string);
-// The value of the node
-template <typename T> QVariant nodeGetValue(const T value);
 // Link an indexed position on the source to an indexed position on the destination
 template <typename T> bool nodeConnect(T &source, int sourceIndex, T &destination, int destinationIndex);
 // Confirm that a connection is possible (e.g. types match and index isn't already connected)
@@ -45,10 +41,12 @@ template <typename T> bool nodeConnectable(const T &source, int sourceIndex, con
 template <typename T> bool nodeDisconnect(T &source, int sourceIndex, T &destination, int destinationIndex);
 
 template <typename T>
-concept Graphable = requires(T a) {
+concept Graphable = requires(T a, const std::string name) {
   { nodeName(a) } -> std::same_as<std::string>;
   { nodeTypeName(a) } -> std::same_as<std::string>;
   { nodeTypeIcon(a) } -> std::same_as<std::string>;
+  { setNodeName(a, name) };
+  { nodeGetValue(a) } -> std::same_as<QVariant>;
 };
 
 // A wrapper with supplemental information for a node

--- a/src/gui/models/nodeGraph/phantom.h
+++ b/src/gui/models/nodeGraph/phantom.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 

--- a/src/gui/models/nodeGraph/phantom.h
+++ b/src/gui/models/nodeGraph/phantom.h
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Team Dissolve and contributors
+
+#pragma once
+
+/*
+
+  The Phantom type is a compile time marker of zero size that allows
+  the passing of type info to a function.  For example, you could have
+  the `getBits` function with overloads.
+
+  >>>
+    int getBits(Phantom<char> phantom) { return 8; }
+    int getBits(Phantom<double> phantom) { return 64; }
+  <<<
+
+  Now, there's two other ways that this could have been written
+
+  >>>
+    int getBits(char phantom) { return 8; }
+    int getBits(double phantom) { return 64; }
+  <<<
+
+  While this works well for our trivial example, imagine that we had a
+  type with an expensive constructor.  If the information is purely
+  related to the type, there's no need to instantiate a copy of it to
+  determine what we already know.
+
+  The other solution would be to use a function template
+
+  >>>
+    template <typename T> int getBits();
+    template <> int getBits<char> { return 8; }
+    template <> int getBits<double> { return 64; }
+  <<<
+
+  This works up until the moment that we have a type for which
+  `getBits` is undefined.  We would not implement the template
+  overload for that type, but attempts to call that function would
+  return an odd linker error.  After all, we *have* provided a
+  function header that declares that `getBits` is defined for *all*
+  types T.
+
+  Using Phantom types, we can still get the overloads at compile time,
+  but we're only producing headers for explicitly the types that we
+  want to support.
+
+ */
+template <typename T> struct Phantom
+{
+};

--- a/src/gui/qml/nodeGraph/ExampleDelegate.qml
+++ b/src/gui/qml/nodeGraph/ExampleDelegate.qml
@@ -26,6 +26,7 @@ Item {
 
                 Text {
                     id: root
+
                     anchors.fill: parent
                     height: contentHeight
                     text: value
@@ -52,6 +53,7 @@ Item {
 
                 Text {
                     id: root
+
                     anchors.fill: parent
                     color: value != null ? "black" : "red"
                     height: contentHeight
@@ -76,16 +78,19 @@ Item {
 
                 ColumnLayout {
                     id: root
+
                     anchors.fill: parent
 
                     Text {
                         id: xnode
+
                         height: contentHeight
                         text: "X: " + px
                         width: contentWidth
                     }
                     Text {
                         id: ynode
+
                         height: contentHeight
                         text: "Y: " + py
                         width: contentWidth

--- a/src/gui/qml/nodeGraph/GeneratorDelegate.qml
+++ b/src/gui/qml/nodeGraph/GeneratorDelegate.qml
@@ -33,6 +33,7 @@ Item {
                     }
                     TextField {
                         id: root
+
                         text: temperature
                     }
                     Text {
@@ -67,6 +68,7 @@ Item {
 
                     Text {
                         id: root
+
                         text: name
                     }
                     Text {
@@ -98,6 +100,7 @@ Item {
 
                     Text {
                         id: root
+
                         text: "name"
                     }
                 }
@@ -122,6 +125,7 @@ Item {
 
                 Text {
                     id: root
+
                     anchors.fill: parent
                     color: value != null ? "black" : "red"
                     height: contentHeight
@@ -146,16 +150,19 @@ Item {
 
                 ColumnLayout {
                     id: root
+
                     anchors.fill: parent
 
                     Text {
                         id: xnode
+
                         height: contentHeight
                         text: "X: " + px
                         width: contentWidth
                     }
                     Text {
                         id: ynode
+
                         height: contentHeight
                         text: "Y: " + py
                         width: contentWidth

--- a/src/gui/qml/nodeGraph/GraphView.qml
+++ b/src/gui/qml/nodeGraph/GraphView.qml
@@ -6,12 +6,13 @@ import Qt.labs.qmlmodels
 
 Pane {
     id: graphRoot
+
     property double curveOffset: 125
     property variant delegate
     property variant edgeModel
+    property var nameLookup: ({})
     property variant nodeModel
     property variant rootModel
-    property var nameLookup: ({})
 
     // Edge connections
     Repeater {
@@ -44,9 +45,11 @@ Pane {
     // Actual nodes
     Repeater {
         id: nodeRepeater
+
         delegate: graphRoot.delegate
         model: nodeModel
-        onItemAdded: function(index, item) {
+
+        onItemAdded: function (index, item) {
             nameLookup[item.nodeType] = index;
         }
     }

--- a/src/gui/qml/nodeGraph/NodeBox.qml
+++ b/src/gui/qml/nodeGraph/NodeBox.qml
@@ -5,6 +5,7 @@ import Qt.labs.qmlmodels
 
 GroupBox {
     id: root
+
     property double basey: header.height
     property string image
     property string nodeType
@@ -15,6 +16,7 @@ GroupBox {
 
     label: RowLayout {
         id: header
+
         Image {
             clip: true
             fillMode: Image.PreserveAspectFit
@@ -24,24 +26,25 @@ GroupBox {
         }
         TextField {
             id: titleLabel
+
             font.pointSize: 14
             text: root.nodeType
         }
         Button {
-            onClicked: root.deleted()
-
             contentItem: Image {
                 fillMode: Image.PreserveAspectFit
                 source: "qrc:/Dissolve/icons/cross.svg"
                 sourceSize.height: titleLabel.height
                 sourceSize.width: titleLabel.height
             }
+
+            onClicked: root.deleted()
         }
         DragHandler {
             target: null
 
-            xAxis.onActiveValueChanged: delta => posX += delta;
-            yAxis.onActiveValueChanged: delta => posY += delta;
+            xAxis.onActiveValueChanged: delta => posX += delta
+            yAxis.onActiveValueChanged: delta => posY += delta
         }
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ function(dissolve_add_test)
     target_include_directories(${TEST_NAME} PRIVATE ${Qt6Widgets_INCLUDE_DIRS})
     target_link_libraries(
       ${TEST_NAME}
-      PUBLIC keywordWidgets models widgets render delegates
+      PUBLIC keywordWidgets models widgets render delegates nodeGraphModel
       PRIVATE Qt6::Core Qt6::Widgets
     )
   endif(DISSOLVE_UNIT_TEST_GUI)

--- a/tests/gui/graphModel.cpp
+++ b/tests/gui/graphModel.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "gui/models/dissolveModel.h"
 #include "gui/models/nodeGraph/exampleGraphModel.h"


### PR DESCRIPTION
# This PR merges into GraphViewModules and *not* develop

I'm mostly posting this PR to ensure that the rest of the team will be comfortable with the use of concepts in the module graphs.  One of the biggest changes that comes out of all of this is that several templated functions have been turned into regular, overloaded functions.  It also ensures at compile time that a type is capable of being displayed as a graph.  This check was previously performed at link time with complaints about missing implementations of template functions.

The most interesting files to look at are:

- [src/gui/models/nodeGraph/nodeWrapper.h](https://github.com/disorderedmaterials/dissolve/compare/GraphViewModules...NodeConcept?expand=1#diff-02460a0ca5be38eec6fe68eaf1d8168edc11c2f8c8fc614233be0660ceaa82cd) This is where the concept is defined
- [src/gui/models/nodeGraph/phantom.h](https://github.com/disorderedmaterials/dissolve/compare/GraphViewModules...NodeConcept?expand=1#diff-6a40a72aa2c1cf89d81196b969db7dba99f3d8cfaaa407462502e1a0cd577b11) An implementation of phantom types to allow `nodeRoleNames` to work without being a template function, despite not being passed an instance of the type