### PR TITLE
fix: Intramolecular PairPotential energy was double-counted in Molecule-focussed energy calculation

### DIFF
--- a/src/kernels/energy.cpp
+++ b/src/kernels/energy.cpp
@@ -253,53 +253,56 @@ PairPotentialEnergyValue EnergyKernel::pairPotentialEnergy(const Molecule &mol, 
                             auto &ii = *i;
                             auto mimRequired = neighbour.requiresMIM_;
                             auto &nbrCellAtoms = neighbour.neighbour_.atoms();
-                            return acc +
-                                   std::accumulate(
-                                       nbrCellAtoms.begin(), nbrCellAtoms.end(), PairPotentialEnergyValue(),
-                                       [&ii, mimRequired, includeIntraMolecular, this](const auto innerAcc, const auto *j)
-                                       {
-                                           auto &jj = *j;
+                            return acc + std::accumulate(
+                                             nbrCellAtoms.begin(), nbrCellAtoms.end(), PairPotentialEnergyValue(),
+                                             [&ii, mimRequired, includeIntraMolecular, this](const auto innerAcc, const auto *j)
+                                             {
+                                                 auto &jj = *j;
 
-                                           // Same molecule?
-                                           auto sameMol = ii.molecule().get() == jj.molecule().get();
-                                           if (sameMol)
-                                           {
-                                               if (!includeIntraMolecular)
-                                                   return innerAcc;
-                                               else if (&ii == &jj)
-                                                   return innerAcc;
-                                           }
+                                                 // Don't consider atoms within the target molecule here - add it on afterwards
+                                                 if (ii.molecule().get() == jj.molecule().get())
+                                                     return innerAcc;
 
-                                           // Calculate rSquared distance between atoms, and check it against
-                                           // the stored cutoff distance
-                                           auto rSq = mimRequired ? box_->minimumDistanceSquared(ii.r(), jj.r())
-                                                                  : (ii.r() - jj.r()).magnitudeSq();
-                                           if (rSq > cutoffDistanceSquared_)
-                                               return innerAcc;
+                                                 // Calculate rSquared distance between atoms, and check it against
+                                                 // the stored cutoff distance
+                                                 auto rSq = mimRequired ? box_->minimumDistanceSquared(ii.r(), jj.r())
+                                                                        : (ii.r() - jj.r()).magnitudeSq();
+                                                 if (rSq > cutoffDistanceSquared_)
+                                                     return innerAcc;
 
-                                           // If the same molecule need to check scaling (other checks already made above)
-                                           if (sameMol)
-                                           {
-                                               auto &&[scalingType, elec14, vdw14] = ii.scaling(&jj);
-                                               if (scalingType == SpeciesAtom::ScaledInteraction::NotScaled)
-                                                   return innerAcc +
-                                                          PairPotentialEnergyValue(0.0, pairPotentialEnergy(ii, jj, sqrt(rSq)));
-                                               else if (scalingType == SpeciesAtom::ScaledInteraction::Scaled)
-                                                   return innerAcc +
-                                                          PairPotentialEnergyValue(
-                                                              0.0, pairPotentialEnergy(ii, jj, sqrt(rSq), elec14, vdw14));
-                                               else
-                                                   return innerAcc;
-                                           }
-                                           else
-                                               return innerAcc +
-                                                      PairPotentialEnergyValue(pairPotentialEnergy(ii, jj, sqrt(rSq)), 0.0);
-                                       });
+                                                 return innerAcc +
+                                                        PairPotentialEnergyValue(pairPotentialEnergy(ii, jj, sqrt(rSq)), 0.0);
+                                             });
                         });
                 });
 
             return totalAcc + localEnergy;
         });
+
+    // Include intramolecular pairpotential (self terms)?
+    if (includeIntraMolecular)
+    {
+        auto intra = 0.0;
+        dissolve::for_each_pair(ParallelPolicies::seq, 0, mol.nAtoms(),
+                                [&](int i, int j)
+                                {
+                                    if (i == j)
+                                        return;
+                                    const auto &ii = *mol.atom(i);
+                                    const auto &jj = *mol.atom(j);
+                                    auto rSq = box_->minimumDistanceSquared(ii.r(), jj.r());
+
+                                    if (rSq <= cutoffDistanceSquared_)
+                                    {
+                                        auto &&[scalingType, elec14, vdw14] = ii.scaling(&jj);
+                                        if (scalingType == SpeciesAtom::ScaledInteraction::NotScaled)
+                                            intra += pairPotentialEnergy(ii, jj, sqrt(rSq));
+                                        else if (scalingType == SpeciesAtom::ScaledInteraction::Scaled)
+                                            intra += pairPotentialEnergy(ii, jj, sqrt(rSq), elec14, vdw14);
+                                    }
+                                });
+        totalEnergy += PairPotentialEnergyValue(0.0, intra);
+    }
 
     return totalEnergy;
 }

--- a/src/kernels/energy.cpp
+++ b/src/kernels/energy.cpp
@@ -363,11 +363,8 @@ PairPotentialEnergyValue EnergyKernel::totalMoleculePairPotentialEnergy(bool inc
         molecularEnergy += pairPotentialEnergy(*mol, includeIntraMolecular);
 
     // In the typical case where there is more than one molecule, our sum will contain double the intermolecular
-    // pairpotential energy, and zero intramolecular energy
-    if (mols.size() > 1)
-        molecularEnergy *= 0.5;
-
-    return molecularEnergy;
+    // pairpotential energy
+    return {molecularEnergy.interMolecular() * 0.5, molecularEnergy.intraMolecular()};
 }
 
 // Return total energy of supplied atom with the world

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -285,14 +285,16 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         Timer moleculeTimer;
         auto kernel = KernelProducer::energyKernel(targetConfiguration_, moduleContext.processPool(),
                                                    moduleContext.dissolve().potentialMap(), cutoff);
-        auto molecularPPEnergy = kernel->totalMoleculePairPotentialEnergy(false).total();
-        molecularPPEnergy += correctSelfEnergy;
+        auto molecularPPEnergyInter = kernel->totalMoleculePairPotentialEnergy(false).total();
+        auto molecularPPEnergyFull = kernel->totalMoleculePairPotentialEnergy(true).total();
         moleculeTimer.stop();
 
         Messenger::print("Production interatomic pairpotential energy is {:15.9e} kJ/mol\n", ppEnergy.total());
         Messenger::print("Production intramolecular energy is {:15.9e} kJ/mol\n", boundEnergy);
         Messenger::print("Total production energy is {:15.9e} kJ/mol\n", ppEnergy.total() + boundEnergy);
-        Messenger::print("Molecular energy (excluding bound terms) is {:15.9e} kJ/mol\n", molecularPPEnergy);
+        Messenger::print("Molecular pairpotential energy (excluding intramolecular terms) is {:15.9e} kJ/mol\n",
+                         molecularPPEnergyInter);
+        Messenger::print("Molecular pairpotential energy (full) is {:15.9e} kJ/mol\n", molecularPPEnergyFull);
         Messenger::print("Time to do interatomic energy was {}.\n", interTimer.totalTimeString());
         Messenger::print("Time to do intramolecular energy was {}.\n", intraTimer.totalTimeString());
         Messenger::print("Time to do intermolecular energy was {}.\n", moleculeTimer.totalTimeString());
@@ -300,18 +302,22 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
         // Compare production vs 'correct' values
         auto interDelta = correctInterEnergy - ppEnergy.total();
         auto intraDelta = correctIntraEnergy - boundEnergy;
-        auto moleculeDelta = correctInterEnergy - molecularPPEnergy;
+        auto moleculeDeltaA = correctInterEnergy - molecularPPEnergyFull;
+        auto moleculeDeltaB = correctInterEnergy - (molecularPPEnergyInter + correctSelfEnergy);
         Messenger::print("Comparing 'correct' with production values...\n");
         Messenger::print("Interatomic energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n", interDelta,
                          fabs(interDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
         Messenger::print("Intramolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
                          intraDelta, fabs(intraDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
-        Messenger::print("Intermolecular energy delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
-                         moleculeDelta, fabs(moleculeDelta) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+        Messenger::print("Molecular pairpotential energy A delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
+                         moleculeDeltaA, fabs(moleculeDeltaA) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
+        Messenger::print("Molecular pairpotential energy B delta is {:15.9e} kJ/mol and is {} (threshold is {:10.3e} kJ/mol)\n",
+                         moleculeDeltaB, fabs(moleculeDeltaB) < testThreshold_ ? "OK" : "NOT OK", testThreshold_);
 
         // All OK?
         if (!moduleContext.processPool().allTrue((fabs(interDelta) < testThreshold_) && (fabs(intraDelta) < testThreshold_) &&
-                                                 (fabs(moleculeDelta) < testThreshold_)))
+                                                 (fabs(moleculeDeltaA) < testThreshold_) &&
+                                                 (fabs(moleculeDeltaB) < testThreshold_)))
             return ExecutionResult::Failed;
     }
 


### PR DESCRIPTION
This PR fixes a horrible little bug in the `EnergyKernel::pairPotential(Molecule &mol...)` function where the molecule's self-energy was double-counted. This led to odd, biased behaviour of the `IntraShake` module (the only user of the routine in this manner).