### PR TITLE
fix: Fix IntraShake

### DIFF
--- a/src/modules/intraShake/intraShake.cpp
+++ b/src/modules/intraShake/intraShake.cpp
@@ -18,8 +18,6 @@ IntraShakeModule::IntraShakeModule() : Module(ModuleTypes::IntraShake)
     keywords_.add<IntegerKeyword>("ShakesPerTerm", "Number of shakes per term", nShakesPerTerm_, 1);
     keywords_.add<DoubleKeyword>("TargetAcceptanceRate", "Target acceptance rate for Monte Carlo moves", targetAcceptanceRate_,
                                  0.001, 1.0);
-    keywords_.add<BoolKeyword>(
-        "TermEnergyOnly", "Whether only the energy of the intramolecular term is calculated and assessed", termEnergyOnly_);
     keywords_.add<SpeciesVectorKeyword>("RestrictToSpecies", "Restrict the calculation to the specified Species",
                                         restrictToSpecies_);
 

--- a/src/modules/intraShake/intraShake.h
+++ b/src/modules/intraShake/intraShake.h
@@ -42,8 +42,6 @@ class IntraShakeModule : public Module
     int nShakesPerTerm_{1};
     // Target acceptance rate for Monte Carlo moves
     double targetAcceptanceRate_{0.33};
-    // Whether only the energy of the intramolecular term is calculated and assessed
-    bool termEnergyOnly_{false};
     // Step size for torsion adjustments (degrees)
     double torsionStepSize_{10.0};
     // Minimum step size for torsion adjustments (degrees)

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -38,9 +38,6 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                          "is {} <= delta <= {}).\n",
                          torsionStepSize_, torsionStepSizeMin_, torsionStepSizeMax_);
     Messenger::print("IntraShake: Target acceptance rate is {}.\n", targetAcceptanceRate_);
-    if (termEnergyOnly_)
-        Messenger::print("IntraShake: Only term energy will be considered (interactions with the rest of the"
-                         "system will be ignored).\n");
     if (!restrictToSpecies_.empty())
         Messenger::print("IntraShake: Calculation will be restricted to species: {}\n",
                          joinStrings(restrictToSpecies_, "  ", [](const auto &sp) { return sp->name(); }));
@@ -223,15 +220,6 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                 {
                     // Refuse to change a torsion which is in a cycle
                     if (torsion.inCycle())
-                        continue;
-
-                    if (torsion.indexI() != 2)
-                        continue;
-                    if (torsion.indexJ() != 0)
-                        continue;
-                    if (torsion.indexK() != 1)
-                        continue;
-                    if (torsion.indexL() != 3)
                         continue;
 
                     // Get Atom pointers

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -86,15 +86,11 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
         }
     }
 
-    int shake, nBondAttempts = 0, nAngleAttempts = 0, nTorsionAttempts = 0, nBondAccepted = 0, nAngleAccepted = 0,
-               nTorsionAccepted = 0;
-    int terminus;
-    bool accept;
-    double ppEnergy, newPPEnergy, intraEnergy, newIntraEnergy, delta, totalDelta = 0.0;
-    Vec3<double> vji, vjk, v;
+    auto shake = 0, nBondAttempts = 0, nAngleAttempts = 0, nTorsionAttempts = 0, nBondAccepted = 0, nAngleAccepted = 0,
+         nTorsionAccepted = 0;
+    auto totalDelta = 0.0;
     Matrix3 transform;
     const auto *box = targetConfiguration_->box();
-    Atom *i, *j, *k, *l;
 
     Timer timer;
     while (distributor.cycle())
@@ -127,28 +123,28 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
             changeStore.add(mol);
 
             // Calculate reference non-geometry energy for Molecule
-            ppEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
+            auto ppEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
 
             // Loop over defined bonds
             if (adjustBonds_)
                 for (const auto &bond : mol->species()->bonds())
                 {
                     // Get Atom pointers
-                    i = mol->atom(bond.indexI());
-                    j = mol->atom(bond.indexJ());
+                    auto i = mol->atom(bond.indexI());
+                    auto j = mol->atom(bond.indexJ());
 
                     // Store current energy of this intramolecular term, or the whole Molecule if it
                     // is present in a cycle
-                    intraEnergy = bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
+                    auto intraEnergy = bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
 
                     // Select random terminus
-                    terminus = randomBuffer.random() > 0.5 ? 1 : 0;
+                    auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
 
                     // Loop over number of shakes per term
                     for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
                         // Get translation vector, normalise, and apply random delta
-                        vji = box->minimumVector(i->r(), j->r());
+                        auto vji = box->minimumVector(i->r(), j->r());
                         vji.normalise();
                         vji *= randomBuffer.randomPlusMinusOne() * bondStepSize_;
 
@@ -159,15 +155,16 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         targetConfiguration_->updateAtomLocations(bond.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        newIntraEnergy = bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
+                        auto newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
+                        auto newIntraEnergy =
+                            bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
 
                         // Trial the transformed Molecule
-                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                        accept = delta < 0 ? true : (randomBuffer.random() < exp(-delta * rRT));
+                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
 
                         // Accept new (current) positions of the Molecule's Atoms?
-                        if (accept)
+                        if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
                             ppEnergy = newPPEnergy;
@@ -187,23 +184,24 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                 for (const auto &angle : mol->species()->angles())
                 {
                     // Get Atom pointers
-                    i = mol->atom(angle.indexI());
-                    j = mol->atom(angle.indexJ());
-                    k = mol->atom(angle.indexK());
+                    auto i = mol->atom(angle.indexI());
+                    auto j = mol->atom(angle.indexJ());
+                    auto k = mol->atom(angle.indexK());
 
                     // Store current energy of this intramolecular term
-                    intraEnergy = angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
+                    auto intraEnergy =
+                        angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
 
                     // Select random terminus
-                    terminus = randomBuffer.random() > 0.5 ? 1 : 0;
+                    auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
 
                     // Loop over number of shakes per term
                     for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
                         // Get bond vectors and calculate cross product to get rotation axis
-                        vji = box->minimumVector(j->r(), i->r());
-                        vjk = box->minimumVector(j->r(), k->r());
-                        v = vji * vjk;
+                        auto vji = box->minimumVector(j->r(), i->r());
+                        auto vjk = box->minimumVector(j->r(), k->r());
+                        auto v = vji * vjk;
 
                         // Create suitable transformation matrix
                         transform.createRotationAxis(v, randomBuffer.randomPlusMinusOne() * angleStepSize_, true);
@@ -215,16 +213,16 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         targetConfiguration_->updateAtomLocations(angle.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        newIntraEnergy =
+                        auto newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
+                        auto newIntraEnergy =
                             angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
 
                         // Trial the transformed Molecule
-                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                        accept = delta < 0 || (randomBuffer.random() < exp(-delta * rRT));
+                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
 
                         // Accept new (current) positions of the Molecule's Atoms?
-                        if (accept)
+                        if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
                             ppEnergy = newPPEnergy;
@@ -248,22 +246,22 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         continue;
 
                     // Get Atom pointers
-                    i = mol->atom(torsion.indexI());
-                    j = mol->atom(torsion.indexJ());
-                    k = mol->atom(torsion.indexK());
-                    l = mol->atom(torsion.indexL());
+                    auto i = mol->atom(torsion.indexI());
+                    auto j = mol->atom(torsion.indexJ());
+                    auto k = mol->atom(torsion.indexK());
+                    auto l = mol->atom(torsion.indexL());
 
                     // Store current energy of this intramolecular term
-                    intraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
+                    auto intraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
 
                     // Select random terminus
-                    terminus = randomBuffer.random() > 0.5 ? 1 : 0;
+                    auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
 
                     // Loop over number of shakes per term
                     for (shake = 0; shake < nShakesPerTerm_; ++shake)
                     {
                         // Get bond vectors j-k to get rotation axis
-                        vjk = box->minimumVector(j->r(), k->r());
+                        auto vjk = box->minimumVector(j->r(), k->r());
 
                         // Create suitable transformation matrix
                         transform.createRotationAxis(vjk, randomBuffer.randomPlusMinusOne() * torsionStepSize_, true);
@@ -275,15 +273,15 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         targetConfiguration_->updateAtomLocations(torsion.attachedAtoms(terminus), indexOffset);
 
                         // Calculate new energy
-                        newPPEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        newIntraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
+                        auto newPPEnergy =
+                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
+                        auto newIntraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
 
                         // Trial the transformed Molecule
-                        delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
-                        accept = delta < 0 || (randomBuffer.random() < exp(-delta * rRT));
+                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
 
                         // Accept new (current) positions of the Molecule's Atoms?
-                        if (accept)
+                        if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
                             ppEnergy = newPPEnergy;

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -122,8 +122,8 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
             // Set current atom targets in ChangeStore (whole molecule)
             changeStore.add(mol);
 
-            // Calculate reference non-geometry energy for Molecule
-            auto ppEnergy = termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
+            // Calculate starting reference energy for Molecule
+            auto referenceEnergy = kernel->totalEnergy(*mol);
 
             // Loop over defined bonds
             if (adjustBonds_)
@@ -132,10 +132,6 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                     // Get Atom pointers
                     auto i = mol->atom(bond.indexI());
                     auto j = mol->atom(bond.indexJ());
-
-                    // Store current energy of this intramolecular term, or the whole Molecule if it
-                    // is present in a cycle
-                    auto intraEnergy = bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
 
                     // Select random terminus
                     auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
@@ -154,21 +150,15 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         // Update Cell positions of the adjusted Atoms
                         targetConfiguration_->updateAtomLocations(bond.attachedAtoms(terminus), indexOffset);
 
-                        // Calculate new energy
-                        auto newPPEnergy =
-                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        auto newIntraEnergy =
-                            bond.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->bondEnergy(bond, *i, *j);
-
-                        // Trial the transformed Molecule
-                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        // Calculate new energy and delta
+                        auto newEnergy = kernel->totalEnergy(*mol);
+                        auto delta = newEnergy.total() - referenceEnergy.total();
 
                         // Accept new (current) positions of the Molecule's Atoms?
                         if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
-                            ppEnergy = newPPEnergy;
-                            intraEnergy = newIntraEnergy;
+                            referenceEnergy = newEnergy;
                             distributor.increase(totalDelta, delta);
                             distributor.increment(nBondAccepted);
                         }
@@ -187,10 +177,6 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                     auto i = mol->atom(angle.indexI());
                     auto j = mol->atom(angle.indexJ());
                     auto k = mol->atom(angle.indexK());
-
-                    // Store current energy of this intramolecular term
-                    auto intraEnergy =
-                        angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
 
                     // Select random terminus
                     auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
@@ -212,21 +198,15 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         // Update Cell positions of the adjusted Atoms
                         targetConfiguration_->updateAtomLocations(angle.attachedAtoms(terminus), indexOffset);
 
-                        // Calculate new energy
-                        auto newPPEnergy =
-                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        auto newIntraEnergy =
-                            angle.inCycle() ? kernel->totalGeometryEnergy(*mol) : kernel->angleEnergy(angle, *i, *j, *k);
-
-                        // Trial the transformed Molecule
-                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        // Calculate new energy and delta
+                        auto newEnergy = kernel->totalEnergy(*mol);
+                        auto delta = newEnergy.total() - referenceEnergy.total();
 
                         // Accept new (current) positions of the Molecule's Atoms?
                         if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
-                            ppEnergy = newPPEnergy;
-                            intraEnergy = newIntraEnergy;
+                            referenceEnergy = newEnergy;
                             distributor.increase(totalDelta, delta);
                             distributor.increment(nAngleAccepted);
                         }
@@ -245,14 +225,20 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                     if (torsion.inCycle())
                         continue;
 
+                    if (torsion.indexI() != 2)
+                        continue;
+                    if (torsion.indexJ() != 0)
+                        continue;
+                    if (torsion.indexK() != 1)
+                        continue;
+                    if (torsion.indexL() != 3)
+                        continue;
+
                     // Get Atom pointers
                     auto i = mol->atom(torsion.indexI());
                     auto j = mol->atom(torsion.indexJ());
                     auto k = mol->atom(torsion.indexK());
                     auto l = mol->atom(torsion.indexL());
-
-                    // Store current energy of this intramolecular term
-                    auto intraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
 
                     // Select random terminus
                     auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;
@@ -272,20 +258,15 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         // Update Cell positions of the adjusted Atoms
                         targetConfiguration_->updateAtomLocations(torsion.attachedAtoms(terminus), indexOffset);
 
-                        // Calculate new energy
-                        auto newPPEnergy =
-                            termEnergyOnly_ ? 0.0 : kernel->totalEnergy(*mol, EnergyKernel::ExcludeGeometry).total();
-                        auto newIntraEnergy = kernel->torsionEnergy(torsion, *i, *j, *k, *l);
-
-                        // Trial the transformed Molecule
-                        auto delta = (newPPEnergy + newIntraEnergy) - (ppEnergy + intraEnergy);
+                        // Calculate new energy and delta
+                        auto newEnergy = kernel->totalEnergy(*mol);
+                        auto delta = newEnergy.total() - referenceEnergy.total();
 
                         // Accept new (current) positions of the Molecule's Atoms?
                         if (delta < 0 || (randomBuffer.random() < exp(-delta * rRT)))
                         {
                             changeStore.updateAll();
-                            ppEnergy = newPPEnergy;
-                            intraEnergy = newIntraEnergy;
+                            referenceEnergy = newEnergy;
                             distributor.increase(totalDelta, delta);
                             distributor.increment(nTorsionAccepted);
                         }

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -223,10 +223,8 @@ Module::ExecutionResult IntraShakeModule::process(ModuleContext &moduleContext)
                         continue;
 
                     // Get Atom pointers
-                    auto i = mol->atom(torsion.indexI());
                     auto j = mol->atom(torsion.indexJ());
                     auto k = mol->atom(torsion.indexK());
-                    auto l = mol->atom(torsion.indexL());
 
                     // Select random terminus
                     auto terminus = randomBuffer.random() > 0.5 ? 1 : 0;

--- a/web/docs/userguide/modules/evolution/intrashake/_index.md
+++ b/web/docs/userguide/modules/evolution/intrashake/_index.md
@@ -6,7 +6,7 @@ description: Perform Monte Carlo on intramolecular terms
 
 ## Overview
 
-The `IntraShake` module performs Monte Carlo "shakes" of intramolecular terms within molecules, covering defined bond, angle, and torsions. All moves take into account both the full intermolecular and intramolecular energies of the atoms.
+The `IntraShake` module performs Monte Carlo "shakes" of intramolecular terms within molecules, covering defined bond, angle, and torsions. All moves take into account both the full intermolecular and intramolecular energies of the atoms in the molecule. This encompasses the full pair potential energy within the cutoff range of the molecule's atoms, as well as any intramolecular pair potential energy contributions.
 
 ## Description
 
@@ -27,15 +27,14 @@ The basic algorithm is the same as documented for the {{< module "AtomShake" >}}
 |`RestrictToSpecies`|`Species ...`|--|Restrict Monte Carlo moves to only molecules of the specified species. Molecules of other species types remain at their current positions.|
 |`ShakesPerTerm`|`int`|`1`|Number of shakes $n$ to attempt per term|
 |`TargetAcceptanceRate`|`alpha`|`0.33`|Target acceptance rate $\alpha$ for Monte Carlo moves|
-|`TermEnergyOnly`|`bool`|`false`|Whether to ignore all interatomic pair potential energy in the procedure, focussing entirely on the energy of the intramolecular term|
 
 ### Bonds
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`AdjustBonds`|`bool`|`true`|Whether bond terms should be shaken|
-|`BondStepSize`|`delta`|`0.05`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over bonds. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
-|`BondStepSizeMax`|`deltamax`|`1.0`|Maximum allowed value for bond step size, $\delta_{max}$, in Angstroms|
+|`BondStepSize`|`delta`|`0.01`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over bonds. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
+|`BondStepSizeMax`|`deltamax`|`0.2`|Maximum allowed value for bond step size, $\delta_{max}$, in Angstroms|
 |`BondStepSizeMin`|`deltamin`|`0.001`|Minimum allowed value for bond step size, $\delta_{min}$, in Angstroms|
 
 ### Angles
@@ -43,18 +42,18 @@ The basic algorithm is the same as documented for the {{< module "AtomShake" >}}
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`AdjustAngles`|`bool`|`true`|Whether angle terms should be shaken|
-|`AngleStepSize`|`delta`|`0.05`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over angles. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
-|`AngleStepSizeMax`|`deltamax`|`1.0`|Maximum allowed value for angle step size, $\delta_{max}$, in Angstroms|
-|`AngleStepSizeMin`|`deltamin`|`0.001`|Minimum allowed value for angle step size, $\delta_{min}$, in Angstroms|
+|`AngleStepSize`|`delta`|`5.0`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over angles. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
+|`AngleStepSizeMax`|`deltamax`|`20.0`|Maximum allowed value for angle step size, $\delta_{max}$, in Angstroms|
+|`AngleStepSizeMin`|`deltamin`|`0.01`|Minimum allowed value for angle step size, $\delta_{min}$, in Angstroms|
 
 ### Torsions
 
 |Keyword|Arguments|Default|Description|
 |:------|:--:|:-----:|-----------|
 |`AdjustTorsions`|`bool`|`true`|Whether torsion terms should be shaken|
-|`TorsionStepSize`|`delta`|`0.05`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over torsions. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
-|`TorsionStepSizeMax`|`deltamax`|`1.0`|Maximum allowed value for torsion step size, $\delta_{max}$, in Angstroms|
-|`TorsionStepSizeMin`|`deltamin`|`0.001`|Minimum allowed value for torsion step size, $\delta_{min}$, in Angstroms|
+|`TorsionStepSize`|`delta`|`10.0`|Step size $\delta$ in Angstroms to use in Monte Carlo moves over torsions. As detailed above, the step size is dynamically updated after the module has run, with the updated value being saved in the restart file.|
+|`TorsionStepSizeMax`|`deltamax`|`45.0`|Maximum allowed value for torsion step size, $\delta_{max}$, in Angstroms|
+|`TorsionStepSizeMin`|`deltamin`|`0.5`|Minimum allowed value for torsion step size, $\delta_{min}$, in Angstroms|
 
 ### Advanced
 


### PR DESCRIPTION
Fixes `IntraShakeModule` which would not correctly consider the full intramolecular energy of the molecule (particularly bad for torsion adjustments).