### PR TITLE
chore: added concurrency group to the pr workflow to automatically cancel previous workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,10 @@ on:
     - '.github/ISSUE_TEMPLATE/**'
     - 'README.md'
 
+concurrency:
+  group: pull-request-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
 
   Checkout:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ ui_*
 moc_*
 *.kdev4
 build/
+!/.github/workflows/build
 build-*/
 *.exe
 


### PR DESCRIPTION
This is supposed to be another update for sustainability and optimising resources. I noticed when I pushed two subsequent changes, the previous workflow keep running. As can be seen in the actions list below.

![image](https://github.com/user-attachments/assets/81467515-e419-4c3c-94ba-21b8fe4f89c4)

I have added [concurrency](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) to `pr.yml` to stop the previous workflow.

I have tested it as well and it work fine. This can be verified from the the actions list.
<img width="1020" alt="image" src="https://github.com/user-attachments/assets/7b9f5025-20c3-42ae-91e8-a06667e44b94" />

The workflow associated with the latest commit will run and jobs from the previous commit will automatically be cancelled.
<img width="597" alt="image" src="https://github.com/user-attachments/assets/49942279-d55a-40a9-8778-0ced2b27a89a" />


