### PR TITLE
chore: skip continuous workflow on forks

### DIFF
--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -16,6 +16,7 @@ on:
 jobs:
 
   Checkout:
+    if: github.event.repository.fork == false
     uses: "./.github/workflows/_checkout.yml"
     with:
       bump: true

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ build-*/
 changes
 *.tokens
 .gdb_history
+*.DS_Store
 
 # Example files
 *.beat


### PR DESCRIPTION
I feel it might be unnecessary to run the continuous workflow on forks. So, I have disabled it. It fails on forks. It has a runtime of over 2 hours. Skipping it might be more sustainable. 

<img width="980" alt="image" src="https://github.com/user-attachments/assets/fc1e1a02-00fa-4b99-8200-2f4188a952a6" />
