### PR TITLE
build: QML modules CMakeLists for Qt 6.7.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,9 @@ if(GUI)
   set(CMAKE_AUTORCC ON)
   set(CMAKE_AUTOUIC ON)
 
+  # Compile QML to build subdirectory qml
+  set(QT_QML_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/qml)
+
   # Disable Qt macros
   add_definitions(-DQT_NO_KEYWORDS)
 endif(GUI)
@@ -396,14 +399,16 @@ if(GUI)
             ${THREADING_LINK_LIBS}
   )
 
+  set_target_properties(${qmlgui_target_name} PROPERTIES QML_IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY})
+
   # Main Dissolve GUI
   target_link_libraries(
     ${qmlgui_target_name}
     PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS}
            # Module gui libs
-           gui-qml ${NO_WHOLE_ARCHIVE_FLAG} QuickPlotplugin
+           gui-qml models ${NO_WHOLE_ARCHIVE_FLAG} QuickPlotplugin
     PRIVATE # External libs
-            Qt6::Quick3D Qt6::Qml ${CORE_LINK_LIBS} ${THREADING_LINK_LIBS}
+            Qt6::Quick3D Qt6::Qml Qt6::Widgets ${CORE_LINK_LIBS} ${THREADING_LINK_LIBS}
   )
 
   qt_generate_deploy_qml_app_script(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,6 +391,7 @@ if(GUI)
     PRIVATE # External libs
             Qt6::Widgets
             Qt6::Core
+            Qt6::Quick3D
             OpenGL::GL
             ${GUI_LINK_LIBS}
             ${FREETYPE_LIBRARIES}
@@ -401,12 +402,17 @@ if(GUI)
 
   set_target_properties(${qmlgui_target_name} PROPERTIES QML_IMPORT_PATH ${QT_QML_OUTPUT_DIRECTORY})
 
+  # Link to models when developing QML Dissolve in Visual Studio
+  if(MSVC_DEV)
+    set(QML_GUI_LIBS models)
+  endif(MSVC_DEV)
+
   # Main Dissolve GUI
   target_link_libraries(
     ${qmlgui_target_name}
     PUBLIC ${WHOLE_ARCHIVE_FLAG} ${BASIC_LINK_LIBS}
            # Module gui libs
-           gui-qml models ${NO_WHOLE_ARCHIVE_FLAG} QuickPlotplugin
+           gui-qml ${QML_GUI_LIBS} ${NO_WHOLE_ARCHIVE_FLAG} QuickPlotplugin
     PRIVATE # External libs
             Qt6::Quick3D Qt6::Qml Qt6::Widgets ${CORE_LINK_LIBS} ${THREADING_LINK_LIBS}
   )


### PR DESCRIPTION
Embarked on modularising our QML starting with building Dissolve 2 with QuickPlot on my Visual Studio setup. This initially didn't work due to an odd QML module import error [which transpired to be specific to Qt `6.4.2`](https://github.com/conan-io/conan-center-index/issues/17005). I rebuilt with Qt upgraded to `6.7.2`, and made some minor adjustments to the top-level CMakeLists, and this seems to be working now. Note that I have bundled our qml modules into a single subdirectory in `build`, for keeping things organised.