### PR TITLE
build: Fix generation of continuous ChangeLog.md

### DIFF
--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -131,7 +131,7 @@ jobs:
         shell: bash
         run: |
           set -ex
-          ./changeversion -l
+          ./changeversion -l | tee ChangeLog.md
 
       - name: Bump Version
         if: inputs.bump == 'true'


### PR DESCRIPTION
ChangeLog.md was printed out during the continuous CI, but wasn't saved anywhere, breaking publishing.