### PR TITLE
build: Disable windows build pending ANTLR4 fix

### DIFF
--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'


### PR DESCRIPTION
Given the ANTLR4 issue (details below) this PR disables windows build and packaging in the `continuous.yml` workflow, with the intention that we can and should still be publishing our working Linux builds to IDAaaS etc.

### Context
The Windows build which now fails when building the ANTLR4 runtime - this is Windows-specific (at least at present) and is due to Microsoft knowingly making breaking changes to their compilers: https://github.com/microsoft/STL/pull/5105

It was in fact fixed in ANTLR4 in their development version five days ago, but there is no current release or conan package which contains the fix yet. For now we either wait (there is an issue in asking for an update already) or fix it by spinning our own bleeding-edge version of ANTLR4 directly from their develop branch.