### PR TITLE
fix: Adding a Species to a Configuration caused a crash if its forcefield was missing

### DIFF
--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -53,6 +53,10 @@ bool AddGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (species_ && coordinateSets_)
         return Messenger::error("Specify either target Species or target coordinate sets, but not both.\n");
 
+    // Check if the Species itself is valid
+    if (!species_->checkSetUp())
+        return false;
+
     // Check for a periodic species in the case of boxAction_ == Set
     if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
     {

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -58,6 +58,10 @@ bool AddOnSphereGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (!speciesSite_)
         return Messenger::error("No target species site specified in AddOnSphere node.\n");
 
+    // Check if the Species itself is valid
+    if (!speciesSite_->parent()->checkSetUp())
+        return false;
+
     // Check site multiplicity
     if (speciesSite_->instances().size() > 1)
         return Messenger::error("Site must have a single instance - i.e. be unique in the parent species.\n");

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -42,6 +42,10 @@ bool AddPairGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (!speciesA_ || !speciesB_)
         return Messenger::error("One or both target species not specified in Add node.\n");
 
+    // Check if the Species itself is valid
+    if (!speciesA_->checkSetUp() || !speciesB_->checkSetUp())
+        return false;
+
     // Can't set box
     if (boxAction_ == AddGeneratorNodeBase::BoxActionStyle::Set)
         return Messenger::error("Can't set periodic box when using AddPair.\n");


### PR DESCRIPTION
This PR protects against adding a Species to a Box with one of the Add* nodes that has in incomplete or malformed forcefield, as this would cause a crash.

Closes #1990.