### PR TITLE
fix: filterBySiteProximity initialising vectors incorrectly

### DIFF
--- a/src/analyser/siteFilter.cpp
+++ b/src/analyser/siteFilter.cpp
@@ -17,7 +17,8 @@ SiteFilter::SiteFilter(Configuration *cfg, const Analyser::SiteVector &sitesToFi
 std::pair<Analyser::SiteVector, Analyser::SiteMap>
 SiteFilter::filterBySiteProximity(const Analyser::SiteVector &otherSites, Range range, int minCount, int maxCount) const
 {
-    Analyser::SiteVector filteredSites(targetSites_.size()), neighbours;
+    Analyser::SiteVector filteredSites, neighbours;
+    filteredSites.reserve(targetSites_.size());
     Analyser::SiteMap filteredSiteMap;
     const auto *box = configuration_->box();
     for (auto &&[site, index] : targetSites_)

--- a/src/analyser/siteFilter.cpp
+++ b/src/analyser/siteFilter.cpp
@@ -19,7 +19,6 @@ SiteFilter::filterBySiteProximity(const Analyser::SiteVector &otherSites, Range 
 {
     Analyser::SiteVector filteredSites, neighbours;
     filteredSites.reserve(targetSites_.size());
-    
     Analyser::SiteMap filteredSiteMap;
     const auto *box = configuration_->box();
     for (auto &&[site, index] : targetSites_)

--- a/src/analyser/siteFilter.cpp
+++ b/src/analyser/siteFilter.cpp
@@ -19,6 +19,7 @@ SiteFilter::filterBySiteProximity(const Analyser::SiteVector &otherSites, Range 
 {
     Analyser::SiteVector filteredSites, neighbours;
     filteredSites.reserve(targetSites_.size());
+    
     Analyser::SiteMap filteredSiteMap;
     const auto *box = configuration_->box();
     for (auto &&[site, index] : targetSites_)


### PR DESCRIPTION
filterBySiteProximity including default initialisation values in return. Now uses .reserve() to remove these.