### PR TITLE
Node parameter setting

### DIFF
--- a/src/nodes/add.cpp
+++ b/src/nodes/add.cpp
@@ -14,8 +14,8 @@ AddNode::AddNode()
  * Definition (Virtuals)
  */
 
-// Return short name of the node
-std::string_view AddNode::name() const { return "Add"; }
+// Return type of the node
+std::string_view AddNode::type() const { return "Add"; }
 
 // Return short summary of the node's purpose
 std::string_view AddNode::summary() const { return "Performs addition of operands A and B"; }

--- a/src/nodes/add.h
+++ b/src/nodes/add.h
@@ -17,8 +17,8 @@ class AddNode : public Node
      * Definition
      */
     public:
-    // Return short name of the node
-    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
     // Return short summary of the node's purpose
     std::string_view summary() const override;
 

--- a/src/nodes/atomShake.cpp
+++ b/src/nodes/atomShake.cpp
@@ -30,7 +30,7 @@ AtomShakeNode::AtomShakeNode()
     // executeIfTargetsUnchanged_ = true;
 }
 
-std::string_view AtomShakeNode::name() const { return "Atom Shake"; }
+std::string_view AtomShakeNode::type() const { return "Atom Shake"; }
 
 std::string_view AtomShakeNode::summary() const
 {

--- a/src/nodes/atomShake.cpp
+++ b/src/nodes/atomShake.cpp
@@ -6,7 +6,7 @@
 AtomShakeNode::AtomShakeNode()
 {
     addInput<Configuration *>("Configuration", "Set target configuration for the module", targetConfiguration_)
-        ->setFlags(ParameterBase::Invalidates);
+        ->setFlags(ParameterBase::ClearData);
 
     //    keywords_.setOrganisation("Options", "Control", "Number of move attempts per atom and the target acceptance rate.");
     addInput<int>("ShakesPerAtom", "Number of shakes to attempt per atom", nShakesPerAtom_);

--- a/src/nodes/atomShake.h
+++ b/src/nodes/atomShake.h
@@ -14,7 +14,7 @@ class AtomShakeNode : public Node
     ~AtomShakeNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     /*

--- a/src/nodes/derivative.cpp
+++ b/src/nodes/derivative.cpp
@@ -7,7 +7,7 @@ DerivativeNode::DerivativeNode()
     addOutput<Data1D>("Derivative", "The elementwise derivative of the input", derivative_);
 }
 
-std::string_view DerivativeNode::name() const { return "Derivative"; }
+std::string_view DerivativeNode::type() const { return "Derivative"; }
 
 std::string_view DerivativeNode::summary() const { return "Computes the derivate of a 1D data series"; }
 

--- a/src/nodes/derivative.h
+++ b/src/nodes/derivative.h
@@ -14,7 +14,7 @@ class DerivativeNode : public Node
     ~DerivativeNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     /*

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -14,7 +14,7 @@ class DissolveNode : public Node
     ~DissolveNode() override = default;
 
     public:
-    std::string_view name() const override { return "Dissolve"; }
+    std::string_view type() const override { return "Dissolve"; }
     std::string_view summary() const override { return "Parent node of all simulations"; }
 
     /*

--- a/src/nodes/dotProduct.cpp
+++ b/src/nodes/dotProduct.cpp
@@ -7,7 +7,7 @@ DotProductNode::DotProductNode()
     addOutput<double>("Product", "The inner product of the vectors", dotProduct_);
 }
 
-std::string_view DotProductNode::name() const { return "Dot Product"; }
+std::string_view DotProductNode::type() const { return "Dot Product"; }
 
 std::string_view DotProductNode::summary() const { return "Computes the dot product of a pair of vectors u and v"; }
 

--- a/src/nodes/dotProduct.h
+++ b/src/nodes/dotProduct.h
@@ -14,7 +14,7 @@ class DotProductNode : public Node
     ~DotProductNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     /*

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -108,8 +108,7 @@ NodeConstants::ProcessResult Edge::pull()
      * current versionIndex ready for next time.
      */
     auto result = NodeConstants::ProcessResult::Failed;
-    if (sourceNodeVersionIndex_ == NodeConstants::InvalidVersion ||
-        sourceNode_.versionIndex() == NodeConstants::InvalidVersion || (sourceNodeVersionIndex_ != sourceNode_.versionIndex()))
+    if (!sourceNode_.isUpToDate() || (sourceNodeVersionIndex_ != sourceNode_.versionIndex()))
     {
         result = sourceNode_.run();
         if (result != NodeConstants::ProcessResult::Success && result != NodeConstants::ProcessResult::Unchanged)

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -12,10 +12,8 @@ Edge::Edge(Node &sourceNode, ParameterBase &sourceOutput, Node &targetNode, Para
 Edge::~Edge()
 {
     // Detach from the source and target nodes
-    if (sourceNode_)
-        sourceNode_->removeEdge(this);
-    if (targetNode_)
-        targetNode_->removeEdge(this);
+    sourceNode_.unlinkEdge(this);
+    targetNode_.unlinkEdge(this);
 }
 
 // Local EdgeConstructor class to allow creation of memory-managed Edge instances
@@ -83,7 +81,7 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     auto edge = std::make_unique<EdgeConstructor>(*sourceNode, *sourceOutput, *targetNode, *targetInput);
 
     // Notify nodes about the new edge
-    if (!sourceNode->addEdge(edge.get()) || !targetNode->addEdge(edge.get()))
+    if (!sourceNode->linkEdge(edge.get()) || !targetNode->linkEdge(edge.get()))
         return {};
 
     return edge;

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -9,6 +9,15 @@ Edge::Edge(Node &sourceNode, ParameterBase &sourceOutput, Node &targetNode, Para
 {
 }
 
+Edge::~Edge()
+{
+    // Detach from the source and target nodes
+    if (sourceNode_)
+        sourceNode_->removeEdge(this);
+    if (targetNode_)
+        targetNode_->removeEdge(this);
+}
+
 // Local EdgeConstructor class to allow creation of memory-managed Edge instances
 class EdgeConstructor : public Edge
 {

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -107,10 +107,9 @@ NodeConstants::ProcessResult Edge::pull()
      * itself we need to pull from or run the source node to get the updated output. We can then store the source node's
      * current versionIndex ready for next time.
      */
-    auto result = NodeConstants::ProcessResult::Failed;
     if (!sourceNode_.isUpToDate() || (sourceNodeVersionIndex_ != sourceNode_.versionIndex()))
     {
-        result = sourceNode_.run();
+        auto result = sourceNode_.run();
         if (result != NodeConstants::ProcessResult::Success && result != NodeConstants::ProcessResult::Unchanged)
         {
             Messenger::error("Failed to pull updated value from node '{}'\n", sourceNode_.name());
@@ -120,13 +119,10 @@ NodeConstants::ProcessResult Edge::pull()
         // Update version index
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();
 
-        // If the source node's run() result was Unchanged, return success anyway as we need to flag to our target node
-        // that its data has changed and needs to run again.
-        result = NodeConstants::ProcessResult::Success;
+        // Copy the parameter data over
+        return targetInput_.assign(&sourceOutput_) ? NodeConstants::ProcessResult::Success
+                                                   : NodeConstants::ProcessResult::Failed;
     }
-    else
-        result = NodeConstants::ProcessResult::Unchanged;
 
-    // Copy the parameter data over
-    return targetInput_.assign(&sourceOutput_) ? result : NodeConstants::ProcessResult::Failed;
+    return NodeConstants::ProcessResult::Unchanged;
 }

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -20,15 +20,16 @@ struct EdgeDefinition
 // Edge
 class Edge
 {
-    private:
-    // Edge definition
-    EdgeDefinition definition_;
+    public:
+    ~Edge();
 
     protected:
     // The constructor is private because it can only be constructed by the factory method
     Edge(Node &sourceNode, ParameterBase &sourceOutput, Node &targetNode, ParameterBase &targetInput);
 
     private:
+    // Edge definition
+    EdgeDefinition definition_;
     // Store references instead of pointers to the linked nodes and parameters for two reasons:
     // 1) Neither end of the link should EVER be null
     // 2) The link itself is immutable.  You can create links and

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -19,6 +19,37 @@ bool Graph::addEdge(const EdgeDefinition &definition)
     return true;
 }
 
+// Remove edge between nodes
+bool Graph::removeEdge(const EdgeDefinition &definition)
+{
+    auto edge = findEdge(definition);
+    if (!edge)
+        return Messenger::error("Edge doesn't exist, so can't remove it.\n");
+    else
+        return removeEdge(edge);
+}
+bool Graph::removeEdge(Edge *edgeToRemove)
+{
+    auto it =
+        std::find_if(edges_.begin(), edges_.end(), [edgeToRemove](const auto &edge) { return edge.get() == edgeToRemove; });
+    if (it == edges_.end())
+        return Messenger::error("Edge pointer doesn't exist, so can't remove it.\n");
+    edges_.erase(it);
+    return true;
+}
+
+// Find edge between nodes
+Edge *Graph::findEdge(const EdgeDefinition &definition) const
+{
+    auto it =
+        std::find_if(edges_.begin(), edges_.end(), [definition](const auto &edge) { return edge->definition() == definition; });
+
+    if (it != edges_.end())
+        return it->get();
+
+    return {};
+}
+
 // Return named node, if it exists
 Node *Graph::node(std::string_view name)
 {

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -5,7 +5,7 @@ void Graph::addNode(std::unique_ptr<Node> &&node, std::string_view name)
 {
     node->setParentGraph(this);
     node->setName(name);
-    nodes_.emplace_back(std::move(node));
+    nodes_.insert(std::make_pair<std::string, std::unique_ptr<Node>>(std::string(name), std::move(node)));
 }
 
 // Add parameter link between nodes
@@ -54,10 +54,8 @@ Edge *Graph::findEdge(const EdgeDefinition &definition) const
 // Return named node, if it exists
 Node *Graph::node(std::string_view name)
 {
-    auto it = std::find_if(nodes_.begin(), nodes_.end(),
-                           [name](const auto &node) { return DissolveSys::sameString(node->name(), name); });
-    if (it != nodes_.end())
-        return it->get();
+    if (nodes_.contains(std::string(name)))
+        return nodes_[std::string(name)].get();
 
     return nullptr;
 }
@@ -78,7 +76,7 @@ std::string_view Graph::summary() const { return "A node which contains its own 
 SerialisedValue Graph::serialise() const
 {
     SerialisedValue graph, result = Node::serialise();
-    for (auto &node : nodes_)
+    for (auto &[name, node] : nodes_)
         graph[std::string(node->name())] = *node;
     result["graph"] = graph;
     return result;

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -4,7 +4,8 @@
 void Graph::addNode(std::unique_ptr<Node> &&node, std::string_view name)
 {
     node->setParentGraph(this);
-    nodes_.insert(std::make_pair(name, std::move(node)));
+    node->setName(name);
+    nodes_.emplace_back(std::move(node));
 }
 
 // Add parameter link between nodes
@@ -53,8 +54,10 @@ Edge *Graph::findEdge(const EdgeDefinition &definition) const
 // Return named node, if it exists
 Node *Graph::node(std::string_view name)
 {
-    if (nodes_.contains(name))
-        return nodes_[name].get();
+    auto it = std::find_if(nodes_.begin(), nodes_.end(),
+                           [name](const auto &node) { return DissolveSys::sameString(node->name(), name); });
+    if (it != nodes_.end())
+        return it->get();
 
     return nullptr;
 }
@@ -65,8 +68,8 @@ Graph::Nodes &Graph::nodes() { return nodes_; }
 // Return edges on the graph
 Graph::Edges &Graph::edges() { return edges_; }
 
-// Return short name of the node
-std::string_view Graph::name() const { return "Graph"; }
+// Return type of the node
+std::string_view Graph::type() const { return "Graph"; }
 
 // Return short summary of the node's purpose
 std::string_view Graph::summary() const { return "A node which contains its own inner graph"; }
@@ -75,8 +78,8 @@ std::string_view Graph::summary() const { return "A node which contains its own 
 SerialisedValue Graph::serialise() const
 {
     SerialisedValue graph, result = Node::serialise();
-    for (auto &[k, v] : nodes_)
-        graph[std::string(k)] = *v;
+    for (auto &node : nodes_)
+        graph[std::string(node->name())] = *node;
     result["graph"] = graph;
     return result;
 }

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -42,13 +42,13 @@ class Graph : public Node
     static std::unique_ptr<Node> produceNode(const std::string_view &nodeType) { return registry.find(nodeType)->second(); }
     // Add node
     void addNode(std::unique_ptr<Node> &&node, std::string_view name);
-    // Add parameter link between nodes
+    // Add edge between nodes
     bool addEdge(const EdgeDefinition &definition);
     // Return named node, if it exists
     Node *node(std::string_view name);
     // Return container of nodes
     Nodes &nodes();
-    // Return container of parameter links between nodes
+    // Return container of edges between nodes
     Edges &edges();
 
     // Express as a serialisable value

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -22,7 +22,7 @@ class Graph : public Node
     /*
      * Nodes and edges
      */
-    using Nodes = std::vector<std::unique_ptr<Node>>;
+    using Nodes = std::map<std::string, std::unique_ptr<Node>>;
     using Edges = std::vector<std::unique_ptr<Edge>>;
 
     private:

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -22,7 +22,7 @@ class Graph : public Node
     /*
      * Nodes and edges
      */
-    using Nodes = std::map<std::string_view, std::unique_ptr<Node>>;
+    using Nodes = std::vector<std::unique_ptr<Node>>;
     using Edges = std::vector<std::unique_ptr<Edge>>;
 
     private:
@@ -34,8 +34,8 @@ class Graph : public Node
     Edges edges_;
 
     public:
-    // Return short name of the node
-    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
     // Return short summary of the node's purpose
     std::string_view summary() const override;
     // Produce a registered node by type

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -44,6 +44,11 @@ class Graph : public Node
     void addNode(std::unique_ptr<Node> &&node, std::string_view name);
     // Add edge between nodes
     bool addEdge(const EdgeDefinition &definition);
+    // Remove edge between nodes
+    bool removeEdge(const EdgeDefinition &definition);
+    bool removeEdge(Edge *edgeToRemove);
+    // Find edge between nodes
+    Edge *findEdge(const EdgeDefinition &definition) const;
     // Return named node, if it exists
     Node *node(std::string_view name);
     // Return container of nodes

--- a/src/nodes/integrator.cpp
+++ b/src/nodes/integrator.cpp
@@ -20,7 +20,7 @@ EnumOptions<Integrator1DNode::Method> Integrator1DNode::types()
                                                  });
 }
 
-std::string_view Integrator1DNode::name() const { return "Integrator"; }
+std::string_view Integrator1DNode::type() const { return "Integrator"; }
 
 std::string_view Integrator1DNode::summary() const { return "Computes the integral for a 1D data series"; }
 

--- a/src/nodes/integrator.h
+++ b/src/nodes/integrator.h
@@ -16,7 +16,7 @@ class Integrator1DNode : public Node
     ~Integrator1DNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     // Integrator type

--- a/src/nodes/multiply.cpp
+++ b/src/nodes/multiply.cpp
@@ -11,8 +11,8 @@ MultiplyNode::MultiplyNode()
  * Definition (Virtuals)
  */
 
-// Return short name of the node
-std::string_view MultiplyNode::name() const { return "Multiply"; }
+// Return type of the node
+std::string_view MultiplyNode::type() const { return "Multiply"; }
 
 // Return short summary of the node's purpose
 std::string_view MultiplyNode::summary() const { return "Performs multiplication of factors A and B"; }

--- a/src/nodes/multiply.h
+++ b/src/nodes/multiply.h
@@ -14,8 +14,8 @@ class MultiplyNode : public Node
     ~MultiplyNode() override = default;
 
     public:
-    // Return short name of the node
-    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
     // Return short summary of the node's purpose
     std::string_view summary() const override;
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -5,6 +5,16 @@
 #include "base/sysFunc.h"
 
 /*
+ * Definition
+ */
+
+// Set node name
+void Node::setName(std::string_view newName) { name_ = newName; }
+
+// Return node name
+std::string_view Node::name() const { return name_; }
+
+/*
  * Inputs, Outputs & Options
  */
 
@@ -203,6 +213,7 @@ SerialisedValue Node::serialise() const
 {
     SerialisedValue result, inputs, options;
     result["name"] = name();
+    result["type"] = type();
 
     if (!inputs_.empty())
     {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -52,7 +52,11 @@ void Node::removeEdge(Edge *edge)
 int Node::versionIndex() const { return versionIndex_; }
 
 // Invalidate the current node, resetting the version index
-void Node::invalidate() { versionIndex_ = NodeConstants::InvalidVersion; }
+void Node::invalidate()
+{
+    versionIndex_ = NodeConstants::InvalidVersion;
+    clearData();
+}
 
 // Flag that the node data needs to be updated
 void Node::setUpdateRequired() { upToDate_ = false; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -39,9 +39,25 @@ bool Node::addEdge(Edge *edge)
 // Remove edge
 void Node::removeEdge(Edge *edge)
 {
-    // TODO
-    // inputEdges_.erase(std::remove_if(inputEdges_.begin(), inputEdges_.end(), [edge](const auto &it) { return edge ==
-    // it.second; } ), inputEdges_.end());
+    // If we are the Edge's targetNode_ then we should have its pointer in inputEdges_
+    if (edge->targetNode() == this)
+    {
+        auto it = std::find_if(inputEdges_.begin(), inputEdges_.end(),
+                               [edge](const auto &inputEdge) { return edge == inputEdge.second; });
+        if (it == inputEdges_.end())
+            Messenger::error("Tried to remove an Edge from a target node ('{}') which knew nothing about it.\n", name());
+        else
+        {
+            inputEdges_.erase(it);
+            invalidate();
+        }
+    }
+    else if (edge->sourceNode() == this)
+    {
+        // We are the source node for the edge - nothing for us to do at present
+    }
+    else
+        Messenger::error("Node '{}' is neither the source nor the target for the Edge being removed.\n", name());
 }
 
 /*

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -50,7 +50,7 @@ bool Node::linkEdge(Edge *edge)
 void Node::unlinkEdge(Edge *edge)
 {
     // If we are the Edge's targetNode_ then we should have its pointer in inputEdges_
-    if (edge->targetNode() == this)
+    if (&edge->targetNode() == this)
     {
         auto it = std::find_if(inputEdges_.begin(), inputEdges_.end(),
                                [edge](const auto &inputEdge) { return edge == inputEdge.second; });
@@ -62,7 +62,7 @@ void Node::unlinkEdge(Edge *edge)
             invalidate();
         }
     }
-    else if (edge->sourceNode() == this)
+    else if (&edge->sourceNode() == this)
     {
         // We are the source node for the edge - nothing for us to do at present
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -18,8 +18,8 @@ std::string_view Node::name() const { return name_; }
  * Inputs, Outputs & Options
  */
 
-// Add edge
-bool Node::addEdge(Edge *edge)
+// Link edge, returning whether we accept it
+bool Node::linkEdge(Edge *edge)
 {
     // The supplied Edge was created via our parent Graph, but we will still check to see whether we accept it
     if (&edge->targetNode() == this)
@@ -46,8 +46,8 @@ bool Node::addEdge(Edge *edge)
     return true;
 }
 
-// Remove edge
-void Node::removeEdge(Edge *edge)
+// Unlink edge
+void Node::unlinkEdge(Edge *edge)
 {
     // If we are the Edge's targetNode_ then we should have its pointer in inputEdges_
     if (edge->targetNode() == this)
@@ -55,7 +55,7 @@ void Node::removeEdge(Edge *edge)
         auto it = std::find_if(inputEdges_.begin(), inputEdges_.end(),
                                [edge](const auto &inputEdge) { return edge == inputEdge.second; });
         if (it == inputEdges_.end())
-            Messenger::error("Tried to remove an Edge from a target node ('{}') which knew nothing about it.\n", name());
+            Messenger::error("Tried to unlink an Edge from a target node ('{}') which knew nothing about it.\n", name());
         else
         {
             inputEdges_.erase(it);
@@ -67,7 +67,7 @@ void Node::removeEdge(Edge *edge)
         // We are the source node for the edge - nothing for us to do at present
     }
     else
-        Messenger::error("Node '{}' is neither the source nor the target for the Edge being removed.\n", name());
+        Messenger::error("Node '{}' is neither the source nor the target for the Edge being unlinked.\n", name());
 }
 
 /*

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -108,12 +108,13 @@ NodeConstants::ProcessResult Node::run()
                 break;
             case (NodeConstants::ProcessResult::Success):
                 ++versionIndex_;
+                upToDate_ = true;
+                break;
             case (NodeConstants::ProcessResult::Unchanged):
+                upToDate_ = true;
                 break;
         }
     }
-
-    upToDate_ = true;
 
     return result;
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -158,6 +158,13 @@ Graph *Node::parentGraph() const { return parentGraph_; }
 Node::EdgeMap &Node::links() { return inputEdges_; }
 
 /*
+ * Data
+ */
+
+// Clear any local data
+void Node::clearData() {}
+
+/*
  * I/O
  */
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -22,6 +22,9 @@ bool Node::addEdge(Edge *edge)
 
         // All good, so add the input to our list
         inputEdges_[edge->targetInput().name()] = edge;
+
+        // Adding an Edge to an input always invalidates the target
+        invalidate();
     }
     else if (&edge->sourceNode() == this)
     {
@@ -51,6 +54,12 @@ int Node::versionIndex() const { return versionIndex_; }
 // Invalidate the current node, resetting the version index
 void Node::invalidate() { versionIndex_ = NodeConstants::InvalidVersion; }
 
+// Flag that the node data needs to be updated
+void Node::setUpdateRequired() { upToDate_ = false; }
+
+// Return whether the node's data is up-to-date
+bool Node::isUpToDate() const { return upToDate_; }
+
 // Check that all required inputs are present, and that all inputs are valid
 bool Node::inputsAreValid() const
 {
@@ -72,8 +81,7 @@ bool Node::inputsAreValid() const
 // Run the node, retrieving dependent inputs as necessary
 NodeConstants::ProcessResult Node::run()
 {
-    // Check our input links - if any are out-of-date we must retrieve new values
-    auto nInputLinksChanged = 0;
+    // Check our input links - if any are out-of-date we must retrieve new values. This will automatically unset upToDate_
     for (auto &[inputName, edge] : inputEdges_)
     {
         auto edgeResult = edge->pull();
@@ -83,7 +91,6 @@ NodeConstants::ProcessResult Node::run()
             case (NodeConstants::ProcessResult::InputsNotSatisfied):
                 return NodeConstants::ProcessResult::Failed;
             case (NodeConstants::ProcessResult::Success):
-                ++nInputLinksChanged;
             case (NodeConstants::ProcessResult::Unchanged):
                 break;
         }
@@ -91,7 +98,7 @@ NodeConstants::ProcessResult Node::run()
 
     // If input links have updated or we are currently flagged as invalid we must reprocess
     auto result = NodeConstants::ProcessResult::Unchanged;
-    if (nInputLinksChanged > 0 || versionIndex_ == NodeConstants::InvalidVersion)
+    if (!upToDate_ || versionIndex_ == NodeConstants::InvalidVersion)
     {
         result = process();
         switch (result)
@@ -105,6 +112,8 @@ NodeConstants::ProcessResult Node::run()
                 break;
         }
     }
+
+    upToDate_ = true;
 
     return result;
 }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -85,10 +85,10 @@ class Node : public Serialisable<>
     EdgeMap inputEdges_;
 
     public:
-    // Add edge, returning whether we accept it
-    bool addEdge(Edge *edge);
-    // Remove edge
-    void removeEdge(Edge *edge);
+    // Link edge, returning whether we accept it
+    bool linkEdge(Edge *edge);
+    // Unlink edge
+    void unlinkEdge(Edge *edge);
     // Add input parameter
     template <class T> std::shared_ptr<ParameterBase> addOption(std::string_view name, std::string_view description, T &data)
     {

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -25,16 +25,22 @@ class Node : public Serialisable<>
 
     using EdgeMap = std::map<std::string_view, Edge *>;
 
-    private:
-    // Node parent graph
-    Graph *parentGraph_;
-
     /*
      * Definition
      */
+    private:
+    // Name of the node (unique within it's parent Graph)
+    std::string name_;
+    // Node parent graph
+    Graph *parentGraph_;
+
     public:
-    // Return short name of the node
-    virtual std::string_view name() const = 0;
+    // Set node name
+    void setName(std::string_view newName);
+    // Return node name
+    std::string_view name() const;
+    // Return node type
+    virtual std::string_view type() const = 0;
     // Return short summary of the node's purpose
     virtual std::string_view summary() const = 0;
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -156,6 +156,17 @@ class Node : public Serialisable<>
     // Returns the node parent graph
     Graph *parentGraph() const;
 
+    /*
+     * Data
+     */
+    public:
+    // Clear any local data
+    virtual void clearData();
+
+    /*
+     * I/O
+     */
+    public:
     // Express as a serialisable value
     SerialisedValue serialise() const override;
     // Read values from a serialisable value

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -44,6 +44,8 @@ class Node : public Serialisable<>
     private:
     // Version index for the node, bumped whenever result outputs change
     int versionIndex_{NodeConstants::InvalidVersion};
+    // Whether the node's data is up-to-date
+    bool upToDate_{false};
 
     protected:
     // Perform processing
@@ -54,6 +56,10 @@ class Node : public Serialisable<>
     int versionIndex() const;
     // Invalidate the current node, resetting versionIndex_
     void invalidate();
+    // Flag that the node data needs to be updated
+    void setUpdateRequired();
+    // Return whether the node's data is up-to-date
+    bool isUpToDate() const;
     // Check that all required inputs are present, and that all inputs are valid
     bool inputsAreValid() const;
     // Run the node, retrieving dependent inputs as necessary

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -35,8 +35,8 @@ const Flags<ParameterBase::ParameterFlags> &ParameterBase::flags() const { retur
  * Data
  */
 
-// Invalidate the parent node (e.g. because our value has changed and we are an Invalidating parameter)
-void ParameterBase::invalidateParent() const { return parent_->invalidate(); }
+// Flag that an update is required in the parent node
+void ParameterBase::setParentUpdateRequired() const { parent_->setUpdateRequired(); }
 
 // Clear data in the parent node
 void ParameterBase::clearDataInParent() const { parent_->clearData(); }

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -37,3 +37,6 @@ const Flags<ParameterBase::ParameterFlags> &ParameterBase::flags() const { retur
 
 // Invalidate the parent node (e.g. because our value has changed and we are an Invalidating parameter)
 void ParameterBase::invalidateParent() const { return parent_->invalidate(); }
+
+// Clear data in the parent node
+void ParameterBase::clearDataInParent() const { parent_->clearData(); }

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -21,11 +21,11 @@ class ParameterBase : public Serialisable<>
     // Parameter Flags
     enum ParameterFlags
     {
-        Required,     /* Indicates that this (input) has no default value and must have a link */
-        NoInvalidate, /* Indicates that changing the parameters value does not invalidate the node */
-        ClearData,    /* Indicates that any local data should be cleared if the parameter is changed */
-        Input,        /* Indicates that the parameter is meant to be a sink for data and not a source */
-        Output,       /* Indicates that the parameter is meant to be a source of data and not a sink */
+        Required,  /* Indicates that this (input) has no default value and must have a link */
+        NoUpdate,  /* Indicates that changing the parameters value does not warrant a node update */
+        ClearData, /* Indicates that any local data should be cleared if the parameter is changed */
+        Input,     /* Indicates that the parameter is meant to be a sink for data and not a source */
+        Output,    /* Indicates that the parameter is meant to be a source of data and not a sink */
     };
 
     /*
@@ -63,8 +63,8 @@ class ParameterBase : public Serialisable<>
     public:
     // Return whether the contained data represents the default value
     virtual bool isDefault() const = 0;
-    // Invalidate the parent node
-    void invalidateParent() const;
+    // Flag that an update is required in the parent node
+    void setParentUpdateRequired() const;
     // Clear data in the parent node
     void clearDataInParent() const;
     // Assign the value of another parameter to this one.
@@ -105,9 +105,9 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         {
             data_ = value;
 
-            // Changing parameters always invalidates nodes, unless the NoInvalidate flag is set
-            if (!flags_.isSet(NoInvalidate))
-                invalidateParent();
+            // Changing parameters always flags an update as being required, unless the NoUpdate flag is set
+            if (!flags_.isSet(NoUpdate))
+                setParentUpdateRequired();
 
             // Setting some parameters forces any local data to be cleared
             if (flags_.isSet(ClearData))

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -21,10 +21,11 @@ class ParameterBase : public Serialisable<>
     // Parameter Flags
     enum ParameterFlags
     {
-        Required,    /* Indicates that this (input) has no default value and must have a link */
-        Invalidates, /* Indicates that the node's data is invalidated if the parameter is changed */
-        Input,       /* Indicates that the parameter is meant to be a sink for data and not a source */
-        Output,      /* Indicates that the parameter is meant to be a source of data and not a sink */
+        Required,     /* Indicates that this (input) has no default value and must have a link */
+        NoInvalidate, /* Indicates that changing the parameters value does not invalidate the node */
+        ClearData,    /* Indicates that any local data should be cleared if the parameter is changed */
+        Input,        /* Indicates that the parameter is meant to be a sink for data and not a source */
+        Output,       /* Indicates that the parameter is meant to be a source of data and not a sink */
     };
 
     /*
@@ -62,8 +63,10 @@ class ParameterBase : public Serialisable<>
     public:
     // Return whether the contained data represents the default value
     virtual bool isDefault() const = 0;
-    // Invalidate the parent node (e.g. because our value has changed and we are an Invalidating parameter)
+    // Invalidate the parent node
     void invalidateParent() const;
+    // Clear data in the parent node
+    void clearDataInParent() const;
     // Assign the value of another parameter to this one.
     virtual bool assign(ParameterBase *other) = 0;
     // Access the full parameter from the base
@@ -101,8 +104,14 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         if (data_ != value)
         {
             data_ = value;
-            if (flags_.isSet(Invalidates))
+
+            // Changing parameters always invalidates nodes, unless the NoInvalidate flag is set
+            if (!flags_.isSet(NoInvalidate))
                 invalidateParent();
+
+            // Setting some parameters forces any local data to be cleared
+            if (flags_.isSet(ClearData))
+                clearDataInParent();
         }
     }
     // Return the parameter value

--- a/src/nodes/subtract.cpp
+++ b/src/nodes/subtract.cpp
@@ -11,8 +11,8 @@ SubtractNode::SubtractNode()
  * Definition (Virtuals)
  */
 
-// Return short name of the node
-std::string_view SubtractNode::name() const { return "Subtract"; }
+// Return type of the node
+std::string_view SubtractNode::type() const { return "Subtract"; }
 
 // Return short summary of the node's purpose
 std::string_view SubtractNode::summary() const { return "Performs the subtraction A - B"; }

--- a/src/nodes/subtract.h
+++ b/src/nodes/subtract.h
@@ -14,8 +14,8 @@ class SubtractNode : public Node
     ~SubtractNode() override = default;
 
     public:
-    // Return short name of the node
-    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
     // Return short summary of the node's purpose
     std::string_view summary() const override;
 

--- a/src/nodes/vec3Assembly.cpp
+++ b/src/nodes/vec3Assembly.cpp
@@ -8,7 +8,7 @@ Vec3AssemblyNode::Vec3AssemblyNode()
     addOutput<Vec3<double>>("outputVector_", "The assembed vector", outputVector_);
 }
 
-std::string_view Vec3AssemblyNode::name() const { return "Vector3 Assembly"; }
+std::string_view Vec3AssemblyNode::type() const { return "Vector3 Assembly"; }
 
 std::string_view Vec3AssemblyNode::summary() const { return "Assemble a 3-vector from x, y, and z values."; }
 

--- a/src/nodes/vec3Assembly.h
+++ b/src/nodes/vec3Assembly.h
@@ -14,7 +14,7 @@ class Vec3AssemblyNode : public Node
     ~Vec3AssemblyNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     /*

--- a/src/nodes/vec3Decomposition.cpp
+++ b/src/nodes/vec3Decomposition.cpp
@@ -8,7 +8,7 @@ Vec3DecompositionNode::Vec3DecompositionNode()
     addOutput<double>("Z", "The first component of the vector", z_);
 }
 
-std::string_view Vec3DecompositionNode::name() const { return "Vector3 Decomposition"; }
+std::string_view Vec3DecompositionNode::type() const { return "Vector3 Decomposition"; }
 
 std::string_view Vec3DecompositionNode::summary() const { return "Decompose a 3-vector into x, y, and z components."; }
 

--- a/src/nodes/vec3Decomposition.h
+++ b/src/nodes/vec3Decomposition.h
@@ -14,7 +14,7 @@ class Vec3DecompositionNode : public Node
     ~Vec3DecompositionNode() override = default;
 
     public:
-    std::string_view name() const override;
+    std::string_view type() const override;
     std::string_view summary() const override;
 
     /*

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -86,49 +86,107 @@ TEST_F(GraphFlowTest, Basic)
 
     // Check nodes in isolation first - all should be able to run and give meaningful results
     EXPECT_TRUE(x_->inputsAreValid());
+    EXPECT_FALSE(x_->isUpToDate());
     EXPECT_EQ(x_->versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(x_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(x_->versionIndex(), 0);
     EXPECT_EQ(xResult_->get().asInteger(), 3);
+    EXPECT_TRUE(x_->isUpToDate());
 
     EXPECT_TRUE(y_->inputsAreValid());
+    EXPECT_FALSE(y_->isUpToDate());
     EXPECT_EQ(y_->versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(y_->versionIndex(), 0);
     EXPECT_EQ(yResult_->get().asInteger(), 7);
+    EXPECT_TRUE(y_->isUpToDate());
 
     EXPECT_TRUE(z_->inputsAreValid());
+    EXPECT_FALSE(z_->isUpToDate());
     EXPECT_EQ(z_->versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(z_->versionIndex(), 0);
     EXPECT_EQ(zResult_->get().asInteger(), 0);
+    EXPECT_TRUE(z_->isUpToDate());
 
     // Running nodes again should not increase version index since the inputs have no dependencies
     EXPECT_EQ(x_->run(), NodeConstants::ProcessResult::Unchanged);
     EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_TRUE(x_->isUpToDate());
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
     EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_TRUE(y_->isUpToDate());
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Unchanged);
     EXPECT_EQ(z_->versionIndex(), 0);
+    EXPECT_TRUE(z_->isUpToDate());
 
     // Add the edge between x's "Result" and z's "A" input
     EXPECT_TRUE(graph_.addEdge({"x", "Result", "z", "A"}));
+    EXPECT_EQ(z_->versionIndex(), NodeConstants::InvalidVersion);
 
     // If we now run z we should use x's output without changing x itself
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(z_->versionIndex(), 1);
+    EXPECT_EQ(z_->versionIndex(), 0);
     EXPECT_EQ(zResult_->get().asInteger(), 3);
     EXPECT_EQ(x_->versionIndex(), 0);
 
     // Complete the graph and link y's "Result" output to z's "B" input
     EXPECT_TRUE(graph_.addEdge({"y", "Result", "z", "B"}));
+    EXPECT_EQ(z_->versionIndex(), NodeConstants::InvalidVersion);
 
     // As before, if we now run z we should use x's and y's output without changing x or y
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(z_->versionIndex(), 2);
+    EXPECT_EQ(z_->versionIndex(), 0);
     EXPECT_EQ(zResult_->get().asInteger(), 10);
     EXPECT_EQ(x_->versionIndex(), 0);
     EXPECT_EQ(y_->versionIndex(), 0);
 };
+
+TEST_F(GraphFlowTest, SetInput)
+{
+    // Get the basic graph
+    createGraph(true);
+
+    // Run z - all nodes should update
+    EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(z_->versionIndex(), 0);
+    EXPECT_EQ(zResult_->get().asInteger(), 10);
+    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+
+    // Set the input A of 'x' manually. This should invalidate 'x' alone.
+    xA_->set(0);
+    EXPECT_FALSE(x_->isUpToDate());
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(z_->versionIndex(), 0);
+
+    // Run z again - it should be forced to reprocess and update itself, along with 'x' - 'y' remains unchanged
+    EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 1);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(z_->versionIndex(), 1);
+    EXPECT_EQ(zResult_->get().asInteger(), 9);
+
+    // One more time
+    xB_->set(10);
+    EXPECT_FALSE(x_->isUpToDate());
+    EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 2);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(z_->versionIndex(), 2);
+    EXPECT_EQ(zResult_->get().asInteger(), 17);
+
+    // And now for y
+    yB_->set(5);
+    EXPECT_TRUE(x_->isUpToDate());
+    EXPECT_FALSE(y_->isUpToDate());
+    EXPECT_TRUE(z_->isUpToDate());
+    EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 2);
+    EXPECT_EQ(y_->versionIndex(), 1);
+    EXPECT_EQ(z_->versionIndex(), 3);
+    EXPECT_EQ(zResult_->get().asInteger(), 18);
+}
 
 } // namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -189,4 +189,32 @@ TEST_F(GraphFlowTest, SetInput)
     EXPECT_EQ(zResult_->get().asInteger(), 18);
 }
 
+TEST_F(GraphFlowTest, RemoveEdges)
+{
+    // Get the basic graph
+    createGraph(true);
+
+    // Run z - all nodes should update
+    EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(z_->versionIndex(), 0);
+    EXPECT_EQ(zResult_->get().asInteger(), 10);
+    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+
+    // Remove edge between x and z - this will invalidate z but not x
+    EXPECT_TRUE(graph_.removeEdge({"x", "Result", "z", "A"}));
+    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(z_->versionIndex(), NodeConstants::InvalidVersion);
+
+    // Now remove edge between y and z - this will invalidate z but not y
+    EXPECT_TRUE(graph_.removeEdge({"y", "Result", "z", "B"}));
+    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(z_->versionIndex(), NodeConstants::InvalidVersion);
+
+    // Try to remove a non-existent edge
+    EXPECT_FALSE(graph_.removeEdge({"Q", "Result", "z", "C"}));
+}
+
 } // namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -35,7 +35,7 @@ class GraphFlowTest : public ::testing::Test
         graph_.addNode(NodeRegistry::produce("Add"), "y");
         graph_.addNode(NodeRegistry::produce("Add"), "z");
 
-        x_ = dynamic_cast<AddNode *>(graph_.nodes()["x"].get());
+        x_ = dynamic_cast<AddNode *>(graph_.node("x"));
         ASSERT_TRUE(x_);
         xA_ = x_->findInput("A")->upcast<Number>();
         xB_ = x_->findInput("B")->upcast<Number>();
@@ -45,7 +45,7 @@ class GraphFlowTest : public ::testing::Test
         ASSERT_TRUE(xResult_);
         xA_->set(1);
         xB_->set(2);
-        y_ = dynamic_cast<AddNode *>(graph_.nodes()["y"].get());
+        y_ = dynamic_cast<AddNode *>(graph_.node("y"));
         ASSERT_TRUE(y_);
         yA_ = y_->findInput("A")->upcast<Number>();
         yB_ = y_->findInput("B")->upcast<Number>();
@@ -55,7 +55,7 @@ class GraphFlowTest : public ::testing::Test
         ASSERT_TRUE(yResult_);
         yA_->set(3);
         yB_->set(4);
-        z_ = dynamic_cast<AddNode *>(graph_.nodes()["z"].get());
+        z_ = dynamic_cast<AddNode *>(graph_.node("z"));
         ASSERT_TRUE(z_);
         zA_ = z_->findInput("A")->upcast<Number>();
         zB_ = z_->findInput("B")->upcast<Number>();

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -35,11 +35,11 @@ class GraphCoreTest : public ::testing::Test
         graph_.addNode(NodeRegistry::produce("Add"), "y");
         graph_.addNode(NodeRegistry::produce("Add"), "z");
 
-        x_ = dynamic_cast<AddNode *>(graph_.nodes()["x"].get());
+        x_ = dynamic_cast<AddNode *>(graph_.node("x"));
         ASSERT_TRUE(x_);
-        y_ = dynamic_cast<AddNode *>(graph_.nodes()["y"].get());
+        y_ = dynamic_cast<AddNode *>(graph_.node("y"));
         ASSERT_TRUE(y_);
-        z_ = dynamic_cast<AddNode *>(graph_.nodes()["z"].get());
+        z_ = dynamic_cast<AddNode *>(graph_.node("z"));
         ASSERT_TRUE(z_);
 
         EXPECT_TRUE(graph_.addEdge({"x", "Result", "z", "A"}));


### PR DESCRIPTION
This PR builds on #2087 and helps to clarify how our graph nodes interact and affect each other.

A node has two principal "state" variables:
1) `versionIndex_` - used to track effectively the number of times the node has been run since the last modification to its edge connectivity.
2) `upToDate_` - whether the node's current data is valid (and it doesn't need to `run()` again at present)

When a node A is `run()` it first checks all of its input `Edge`s and attempts to `pull()` the data from each - if the connected source node B is out of date or the last version index stored in the `Edge` is different from that of B, the node B is `run()` and the relevant data copied to the input parameter on A, and the new version index of B stored in the `Edge`. This automatically sets the `upToDate_` flag on A as `false`, and will force A to call `process()` in order to update itself (once all `Edge`s are checked) and set `upToDate_` back to `true` (as well as incrementing `versionIndex_`.

As alluded to in 1) above, adding or removing an `Edge` to/from a node's input parameters invalidates the node, setting `versionIndex_` back to `InvalidVersion` and clearing any local data.

One other significant change here is moving from storing nodes in a `std::map<std::string_view, std::unique_ptr<Node>>` to a straight `std::vector<std::unique_ptr<Node>>` and setting the name on the `Node` itself. This allows a `Node` to know what its own name is, and allows `Node`s to write data to (say) a file named after itself,  and `Edge`s to return a text description of the connection it represents for serialisation.

Closes #2094.
Closes #2089.
Closes #2090.