### PR TITLE
fix: Crash when closing DataManager dialog

### DIFF
--- a/src/gui/dataManagerDialog.cpp
+++ b/src/gui/dataManagerDialog.cpp
@@ -24,5 +24,11 @@ DataManagerDialog::DataManagerDialog(QWidget *parent, Dissolve &dissolve, Generi
     topLeftLayout->addWidget(view_);
     setLayout(topLeftLayout);
 
-    QObject::connect(&simModel_, SIGNAL(closeClicked()), this, SLOT(accept()));
+    QObject::connect(&simModel_, SIGNAL(closeClicked()), this, SLOT(closeClicked()));
+}
+
+void DataManagerDialog::closeClicked()
+{
+    view_->rootContext()->setContextProperty("simModel", nullptr);
+    accept();
 }

--- a/src/gui/dataManagerDialog.h
+++ b/src/gui/dataManagerDialog.h
@@ -32,4 +32,7 @@ class DataManagerDialog : public QDialog
      */
     private:
     QQuickWidget *view_{nullptr};
+
+    private Q_SLOTS:
+    void closeClicked();
 };

--- a/src/gui/qml/simulationDataManager/SimulationDataManager.qml
+++ b/src/gui/qml/simulationDataManager/SimulationDataManager.qml
@@ -12,6 +12,8 @@ Page {
     }
     function getHeaderStringArray(model) {
         var headerArray = [];
+        if (!model)
+            return headerArray;
         for (var i = 0; i < model.columnCount(); ++i) {
             headerArray.push(qsTr(model.headerData(i, Qt.Horizontal)));
         }
@@ -51,7 +53,7 @@ Page {
                 Layout.preferredHeight: contentHeight
                 Layout.preferredWidth: contentWidth
                 clip: true
-                enabled: simModel.rowCount() == 0 ? false : true
+                enabled: !simModel || simModel.rowCount() == 0 ? false : true
                 model: getHeaderStringArray(simModel)
                 syncView: table
             }


### PR DESCRIPTION
This quick PR fixes a crash in the `DataManagerDialog` when closing the window.

Closes #2050.