### PR TITLE
feat: Dissolve graph, constructor parent graph assignment

### DIFF
--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -69,4 +69,3 @@ void Dissolve::clear()
 
 // Return data associated with processing Modules
 GenericList &Dissolve::processingModuleData() { return processingModuleData_; }
-

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -6,7 +6,7 @@
 #include "classes/kVector.h"
 #include "classes/neutronWeights.h"
 #include "classes/species.h"
-#include "nodes/graph.h"
+#include "nodes/dissolve.h"
 
 Dissolve::Dissolve(CoreData &coreData) : coreData_(coreData)
 {

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -54,6 +54,9 @@ void Dissolve::clear()
     iteration_ = 0;
     nIterationsPerformed_ = 0;
 
+    // Graph
+    graphNode_ = std::make_unique<DissolveGraph>(*this);
+
     // I/O
     setInputFilename("");
     restartFilename_.clear();

--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -67,9 +67,3 @@ void Dissolve::clear()
 // Return data associated with processing Modules
 GenericList &Dissolve::processingModuleData() { return processingModuleData_; }
 
-/*
- * Graph node
- */
-
-// Set the Dissolve graph node
-void Dissolve::setGraph() { graphNode_ = std::move(Graph::produceNode("Dissolve")); }

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -26,7 +26,7 @@ class Molecule;
 class Dissolve : public Serialisable<>
 {
     public:
-    Dissolve(CoreData &coreData) : graphNode_(std::make_unique<DissolveGraph>(*this)) {}
+    Dissolve(CoreData &coreData);
     ~Dissolve();
 
     /*

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -26,7 +26,7 @@ class Molecule;
 class Dissolve : public Serialisable<>
 {
     public:
-    Dissolve(CoreData &coreData) : graphNode_(*this);
+    Dissolve(CoreData &coreData) : graphNode_(std::make_unique<DissolveGraph>(*this));
     ~Dissolve();
 
     /*
@@ -131,7 +131,7 @@ class Dissolve : public Serialisable<>
 
     private:
     // Dissolve graph node
-    DissolveGraph graphNode_;
+    std::unique_ptr<DissolveGraph> graphNode_;
 
     /*
      * Simulation

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -12,7 +12,6 @@
 #include "data/elements.h"
 #include "module/layer.h"
 #include "module/module.h"
-#include "nodes/node.h"
 
 // Forward Declarations
 class Atom;

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -26,7 +26,7 @@ class Molecule;
 class Dissolve : public Serialisable<>
 {
     public:
-    Dissolve(CoreData &coreData) : graphNode_(this);
+    Dissolve(CoreData &coreData) : graphNode_(*this);
     ~Dissolve();
 
     /*

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -26,7 +26,7 @@ class Molecule;
 class Dissolve : public Serialisable<>
 {
     public:
-    Dissolve(CoreData &coreData);
+    Dissolve(CoreData &coreData) : graphNode_(this);
     ~Dissolve();
 
     /*

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -18,6 +18,7 @@
 class Atom;
 class Box;
 class Cell;
+class DissolveGraph;
 class Isotopologue;
 class Molecule;
 
@@ -130,7 +131,7 @@ class Dissolve : public Serialisable<>
 
     private:
     // Dissolve graph node
-    std::unique_ptr<Node> graphNode_;
+    DissolveGraph graphNode_;
 
     /*
      * Simulation

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -26,7 +26,7 @@ class Molecule;
 class Dissolve : public Serialisable<>
 {
     public:
-    Dissolve(CoreData &coreData) : graphNode_(std::make_unique<DissolveGraph>(*this));
+    Dissolve(CoreData &coreData) : graphNode_(std::make_unique<DissolveGraph>(*this)) {}
     ~Dissolve();
 
     /*

--- a/src/nodes/CMakeLists.txt
+++ b/src/nodes/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(
   constants.h
   derivative.cpp
   derivative.h
+  dissolve.cpp
   dissolve.h
   dotProduct.cpp
   dotProduct.h

--- a/src/nodes/CMakeLists.txt
+++ b/src/nodes/CMakeLists.txt
@@ -13,25 +13,26 @@ add_library(
   dotProduct.h
   edge.cpp
   edge.h
-  integrator.cpp
-  integrator.h
   graph.cpp
   graph.h
+  integrator.cpp
+  integrator.h
   multiply.cpp
   multiply.h
   node.cpp
   node.h
   number.cpp
   number.h
+  parameter.cpp
+  parameter.h
+  registry.cpp
+  registry.h
   subtract.cpp
   subtract.h
   vec3Assembly.cpp
   vec3Assembly.h
   vec3Decomposition.cpp
   vec3Decomposition.h
-  parameter.cpp
-  parameter.h
-  registry.h
 )
 
 target_include_directories(nodes PRIVATE ${PROJECT_SOURCE_DIR}/src)

--- a/src/nodes/add.cpp
+++ b/src/nodes/add.cpp
@@ -3,7 +3,7 @@
 
 #include "nodes/add.h"
 
-AddNode::AddNode()
+AddNode::AddNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Number>("A", "First operand to the addition", a_);
     addInput<Number>("B", "Second operand to the addition", b_);

--- a/src/nodes/add.h
+++ b/src/nodes/add.h
@@ -10,7 +10,7 @@
 class AddNode : public Node
 {
     public:
-    AddNode();
+    AddNode(Graph *parentGraph);
     ~AddNode() override = default;
 
     /*

--- a/src/nodes/atomShake.cpp
+++ b/src/nodes/atomShake.cpp
@@ -3,7 +3,7 @@
 
 #include "nodes/atomShake.h"
 
-AtomShakeNode::AtomShakeNode()
+AtomShakeNode::AtomShakeNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Configuration *>("Configuration", "Set target configuration for the module", targetConfiguration_)
         ->setFlags(ParameterBase::ClearData);

--- a/src/nodes/atomShake.h
+++ b/src/nodes/atomShake.h
@@ -10,7 +10,7 @@
 class AtomShakeNode : public Node
 {
     public:
-    AtomShakeNode();
+    AtomShakeNode(Graph *parentGraph);
     ~AtomShakeNode() override = default;
 
     public:

--- a/src/nodes/derivative.cpp
+++ b/src/nodes/derivative.cpp
@@ -1,7 +1,7 @@
 #include "derivative.h"
 #include "math/derivative.h"
 
-DerivativeNode::DerivativeNode()
+DerivativeNode::DerivativeNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Data1D>("Data1D", "Input 1D data series", inputData_);
     addOutput<Data1D>("Result", "The elementwise derivative of the input", derivative_);

--- a/src/nodes/derivative.h
+++ b/src/nodes/derivative.h
@@ -6,11 +6,11 @@
 #include "math/data1D.h"
 #include "nodes/node.h"
 
-// DerivativeNode Node
+// Derivative1D Node
 class DerivativeNode : public Node
 {
     public:
-    DerivativeNode();
+    DerivativeNode(Graph *parentGraph);
     ~DerivativeNode() override = default;
 
     public:

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -1,7 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
 #include "nodes/dissolve.h"
 
+DissolveGraph::DissolveGraph(Dissolve &dissolve) : Graph(nullptr), dissolve_(dissolve) {}
+
 // Return dissolve
-Dissolve& DissolveGraph::dissolve() const { return dissolve_; }
+Dissolve &DissolveGraph::dissolve() const { return dissolve_; }
 
 // Return world pool
-const ProcessPool& DissolveGraph::processPool() const { return dissolve_.worldPool(); }
+const ProcessPool &DissolveGraph::processPool() const { return dissolve_.worldPool(); }

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -4,4 +4,4 @@
 Dissolve& DissolveGraph::dissolve() const { return dissolve_; }
 
 // Return world pool
-ProcessPool& DissolveGraph::processPool() const { return dissolve_.worldPool(); }
+const ProcessPool& DissolveGraph::processPool() const { return dissolve_.worldPool(); }

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -5,6 +5,19 @@
 
 DissolveGraph::DissolveGraph(Dissolve &dissolve) : Graph(nullptr), dissolve_(dissolve) {}
 
+/*
+ * Definitions (Virtuals)
+ */
+
+// Return node name
+std::string_view DissolveGraph::name() const { return "Root"; }
+
+// Return type of the node
+std::string_view DissolveGraph::type() const { return "Dissolve"; }
+
+// Return short summary of the node's purpose
+std::string_view DissolveGraph::summary() const { return "Parent node of all simulations"; }
+
 // Return dissolve
 Dissolve &DissolveGraph::dissolve() const { return dissolve_; }
 

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -1,0 +1,13 @@
+#include "nodes/dissolve.h"
+
+// Return dissolve
+Dissolve& DissolveGraph::dissolve() const
+{ 
+	return dissolve_;
+}
+
+// Return world pool
+ProcessPool& DissolveGraph::processPool() const
+{ 
+	return dissolve_.worldPool();
+}

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -1,13 +1,7 @@
 #include "nodes/dissolve.h"
 
 // Return dissolve
-Dissolve& DissolveGraph::dissolve() const
-{ 
-	return dissolve_;
-}
+Dissolve& DissolveGraph::dissolve() const { return dissolve_; }
 
 // Return world pool
-ProcessPool& DissolveGraph::processPool() const
-{ 
-	return dissolve_.worldPool();
-}
+ProcessPool& DissolveGraph::processPool() const { return dissolve_.worldPool(); }

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "classes/configuration.h"
 #include "main/dissolve.h"
+#include "nodes/edge.h"
 #include "nodes/graph.h"
 
 // Main Dissolve Node

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -14,12 +14,19 @@ class DissolveGraph : public Graph
     DissolveGraph(Dissolve &dissolve);
     ~DissolveGraph() = default;
 
+    /*
+     * Definition (Virtuals)
+     */
     public:
-    std::string_view type() const override { return "Dissolve"; }
-    std::string_view summary() const override { return "Parent node of all simulations"; }
+    // Return node name
+    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
+    // Return short summary of the node's purpose
+    std::string_view summary() const override;
 
     /*
-     * Definition
+     * Data
      */
     private:
     // Dissolve reference

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -11,8 +11,8 @@
 class DissolveGraph : public Graph
 {
     public:
-    explicit DissolveNode(Dissolve& dissolve) : Node(this), dissolve_(dissolve) {};
-    ~DissolveNode() override = default;
+    explicit DissolveGraph(Dissolve& dissolve) : dissolve_(dissolve) {}
+    ~DissolveGraph() = default;
 
     public:
     std::string_view type() const override { return "Dissolve"; }
@@ -29,5 +29,5 @@ class DissolveGraph : public Graph
     // Return dissolve
     Dissolve &dissolve() const override;
     // Return world pool
-    ProcessPool &processPool() const override;
+    const ProcessPool &processPool() const override;
 };

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -4,13 +4,14 @@
 #pragma once
 
 #include "classes/configuration.h"
-#include "nodes/node.h"
+#include "main/dissolve.h"
+#include "nodes/graph.h"
 
 // AtomShake Node
-class DissolveNode : public Node
+class DissolveGraph : public Graph
 {
     public:
-    DissolveNode(){};
+    explicit DissolveNode(Dissolve& dissolve) : Node(this), dissolve_(dissolve) {};
     ~DissolveNode() override = default;
 
     public:
@@ -21,10 +22,12 @@ class DissolveNode : public Node
      * Definition
      */
     private:
-    /*
-     * Processing
-     */
-    private:
-    // Run main processing
-    Module::ExecutionResult process(ModuleContext &moduleContext);
+    // Dissolve reference
+    Dissolve& dissolve_;
+
+    public:
+    // Return dissolve
+    Dissolve &dissolve() const override;
+    // Return world pool
+    ProcessPool &processPool() const override;
 };

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -7,7 +7,7 @@
 #include "main/dissolve.h"
 #include "nodes/graph.h"
 
-// Dissolve graph
+// Main Dissolve node
 class DissolveGraph : public Graph
 {
     public:

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -7,11 +7,11 @@
 #include "main/dissolve.h"
 #include "nodes/graph.h"
 
-// Main Dissolve node
+// Main Dissolve Node
 class DissolveGraph : public Graph
 {
     public:
-    explicit DissolveGraph(Dissolve& dissolve) : dissolve_(dissolve) {}
+    DissolveGraph(Dissolve &dissolve);
     ~DissolveGraph() = default;
 
     public:
@@ -23,7 +23,7 @@ class DissolveGraph : public Graph
      */
     private:
     // Dissolve reference
-    Dissolve& dissolve_;
+    Dissolve &dissolve_;
 
     public:
     // Return dissolve

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -7,7 +7,7 @@
 #include "main/dissolve.h"
 #include "nodes/graph.h"
 
-// AtomShake Node
+// Dissolve graph
 class DissolveGraph : public Graph
 {
     public:

--- a/src/nodes/dotProduct.cpp
+++ b/src/nodes/dotProduct.cpp
@@ -1,6 +1,6 @@
 #include "dotProduct.h"
 
-DotProductNode::DotProductNode()
+DotProductNode::DotProductNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Vec3<double>>("U", "Vector dot product factor", u_);
     addInput<Vec3<double>>("V", "Vector dot product factor", v_);

--- a/src/nodes/dotProduct.h
+++ b/src/nodes/dotProduct.h
@@ -7,11 +7,11 @@
 #include "nodes/number.h"
 #include "templates/vector3.h"
 
-// DotProductNode Node
+// DotProduct Node
 class DotProductNode : public Node
 {
     public:
-    DotProductNode();
+    DotProductNode(Graph *parentGraph);
     ~DotProductNode() override = default;
 
     public:

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -39,12 +39,15 @@ Node *Graph::addNode(std::string_view type, std::string_view name)
 {
     // Produce the node
     auto node = NodeRegistry::produce(this, type);
+    auto nodePtr = node.get();
 
     // Ensure we have a unique name
     auto uniqueName = uniqueNodeName(node.get(), name);
 
     reverseNodes_.insert(std::make_pair<Node *, std::string>(node.get(), std::string(uniqueName)));
     nodes_.insert(std::make_pair<std::string, std::unique_ptr<Node>>(std::string(uniqueName), std::move(node)));
+
+    return nodePtr;
 }
 
 // Get name of specified child node

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -37,8 +37,6 @@ std::string Graph::uniqueNodeName(const Node *node, std::string_view baseName) c
 // Add nodes
 void Graph::addNode(std::unique_ptr<Node> &&node, std::string_view name)
 {
-    node->setParentGraph(this);
-
     // Ensure we have a unique name
     auto uniqueName = uniqueNodeName(node.get(), name);
 

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -1,5 +1,7 @@
 #include "nodes/graph.h"
 
+Graph::Graph(Graph *parentGraph) : Node(parentGraph) {}
+
 /*
  * Definition
  */

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -35,8 +35,11 @@ std::string Graph::uniqueNodeName(const Node *node, std::string_view baseName) c
 }
 
 // Add nodes
-void Graph::addNode(std::unique_ptr<Node> &&node, std::string_view name)
+Node *Graph::addNode(std::string_view type, std::string_view name)
 {
+    // Produce the node
+    auto node = NodeRegistry::produce(this, type);
+
     // Ensure we have a unique name
     auto uniqueName = uniqueNodeName(node.get(), name);
 
@@ -147,12 +150,10 @@ void Graph::deserialise(const SerialisedValue &node)
     toMap(node, "nodes",
           [this](const auto name, const auto &value)
           {
-              std::string kind = toml::find<std::string>(value, "type");
-              if (!registry.contains(kind))
-                  Messenger::exception("Attempted to create node of unknown kind: {}", kind);
-              auto child = registry.at(kind)();
+              std::string nodeType = toml::find<std::string>(value, "type");
+              auto child = addNode(nodeType, name);
+
               child->deserialise(value);
-              addNode(std::move(child), name);
           });
     toVector(node, "edges", [this](const auto &value) { addEdge(toml::get<EdgeDefinition>(value)); });
 }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -3,7 +3,6 @@
 // Add nodes
 void Graph::addNode(std::unique_ptr<Node> &&node, std::string_view name)
 {
-    node->setParentGraph(this);
     node->setName(name);
     nodes_.insert(std::make_pair<std::string, std::unique_ptr<Node>>(std::string(name), std::move(node)));
 }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -1,4 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
 #include "nodes/graph.h"
+#include "nodes/edge.h"
+#include "nodes/registry.h"
 
 Graph::Graph(Graph *parentGraph) : Node(parentGraph) {}
 

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -4,13 +4,15 @@
 #pragma once
 
 #include "base/messenger.h"
-#include "nodes/edge.h"
 #include "nodes/node.h"
-#include "nodes/registry.h"
 #include <map>
 #include <memory>
 #include <string>
 #include <vector>
+
+// Forward Declarations
+class Edge;
+class EdgeDefinition;
 
 // Graph
 class Graph : public Node

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -39,7 +39,7 @@ class Graph : public Node
     // Return short summary of the node's purpose
     std::string_view summary() const override;
     // Produce a registered node by type
-    static std::unique_ptr<Node> produceNode(const std::string_view &nodeType) { return registry.find(nodeType)->second(); }
+    static std::unique_ptr<Node> produceNode(const std::string_view &nodeType) { return registry.find(nodeType)->second()(this); }
     // Add node
     void addNode(std::unique_ptr<Node> &&node, std::string_view name);
     // Add edge between nodes

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -16,8 +16,7 @@
 class Graph : public Node
 {
     public:
-    Graph() = default;
-    explicit Graph(Node *parent) : Node(this), parent_(parent) {}
+    Graph(Graph *parentGraph);
     ~Graph() = default;
 
     /*

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -40,8 +40,6 @@ class Graph : public Node
     using Edges = std::vector<std::unique_ptr<Edge>>;
 
     private:
-    // Parent node
-    Node *parent_;
     // Map of node names to nodes
     Nodes nodes_;
     // Map of nodes to node names

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -53,7 +53,7 @@ class Graph : public Node
 
     public:
     // Add node
-    void addNode(std::unique_ptr<Node> &&node, std::string_view name);
+    Node *addNode(std::string_view type, std::string_view name);
     // Get name of specified child node
     std::string_view nodeName(const Node *node) const;
     // Set name of specified child node

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -16,6 +16,7 @@
 class Graph : public Node
 {
     public:
+    Graph() = default;
     explicit Graph(Node *parent) : Node(this), parent_(parent) {}
     ~Graph() = default;
 
@@ -52,10 +53,6 @@ class Graph : public Node
     std::string uniqueNodeName(const Node *node, std::string_view baseName) const;
 
     public:
-    // Return type of the node
-    std::string_view type() const override;
-    // Return short summary of the node's purpose
-    std::string_view summary() const override;
     // Add node
     void addNode(std::unique_ptr<Node> &&node, std::string_view name);
     // Get name of specified child node

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -38,8 +38,6 @@ class Graph : public Node
     std::string_view type() const override;
     // Return short summary of the node's purpose
     std::string_view summary() const override;
-    // Produce a registered node by type
-    static std::unique_ptr<Node> produceNode(const std::string_view &nodeType) { return registry.find(nodeType)->second()(this); }
     // Add node
     void addNode(std::unique_ptr<Node> &&node, std::string_view name);
     // Add edge between nodes

--- a/src/nodes/integrator.cpp
+++ b/src/nodes/integrator.cpp
@@ -1,6 +1,6 @@
 #include "integrator.h"
 
-Integrator1DNode::Integrator1DNode()
+Integrator1DNode::Integrator1DNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Data1D>("Data1D", "Input 1D data series", inputData_);
     addInput<std::string_view>("Method", "Method to use for integration", type_);

--- a/src/nodes/integrator.h
+++ b/src/nodes/integrator.h
@@ -9,11 +9,11 @@
 #include "nodes/node.h"
 #include "nodes/number.h"
 
-// Integrator1DNode Node
+// Integrator1D Node
 class Integrator1DNode : public Node
 {
     public:
-    Integrator1DNode();
+    Integrator1DNode(Graph *parentGraph);
     ~Integrator1DNode() override = default;
 
     public:

--- a/src/nodes/multiply.cpp
+++ b/src/nodes/multiply.cpp
@@ -1,6 +1,6 @@
 #include "nodes/multiply.h"
 
-MultiplyNode::MultiplyNode()
+MultiplyNode::MultiplyNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Number>("A", "First factor to the multiplication", a_);
     addInput<Number>("B", "Second factor to the multiplication", b_);

--- a/src/nodes/multiply.h
+++ b/src/nodes/multiply.h
@@ -6,11 +6,11 @@
 #include "nodes/node.h"
 #include "nodes/number.h"
 
-// MultiplyNode Node
+// Multiply Node
 class MultiplyNode : public Node
 {
     public:
-    MultiplyNode();
+    MultiplyNode(Graph *parentGraph);
     ~MultiplyNode() override = default;
 
     public:

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -189,9 +189,6 @@ std::shared_ptr<ParameterBase> Node::findOption(std::string_view name) const
 // Return Options
 std::map<std::string_view, std::shared_ptr<ParameterBase>> &Node::options() { return options_; };
 
-// Set the node parent graph
-void Node::setParentGraph(Graph *parentGraph) { parentGraph_ = parentGraph; }
-
 // Returns the node parent graph
 Graph *Node::parentGraph() const { return parentGraph_; }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -206,7 +206,7 @@ Node::EdgeMap &Node::links() { return inputEdges_; }
 Dissolve &Node::dissolve() const { return parentGraph_->dissolve(); }
 
 // Return the world pool
-const ProcessPool &Node::processPool() const { return parentGraph_->dissolve().worldPool(); }
+const ProcessPool &Node::processPool() const { return parentGraph_->processPool(); }
 
 /*
  * Data

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -20,7 +20,7 @@ void Node::setName(std::string_view newName)
 }
 
 // Return node name
-std::string_view Node::name() const { return parentGraph_ ? "UnparentedNode" : parentGraph_->nodeName(this); }
+std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeName(this) : "UnparentedNode"; }
 
 /*
  * Inputs, Outputs & Options

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -201,6 +201,12 @@ Graph *Node::parentGraph() const { return parentGraph_; }
 
 Node::EdgeMap &Node::links() { return inputEdges_; }
 
+// Return the Dissolve reference
+Dissolve &Node::dissolve() const { return parentGraph_->dissolve(); }
+
+// Return the world pool
+const ProcessPool &Node::processPool() const { return parentGraph_->dissolve().worldPool(); }
+
 /*
  * Data
  */

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -3,6 +3,7 @@
 
 #include "nodes/node.h"
 #include "base/sysFunc.h"
+#include "nodes/edge.h"
 #include "nodes/graph.h"
 
 /*

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -39,7 +39,7 @@ class Node : public Serialisable<>
     // Set node name
     void setName(std::string_view newName);
     // Return node name
-    std::string_view name() const;
+    virtual std::string_view name() const;
     // Return node type
     virtual std::string_view type() const = 0;
     // Return short summary of the node's purpose

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -7,13 +7,14 @@
 #include "base/serialiser.h"
 #include "module/module.h"
 #include "nodes/constants.h"
-#include "nodes/edge.h"
 #include "nodes/parameter.h"
 #include <map>
 #include <string>
 #include <vector>
 
+// Forward Declarations
 class Graph;
+class Edge;
 
 // Node Base
 class Node : public Serialisable<>

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -163,8 +163,6 @@ class Node : public Serialisable<>
     std::map<std::string_view, std::shared_ptr<ParameterBase>> &options();
     // Get the links owned by this node
     EdgeMap &links();
-    // Set the node parent graph
-    void setParentGraph(Graph *parentGraph);
     // Returns the node parent graph
     Graph *parentGraph() const;
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -165,6 +165,10 @@ class Node : public Serialisable<>
     EdgeMap &links();
     // Returns the node parent graph
     Graph *parentGraph() const;
+    // Return the Dissolve reference
+    virtual Dissolve &dissolve() const;
+    // Return the world pool
+    virtual const ProcessPool &processPool() const;
 
     /*
      * Data

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -37,7 +37,11 @@ void NodeRegistry::instantiateNodeProducers()
 }
 
 // Check whether the supplied node type is known
-bool NodeRegistry::hasNodeType(std::string_view nodeType) { return producers_.contains(nodeType); }
+bool NodeRegistry::hasNodeType(std::string_view nodeType)
+{
+    instantiateNodeProducers();
+    return producers_.contains(nodeType);
+}
 
 // Produce a node of the given type with the specified Graph parent
 std::unique_ptr<Node> NodeRegistry::produce(Graph *parent, std::string_view nodeType)

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "registry.h"
+#include "add.h"
+#include "atomShake.h"
+#include "derivative.h"
+#include "dissolve.h"
+#include "dotProduct.h"
+#include "integrator.h"
+#include "multiply.h"
+#include "subtract.h"
+#include "vec3Assembly.h"
+#include "vec3Decomposition.h"
+#include <memory>
+#include <string>
+
+// Static Singletons
+std::map<std::string_view, NodeProducer> NodeRegistry::producers_;
+
+// Instantiate Node Producers
+void NodeRegistry::instantiateNodeProducers()
+{
+    // Only need to do this once
+    if (!producers_.empty())
+        return;
+
+    producers_ = {{"Add", makeDerivedNode<AddNode>()},
+                  {"AtomShake", makeDerivedNode<AtomShakeNode>()},
+                  {"Derivative", makeDerivedNode<DerivativeNode>()},
+                  {"DotProduct", makeDerivedNode<DotProductNode>()},
+                  {"Integrator", makeDerivedNode<Integrator1DNode>()},
+                  {"Multiply", makeDerivedNode<MultiplyNode>()},
+                  {"Subtract", makeDerivedNode<SubtractNode>()},
+                  {"Vec3Assembly", makeDerivedNode<Vec3AssemblyNode>()},
+                  {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>()}};
+}
+
+// Check whether the supplied node type is known
+bool NodeRegistry::hasNodeType(std::string_view nodeType) { return producers_.contains(nodeType); }
+
+// Produce a node of the given type with the specified Graph parent
+std::unique_ptr<Node> NodeRegistry::produce(Graph *parent, std::string_view nodeType)
+{
+    instantiateNodeProducers();
+
+    // Check for valid node type and produce
+    if (!producers_.contains(nodeType))
+        Messenger::exception("Attempted to create node of unknown type: {}\n", nodeType);
+
+    return producers_.at(nodeType)(parent);
+}

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -18,6 +18,12 @@
 // Static Singletons
 std::map<std::string_view, NodeProducer> NodeRegistry::producers_;
 
+// Makes unique pointer to derived node instance
+template <typename T> NodeProducer makeDerivedNode()
+{
+    return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
+}
+
 // Instantiate Node Producers
 void NodeRegistry::instantiateNodeProducers()
 {

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -8,12 +8,6 @@
 
 using NodeProducer = std::function<std::unique_ptr<Node>(Graph *parent)>;
 
-// Makes unique pointer to derived node instance
-template <typename T> NodeProducer makeDerivedNode()
-{
-    return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
-}
-
 // Registry of all Producible Node Types
 class NodeRegistry
 {

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -22,7 +22,7 @@
 using NodeProducer = std::function<std::unique_ptr<Node>(void)>;
 
 // Makes unique pointer to derived node instance
-template <typename T> NodeProducer makeDerivedNode(Graph* graph)
+template <typename T> NodeProducer makeDerivedNode(Graph* graph = nullptr)
 {
     auto nodeLambda = [=]() -> std::unique_ptr<Node> { return std::make_unique<T>(graph); };
     return nodeLambda;

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -3,53 +3,31 @@
 
 #pragma once
 
-#include "add.h"
-#include "atomShake.h"
-#include "derivative.h"
-#include "dissolve.h"
-#include "dotProduct.h"
-#include "integrator.h"
-#include "multiply.h"
 #include "node.h"
-#include "subtract.h"
-#include "vec3Assembly.h"
-#include "vec3Decomposition.h"
-#include <functional>
-#include <map>
-#include <memory>
 #include <string>
 
-using NodeProducer = std::function<std::unique_ptr<Node>(void)>;
+using NodeProducer = std::function<std::unique_ptr<Node>(Graph *parent)>;
 
 // Makes unique pointer to derived node instance
-template <typename T> NodeProducer makeDerivedNode(Graph* graph = nullptr)
+template <typename T> NodeProducer makeDerivedNode()
 {
-    auto nodeLambda = [=]() -> std::unique_ptr<Node> { return std::make_unique<T>(graph); };
-    return nodeLambda;
+    return [=](Graph *parent) -> std::unique_ptr<Node> { return std::make_unique<T>(parent); };
 }
 
-// Node registry
-const std::map<std::string_view, NodeProducer> registry{
-    {"Add", makeDerivedNode<AddNode>},
-    {"AtomShake", makeDerivedNode<AtomShakeNode>},
-    {"Derivative", makeDerivedNode<DerivativeNode>},
-    {"DotProduct", makeDerivedNode<DotProductNode>},
-    {"Integrator", makeDerivedNode<Integrator1DNode>},
-    {"Multiply", makeDerivedNode<MultiplyNode>},
-    {"Subtract", makeDerivedNode<SubtractNode>},
-    {"Vec3Assembly", makeDerivedNode<Vec3AssemblyNode>},
-    {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>},
-    // etc...
-};
-
+// Registry of all Producible Node Types
 class NodeRegistry
 {
+    private:
+    // Available Node producers
+    static std::map<std::string_view, NodeProducer> producers_;
+
+    private:
+    // Instantiate Node Producers
+    static void instantiateNodeProducers();
+
     public:
-    static std::unique_ptr<Node> produce(std::string_view nodeName)
-    {
-        if (registry.contains(nodeName))
-            return registry.at(nodeName)();
-        else
-            return {};
-    }
+    // Check whether the supplied node type is known
+    static bool hasNodeType(std::string_view nodeType);
+    // Produce a node of the given type with the specified Graph parent
+    static std::unique_ptr<Node> produce(Graph *parent, std::string_view nodeType);
 };

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -22,24 +22,23 @@
 using NodeProducer = std::function<std::unique_ptr<Node>(void)>;
 
 // Makes unique pointer to derived node instance
-template <typename T> NodeProducer makeDerivedNode()
+template <typename T> NodeProducer makeDerivedNode(Graph* graph)
 {
-    auto nodeLambda = []() -> std::unique_ptr<Node> { return std::make_unique<T>(); };
+    auto nodeLambda = [=]() -> std::unique_ptr<Node> { return std::make_unique<T>(graph); };
     return nodeLambda;
 }
 
 // Node registry
 const std::map<std::string_view, NodeProducer> registry{
-    {"Add", makeDerivedNode<AddNode>()},
-    {"AtomShake", makeDerivedNode<AtomShakeNode>()},
-    {"Derivative", makeDerivedNode<DerivativeNode>()},
-    {"Dissolve", makeDerivedNode<DissolveNode>()},
-    {"DotProduct", makeDerivedNode<DotProductNode>()},
-    {"Integrator", makeDerivedNode<Integrator1DNode>()},
-    {"Multiply", makeDerivedNode<MultiplyNode>()},
-    {"Subtract", makeDerivedNode<SubtractNode>()},
-    {"Vec3Assembly", makeDerivedNode<Vec3AssemblyNode>()},
-    {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>()},
+    {"Add", makeDerivedNode<AddNode>},
+    {"AtomShake", makeDerivedNode<AtomShakeNode>},
+    {"Derivative", makeDerivedNode<DerivativeNode>},
+    {"DotProduct", makeDerivedNode<DotProductNode>},
+    {"Integrator", makeDerivedNode<Integrator1DNode>},
+    {"Multiply", makeDerivedNode<MultiplyNode>},
+    {"Subtract", makeDerivedNode<SubtractNode>},
+    {"Vec3Assembly", makeDerivedNode<Vec3AssemblyNode>},
+    {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>},
     // etc...
 };
 

--- a/src/nodes/subtract.cpp
+++ b/src/nodes/subtract.cpp
@@ -1,6 +1,6 @@
 #include "nodes/subtract.h"
 
-SubtractNode::SubtractNode()
+SubtractNode::SubtractNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Number>("A", "First operand to the subtraction", a_);
     addInput<Number>("B", "Second operand to the subtraction, subtracted from A", b_);

--- a/src/nodes/subtract.h
+++ b/src/nodes/subtract.h
@@ -6,11 +6,11 @@
 #include "nodes/node.h"
 #include "nodes/number.h"
 
-// SubractNode Node
+// Subtract Node
 class SubtractNode : public Node
 {
     public:
-    SubtractNode();
+    explicit SubtractNode(Graph *parentGraph);
     ~SubtractNode() override = default;
 
     public:

--- a/src/nodes/vec3Assembly.cpp
+++ b/src/nodes/vec3Assembly.cpp
@@ -1,6 +1,6 @@
 #include "vec3Assembly.h"
 
-Vec3AssemblyNode::Vec3AssemblyNode()
+Vec3AssemblyNode::Vec3AssemblyNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<double>("X", "The x value of the assembled vector", x_);
     addInput<double>("Y", "The y value of the assembled vector", y_);

--- a/src/nodes/vec3Assembly.h
+++ b/src/nodes/vec3Assembly.h
@@ -6,11 +6,11 @@
 #include "nodes/node.h"
 #include "templates/vector3.h"
 
-// Vec3AssemblyNode Node
+// Vec3Assembly Node
 class Vec3AssemblyNode : public Node
 {
     public:
-    Vec3AssemblyNode();
+    Vec3AssemblyNode(Graph *parentGraph);
     ~Vec3AssemblyNode() override = default;
 
     public:

--- a/src/nodes/vec3Decomposition.cpp
+++ b/src/nodes/vec3Decomposition.cpp
@@ -1,6 +1,6 @@
 #include "vec3Decomposition.h"
 
-Vec3DecompositionNode::Vec3DecompositionNode()
+Vec3DecompositionNode::Vec3DecompositionNode(Graph *parentGraph) : Node(parentGraph)
 {
     addInput<Vec3<double>>("V", "The 3-dimensional vector to be decomposed", inputVector_);
     addOutput<Number>("X", "The x component of the vector", x_);

--- a/src/nodes/vec3Decomposition.h
+++ b/src/nodes/vec3Decomposition.h
@@ -7,11 +7,11 @@
 #include "nodes/number.h"
 #include "templates/vector3.h"
 
-// Vec3DecompositionNode Node
+// Vec3Decomposition Node
 class Vec3DecompositionNode : public Node
 {
     public:
-    Vec3DecompositionNode();
+    Vec3DecompositionNode(Graph *parentGraph);
     ~Vec3DecompositionNode() override = default;
 
     public:

--- a/tests/data/dissolve/input/simple_addition_graph.toml
+++ b/tests/data/dissolve/input/simple_addition_graph.toml
@@ -1,5 +1,5 @@
-name = ""
-type = "Graph"
+name = "Root"
+type = "Dissolve"
 edges = [
   {sourceNode = "x", sourceOutput = "Result", targetNode = "z", targetInput = "A"},
   {sourceNode = "y", sourceOutput = "Result", targetNode = "z" ,targetInput = "B"}

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
+#include "nodes/add.h"
+#include "nodes/edge.h"
 #include "nodes/graph.h"
 #include "nodes/number.h"
-#include "nodes/edge.h"
-#include "nodes/add.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -3,7 +3,8 @@
 
 #include "nodes/graph.h"
 #include "nodes/number.h"
-#include "nodes/registry.h"
+#include "nodes/edge.h"
+#include "nodes/add.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -30,12 +31,12 @@ class GraphFlowTest : public ::testing::Test
          *    -----------------/
          */
 
-        // Create nodes and get references to them
-        graph_.addNode(NodeRegistry::produce("Add"), "x");
-        graph_.addNode(NodeRegistry::produce("Add"), "y");
-        graph_.addNode(NodeRegistry::produce("Add"), "z");
+        // Create nodes
+        auto *x = graph_.addNode("Add", "x");
+        x_ = dynamic_cast<AddNode *>(x);
+        y_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "y"));
+        z_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "z"));
 
-        x_ = dynamic_cast<AddNode *>(graph_.node("x"));
         ASSERT_TRUE(x_);
         xA_ = x_->findInput("A")->upcast<Number>();
         xB_ = x_->findInput("B")->upcast<Number>();
@@ -45,7 +46,7 @@ class GraphFlowTest : public ::testing::Test
         ASSERT_TRUE(xResult_);
         xA_->set(1);
         xB_->set(2);
-        y_ = dynamic_cast<AddNode *>(graph_.node("y"));
+
         ASSERT_TRUE(y_);
         yA_ = y_->findInput("A")->upcast<Number>();
         yB_ = y_->findInput("B")->upcast<Number>();
@@ -55,7 +56,7 @@ class GraphFlowTest : public ::testing::Test
         ASSERT_TRUE(yResult_);
         yA_->set(3);
         yB_->set(4);
-        z_ = dynamic_cast<AddNode *>(graph_.node("z"));
+
         ASSERT_TRUE(z_);
         zA_ = z_->findInput("A")->upcast<Number>();
         zB_ = z_->findInput("B")->upcast<Number>();

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -2,10 +2,10 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "nodes/graph.h"
-#include "nodes/edge.h"
-#include "nodes/number.h"
 #include "nodes/add.h"
 #include "nodes/dissolve.h"
+#include "nodes/edge.h"
+#include "nodes/number.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -5,6 +5,7 @@
 #include "nodes/edge.h"
 #include "nodes/number.h"
 #include "nodes/add.h"
+#include "nodes/dissolve.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -12,7 +13,7 @@ namespace UnitTest
 class GraphCoreTest : public ::testing::Test
 {
     public:
-    GraphCoreTest() : graph_(nullptr) {}
+    GraphCoreTest() : dissolve_(coreData_), root_(dissolve_) {}
 
     // Create a graph for testing
     void createGraph()
@@ -32,20 +33,23 @@ class GraphCoreTest : public ::testing::Test
          */
 
         // Create nodes
-        x_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "x"));
-        y_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "y"));
-        z_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "z"));
+        x_ = dynamic_cast<AddNode *>(root_.addNode("Add", "x"));
+        y_ = dynamic_cast<AddNode *>(root_.addNode("Add", "y"));
+        z_ = dynamic_cast<AddNode *>(root_.addNode("Add", "z"));
 
         ASSERT_TRUE(x_);
         ASSERT_TRUE(y_);
         ASSERT_TRUE(z_);
 
-        EXPECT_TRUE(graph_.addEdge({"x", "Result", "z", "A"}));
-        EXPECT_TRUE(graph_.addEdge({"y", "Result", "z", "B"}));
+        EXPECT_TRUE(root_.addEdge({"x", "Result", "z", "A"}));
+        EXPECT_TRUE(root_.addEdge({"y", "Result", "z", "B"}));
     }
 
     protected:
-    Graph graph_;
+    // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
+    CoreData coreData_;
+    Dissolve dissolve_;
+    DissolveGraph root_;
     AddNode *x_{nullptr}, *y_{nullptr}, *z_{nullptr};
 };
 
@@ -80,8 +84,10 @@ TEST_F(GraphCoreTest, Serialisation)
 {
     createGraph();
 
-    Graph copy(nullptr);
-    auto serialised = graph_.serialise();
+    CoreData cd;
+    Dissolve d(cd);
+    DissolveGraph copy(d);
+    auto serialised = root_.serialise();
 
     SerialisedValue contents = toml::parse("dissolve/input/simple_addition_graph.toml");
     compare_toml("", serialised, contents);

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -2,8 +2,9 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "nodes/graph.h"
+#include "nodes/edge.h"
 #include "nodes/number.h"
-#include "nodes/registry.h"
+#include "nodes/add.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -30,16 +31,13 @@ class GraphCoreTest : public ::testing::Test
          *    -----------------/
          */
 
-        // Create nodes and get references to them
-        graph_.addNode(NodeRegistry::produce("Add"), "x");
-        graph_.addNode(NodeRegistry::produce("Add"), "y");
-        graph_.addNode(NodeRegistry::produce("Add"), "z");
+        // Create nodes
+        x_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "x"));
+        y_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "y"));
+        z_ = dynamic_cast<AddNode *>(graph_.addNode("Add", "z"));
 
-        x_ = dynamic_cast<AddNode *>(graph_.node("x"));
         ASSERT_TRUE(x_);
-        y_ = dynamic_cast<AddNode *>(graph_.node("y"));
         ASSERT_TRUE(y_);
-        z_ = dynamic_cast<AddNode *>(graph_.node("z"));
         ASSERT_TRUE(z_);
 
         EXPECT_TRUE(graph_.addEdge({"x", "Result", "z", "A"}));


### PR DESCRIPTION
This PR demonstrates two changes to how we manage nodes and the top-level `Dissolve` graph
- Nodes no longer rely on a call to `setParentGraph` post-initialisation: the `parentGraph_` is now a constructor argument, which means that the parent `Graph*` gets passed into the factory lambda via the `produceNode` method
- The top-level `Dissolve` graph is no longer just another registered `Node`, but a new type `DissolveGraph`, and is initialised along with `Dissolve`