### PR TITLE
refactor: Add framework for serialising and deserialising enum

### DIFF
--- a/src/base/enumOptions.h
+++ b/src/base/enumOptions.h
@@ -219,3 +219,9 @@ template <class E> class EnumOptions : public EnumOptionsBase
 
     E deserialise(const SerialisedValue &node) { return enumeration(std::string(node.as_string())); }
 };
+
+template <typename T>
+concept HasEnumOptions = requires(T a)
+{
+    getEnumOptions(a);
+};

--- a/src/nodes/md/md.cpp
+++ b/src/nodes/md/md.cpp
@@ -32,3 +32,5 @@ MDNode::MDNode(Graph *parentGraph) : Node(parentGraph)
 std::string_view MDNode::type() const { return "MD"; }
 
 std::string_view MDNode::summary() const { return "Run a short molecular dynamics simulation."; }
+
+EnumOptions<MDNode::TimestepType> getEnumOptions(MDNode::TimestepType) { return MDNode::timestepType(); }

--- a/src/nodes/md/md.h
+++ b/src/nodes/md/md.h
@@ -100,3 +100,5 @@ class MDNode : public Node
     // Run main processing
     NodeConstants::ProcessResult process() override;
 };
+
+EnumOptions<MDNode::TimestepType> getEnumOptions(MDNode::TimestepType);

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/enumOptions.h"
 #include "base/serialiser.h"
 #include "nodes/number.h"
 #include "templates/flags.h"
@@ -139,7 +140,9 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         SerialisedValue result = {};
 
         // Serialise non-pointer values
-        if constexpr (std::is_convertible<T, Number>::value)
+        if constexpr (HasEnumOptions<T>)
+            result["data"] = getEnumOptions(data_).serialise(data_);
+        else if constexpr (std::is_convertible<T, Number>::value)
             result["data"] = data_;
         else if constexpr (std::is_convertible<T, std::string>::value)
             result["data"] = data_;
@@ -161,6 +164,11 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         if constexpr (std::is_pointer<T>::value)
         {
             data_ = nullptr;
+        }
+        else if constexpr (HasEnumOptions<T>)
+        {
+            T proxy; // Fake T value to get the corret overload
+            data_ = getEnumOptions(proxy).deserialise(node);
         }
         else if constexpr (std::is_convertible<T, std::optional<double>>::value)
         {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -130,6 +130,17 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         set(upcasted->get());
         return true;
     }
+
+    // Helper templates for handling serialisation
+
+    template <typename V> struct is_ptr_vector : std::false_type
+    {
+    };
+
+    template <serialisablePointer E> struct is_ptr_vector<std::vector<E>> : std::true_type
+    {
+    };
+
     /*
      * I/O
      */
@@ -165,6 +176,8 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         {
             data_ = nullptr;
         }
+        else if constexpr (is_ptr_vector<T>::value)
+            data_.clear();
         else if constexpr (HasEnumOptions<T>)
         {
             T proxy; // Fake T value to get the corret overload


### PR DESCRIPTION
This adds a concept for enums with an associated EnumOptions instance.  If you implement the `hasEnumOptions` function for the type, then serialisation of the parameter can be handled automatically.

One caveat is that this will fail for any enums that are not default constructible.  However, I'm not sure it's possible to make an enum that isn't default constructible without conjuring demons.

Note that this does *not* handle the case of deserialising vectors of pointers.