### PR TITLE
build: Fix publishing of benchmark results in new CI

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -128,7 +128,7 @@ runs:
       git reset HEAD --hard
 
   - name: Store benchmark result
-    uses: rhysd/github-action-benchmark@v1
+    uses: benchmark-action/github-action-benchmark@v1
     if: inputs.publishBenchmarks == 'true' && inputs.benchmark == 'true'
     with:
       tool: 'googlecpp'

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -124,6 +124,9 @@ runs:
 
       cat all_benchmark_results.json
 
+      # Must reset to HEAD here otherwise the benchmark publishing step will (rightly) fail
+      git reset HEAD --hard
+
   - name: Store benchmark result
     uses: rhysd/github-action-benchmark@v1
     if: inputs.publishBenchmarks == 'true' && inputs.benchmark == 'true'


### PR DESCRIPTION
A quick PR to fix the pushing of benchmark results to our GH pages, which failed because `_checkout.yml` had modified some files and git refused (correctly) to clobber them.