### PR TITLE
build: Add missing GSL libs to OSX package

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -180,6 +180,10 @@ runs:
       cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../
       cmake --build . --config Release
 
+      # Copy over gsl libs so we can ship them with the bundle. Our exe is only linked to two of the four libs present, and this breaks the binary if we don't include them all in the package.
+      mkdir gsl
+      cp -v $(brew --prefix gsl)/lib/*.dylib ./gsl
+
   - name: Upload Raw Build Artifacts
     if: ${{ inputs.cacheOnly == 'false' }}
     uses: actions/upload-artifact@v4

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -55,6 +55,7 @@ runs:
       # Copy dependencies into Frameworks folder in app bundle
       cp -v ./build/antlr4-cppruntime/lib/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
       cp -v ./build/onetbb/lib/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
+      cp -v ./build/gsl/*.dylib ${packageName}/${appDirName}/Contents/Frameworks/
 
   - name: Create Disk Image
     shell: bash

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -44,9 +44,6 @@ runs:
       Qt6_ROOT=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos/
       export PATH="$(python3 -m site --user-base)/bin:$PATH"
 
-      # Add rpath to packaged Frameworks
-      install_name_tool -add_rpath "@executable_path/../Frameworks/" build/bin/dissolve-gui.app/Contents/MacOS/dissolve-gui
-
       # Set variables
       appName=Dissolve-GUI-${{ runner.arch }}
       appDirName=${appName}.app


### PR DESCRIPTION
This PR adds some missing GSL libs into the OSX package - while the Dissolve GUI links to two of the available dylibs there are clearly dependencies of those dylibs on two others in the Homebrew-installed location.