### PR TITLE
fix: Allow variable Qt6 version in powershell

### DIFF
--- a/develop.ps1
+++ b/develop.ps1
@@ -126,7 +126,7 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
     aqt install-qt --outputdir $qtInstallationDir windows desktop $qtVersion win64_msvc2019_64 -m all
 
     # Export Qt6_DIR to system environment variables
-    $qt6Dir = Join-Path -Path $dependencies -ChildPath "qt\$qtVersion\msvc2019_64"
+    $qt6Dir = Join-Path -Path "$projectDir\$dependencies" -ChildPath "qt\$qtVersion\msvc2019_64"
     $qt6BinDir = Join-Path -Path $qt6Dir -ChildPath "bin"
     $qt6CMakeDir = Join-Path -Path $qt6Dir -ChildPath "lib\cmake"
     
@@ -135,7 +135,7 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
 
     Write-Host "Adding Qt6 directory to system PATH... " @info_colors
     if ($systemPath -notmatch [regex]::Escape($qt6BinDir)) {
-        [Environment]::SetEnvironmentVariable("PATH", "$(Join-Path -Path $projectDir -ChildPath $qt6BinDir);$systemPath", [EnvironmentVariableTarget]::Machine)
+        [Environment]::SetEnvironmentVariable("PATH", "$qt6BinDir;$systemPath", [EnvironmentVariableTarget]::Machine)
         Write-Host "Qt6 binary directory path added to system PATH." @info_colors
     } else {
         Write-Host "Did not write to PATH: Qt6 binary directory path already exists in system PATH." @info_colors
@@ -311,7 +311,7 @@ $cacheVariables = @{
     Java_JAVA_EXECUTABLE = $javaExePath
     MULTI_THREADING = $threading
     MSVC_DEV = "ON"
-    CMAKE_PREFIX_PATH = "$(Join-Path -Path $projectDir -ChildPath $qt6CMakeDir)"
+    CMAKE_PREFIX_PATH = "$qt6CMakeDir"
 }
 
 $cmakeUserPresets = [PSCustomObject]@{

--- a/develop.ps1
+++ b/develop.ps1
@@ -3,7 +3,7 @@
         Script to install dependencies for Dissolve development environment in Visual Studio.
     .DESCRIPTION
         Installs the following dependencies for Dissolve (separate and prior to Conan-managed packages):
-            - Qt 6.4.2
+            - Qt6 <VERSION>
             - Freetype
             - FTGL
             - Antlr4 (Java backend)
@@ -119,7 +119,6 @@ $qt6Dir = ""
 if (-not [string]::IsNullOrEmpty($qtVersion))
 {
     # Install Qt6
-    $qtVersion = "6.4.2"
     $qtInstallationDir = Join-Path -Path $dependencies -ChildPath "qt"
     New-Item -ItemType Directory -Path $qtInstallationDir -ErrorAction SilentlyContinue
 

--- a/develop.ps1
+++ b/develop.ps1
@@ -114,7 +114,7 @@ $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariable
 [Environment]::SetEnvironmentVariable("PATH", "$(Join-Path -Path $projectDir -ChildPath "msvc-env\$pythonEnvSourceDir");$systemPath", [EnvironmentVariableTarget]::Machine)
 Write-Host "Python packages directory path added to system PATH." @info_colors
 
-$qt6Dir = ""
+$qt6CMakeDir = ""
 
 if (-not [string]::IsNullOrEmpty($qtVersion))
 {
@@ -128,6 +128,7 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
     # Export Qt6_DIR to system environment variables
     $qt6Dir = Join-Path -Path $dependencies -ChildPath "qt\$qtVersion\msvc2019_64"
     $qt6BinDir = Join-Path -Path $qt6Dir -ChildPath "bin"
+    $qt6CMakeDir = Join-Path -Path $qt6Dir -ChildPath "lib\cmake"
     
     Write-Host "Locating system PATH... " @info_colors
     $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
@@ -310,7 +311,7 @@ $cacheVariables = @{
     Java_JAVA_EXECUTABLE = $javaExePath
     MULTI_THREADING = $threading
     MSVC_DEV = "ON"
-    CMAKE_PREFIX_PATH = "$qt6Dir"
+    CMAKE_PREFIX_PATH = "$(Join-Path -Path $projectDir -ChildPath $qt6CMakeDir)"
 }
 
 $cmakeUserPresets = [PSCustomObject]@{

--- a/web/docs/userguide/developers/vs2022.md
+++ b/web/docs/userguide/developers/vs2022.md
@@ -38,7 +38,7 @@ This script can be used to install the following packages into a `dependencies` 
 
 A specific version of Qt can be specified for installation via the `-qtVersion` parameter (i.e. 6.4.2).
 If you have an existing system Qt6 installation, the script can default to using this by ignoring the `-qtVersion` parameter.
-Ensure that the system Qt `msvc2019_64` binaries are added to the PATH prior to using your own Qt installation.
+Ensure that the system Qt `msvc2019_64` binaries (`bin`) and CMake module (`lib\cmake`) directories are added to the PATH prior to using your own Qt installation.
 
 The script defaults to configuring dependencies for `Debug`. If you want to develop in `Release` mode, use the appropriate flag:
 ```shell


### PR DESCRIPTION
Noticed that the Qt6 version was still fixed at `6.4.2`, but currently needing to experiment with a newer version of Qt6 so need to fix this. 