### PR TITLE
build: Enable cppCheck tests on ci

### DIFF
--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -81,4 +81,6 @@ runs:
     shell: bash
     run: |
       set -ex
-      nix develop --command scripts/cppCheckTest.sh 0 1
+      MAX_ERRORS=0
+      MAX_WARNINGS=1
+      nix develop --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -83,4 +83,4 @@ runs:
       set -ex
       MAX_ERRORS=2
       MAX_WARNINGS=1
-      nix develop --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS
+      nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -83,10 +83,4 @@ runs:
       set -ex
       MAX_ERRORS=2
       MAX_WARNINGS=1
-      if nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS; then
-          true
-      else
-          cat check.log
-          echo "Expected onl $MAX_ERRORS errors and $MAX_WARNINGS warnings"
-          false
-      fi
+      nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -76,3 +76,9 @@ runs:
       git diff
       # Run quiet diff to fail the job if any changes were made (see man git-diff)
       git diff --quiet
+
+  - name: Cpp Check
+    shell: bash
+    run: |
+      set -ex
+      nix develop --command scripts/cppCheckTest.sh 0 1

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -81,6 +81,6 @@ runs:
     shell: bash
     run: |
       set -ex
-      MAX_ERRORS=0
+      MAX_ERRORS=2
       MAX_WARNINGS=1
       nix develop --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -83,4 +83,10 @@ runs:
       set -ex
       MAX_ERRORS=2
       MAX_WARNINGS=1
-      nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS
+      if nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS; then
+          true
+      else
+          cat check.log
+          echo "Expected onl $MAX_ERRORS errors and $MAX_WARNINGS warnings"
+          false
+      fi

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -81,6 +81,6 @@ runs:
     shell: bash
     run: |
       set -ex
-      MAX_ERRORS=2
+      MAX_ERRORS=3
       MAX_WARNINGS=1
       nix develop -L --command scripts/cppCheckTest.sh $MAX_ERRORS $MAX_WARNINGS

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,7 @@
               cmake-format
               cmake-language-server
               conan
+              cppcheck
               direnv
               gdb
               gtk3

--- a/scripts/cppCheckTest.sh
+++ b/scripts/cppCheckTest.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+set -e
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 MAX_ERRORS MAX_WARNINGS" >&2
+    exit 1
+fi
+
+MAX_ERRORS=$1
+MAX_WARNINGS=$2
+
+cppcheck --check-level=exhaustive src 2> check.log
+ERRORS=$( cat check.log | grep -c "error:" )
+WARNINGS=$( cat check.log | grep -c "warning:" )
+
+if [ "$ERRORS" -gt "$MAX_ERRORS" ]; then
+    cat check.log
+    echo "Wanted $MAX_ERRORS errors, but found $ERRORS"
+    false
+else
+
+    if [ "$WARNINGS" -gt "$MAX_WARNINGS" ]; then
+        cat check.log
+        echo "Wanted $MAX_WARNINGS warnings, but found $WARNINGS"
+        false
+    fi
+fi

--- a/scripts/cppCheckTest.sh
+++ b/scripts/cppCheckTest.sh
@@ -10,7 +10,7 @@ fi
 MAX_ERRORS=$1
 MAX_WARNINGS=$2
 
-cppcheck --check-level=exhaustive src 2> check.log
+cppcheck --check-level=exhaustive src 2> check.log || true
 ERRORS=$( cat check.log | grep -c "error:" )
 WARNINGS=$( cat check.log | grep -c "warning:" )
 

--- a/scripts/cppCheckTest.sh
+++ b/scripts/cppCheckTest.sh
@@ -10,7 +10,9 @@ fi
 MAX_ERRORS=$1
 MAX_WARNINGS=$2
 
+# Use or true because the script should continue even if cppcheck fails
 cppcheck --check-level=exhaustive src 2> check.log || true
+
 ERRORS=$( cat check.log | grep -c "error:" )
 WARNINGS=$( cat check.log | grep -c "warning:" )
 

--- a/src/classes/partialSet.cpp
+++ b/src/classes/partialSet.cpp
@@ -119,9 +119,9 @@ void PartialSet::reset()
         ParallelPolicies::par, 0, atomTypeMix_.nItems(),
         [&](int i, int j)
         {
-            std::fill(partials_[{i, j}].values().begin(), partials_[{i, j}].values().end(), 0.0);
-            std::fill(boundPartials_[{i, j}].values().begin(), boundPartials_[{i, j}].values().end(), 0.0);
-            std::fill(unboundPartials_[{i, j}].values().begin(), unboundPartials_[{i, j}].values().end(), 0.0);
+            std::ranges::fill(partials_[{i, j}].values(), 0.0);
+            std::ranges::fill(boundPartials_[{i, j}].values(), 0.0);
+            std::ranges::fill(unboundPartials_[{i, j}].values(), 0.0);
             emptyBoundPartials_[{i, j}] = true;
         },
         half_);

--- a/src/data/sginfo/sgsi.c
+++ b/src/data/sginfo/sgsi.c
@@ -5,10 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef APP_INCLUDE
-#include APP_INCLUDE
-#endif
-
 #ifndef AppMalloc
 #define AppMalloc(ptr, n) (ptr) = malloc((n) * sizeof(*(ptr)))
 #endif

--- a/src/gui/addConfigurationDialog.cpp
+++ b/src/gui/addConfigurationDialog.cpp
@@ -188,6 +188,8 @@ void AddConfigurationDialog::finalise()
 
         // Add a GeneralRegion node
         regionNode = generator.createRootNode<GeneralRegionGeneratorNode>({});
+        if (!regionNode)
+          Messenger::exception("Failed to create root node");
         regionNode->keywords().set("Tolerance", 5.0);
     }
     else

--- a/src/gui/addConfigurationDialog.cpp
+++ b/src/gui/addConfigurationDialog.cpp
@@ -189,7 +189,7 @@ void AddConfigurationDialog::finalise()
         // Add a GeneralRegion node
         regionNode = generator.createRootNode<GeneralRegionGeneratorNode>({});
         if (!regionNode)
-          Messenger::exception("Failed to create root node");
+            Messenger::exception("Failed to create root node");
         regionNode->keywords().set("Tolerance", 5.0);
     }
     else


### PR DESCRIPTION
With a recent discusson on Mantid trying to close up the thousands of issues detected via cppcheck, I thought it would be worth running it on Dissolve (again?  it feels like we've done this before, but I can't quite remember).  The good news is that we only found fifteen errors, most of which are either from the Space Group Info code or issues with Qt moc.  I've cleaned up the other two errors.  I've also created a QC check to ensure that we're not adding new issues in future PRs.

Running cppcheck adds about two minutes to the QC check, so I've added it at the end.  