### PR TITLE
build: More adjustments to updated CI

### DIFF
--- a/.github/workflows/_publish.yml
+++ b/.github/workflows/_publish.yml
@@ -87,5 +87,5 @@ jobs:
       shell: bash
       run: |
         echo "Publishing to Harbor, tagged as [${{ inputs.publishType }}]..."
-        apptainer remote login --username ${{ secrets.HARBOR_USER }} --password ${{ secrets.HARBOR_SECRET }} docker://harbor.stfc.ac.uk
+        apptainer remote login --username '${{ secrets.HARBOR_USER }}' --password ${{ secrets.HARBOR_SECRET }} docker://harbor.stfc.ac.uk
         apptainer push packages/dissolve-gui-${{ inputs.currentVersion }}.sif oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:${{ inputs.publishType }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -45,8 +45,8 @@ jobs:
     uses: "./.github/workflows/_website.yml"
     with:
       publishType: 'continuous'
-      displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
-      displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      displayMajorVersion: ${{ needs.Checkout.outputs.currentVersionMajor }}
+      displayMinorVersion: ${{ needs.Checkout.outputs.currentVersionMinor }}
       hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 

--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -31,8 +31,8 @@ jobs:
     uses: "./.github/workflows/_website.yml"
     with:
       publishType: 'release'
-      displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
-      displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      displayMajorVersion: ${{ needs.Checkout.outputs.currentVersionMajor }}
+      displayMinorVersion: ${{ needs.Checkout.outputs.currentVersionMinor }}
       hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -25,8 +25,8 @@ jobs:
     uses: "./.github/workflows/_website.yml"
     with:
       publishType: 'legacy'
-      displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
-      displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      displayMajorVersion: ${{ needs.Checkout.outputs.currentVersionMajor }}
+      displayMinorVersion: ${{ needs.Checkout.outputs.currentVersionMinor }}
       hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
     secrets: inherit
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,6 @@ jobs:
     uses: "./.github/workflows/_website.yml"
     with:
       publishType: 'none'
-      displayMajorVersion: ${{ needs.Checkout.outputs.majorVersion }}
-      displayMinorVersion: ${{ needs.Checkout.outputs.minorVersion }}
+      displayMajorVersion: ${{ needs.Checkout.outputs.currentVersionMajor }}
+      displayMinorVersion: ${{ needs.Checkout.outputs.currentVersionMinor }}
       hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}


### PR DESCRIPTION
This PR fixes the passing of major/minor version parts through the workflows.  I think the Harbor issue was caused by the HARBOR_USER being unquoted.  Previously it was passed in as an `env:` input to the workflow, so I guess GHA was clever enough to quote or escape the value. Here, we just referenced the secret without quotes.