### PR TITLE
build: Clean up GH caches after PR runs

### DIFF
--- a/.github/workflows/_clean_cache.yml
+++ b/.github/workflows/_clean_cache.yml
@@ -1,0 +1,31 @@
+name: Clean Caches
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: true
+
+jobs:
+  CleanUpCache:
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Cleanup PR Caches
+        run: |
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+              gh cache delete $cacheKey
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: ${{ inputs.branch }}

--- a/.github/workflows/_clean_cache.yml
+++ b/.github/workflows/_clean_cache.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Cleanup PR Caches
         run: |
-          echo "Fetching list of cache key"
+          echo "Fetching list of cache keys for branch '${{ inputs.branch }}..."
           cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
 
           ## Setting this to not fail the workflow while deleting cache keys.
@@ -22,9 +22,10 @@ jobs:
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR
           do
+              echo " ... $cacheKey"
               gh cache delete $cacheKey
           done
-          echo "Done"
+          echo "Done."
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,6 +38,13 @@ jobs:
       conanHash: ${{ needs.Checkout.outputs.conanHash }}
       nixHash: ${{ needs.Checkout.outputs.nixHash }}
 
+  CleanCache:
+    if: always()
+    needs: [BuildAndPackage]
+    uses: "./.github/workflows/_clean_cache.yml"
+    with:
+      branch: 'refs/pull/${{ github.event.pull_request.number }}/merge'
+
   Web:
     needs: [Checkout]
     uses: "./.github/workflows/_website.yml"


### PR DESCRIPTION
This PR attempts to clean-up the GitHub cache once PRs have finished (successfully, failing, or canceled) removing any cache artifacts that were generated from that specific PR.  Hopefully by doing so we avoid more useful cache entries, such as those semi-permanent ones generated from `develop`, being cleaned up automatically.