### PR TITLE
build: Introduce recreate_release workflow

### DIFF
--- a/.github/workflows/create-release/action.yml
+++ b/.github/workflows/create-release/action.yml
@@ -180,7 +180,7 @@ runs:
         ERRORS=$(echo ${CURRENT_RELEASE_INFO} | jq -r '. | .errors')
         if [ "x$ERRORS" = "x" ]
         then
-          echo "Error: Failed to create release."
+          echo "::error::Failed to create release."
           echo "Reported error(s) are:"
           echo $ERRORS
           exit 1
@@ -201,7 +201,7 @@ runs:
         UPLOAD_URL=$(echo ${CURRENT_RELEASE_INFO} | jq -r '. | .upload_url' | cut -d '{' -f 1)
         if [ "x$UPLOAD_URL" = "x" ]
         then
-          echo "Error: Failed to determine upload url for release."
+          echo "::error::Failed to determine upload url for release."
           exit 1
         fi
         echo " -- Upload url is: $UPLOAD_URL"
@@ -220,7 +220,7 @@ runs:
           ARTIFACT_URL=$(echo $ARTIFACT_DATA | jq -r '. | .browser_download_url')
           if [ "x$ARTIFACT_ID" = "x" ] || [ "$ARTIFACT_ID" = "null" ]
           then
-            echo "Error: Failed to upload artifact."
+            echo "::error::Failed to upload artifact."
             echo "Returned data was: $ARTIFACT_DATA"
             exit 1
           fi

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -91,7 +91,7 @@ jobs:
             exit 1
           fi
 
-          # Before we change the version we generate the ChangeLog.md inathe  temp dir so we don't commit it
+          # Before we change the version we generate the ChangeLog.md in the temp dir so we don't commit it
           ./changeversion -l > ${{ runner.temp }}/ChangeLog.md
 
           # Set new version, check authoritative, and check consistency

--- a/.github/workflows/recreate_release.yml
+++ b/.github/workflows/recreate_release.yml
@@ -1,0 +1,78 @@
+name: Recreate Release
+description: A purely workflow dispatch action that re-releases a version based on a specific commit SHA pointing to a "[Release]"-prefixed merge commit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      cacheOnly:
+        type: boolean
+        default: false
+      releaseRef:
+        type: string
+        required: true
+        default: ""
+
+jobs:
+
+  AssertRelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.checkoutRef }}
+          fetch-depth: 0
+
+      - name: Confirm Release Prefix
+        shell: bash
+        run: |
+          set -ex
+          message=$(git log -1 --pretty=%B | head -n 1)
+          if $(echo $message | head -n 1 | grep -q "\[Release\]")
+          then
+            echo "Found a valid [Release] tag: $message"
+          else
+            echo "::error::SHA ${{ inputs.releaseRef }} does not appear to be a release."
+            echo "::error::Commit message is: $message"
+            exit 1
+          fi
+
+  Checkout:
+    needs: [AssertRelease]
+    uses: "./.github/workflows/_checkout.yml"
+    secrets: inherit
+    with:
+      checkoutRef: ${{ github.event.pull_request.merge_commit_sha }}
+      publishType: 'release'
+
+  BuildAndPackage:
+    needs: [Checkout]
+    uses: "./.github/workflows/_build_and_package.yml"
+    with:
+      currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
+      antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
+      conanHash: ${{ needs.Checkout.outputs.conanHash }}
+      nixHash: ${{ needs.Checkout.outputs.nixHash }}
+
+  Web:
+    needs: [Checkout]
+    uses: "./.github/workflows/_website.yml"
+    with:
+      publishType: 'release'
+      displayMajorVersion: ${{ needs.Checkout.outputs.currentVersionMajor }}
+      displayMinorVersion: ${{ needs.Checkout.outputs.currentVersionMinor }}
+      hugoVersion: ${{ needs.Checkout.outputs.hugoVersion }}
+    secrets: inherit
+
+  Publish:
+    needs: [Checkout,BuildAndPackage,Web]
+    uses: "./.github/workflows/_publish.yml"
+    with:
+      publishType: 'release'
+      currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      releaseTag: ${{ needs.Checkout.outputs.currentVersion }}
+      releaseName: "Release ${{ needs.Checkout.outputs.currentVersion }}"
+      releaseBody: ${{ github.event.pull_request.body }}
+      apptainerVersion: ${{ needs.Checkout.outputs.apptainerVersion }}
+    secrets: inherit

--- a/.github/workflows/recreate_release.yml
+++ b/.github/workflows/recreate_release.yml
@@ -4,9 +4,6 @@ description: A purely workflow dispatch action that re-releases a version based 
 on:
   workflow_dispatch:
     inputs:
-      cacheOnly:
-        type: boolean
-        default: false
       releaseBranch:
         description: The target release branch suffix, e.g. 1.7.X, to build
         type: string

--- a/.github/workflows/recreate_release.yml
+++ b/.github/workflows/recreate_release.yml
@@ -7,42 +7,19 @@ on:
       cacheOnly:
         type: boolean
         default: false
-      releaseRef:
+      releaseBranch:
+        description: The target release branch suffix, e.g. 1.7.X, to build
         type: string
         required: true
         default: ""
 
 jobs:
 
-  AssertRelease:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.checkoutRef }}
-          fetch-depth: 0
-
-      - name: Confirm Release Prefix
-        shell: bash
-        run: |
-          set -ex
-          message=$(git log -1 --pretty=%B | head -n 1)
-          if $(echo $message | head -n 1 | grep -q "\[Release\]")
-          then
-            echo "Found a valid [Release] tag: $message"
-          else
-            echo "::error::SHA ${{ inputs.releaseRef }} does not appear to be a release."
-            echo "::error::Commit message is: $message"
-            exit 1
-          fi
-
   Checkout:
-    needs: [AssertRelease]
     uses: "./.github/workflows/_checkout.yml"
     secrets: inherit
     with:
-      checkoutRef: ${{ github.event.pull_request.merge_commit_sha }}
+      checkoutRef: "release/${{ inputs.releaseBranch }}"
       publishType: 'release'
 
   BuildAndPackage:


### PR DESCRIPTION
This PR adds the workflow-dispatch `recreate_release` in order to allow us to manually run the release pipeline.  Under normal circumstances we run `prepare_release.yml` by hand which performs various checks before creating a "[Release] X.Y.Z" PR containing the changelog preview. Once merged into `develop` the `detect_release.yml` picks up this merge commit and generates the release.  However, in the case where the release CI fails due to broken actions (!) or other issues (double !) it is currently impossible to rerun the release without rewriting history on `develop` and deleting the "[Release] X.Y.Z" commit.

The new `recreate_release` workflow takes a target release branch (e.g. `1.7.X`)  and runs the release pipeline from there, the idea being that commits containing the necessary fixes can be pushed onto the target branch so that they are visible to the CI, and remove the need for destructive `develop` branch operations in future.