### PR TITLE
fix: potential range check not handling empty configs or size factors

### DIFF
--- a/src/gui/configurationTab.cpp
+++ b/src/gui/configurationTab.cpp
@@ -220,14 +220,14 @@ void ConfigurationTab::on_GenerateButton_clicked(bool checked)
     // Clear the messages
     dissolveWindow_->clearMessages();
 
-    // Check pair potential range against box geometries
-    dissolveWindow_->checkPairPotentialRange();
-
     // Make sure the potential map is up to date
     dissolve_.updatePairPotentials();
 
     // Initialise the content
     configuration_->initialiseContent({dissolve_.worldPool(), dissolve_});
+
+    // Check pair potential range against box geometries
+    dissolveWindow_->checkPairPotentialRange();
 
     // Update
     updateControls();

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#include "gui/gui.h"
 #include "base/lineParser.h"
 #include "base/messenger.h"
 #include "gui/configurationTab.h"
+#include "gui/gui.h"
 #include "gui/layerTab.h"
 #include "gui/mainTab.h"
 #include "gui/selectRestartFileDialog.h"
@@ -471,10 +471,10 @@ void DissolveWindow::checkPairPotentialRange(QWidget *parent)
     // Return smallest inscribed sphere radius if less than current pair potential range
     for (const auto &config : dissolve_.coreData().configurations())
     {
-        if (config->box()->inscribedSphereRadius() < radius.value_or(dissolve_.pairPotentialRange()) && config->nAtoms() > 0)
-        {
-            radius = config->box()->inscribedSphereRadius();
-        }
+        // Accounting for size factors
+        double reducedRadius = config->box()->inscribedSphereRadius() / config->requestedSizeFactor().value_or(1.0);
+        if (reducedRadius < radius.value_or(dissolve_.pairPotentialRange()) && config->nAtoms() > 0)
+            radius = reducedRadius;
     }
 
     // Prompt to auto-adjust
@@ -485,6 +485,9 @@ void DissolveWindow::checkPairPotentialRange(QWidget *parent)
                                           "Adjust pair potential range to %1?")
                                       .arg(radius.value()),
                                   QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes) == QMessageBox::Yes)
+        {
             dissolve_.setPairPotentialRange(radius.value());
+            dissolve_.updatePairPotentials();
+        }
     }
 }

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
+#include "gui/gui.h"
 #include "base/lineParser.h"
 #include "base/messenger.h"
 #include "gui/configurationTab.h"
-#include "gui/gui.h"
 #include "gui/layerTab.h"
 #include "gui/mainTab.h"
 #include "gui/selectRestartFileDialog.h"

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#include "gui/gui.h"
 #include "base/lineParser.h"
 #include "base/messenger.h"
 #include "gui/configurationTab.h"
+#include "gui/gui.h"
 #include "gui/layerTab.h"
 #include "gui/mainTab.h"
 #include "gui/selectRestartFileDialog.h"

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,7 +69,6 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
-
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,7 +69,7 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
-                                    
+
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);

--- a/src/main/simulation.cpp
+++ b/src/main/simulation.cpp
@@ -69,6 +69,7 @@ bool Dissolve::prepare()
         if (pairPotentialRange_ > maxPPRange)
             return Messenger::error("PairPotential range ({}) is longer than the shortest non-minimum image distance ({}).\n",
                                     pairPotentialRange_, maxPPRange);
+                                    
         // Update species usage for the next check
         for (auto &[sp, pop] : cfg->speciesPopulations())
             globalUsedSpecies.emplace(sp);


### PR DESCRIPTION
Issue:
No check performed when using "Generate" on an empty config.
Not checking box dimensions when using a size factor correctly.