### PR TITLE
build: Use actor name and fake email in checkout.

### DIFF
--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -203,8 +203,8 @@ jobs:
            then
              echo "Release branch ${BRANCH} already exists."
            else
-             git config user.name "${{ env.USER }}"
-             git config user.email "${{ env.EMAIL }}"
+             git config user.name "${{ github.actor }}"
+             git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
              git checkout -b ${BRANCH}
 
              git push --set-upstream origin ${BRANCH}


### PR DESCRIPTION
This PR fixes an issue with `_checkout.yml` which, when running on a "release", set empty GitHub username and email (presumably since the event was created by an Action rather than a human) and subsequently broke the Linux builds where valid credentials were required.