### PR TITLE
fix: Missed copyright years in new files.

### DIFF
--- a/src/classes/potentialSet.cpp
+++ b/src/classes/potentialSet.cpp
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #include "classes/potentialSet.h"
 #include "base/lineParser.h"

--- a/src/classes/potentialSet.h
+++ b/src/classes/potentialSet.h
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2024 Team Dissolve and contributors
+// Copyright (c) 2025 Team Dissolve and contributors
 
 #pragma once
 


### PR DESCRIPTION
Just a couple of years missed in the new classes added in a recent merge.