### PR TITLE
build: Build freetype and ftgl natively for Apple Silicon

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -156,8 +156,7 @@ runs:
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
-      INCLUDE="${RUNNER_TEMP}/ftgl-latest/src;$INCLUDE"
-      LIB="${RUNNER_TEMP}/ftgl-install/lib;$LIB"
+      FTGL_DIR="${RUNNER_TEMP}/ftgl-install"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"
@@ -180,7 +179,7 @@ runs:
 
       # Build
       mkdir build && cd build
-      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR -DFTGL_DIR=${RUNNER_TEMP}/ftgl-install ../
+      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
 
       # Copy over ftgl libs so we can ship them with the bundle

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -180,7 +180,7 @@ runs:
 
       # Build
       mkdir build && cd build
-      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../
+      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR -DFTGL_DIR=${RUNNER_TEMP}/ftgl-install ../
       cmake --build . --config Release
 
       # Copy over ftgl libs so we can ship them with the bundle

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -71,7 +71,7 @@ runs:
     id: cache-freetype
     uses: actions/cache@v4
     with:
-      key: windows-freetype
+      key: osx-freetype
       path: |
         ${{ runner.temp }}/freetype-latest
         ${{ runner.temp }}/freetype-install
@@ -94,7 +94,7 @@ runs:
     run: |
       set -ex
       mkdir freetype-build && cd freetype-build
-      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF
       cmake --build . --target install --config Release
 
   #
@@ -105,7 +105,7 @@ runs:
     id: cache-ftgl
     uses: actions/cache@v4
     with:
-      key: windows-ftgl
+      key: osx-ftgl
       path: |
         ${{ runner.temp }}/ftgl-latest
         ${{ runner.temp }}/ftgl-install
@@ -154,9 +154,7 @@ runs:
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
       Qt6_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos/lib/cmake/Qt6
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
-      INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
-      LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
-      export FTGL_DIR="/Users/runner/work/_temp/ftgl-build/../ftgl-install"
+      export FTGL_DIR="${RUNNER_TEMP}/ftgl-install"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -127,7 +127,7 @@ runs:
       mkdir ftgl-build && cd ftgl-build
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
-      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF
       cmake --build . --target install --config Release
 
   #

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -35,7 +35,7 @@ runs:
     run: |
       set -ex
       brew update-reset
-      brew install ninja gsl
+      brew install gsl
 
   - name: Get ANTLR
     working-directory: ${{ runner.temp }}

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -156,7 +156,7 @@ runs:
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
-      FTGL_DIR="${RUNNER_TEMP}/ftgl-install"
+      export FTGL_DIR="/Users/runner/work/_temp/ftgl-build/../ftgl-install"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -180,10 +180,6 @@ runs:
       cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
 
-      # Copy over ftgl libs so we can ship them with the bundle
-      mkdir ftgl
-      cp -v $(brew --prefix ftgl)/lib/*.dylib ./ftgl
-
   - name: Upload Raw Build Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v4

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -73,8 +73,8 @@ runs:
     with:
       key: windows-freetype
       path: |
-        ${{ runner.temp }}\freetype-latest
-        ${{ runner.temp }}\freetype-install
+        ${{ runner.temp }}/freetype-latest
+        ${{ runner.temp }}/freetype-install
 
   - name: Download FreeType
     if: ${{ steps.cache-freetype.outputs.cache-hit != 'true' }}
@@ -107,8 +107,8 @@ runs:
     with:
       key: windows-ftgl
       path: |
-        ${{ runner.temp }}\ftgl-latest
-        ${{ runner.temp }}\ftgl-install
+        ${{ runner.temp }}/ftgl-latest
+        ${{ runner.temp }}/ftgl-install
 
   - name: Download FTGL
     if: ${{ steps.cache-ftgl.outputs.cache-hit != 'true' }}
@@ -125,8 +125,8 @@ runs:
     run: |
       set -ex
       mkdir ftgl-build && cd ftgl-build
-      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
-      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
+      INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
       cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
       cmake --build . --target install --config Release
 
@@ -154,10 +154,10 @@ runs:
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
       Qt6_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos/lib/cmake/Qt6
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
-      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
-      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
-      INCLUDE="${RUNNER_TEMP}\ftgl-latest\src;$INCLUDE"
-      LIB="${RUNNER_TEMP}\ftgl-install\lib;$LIB"
+      INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
+      INCLUDE="${RUNNER_TEMP}/ftgl-latest/src;$INCLUDE"
+      LIB="${RUNNER_TEMP}/ftgl-install/lib;$LIB"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -94,7 +94,7 @@ runs:
     run: |
       set -ex
       mkdir freetype-build && cd freetype-build
-      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
       cmake --build . --target install --config Release
 
   #
@@ -127,7 +127,7 @@ runs:
       mkdir ftgl-build && cd ftgl-build
       INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
-      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
       cmake --build . --target install --config Release
 
   #

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -4,6 +4,10 @@ description: Build on OSX
 inputs:
   threading:
     default: true
+  freeTypeArchive:
+    default: https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.gz
+  ftglRepo:
+    default: https://github.com/disorderedmaterials/ftgl-2.4.0
   cacheOnly:
     type: boolean
     default: false
@@ -31,7 +35,7 @@ runs:
     run: |
       set -ex
       brew update-reset
-      brew install ftgl ninja gsl
+      brew install ninja gsl
 
   - name: Get ANTLR
     working-directory: ${{ runner.temp }}
@@ -60,6 +64,73 @@ runs:
       aqt install-qt --outputdir ${{ runner.temp }}/qt mac desktop ${{ inputs.qtVersion }} -m all
 
   #
+  # Build / Retrieve Freetype
+  #
+
+  - name: Retrieve FreeType Cache
+    id: cache-freetype
+    uses: actions/cache@v4
+    with:
+      key: windows-freetype
+      path: |
+        ${{ runner.temp }}\freetype-latest
+        ${{ runner.temp }}\freetype-install
+
+  - name: Download FreeType
+    if: ${{ steps.cache-freetype.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      wget ${{ inputs.freeTypeArchive }} -Ofreetype.tgz
+      tar -zxvf freetype.tgz
+      rm freetype.tgz
+      mv freetype-* freetype-latest
+
+  - name: Build FreeType
+    if: ${{ steps.cache-freetype.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      mkdir freetype-build && cd freetype-build
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install
+      cmake --build . --target install --config Release
+
+  #
+  # Build / Retrieve FTGL
+  #
+
+  - name: Retrieve FTGL Cache
+    id: cache-ftgl
+    uses: actions/cache@v4
+    with:
+      key: windows-ftgl
+      path: |
+        ${{ runner.temp }}\ftgl-latest
+        ${{ runner.temp }}\ftgl-install
+
+  - name: Download FTGL
+    if: ${{ steps.cache-ftgl.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      git clone ${{ inputs.ftglRepo }} ftgl-latest
+
+  - name: Build FTGL
+    if: ${{ steps.cache-ftgl.outputs.cache-hit != 'true' }}
+    working-directory: ${{ runner.temp }}
+    shell: bash
+    run: |
+      set -ex
+      mkdir ftgl-build && cd ftgl-build
+      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_INSTALL_PREFIX:path=../ftgl-install
+      cmake --build . --target install --config Release
+
+  #
   # Main Build
   #
 
@@ -83,6 +154,10 @@ runs:
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
       Qt6_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos/lib/cmake/Qt6
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
+      INCLUDE="${RUNNER_TEMP}\freetype-latest;$INCLUDE"
+      LIB="${RUNNER_TEMP}\freetype-install\lib;${RUNNER_TEMP}\freetype-install\bin;$LIB"
+      INCLUDE="${RUNNER_TEMP}\ftgl-latest\src;$INCLUDE"
+      LIB="${RUNNER_TEMP}\ftgl-install\lib;$LIB"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -57,7 +57,6 @@ runs:
 
       # Copy dependencies into Frameworks folder in app bundle
       cp -v ./build/antlr4-cppruntime/lib/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
-      cp -v ./build/ftgl/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
       cp -v ./build/onetbb/lib/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
 
   - name: Create Disk Image

--- a/cmake/Modules/conan-dissolve.cmake
+++ b/cmake/Modules/conan-dissolve.cmake
@@ -22,11 +22,6 @@ set(_conan_options
     ${EXTRA_CONAN_OPTIONS}
 )
 
-# Handle platform-specific requirements
-if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
-    list(APPEND _conan_requires freetype/2.13.2)
-endif()
-
 # Add in testing dependencies?
 if(BUILD_TESTS)
     list(APPEND _conan_requires gtest/1.10.0)

--- a/web/docs/userguide/get/packages.md
+++ b/web/docs/userguide/get/packages.md
@@ -29,7 +29,7 @@ xattr -rd com.apple.quarantine  Dissolve-GUI-<Processor>.app/Contents/MacOS/diss
 chmod +x  Dissolve-GUI-<Processor>.app/Contents/MacOS/dissolve-gui
 ```
 
-You will also need to have [FTGL](https://formulae.brew.sh/formula/ftgleforge.net/projects/ftgl/) installed on your system, which is used for rendering fonts. The libraries should be installed using homebrew, as pre-built Dissolve is linked to the homebrew directories.
+As of version 1.7.0 there is no need to have [FTGL](https://formulae.brew.sh/formula/ftgleforge.net/projects/ftgl/) installed on your system via Homebrew.
 
 ### Linux
 


### PR DESCRIPTION
This PR builds `freetype` and `FTGL` natively in the OSX build (as we currently do for Windows) in order to address issues with installed libs on users systems.

Closes #1777.