### PR TITLE
fix: hugoVersion not passed from top-level workflows

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -45,6 +45,7 @@ jobs:
       publishType: 'continuous'
       displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
       displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 
   Publish:

--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -33,6 +33,7 @@ jobs:
       publishType: 'release'
       displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
       displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 
   Publish:

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -27,6 +27,7 @@ jobs:
       publishType: 'legacy'
       displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
       displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 
   Publish:


### PR DESCRIPTION
Fix round 1 following #2028. This is destined for a quick merge without waiting for CI to complete.