### PR TITLE
doc: Fix image links for ModifierOSites and QSpecies

### DIFF
--- a/web/docs/userguide/modules/analysis/modifierosites/_index.md
+++ b/web/docs/userguide/modules/analysis/modifierosites/_index.md
@@ -8,7 +8,7 @@ description: Calculate the bonding type and total bonding to oxygen in reference
 
 The `ModifierOSites` module calculates how a modifier is bonding into a network. The frequency of bonding to bridging, non-bridging and free oxygen sites, in reference to a network former, is calculated. The total bonds to oxygen as well as the bond lengths to oxygen are also calculated.
 
-{{< cimage src="../modifierosites.png" caption="Representation of the information the ModifierOSites module gives." >}}
+{{< cimage src="modifierosites.png" caption="Representation of the information the ModifierOSites module gives." >}}
 
 ## Options
 

--- a/web/docs/userguide/modules/analysis/qspecies/_index.md
+++ b/web/docs/userguide/modules/analysis/qspecies/_index.md
@@ -8,7 +8,7 @@ description: Calculate the number of bridging oxygen sites bonded to a network f
 
 The `QSpecies` module calculates the Qn distribution of a site, where n is the number of bridging oxygen sites within the distance range specified. It also calculates the frequency of bridging, non-bridging and free oxygen sites.
 
-{{< cimage src="../qspecies.png" caption="Representation of Qn species." >}}
+{{< cimage src="qspecies.png" caption="Representation of Qn species." >}}
 
 ## Options
 


### PR DESCRIPTION
A quick PR to fix the paths to images for the `ModifierOSites` and `QSpecies` module documentation added in #2124.