### PR TITLE
build: Store ChangeLog.md in release branch

### DIFF
--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -44,6 +44,6 @@ jobs:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       releaseTag: ${{ needs.Checkout.outputs.currentVersion }}
       releaseName: "Release ${{ needs.Checkout.outputs.currentVersion }}"
-      releaseBody: ${{ github.event.pull_request.body }}
+      releaseBodyFile: ChangeLog.md
       apptainerVersion: ${{ needs.Checkout.outputs.apptainerVersion }}
     secrets: inherit

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -91,8 +91,8 @@ jobs:
             exit 1
           fi
 
-          # Before we change the version we generate the ChangeLog.md in the temp dir so we don't commit it
-          ./changeversion -l > ${{ runner.temp }}/ChangeLog.md
+          # Before we change the version we generate the ChangeLog.md, overwriting any previous version
+          ./changeversion -l > ChangeLog.md
 
           # Set new version, check authoritative, and check consistency
           ./changeversion -b
@@ -105,6 +105,6 @@ jobs:
         with:
           branch: ${{ steps.prep.outputs.branch }}
           title: "[Release] ${{ steps.prep.outputs.version }}"
-          body-path: ${{ runner.temp }}/ChangeLog.md
+          body-path: ChangeLog.md
           reviewers: trisyoungs
           sign-commits: true

--- a/.github/workflows/recreate_release.yml
+++ b/.github/workflows/recreate_release.yml
@@ -47,6 +47,6 @@ jobs:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       releaseTag: ${{ needs.Checkout.outputs.currentVersion }}
       releaseName: "Release ${{ needs.Checkout.outputs.currentVersion }}"
-      releaseBody: ${{ github.event.pull_request.body }}
+      releaseBodyFile: ChangeLog.md
       apptainerVersion: ${{ needs.Checkout.outputs.apptainerVersion }}
     secrets: inherit


### PR DESCRIPTION
Following the successful use of the new `recreate_release` workflow just now it became apparent that there was no non-trivial way of getting the original git-cliff-generated changes for use in the release body text on GitHub. Here I have just modified the set of release scripts to save and commit the generate changes to `ChangeLog.md` which now gets stored in the `release/X.Y.Z` branch, and can thus be re-used by `recreate_release`.

We won't know if this works until the next release, but there we are,