### PR TITLE
fix: potential range check dialog appearing unnecessarily

### DIFF
--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -471,7 +471,7 @@ void DissolveWindow::checkPairPotentialRange(QWidget *parent)
     // Return smallest inscribed sphere radius if less than current pair potential range
     for (const auto &config : dissolve_.coreData().configurations())
     {
-        if (config->box()->inscribedSphereRadius() < radius.value_or(dissolve_.pairPotentialRange()))
+        if (config->box()->inscribedSphereRadius() < radius.value_or(dissolve_.pairPotentialRange()) && config->nAtoms() > 0)
         {
             radius = config->box()->inscribedSphereRadius();
         }

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
+#include "gui/gui.h"
 #include "base/lineParser.h"
 #include "base/messenger.h"
 #include "gui/configurationTab.h"
-#include "gui/gui.h"
 #include "gui/layerTab.h"
 #include "gui/mainTab.h"
 #include "gui/selectRestartFileDialog.h"

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#include "gui/gui.h"
 #include "base/lineParser.h"
 #include "base/messenger.h"
 #include "gui/configurationTab.h"
+#include "gui/gui.h"
 #include "gui/layerTab.h"
 #include "gui/mainTab.h"
 #include "gui/selectRestartFileDialog.h"

--- a/src/gui/gui_simulation.cpp
+++ b/src/gui/gui_simulation.cpp
@@ -57,6 +57,7 @@ void DissolveWindow::setupIteration(int count)
     // Prepare the simulation
     if (!dissolve_.prepare())
     {
+        checkPairPotentialRange();
         updateStatusBar();
         return;
     }

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,7 +69,6 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
-
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,7 +69,7 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
-                                    
+
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,6 +69,7 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
+                                    
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);


### PR DESCRIPTION
Range check operating unnecessarily on not yet generated configurations.

Fix:
Range check no longer checks empty configurations 
Range check occurs after a prepare() failure, to auto-adjust if necessary.