### PR TITLE
feat: Node and edge containers

### DIFF
--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -6,6 +6,7 @@
 #include "classes/kVector.h"
 #include "classes/neutronWeights.h"
 #include "classes/species.h"
+#include "nodes/graph.h"
 
 Dissolve::Dissolve(CoreData &coreData) : coreData_(coreData)
 {
@@ -65,3 +66,14 @@ void Dissolve::clear()
 
 // Return data associated with processing Modules
 GenericList &Dissolve::processingModuleData() { return processingModuleData_; }
+
+/*
+ * Graph node
+ */
+
+// Set the Dissolve graph node
+void Dissolve::setGraph()
+{
+    auto parentNode = Graph::produceNode("DissolveNode");
+    graphNode_ = std::make_unique<Graph>(parentNode);
+}

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -12,6 +12,7 @@
 #include "data/elements.h"
 #include "module/layer.h"
 #include "module/module.h"
+#include "nodes/node.h"
 
 // Forward Declarations
 class Atom;
@@ -119,6 +120,17 @@ class Dissolve : public Serialisable<>
     public:
     // Return data associated with main processing Modules
     GenericList &processingModuleData();
+
+    /*
+     * Graph node
+     */
+    public:
+    // Set the Dissolve graph node
+    void setGraph();
+
+    private:
+    // Dissolve graph node
+    std::unique_ptr<Node> graphNode_;
 
     /*
      * Simulation

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -12,8 +12,6 @@
 #include "data/elements.h"
 #include "module/layer.h"
 #include "module/module.h"
-#include "nodes/node.h"
-#include <map>
 
 // Forward Declarations
 class Atom;
@@ -121,28 +119,6 @@ class Dissolve : public Serialisable<>
     public:
     // Return data associated with main processing Modules
     GenericList &processingModuleData();
-
-    /*
-     * Nodes and edges
-     */
-    using Nodes = std::map<std::string_view, std::unique_ptr<Node>>;
-    using Edges = std::vector<Node::Edge>;
-
-    private:
-    // Container of nodes
-    Nodes nodes_{};
-    // Container of parameter links between nodes
-    Edges edges_{};
-
-    public:
-    // Add node
-    void addNode(std::unique_ptr<Node> node, std::string_view name);
-    // Add parameter link between nodes
-    void addEdge(Node::Edge &edge);
-    // Return container of nodes
-    Nodes &nodes();
-    // Return container of parameter links between nodes
-    Edges &edges();
 
     /*
      * Simulation

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -135,9 +135,9 @@ class Dissolve : public Serialisable<>
     Edges edges_{};
 
     public:
-    // Return container of nodes
+    // Add node
     void addNode(std::unique_ptr<Node> node, std::string_view name);
-    // Return container of parameter links between nodes
+    // Add parameter link between nodes
     void addEdge(Node::Edge &edge);
     // Return container of nodes
     Nodes &nodes();

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -12,6 +12,8 @@
 #include "data/elements.h"
 #include "module/layer.h"
 #include "module/module.h"
+#include "nodes/node.h"
+#include <map>
 
 // Forward Declarations
 class Atom;
@@ -119,6 +121,28 @@ class Dissolve : public Serialisable<>
     public:
     // Return data associated with main processing Modules
     GenericList &processingModuleData();
+
+    /*
+     * Nodes and edges
+     */
+    using Nodes = std::map<std::string_view, std::unique_ptr<Node>>;
+    using Edges = std::vector<Node::Edge>;
+
+    private:
+    // Container of nodes
+    Nodes nodes_{};
+    // Container of parameter links between nodes
+    Edges edges_{};
+
+    public:
+    // Return container of nodes
+    void addNode(std::unique_ptr<Node> node, std::string_view name);
+    // Return container of parameter links between nodes
+    void addEdge(Node::Edge &edge);
+    // Return container of nodes
+    Nodes &nodes();
+    // Return container of parameter links between nodes
+    Edges &edges();
 
     /*
      * Simulation

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -757,15 +757,3 @@ std::string_view Dissolve::restartFilename() const { return restartFilename_; }
 
 // Return whether a restart filename has been set
 bool Dissolve::hasRestartFilename() const { return (!restartFilename_.empty()); }
-
-// Add nodes
-void Dissolve::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
-
-// Add parameter link between nodes
-void Dissolve::addEdge(Node::Edge &edge) { edges_.push_back(edge); }
-
-// Return container of nodes
-Dissolve::Nodes &Dissolve::nodes() { return nodes_; }
-
-// Return container of parameter links between nodes
-Dissolve::Edges &Dissolve::edges() { return edges_; }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -758,10 +758,10 @@ std::string_view Dissolve::restartFilename() const { return restartFilename_; }
 // Return whether a restart filename has been set
 bool Dissolve::hasRestartFilename() const { return (!restartFilename_.empty()); }
 
-// Return container of nodes
+// Add nodes
 void Dissolve::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
 
-// Return container of parameter links between nodes
+// Add parameter link between nodes
 void Dissolve::addEdge(Node::Edge &edge) { edges_.push_back(edge); }
 
 // Return container of nodes

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -757,3 +757,15 @@ std::string_view Dissolve::restartFilename() const { return restartFilename_; }
 
 // Return whether a restart filename has been set
 bool Dissolve::hasRestartFilename() const { return (!restartFilename_.empty()); }
+
+// Return container of nodes
+void Dissolve::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
+
+// Return container of parameter links between nodes
+void Dissolve::addEdge(Node::Edge &edge) { edges_.push_back(edge); }
+
+// Return container of nodes
+Dissolve::Nodes &Dissolve::nodes() { return nodes_; }
+
+// Return container of parameter links between nodes
+Dissolve::Edges &Dissolve::edges() { return edges_; }

--- a/src/nodes/CMakeLists.txt
+++ b/src/nodes/CMakeLists.txt
@@ -2,12 +2,15 @@ add_library(
   nodes
   atomShake.cpp
   atomShake.h
+  graph.cpp
+  graph.h
   node.cpp
   node.h
   parameter.cpp
   parameter.h
   parameterLink.cpp
   parameterLink.h
+  registry.h
 )
 
 target_include_directories(nodes PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/nodes/CMakeLists.txt
+++ b/src/nodes/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   nodes
   atomShake.cpp
   atomShake.h
+  dissolve.h
   graph.cpp
   graph.h
   node.cpp

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/configuration.h"
+#include "nodes/node.h"
+
+// AtomShake Node
+class DissolveNode : public Node
+{
+    public:
+    DissolveNode() {};
+    ~DissolveNode() override = default;
+
+    /*
+     * Definition
+     */
+    private:
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    Module::ExecutionResult process(ModuleContext &moduleContext);
+};

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -1,7 +1,11 @@
 #include "nodes/graph.h"
 
 // Add nodes
-void Graph::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
+void Graph::addNode(std::unique_ptr<Node> node, std::string_view name)
+{
+	node->setParentGraph(this);
+	nodes_.insert(std::make_pair(name, node));
+}
 
 // Add parameter link between nodes
 void Graph::addEdge(Node::Edge &linkMap) { edges_.push_back(linkMap); }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -4,7 +4,7 @@
 void Graph::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
 
 // Add parameter link between nodes
-void Graph::addEdge(Node::Edge &edge) { edges_.push_back(edge); }
+void Graph::addEdge(Node::Edge &linkMap) { edges_.push_back(linkMap); }
 
 // Return container of nodes
 Graph::Nodes &Graph::nodes() { return nodes_; }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -1,0 +1,13 @@
+#include "nodes/graph.h"
+
+// Add nodes
+void Graph::addNode(std::unique_ptr<Node> node, std::string_view name) { nodes_.insert(std::make_pair(name, node)); }
+
+// Add parameter link between nodes
+void Graph::addEdge(Node::Edge &edge) { edges_.push_back(edge); }
+
+// Return container of nodes
+Graph::Nodes &Graph::nodes() { return nodes_; }
+
+// Return container of parameter links between nodes
+Graph::Edges &Graph::edges() { return edges_; }

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/messenger.h"
+#include "nodes/node.h"
+#include "nodes/registry.h"
+#include <map>
+#include <string>
+#include <vector>
+
+// Graph
+class Graph
+{
+    public:
+    Graph() {};
+    ~Graph() = default;
+
+    /*
+     * Nodes and edges
+     */
+    using Nodes = std::map<std::string_view, std::unique_ptr<Node>>;
+    using Edges = std::vector<Node::Edge>;
+
+    private:
+    // Container of nodes
+    Nodes nodes_{};
+    // Container of parameter links between nodes
+    Edges edges_{};
+
+    public:
+    // Produce a registered node by type
+    static std::unique_ptr<Node> produceNode(const std::string_view& nodeType) { return registry.find(nodeType)(); }
+    // Add node
+    void addNode(std::unique_ptr<Node> node, std::string_view name);
+    // Add parameter link between nodes
+    void addEdge(Node::Edge &edge);
+    // Return container of nodes
+    Nodes &nodes();
+    // Return container of parameter links between nodes
+    Edges &edges();
+};

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -22,7 +22,7 @@ class Graph : public Node
      * Nodes and edges
      */
     using Nodes = std::map<std::string_view, std::unique_ptr<Node>>;
-    using Edges = std::vector<Node::Edge>;
+    using Edges = std::vector<Node::LinkMap>;
 
     private:
     // Parent node
@@ -38,7 +38,7 @@ class Graph : public Node
     // Add node
     void addNode(std::unique_ptr<Node> node, std::string_view name);
     // Add parameter link between nodes
-    void addEdge(Node::Edge &edge);
+    void addEdge(Node::LinkMap &linkMap);
     // Return container of nodes
     Nodes &nodes();
     // Return container of parameter links between nodes

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -7,14 +7,15 @@
 #include "nodes/node.h"
 #include "nodes/registry.h"
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
 // Graph
-class Graph
+class Graph : public Node
 {
     public:
-    Graph() {};
+    explicit Graph(std::unique_ptr<Node> parent) : parent_(parent) {};
     ~Graph() = default;
 
     /*
@@ -24,6 +25,8 @@ class Graph
     using Edges = std::vector<Node::Edge>;
 
     private:
+    // Parent node
+    std::unique_ptr<Node> parent_;
     // Container of nodes
     Nodes nodes_{};
     // Container of parameter links between nodes

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -15,7 +15,7 @@
 class Graph : public Node
 {
     public:
-    explicit Graph(std::unique_ptr<Node> parent) : parent_(parent) {};
+    explicit Graph(std::unique_ptr<Node> parent) : Node(this), parent_(parent) {}
     ~Graph() = default;
 
     /*

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -26,7 +26,7 @@ std::map<std::string_view, std::shared_ptr<ParameterBase>> &Node::inputs() { ret
 // Prepare for processing
 bool Node::preprocess()
 {
-    for (auto &[key, link] : links_)
+    for (auto &[key, link] : inputLinks_)
     {
         // Ignore parameters that don't invalidate
         if (!link.sink().flags().isSet(ParameterBase::Invalidates))

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -49,6 +49,12 @@ bool Node::isSatisfied()
     return satisfied_;
 }
 
+// Set the node parent graph
+void Node::setParentGraph(Graph* parentGraph) { parentGraph_ = parentGraph; }
+
+// Returns the node parent graph
+Graph *Node::parentGraph() const { return parentGraph_; }
+
 // Tell node to recalculate results
 void Node::invalidate() { satisfied_ = false; }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -7,6 +7,7 @@
 #include "module/module.h"
 #include "nodes/parameter.h"
 #include "nodes/parameterLink.h"
+#include <map>
 #include <string>
 #include <vector>
 
@@ -16,6 +17,8 @@ class Node
     public:
     Node() {}
     virtual ~Node() = default;
+
+    using Edge = std::map<std::string_view, ParameterLink>;
 
     /*
      * Definition (Virtuals)
@@ -39,7 +42,7 @@ class Node
     // Input parameters
     std::map<std::string_view, std::shared_ptr<ParameterBase>> inputs_;
     // Inbound Links
-    std::map<std::string_view, ParameterLink> links_;
+    Edge links_;
     // Whether node needs to run to account for updated data
     bool satisfied_{false};
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -11,14 +11,21 @@
 #include <string>
 #include <vector>
 
+class Graph
+
 // Node Base
 class Node
 {
     public:
     Node() {}
+    explicit Node(Graph* parentGraph) : parentGraph_(parentGraph) {}
     virtual ~Node() = default;
 
     using LinkMap = std::map<std::string_view, ParameterLink>;
+
+    private:
+    // Node parent graph
+    Graph *parentGraph_;
 
     /*
      * Definition (Virtuals)
@@ -103,6 +110,10 @@ class Node
     std::shared_ptr<ParameterBase> findInput(std::string_view name) const;
     // Return input parameters
     std::map<std::string_view, std::shared_ptr<ParameterBase>> &inputs();
+    // Set the node parent graph
+    void setParentGraph(Graph *parentGraph);
+    // Returns the node parent graph
+    Graph *parentGraph() const;
 
     /*
      * Processing

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -18,7 +18,7 @@ class Node
     Node() {}
     virtual ~Node() = default;
 
-    using Edge = std::map<std::string_view, ParameterLink>;
+    using LinkMap = std::map<std::string_view, ParameterLink>;
 
     /*
      * Definition (Virtuals)
@@ -42,7 +42,7 @@ class Node
     // Input parameters
     std::map<std::string_view, std::shared_ptr<ParameterBase>> inputs_;
     // Inbound Links
-    Edge links_;
+    LinkMap inputLinks_;
     // Whether node needs to run to account for updated data
     bool satisfied_{false};
 
@@ -52,8 +52,8 @@ class Node
     {
 
         // Confirm that this node hasn't already been linked
-        if (std::find_if(links_.begin(), links_.end(), [name](const auto &it) { return name == it.second.sink().name(); }) !=
-            links_.end())
+        if (std::find_if(inputLinks_.begin(), inputLinks_.end(), [name](const auto &it) { return name == it.second.sink().name(); }) !=
+            inputLinks_.end())
             return false;
 
         // Create link
@@ -63,7 +63,7 @@ class Node
         if (!link)
             return false;
 
-        links_.emplace(std::make_pair(name, *link));
+        inputLinks_.emplace(std::make_pair(name, *link));
         return true;
     }
     // Add input parameter

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -1,4 +1,5 @@
 #include "atomShake.h"
+#include "dissolve.h"
 #include "node.h"
 #include <functional>
 #include <map>
@@ -18,5 +19,6 @@ template <typename T> NodeProducer makeDerivedNode()
 const std::map<std::string, NodeProducer> registry
 {
     {"AtomShake", makeDerivedNode<AtomShakeNode>()},
+    {"Dissolve", makeDerivedNode<DissolveNode>()},
     // etc...
 }


### PR DESCRIPTION
Provides a pair of containers (mapping of string->node, vector of edges) at the core level.
Also introduces a type-alias in `Node` to refer to a map of `ParameterLink`.

`Graph` derives from `Node` - the former contains a parent `std::unique_ptr<Node>`, while the latter contains a raw pointer to its parent `Graph`. `Dissolve` owns a singleton top-level graph which contains all nodes (apart from the `DissolveNode`).


![graphNode](https://github.com/user-attachments/assets/cd04b72d-52ff-49e9-adbf-72183852ce83)
