### PR TITLE
chore: Disable energy benchmark

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,7 +31,7 @@ jobs:
     needs: [Checkout]
     uses: "./.github/workflows/_build_and_package.yml"
     with:
-      benchmark: false
+      benchmark: true
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}

--- a/benchmark/modules/CMakeLists.txt
+++ b/benchmark/modules/CMakeLists.txt
@@ -1,5 +1,5 @@
 dissolve_add_benchmark(SRC angle.cpp)
-dissolve_add_benchmark(SRC energy.cpp)
+# dissolve_add_benchmark(SRC energy.cpp)
 dissolve_add_benchmark(SRC forces.cpp)
 dissolve_add_benchmark(SRC gr.cpp)
 dissolve_add_benchmark(SRC siteRDF.cpp)


### PR DESCRIPTION
This should disable the energy benchmark and hopefully allow the rest to run.