### PR TITLE
fix: Use long int for some accumulators to avoid overflow

### DIFF
--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -69,8 +69,8 @@ Module::ExecutionResult AngleModule::process(ModuleContext &moduleContext)
 
     auto nAAvailable = a.sites().size(), nACumulative = a.sites().size();
     auto nASelections = 1;
-    auto nBAvailable = 0, nBCumulative = 0, nBSelections = 0;
-    auto nCAvailable = 0, nCCumulative = 0, nCSelections = 0;
+    auto nBAvailable = 0l, nBCumulative = 0l, nBSelections = 0l;
+    auto nCAvailable = 0l, nCCumulative = 0l, nCSelections = 0l;
 
     for (const auto &[siteA, indexA] : a.sites())
     {

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -49,8 +49,9 @@ Module::ExecutionResult DAngleModule::process(ModuleContext &moduleContext)
     auto nASelections = 1;
     auto nAAvailable = a.sites().size(), nACumulative = a.sites().size();
     auto nBSelections = nAAvailable;
-    auto nBAvailable = 0, nBCumulative = 0;
-    auto nCSelections = 0, nCAvailable = 0, nCCumulative = 0;
+    auto nBAvailable = 0l, nBCumulative = 0l;
+    auto nCSelections = 0;
+    auto nCAvailable = 0l, nCCumulative = 0l;
 
     for (const auto &[siteA, indexA] : a.sites())
     {


### PR DESCRIPTION
The PR fixes two modules that were prone to integer overflow when a decent number of molecules / sites were being considered (as detailed in #2022). The solution is to just use `long` but there might be a more general discussion to have regarding how we handle large integer accumulators / counters in future.

Closes #2022.