### PR TITLE
fix: Potential scaling in EPSRManager was broken after potential averaging was introduced

### DIFF
--- a/src/modules/epsrManager/process.cpp
+++ b/src/modules/epsrManager/process.cpp
@@ -85,7 +85,7 @@ Module::ExecutionResult EPSRManagerModule::process(ModuleContext &moduleContext)
 
         Messenger::print("Apply scaling factor of {} to potential(s) {}-{}...\n", scaleFactor, typeA, typeB);
         auto count = 0;
-        for (auto &&[key, epData] : newPotentials.potentialMap())
+        for (auto &&[key, epData] : currentPotentials.potentialMap())
         {
             // Is this potential a match
             if ((DissolveSys::sameWildString(typeA, epData.at1->name()) &&


### PR DESCRIPTION
Reference the correct potential so potScale works again with averaging