### PR TITLE
ideas for node and connections

### DIFF
--- a/src/gui-qml/CMakeLists.txt
+++ b/src/gui-qml/CMakeLists.txt
@@ -4,3 +4,5 @@ add_library(gui-qml)
 target_include_directories(gui-qml PRIVATE ${PROJECT_SOURCE_DIR}/src ${PROJECT_BINARY_DIR}/src)
 
 target_link_libraries(gui-qml PRIVATE models base Qt6::QuickWidgets)
+
+add_subdirectory(graphNode)

--- a/src/gui-qml/graphNode/CMakeLists.txt
+++ b/src/gui-qml/graphNode/CMakeLists.txt
@@ -1,0 +1,20 @@
+qt_add_library(graphNode_module STATIC)
+
+qt_add_qml_module(graphNode_module
+	URI
+	"GraphNodeModule"
+	VERSION
+	1.0
+	SOURCES
+	base.h
+	parameter.h
+	node.h
+	nodes/module.h
+	nodes/generator.h
+	nodes/vec3Decomposition.h
+	base.cpp
+	node.cpp
+)
+
+find_package(Qt6 REQUIRED COMPONENTS Core)
+target_link_libraries(graphNode_module PRIVATE Qt6::Core)

--- a/src/gui-qml/graphNode/base.cpp
+++ b/src/gui-qml/graphNode/base.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "base.h"
+
+Node::Node(const std::type_index typeIndex)
+{
+	auto id = GraphNode::typeIndex[typeIndex];
+    attributes_ = GraphNode::registry[id];
+}
+
+/*
+ * Getters
+ */
+
+// Display name of node
+std::string &Node::displayName() const
+{
+	return attributes_.displayName;
+}
+
+// Icon url for node
+QUrl &Node::iconPath() const 
+{ 
+	return attributes_.iconPath;
+}
+
+// Parameters
+Node::ParameterList &Node::parameters() const
+{ 
+	return attributes_.parameters;
+}
+
+/*
+ * Setters
+ */
+
+// Set display name of node
+void &Node::setDisplayName(const std::string &displayName) 
+{ 
+	attributes_.displayName = displayName;
+}

--- a/src/gui-qml/graphNode/base.cpp
+++ b/src/gui-qml/graphNode/base.cpp
@@ -3,12 +3,6 @@
 
 #include "base.h"
 
-Node::Node(const std::type_index typeIndex)
-{
-	auto id = GraphNode::typeIndex[typeIndex];
-    attributes_ = GraphNode::registry[id];
-}
-
 /*
  * Getters
  */

--- a/src/gui-qml/graphNode/base.h
+++ b/src/gui-qml/graphNode/base.h
@@ -36,6 +36,7 @@ class Node : public std::enable_shared_from_this<Node>, Serialisable<const CoreD
     private:
     // Display name of node
     GraphNode::Attributes attributes_;
-    // Edge definition
+    // Edge definition - NOTE: I don't think the pointer to the object containing all connections belongs here, 
+    // most likely we only need the incoming/outoging connections relevant to the Node
     GraphNode::EdgeDefinition *edgeDefinition_;
 };

--- a/src/gui-qml/graphNode/base.h
+++ b/src/gui-qml/graphNode/base.h
@@ -22,7 +22,7 @@ class Node : public std::enable_shared_from_this<Node>, Serialisable<const CoreD
     // Display name of node
     std::string &displayName() const;
     // Icon url for node
-    const QUrl &iconPath() const;
+    const std::string &iconPath() const;
     // Parameters
     GraphNode::ParameterList &parameters() const;
 

--- a/src/gui-qml/graphNode/base.h
+++ b/src/gui-qml/graphNode/base.h
@@ -12,7 +12,7 @@
 class Node : public std::enable_shared_from_this<Node>, Serialisable<const CoreData &>
 {
     public:
-    explicit Node(const std::type_index typeIndex); 
+    explicit Node(const std::type_index typeIndex) : attributes_(GraphNode::registry[typeIndex]) {};
     virtual ~Node() = default;
 
     /*

--- a/src/gui-qml/graphNode/base.h
+++ b/src/gui-qml/graphNode/base.h
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/serialiser.h"
+#include "classes/coreData.h"
+#include "connection.h"
+#include "node.h"
+#include "parameter.h"
+
+class Node : public std::enable_shared_from_this<Node>, Serialisable<const CoreData &>
+{
+    public:
+    explicit Node(const std::type_index typeIndex); 
+    virtual ~Node() = default;
+
+    /*
+     * Getters
+     */
+
+    // Display name of node
+    std::string &displayName() const;
+    // Icon url for node
+    const QUrl &iconPath() const;
+    // Parameters
+    GraphNode::ParameterList &parameters() const;
+
+    /*
+     * Setters
+     */
+
+    // Set display name of node
+    void setDisplayName(const std::string &displayName);
+
+    private:
+    // Display name of node
+    GraphNode::Attributes attributes_;
+    // Edge definition
+    GraphNode::EdgeDefinition *edgeDefinition_;
+};

--- a/src/gui-qml/graphNode/node.cpp
+++ b/src/gui-qml/graphNode/node.cpp
@@ -1,0 +1,12 @@
+#include "node.h"
+
+GraphNode::OutgoingConnections &GraphNode::EdgeDefintion::outgoingConnections(const std::string &nodeName)
+{
+    return connections_[nodeName].first;
+}
+
+
+GraphNode::IncomingConnections &GraphNode::EdgeDefintion::outgoingConnections(const std::string &nodeName)
+{
+    return connections_[nodeName].second;
+}

--- a/src/gui-qml/graphNode/node.h
+++ b/src/gui-qml/graphNode/node.h
@@ -13,7 +13,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <QUrl>
 
 class Node;
 class Module;
@@ -29,10 +28,10 @@ using ParameterList = std::vector<Parameter>;
 struct Attributes
 {
     const std::string typeName;
-    const QUrl iconPath;
+    const std::string iconPath;
     std::string displayName; // Defaults to untitled-<typeName>
     ParameterList parameters;
-    Attributes(const std::string &typeName, const QUrl &iconPath, const ParameterList &parameters, const std::string &displayName = "untitled")
+    Attributes(const std::string &typeName, const std::string &iconPath, const ParameterList &parameters, const std::string &displayName = "untitled")
         : typeName(typeName), iconPath(iconPath), parameters(parameters), displayName(displayName + "-" + typeName)
     {
     }

--- a/src/gui-qml/graphNode/node.h
+++ b/src/gui-qml/graphNode/node.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/serialiser.h"
+#include "classes/coreData.h"
+#include "parameter.h"
+#include <map>
+#include <string>
+#include <type_index>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include <QUrl>
+
+class Node;
+class Module;
+class Generator;
+class Vec3Decomposition;
+
+namespace GraphNode
+{
+// Parameter list type alias
+using ParameterList = std::vector<Parameter>;
+
+// Node type enum
+enum class NodeType
+{
+    Module,
+    Generator,
+    Vec3Decomposition
+    // etc...
+};
+
+// Node type index
+const std::unordered_map<std::type_index, NodeType> typeIndex{
+    {std::type_info(Module), NodeType::Module},
+    {std::type_info(GeneratorNode), NodeType::Generator},
+    {std::type_info(Vec3Decomposition), NodeType::Vec3Decomposition}
+    // etc...
+};
+
+// Node registry
+struct Attributes
+{
+    const std::string typeName;
+    const QUrl iconPath;
+    std::string displayName; // Defaults to untitled-<typeName>
+    ParameterList parameters;
+    Attributes(const std::string &typeName, const QUrl &iconPath, const ParameterList &parameters, const std::string &displayName = "untitled")
+        : typeName(typeName), iconPath(iconPath), parameters(parameters), displayName(displayName + "-" + typeName)
+    {
+    }
+};
+
+const std::map<NodeType, Attributes> registry{
+    {NodeType::Module, Attributes("Module", QUrl("EXAMPLE"), ParameterList{})},
+    {NodeType::Generator, Attributes("Generator", QUrl("EXAMPLE"), ParameterList{})},
+    {NodeType::Vec3Decomposition, Attributes("Vec3Decomposition", QUrl("EXAMPLE"), ParameterList{})}
+    // etc...
+}
+
+// Edge connections
+using IncomingConnections = std::vector<IncomingConnection>;
+using OutgoingConnections = std::vector<OutgoingConnection>;
+using EdgeConnections = std::map<std::string, std::pair<OutgoingConnections, IncomingConnections>>;
+
+struct IncomingConnection
+{
+    Node *destinationNode;
+    Parameter *inputParameter;
+    IncomingConnection(Node *destinationNode, Parameter *inputParameter)
+        : destinationNode(destinationNode), inputParameter(inputParameter) {};
+};
+
+struct OutgoingConnection
+{
+    Node *sourceNode;
+    Parameter *outputParameter;
+    OutgoingConnection(Node *sourceNode, Parameter *outputParameter)
+        : sourceNode(sourceNode), outputParameter(outputParameter) {};
+};
+
+class EdgeDefinition
+{
+    public:
+    EdgeDefinition() {};
+    ~EdgeDefinition() = default;
+
+    // Outgoing connections for graph edge (first in pair) by node name
+    OutgoingConnections &outgoingConnections(const std::string &nodeName);
+    // Incoming connections for graph edge (last in pair) by node name
+    IncomingConnections &incomingConnections(const std::string &nodeName);
+
+    private:
+    // All connections
+    EdgeConnections connections_;
+};
+
+}
+    

--- a/src/gui-qml/graphNode/node.h
+++ b/src/gui-qml/graphNode/node.h
@@ -25,23 +25,6 @@ namespace GraphNode
 // Parameter list type alias
 using ParameterList = std::vector<Parameter>;
 
-// Node type enum
-enum class NodeType
-{
-    Module,
-    Generator,
-    Vec3Decomposition
-    // etc...
-};
-
-// Node type index
-const std::unordered_map<std::type_index, NodeType> typeIndex{
-    {std::type_info(Module), NodeType::Module},
-    {std::type_info(GeneratorNode), NodeType::Generator},
-    {std::type_info(Vec3Decomposition), NodeType::Vec3Decomposition}
-    // etc...
-};
-
 // Node registry
 struct Attributes
 {
@@ -55,10 +38,10 @@ struct Attributes
     }
 };
 
-const std::map<NodeType, Attributes> registry{
-    {NodeType::Module, Attributes("Module", QUrl("EXAMPLE"), ParameterList{})},
-    {NodeType::Generator, Attributes("Generator", QUrl("EXAMPLE"), ParameterList{})},
-    {NodeType::Vec3Decomposition, Attributes("Vec3Decomposition", QUrl("EXAMPLE"), ParameterList{})}
+const std::unordered_map<std::type_index, Attributes> registry{
+    {std::type_info(Module), Attributes("Module", QUrl("EXAMPLE"), ParameterList{})},
+    {std::type_info(Generator), Attributes("Generator", QUrl("EXAMPLE"), ParameterList{})},
+    {std::type_info(Vec3Decomposition), Attributes("Vec3Decomposition", QUrl("EXAMPLE"), ParameterList{})}
     // etc...
 }
 

--- a/src/gui-qml/graphNode/nodes/generator.h
+++ b/src/gui-qml/graphNode/nodes/generator.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base.h"
+
+class Generator : public Node
+{
+    public:
+    Generator() : Node(typeid(this)) {};
+};

--- a/src/gui-qml/graphNode/nodes/module.h
+++ b/src/gui-qml/graphNode/nodes/module.h
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base.h"
+
+class Module : public Node
+{
+    public:
+    Module() : Node(typeid(this)) {};
+
+};

--- a/src/gui-qml/graphNode/nodes/vec3Decomposition.h
+++ b/src/gui-qml/graphNode/nodes/vec3Decomposition.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base.h"
+
+class Vec3Decomposition : public Node
+{
+    public:
+    Vec3Decomposition() : Node(typeid(this)) {};
+};

--- a/src/gui-qml/graphNode/parameter.h
+++ b/src/gui-qml/graphNode/parameter.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+class Parameter
+{
+	// Basically - keywords
+
+
+};


### PR DESCRIPTION
I think the best place to start with this PR are the  following aspects

1) `GraphNode` namespace 
- this is where useful type alias, data structures, and constant variables such as mappings are stored
- the namespace assumes the existence (or usefulness) of a `Parameter` type, of which there would be a fixed set assigned to each `Node` child. These are the connectable equivalents to named variables.
- a singleton `registry` (similar to the `type_index`) mapping `Node`s to their default attributes by their `type_id`. The attributes are a collection of immutable (i.e. string name such as `"Generator"` or `"Math"`, or a path to a QML icon), or mutable (i.e. node's `displayName`)
- `EdgeDefinition` class that manages the various edge connections between graph nodes. All connections belonging to nodes at any instance of time are mapped via the string name (`attributes_.displayName`) of each active node, to a pair of vectors containing incoming and outgoing connections (where connections are represented by `structs` holding pointers to node and parameter engaged in the connection)

2) `Node` base class

3) `Parameter` class
- As mentioned before, this is basically the `Keyword` system from Dissolve.
- I am assuming that we know the full list of parameters that can exist for a given node, so they are enumerated in the `registry` as a `ParameterList` alias
- They could be toggled active on/off from the QML side