### PR TITLE
build: Fix ANTLR4 Conan build on Windows

### DIFF
--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'
@@ -81,7 +81,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest ]
+        os: [ macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -33,6 +33,23 @@ runs:
     with:
       python-version: '3.11'
 
+  - name: Install build components
+    shell: powershell
+    run: |
+      # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+      Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+      $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+      $componentsToInstall= @(
+      "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
+      "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
+      "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+      )
+      [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+      $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+      # should be run twice
+      $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+      $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
   - name: Install Chocolatey Dependencies
     shell: bash
     run: choco install -y ninja wget
@@ -60,6 +77,8 @@ runs:
 
   - name: Setup MSVC Compiler
     uses: ilammy/msvc-dev-cmd@v1
+    with:
+      toolset: '14.39.17.9'
 
   #
   # Build / Retrieve Freetype

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -20,6 +20,9 @@ inputs:
   conanHash:
     type: string
     required: true
+  msvcVersion:
+    type: string
+    default: '14.41.17.11'
 
 runs:
   using: "composite"
@@ -33,16 +36,15 @@ runs:
     with:
       python-version: '3.11'
 
-  - name: Install build components
+  - name: Install Downgraded MSVC
     shell: powershell
     run: |
       # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
       Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
       $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
       $componentsToInstall= @(
-      "Microsoft.VisualStudio.Component.VC.v141.x86.x64"
-      "Microsoft.VisualStudio.Component.VC.14.39.17.9.x86.x64"
-      "Microsoft.VisualStudio.Component.VC.14.39.17.9.ATL"
+      "Microsoft.VisualStudio.Component.VC.${{ inputs.msvcVersion }}.x86.x64"
+      "Microsoft.VisualStudio.Component.VC.${{ inputs.msvcVersion }}.ATL"
       )
       [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
       $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
@@ -78,7 +80,7 @@ runs:
   - name: Setup MSVC Compiler
     uses: ilammy/msvc-dev-cmd@v1
     with:
-      toolset: '14.39.17.9'
+      toolset: ${{ inputs.msvcVersion }}
 
   #
   # Build / Retrieve Freetype

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -29,6 +29,10 @@ runs:
   # Setup / Install Dependencies
   #
 
+  - uses: actions/setup-python@v5
+    with:
+      python-version: '3.11'
+
   - name: Install Chocolatey Dependencies
     shell: bash
     run: choco install -y ninja wget


### PR DESCRIPTION
This PR works around the ANTLR4 conan issue described in #2075 by rolling back the MSVC toolset to the previous minor release (still v143) until the issue is resolved upstream.