### PR TITLE
chore: Change default reference data filetype to mint01 in NeutronSQ module

### DIFF
--- a/src/modules/neutronSQ/neutronSQ.h
+++ b/src/modules/neutronSQ/neutronSQ.h
@@ -33,7 +33,7 @@ class NeutronSQModule : public Module
     // Normalisation to apply to calculated total F(Q)
     StructureFactors::NormalisationType normaliseTo_{StructureFactors::NoNormalisation};
     // Reference F(Q) file and format
-    Data1DImportFileFormat referenceFQ_;
+    Data1DImportFileFormat referenceFQ_{"", Data1DImportFileFormat::Data1DImportFormat::GudrunMint};
     // Minimum Q value to use when Fourier-transforming the data
     std::optional<double> referenceFTQMin_{0.3};
     // Maximum Q value to use when Fourier-transforming the data


### PR DESCRIPTION
One-liner to change the default filetype for reference data to mint01 in the `NeutronSQ` module.

Closes #2036.