### PR TITLE
fix: Checking species setup would crash if CoordinateSets were used

### DIFF
--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -53,8 +53,8 @@ bool AddGeneratorNode::prepare(const GeneratorContext &generatorContext)
     if (species_ && coordinateSets_)
         return Messenger::error("Specify either target Species or target coordinate sets, but not both.\n");
 
-    // Check if the Species itself is valid
-    if (!species_->checkSetUp())
+    // Check if the Species itself is valid (but only if one was specified rather than a coordinate set)
+    if (species_ && !species_->checkSetUp())
         return false;
 
     // Check for a periodic species in the case of boxAction_ == Set

--- a/src/generator/coordinateSets.cpp
+++ b/src/generator/coordinateSets.cpp
@@ -76,6 +76,10 @@ bool CoordinateSetsGeneratorNode::prepare(const GeneratorContext &generatorConte
     if (!species_)
         return Messenger::error("No Species set in CoordinateSets node.\n");
 
+    // Check if the Species itself is valid
+    if (!species_->checkSetUp())
+        return false;
+
     // Clear existing sets?
     if (force_)
         sets_.clear();


### PR DESCRIPTION
A quick fix to undo a horrible crash I introduced.