### PR TITLE
build: Lock cmake to v3 (Windows)

### DIFF
--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -52,6 +52,11 @@ runs:
       $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
       $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
 
+  - name: Setup cmake
+    uses: jwlawson/actions-setup-cmake@v2
+    with:
+      cmake-version: '3.x'
+
   - name: Install Chocolatey Dependencies
     shell: bash
     run: choco install -y ninja wget

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -59,7 +59,7 @@ runs:
 
   - name: Install Chocolatey Dependencies
     shell: bash
-    run: choco install -y ninja wget
+    run: choco install -y wget
 
   - name: Install Python Dependencies
     shell: bash


### PR DESCRIPTION
GitHub have apparently updated some of their `latest` runners to CMake v4 (intentionally or not: see https://github.com/actions/runner-images/issues/11926) so this fixes our Windows build by downgrading to 3.x.