### PR TITLE
build: Don't use freetype from Homebrew on OSX

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -35,7 +35,6 @@ runs:
       set -ex
       brew update-reset
       brew install gsl
-      brew uninstall freetype
 
   - name: Get ANTLR
     working-directory: ${{ runner.temp }}
@@ -127,6 +126,7 @@ runs:
       mkdir ftgl-build && cd ftgl-build
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
+      export FREETYPE_DIR="${RUNNER_TEMP}/freetype-install"
       cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF
       cmake --build . --target install --config Release
 

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -29,13 +29,13 @@ runs:
   # Setup / Install Dependencies
   #
 
-  - name: Install Homebrew Dependencies
-    if: ${{ inputs.cacheOnly == 'false' }}
+  - name: Manage Homebrew Dependencies
     shell: bash
     run: |
       set -ex
       brew update-reset
       brew install gsl
+      brew uninstall freetype
 
   - name: Get ANTLR
     working-directory: ${{ runner.temp }}


### PR DESCRIPTION
A follow-up to #2106, this ensures that the correct freetype is used (our own built & specified one) rather than using the one on Homebrew since that one re-shows the `char*` to `unsigned char*` error when building `FTGL`.

This, in conjunction with #2109 (which is also broken until this gets merged in), should allow #2107 to finally pass!