### PR TITLE
fix: Visual Studio dev workflow

### DIFF
--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -50,6 +50,7 @@ jobs:
         qtVersion: ${{ inputs.qtVersion }}
         antlrVersion: ${{ inputs.antlrVersion }}
         conanHash: ${{ inputs.conanHash }}
+        msvcVersion: ${{ inputs.msvcVersion }}
 
   BuildLinux:
     strategy:

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -107,7 +107,7 @@ jobs:
           ANTLR_VERSION=$(cat ${{ inputs.conanfile }}  | sed -n -e 's%^.*antlr4-cppruntime/%%p')
           echo "antlrVersion=${ANTLR_VERSION}" >> $GITHUB_OUTPUT
 
-          echo "msvcVersion=${inputs.msvcVersion}" >> $GITHUB_OUTPUT
+          echo "msvcVersion=${{ inputs.msvcVersion }}" >> $GITHUB_OUTPUT
 
       - name: Get Hashes
         id: hashes

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -4,6 +4,9 @@ description: Checks out the source and packages the source as an artifact for us
 on:
   workflow_call:
     inputs:
+      msvcVersion:
+        type: string
+        default: '14.41.17.11'
       qtVersion:
         type: string
         default: 6.4.2

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -44,6 +44,9 @@ on:
       currentShortHash:
         description: "Short hash of the current HEAD commit"
         value: ${{ jobs.Checkout.outputs.currentShortHash }}
+      msvcVersion:
+        description: "Version of MSVC required by the project"
+        value: ${{ jobs.Checkout.outputs.msvcVersion }}
       qtVersion:
         description: "Version of Qt required by the project"
         value: ${{ jobs.Checkout.outputs.qtVersion }}
@@ -103,6 +106,8 @@ jobs:
 
           ANTLR_VERSION=$(cat ${{ inputs.conanfile }}  | sed -n -e 's%^.*antlr4-cppruntime/%%p')
           echo "antlrVersion=${ANTLR_VERSION}" >> $GITHUB_OUTPUT
+
+          echo "msvcVersion=${inputs.msvcVersion}" >> $GITHUB_OUTPUT
 
       - name: Get Hashes
         id: hashes

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -76,6 +76,7 @@ jobs:
       currentVersionMinor: ${{ steps.authVersion.outputs.currentVersionMinor }}
       currentVersionPatch: ${{ steps.authVersion.outputs.currentVersionPatch }}
       currentShortHash: ${{ steps.authVersion.outputs.currentShortHash }}
+      msvcVersion: ${{ steps.versions.outputs.msvcVersion }}
       qtVersion: ${{ steps.versions.outputs.qtVersion }}
       antlrVersion: ${{ steps.versions.outputs.antlrVersion }}
       hugoVersion: ${{ steps.versions.outputs.hugoVersion }}

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -44,9 +44,6 @@ on:
       currentShortHash:
         description: "Short hash of the current HEAD commit"
         value: ${{ jobs.Checkout.outputs.currentShortHash }}
-      msvcVersion:
-        description: "Version of MSVC required by the project"
-        value: ${{ jobs.Checkout.outputs.msvcVersion }}
       qtVersion:
         description: "Version of Qt required by the project"
         value: ${{ jobs.Checkout.outputs.qtVersion }}
@@ -65,6 +62,9 @@ on:
       conanHash:
         description: "Hash of the current conanfile"
         value: ${{ jobs.Checkout.outputs.conanHash }}
+      msvcVersion:
+        description: "Version of MSVC required by the project"
+        value: ${{ jobs.Checkout.outputs.msvcVersion }}
 
 jobs:
 

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       msvcVersion:
         type: string
-        default: '14.41.17.11'
+        default: 14.41.17.11
       qtVersion:
         type: string
         default: 6.4.2

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -10,6 +10,9 @@ inputs:
   currentVersion:
     type: string
     description: "Version used for labelling packages and other artifacts"
+  msvcVersion:
+    type: string
+    default: 'UNKNOWN'
   qtVersion:
     type: string
     default: 'UNKNOWN'
@@ -61,3 +64,4 @@ runs:
       conanHash: ${{ inputs.conanHash }}
       qtVersion: ${{ inputs.qtVersion }}
       antlrVersion: ${{ inputs.antlrVersion }}
+      msvcVersion: ${{ inputs.msvcVersion }}

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
   msvcVersion:
     type: string
-    default: '14.41.17.11'
+    required: true
 
 runs:
   using: "composite"

--- a/.github/workflows/cacheConan.yml
+++ b/.github/workflows/cacheConan.yml
@@ -38,6 +38,7 @@ jobs:
           cacheOnly: true
           currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
           qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
+          msvcVersion: ${{ needs.Checkout.output.msvcVersion }}
           antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
           conanHash: ${{ needs.Checkout.outputs.conanHash }}
 

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,6 +35,7 @@ jobs:
       benchmark: true
       publishBenchmarks: true
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -21,6 +21,7 @@ jobs:
     uses: "./.github/workflows/_build_and_package.yml"
     with:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/legacy.yml
+++ b/.github/workflows/legacy.yml
@@ -15,6 +15,7 @@ jobs:
     uses: "./.github/workflows/_build_and_package.yml"
     with:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -45,6 +45,7 @@ jobs:
         arch: x64
 
     - name: 'Set up Python 3.11'
+      id: setup-python
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
@@ -55,6 +56,7 @@ jobs:
       env:
         qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
         antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
+        PythonPath: ${{ steps.setup-python.outputs.python-path }}
       run: | 
         ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -noPython
         

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -56,7 +56,7 @@ jobs:
         qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
         antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       run: | 
-        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion
+        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -noPython
         
     - name: 'Configure and build with CMake'
       shell: bash

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -31,7 +31,7 @@ jobs:
     - name: 'Install Downgraded MSVC'
       shell: powershell
       env:
-        msvcVersion: '14.41.17.11'
+        msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       run: |
         # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
         Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: 'Set up Python 3.11'
+      id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: 'Install Downgraded MSVC'
       shell: powershell
       env:
@@ -44,12 +50,6 @@ jobs:
       with:
         arch: x64
 
-    - name: 'Set up Python 3.11'
-      id: setup-python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-
     - name: 'Install dependencies'
       shell: pwsh
       working-directory: ${{ github.workspace }}
@@ -58,6 +58,7 @@ jobs:
         antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
         PythonPath: ${{ steps.setup-python.outputs.python-path }}
       run: | 
+        Write-Output $env:PythonPath
         ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -noPython
         
     - name: 'Configure and build with CMake'

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -43,7 +43,12 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
       with:
         arch: x64
-      
+
+    - name: 'Set up Python 3.11'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
     - name: 'Install dependencies'
       shell: pwsh
       working-directory: ${{ github.workspace }}
@@ -51,7 +56,7 @@ jobs:
         qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
         antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       run: | 
-        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -forcePythonVersion "3.11"
+        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion
         
     - name: 'Configure and build with CMake'
       shell: bash

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -59,7 +59,7 @@ jobs:
         PythonPath: ${{ steps.setup-python.outputs.python-path }}
       run: | 
         Write-Output $env:PythonPath
-        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -noPython
+        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -pythonPath $env:PythonPath
         
     - name: 'Configure and build with CMake'
       shell: bash

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -6,6 +6,7 @@ on:
     - '*'
     paths:
     - 'develop.ps1'
+    - './.github/workflows/build/windows/action.yml'
 
 jobs:
 

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -21,6 +21,24 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: 'Install Downgraded MSVC'
+      shell: powershell
+      env:
+        msvcVersion: '14.41.17.11'
+      run: |
+        # For versions update see here: https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022
+        Set-Location "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+        $InstallPath = "C:\Program Files\Microsoft Visual Studio\2022\Enterprise"
+        $componentsToInstall= @(
+            "Microsoft.VisualStudio.Component.VC.$env:msvcVersion.x86.x64"
+            "Microsoft.VisualStudio.Component.VC.$env:msvcVersion.ATL"
+        )
+        [string]$workloadArgs = $componentsToInstall | ForEach-Object {" --add " +  $_}
+        $Arguments = ('/c', "vs_installer.exe", 'modify', '--installPath', "`"$InstallPath`"",$workloadArgs, '--quiet', '--norestart', '--nocache')
+        # should be run twice
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+        $process = Start-Process -FilePath cmd.exe -ArgumentList $Arguments -Wait -PassThru -WindowStyle Hidden
+
     - name: 'Set up MSVC toolchain'
       uses: ilammy/msvc-dev-cmd@v1
       with:
@@ -33,7 +51,7 @@ jobs:
         qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
         antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       run: | 
-        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion
+        ./develop.ps1 -release -qtVersion $env:qtVersion -antlrVersion $env:antlrVersion -forcePythonVersion "3.11"
         
     - name: 'Configure and build with CMake'
       shell: bash

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       benchmark: true
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/recreate_release.yml
+++ b/.github/workflows/recreate_release.yml
@@ -24,6 +24,7 @@ jobs:
     uses: "./.github/workflows/_build_and_package.yml"
     with:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
+      msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/develop.ps1
+++ b/develop.ps1
@@ -25,10 +25,10 @@
 
 param (
     [string]$qtVersion,
-    [string]$antlrVersion = "4.13.1",
+    [string]$pythonPath,
     [string]$forcePythonVersion,
-    [switch]$release = $false,
-    [switch]$noPython = $false
+    [string]$antlrVersion = "4.13.1",
+    [switch]$release = $false
 )
 
 $build = "Debug"
@@ -75,11 +75,16 @@ try {
 }
 
 # Find python, install if not found
-if (-not $noPython)
+if (-not [string]::IsNullOrEmpty($pythonPath))
+{
+    Write-Output "Using Python with path $pythonPath..." @info_colors
+    $python = $pythonPath
+}
+else
 {
     if (-not [string]::IsNullOrEmpty($forcePythonVersion))
     {
-        Write-Output "Installing requested Python version $forcePythonVersion..."
+        Write-Output "Installing requested Python version $forcePythonVersion..." @info_colors
         choco install -y python --version=$forcePythonVersion --force
     }
     else
@@ -98,16 +103,18 @@ if (-not $noPython)
             choco install -y python --version=3.12.0
         }
     }
+
+    $python = "python"
 }
 
 refreshenv
 
 # Setup Python packages
-Write-Host "Creating a local Python virtual environment... " @info_colors
-python -m venv msvc-env
+Write-Host "Creating a local Python virtual environment with $(& $python --version)... " @info_colors
+& $python -m venv msvc-env
 
 Write-Host "Checking Python compiler type... " @info_colors
-if ($(python -c "import sys; print(sys.version)") -match "MSC v\.\d+") 
+if ($(& $python -c "import sys; print(sys.version)") -match "MSC v\.\d+")
 { 
     Write-Host " ...Python compiler type evaluated to MSC" @info_colors
     $pythonEnvSourceDir = "Scripts"
@@ -124,11 +131,8 @@ Write-Host "Activating Python virtual environment... " @info_colors
 & $activate
 
 Write-Host "Installing Python packages... " @info_colors
-python -m pip install --upgrade pip
-python -m pip install aqtinstall conan==1.*
-
-$pythonVersion = python --version
-Write-Host "Python Version output:`n$pythonVersion"
+& $python -m pip install --upgrade pip
+& $python -m pip install aqtinstall conan==1.*
 
 $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
 
@@ -143,8 +147,8 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
     $qtInstallationDir = Join-Path -Path $dependencies -ChildPath "qt"
     New-Item -ItemType Directory -Path $qtInstallationDir -ErrorAction SilentlyContinue
 
-    Write-Host "Installing Qt6... " @info_colors
-    aqt install-qt --outputdir $qtInstallationDir windows desktop $qtVersion win64_msvc2019_64 -m all
+    Write-Host "Installing Qt6 using aqt with $(& $python --version)... " @info_colors
+    & $python -m aqt install-qt --outputdir $qtInstallationDir windows desktop $qtVersion win64_msvc2019_64 -m all
 
     # Export Qt6_DIR to system environment variables
     $qt6Dir = Join-Path -Path "$projectDir\$dependencies" -ChildPath "qt\$qtVersion\msvc2019_64"

--- a/develop.ps1
+++ b/develop.ps1
@@ -28,6 +28,7 @@ param (
     [string]$antlrVersion = "4.13.1",
     [string]$forcePythonVersion,
     [switch]$release = $false
+    [switch]$noPython = $false
 )
 
 $build = "Debug"
@@ -74,25 +75,28 @@ try {
 }
 
 # Find python, install if not found
-if (-not [string]::IsNullOrEmpty($forcePythonVersion))
+if (-not $noPython)
 {
-    Write-Output "Installing requested Python version $forcePythonVersion..."
-    choco install -y python --version=$forcePythonVersion --force
-}
-else
-{
-    try {
-        & "python" --version
-        Write-Output "Found system Python..." @info_colors
-        $pythonVersion = $(python -c "import sys; v = sys.version_info; print(v.major == 3, v.minor == 12)")
-        $versionParts = $pythonVersion -split " "
-        if (-not ($versionParts[0] -eq "True" -and $versionParts[1] -eq "True")) {
-            Write-Output "System Python is version $(python --version) and it is recommended to be == 3.12 - installing with Chocolatey..." @info_colors
+    if (-not [string]::IsNullOrEmpty($forcePythonVersion))
+    {
+        Write-Output "Installing requested Python version $forcePythonVersion..."
+        choco install -y python --version=$forcePythonVersion --force
+    }
+    else
+    {
+        try {
+            & "python" --version
+            Write-Output "Found system Python..." @info_colors
+            $pythonVersion = $(python -c "import sys; v = sys.version_info; print(v.major == 3, v.minor == 12)")
+            $versionParts = $pythonVersion -split " "
+            if (-not ($versionParts[0] -eq "True" -and $versionParts[1] -eq "True")) {
+                Write-Output "System Python is version $(python --version) and it is recommended to be == 3.12 - installing with Chocolatey..." @info_colors
+                choco install -y python --version=3.12.0
+            }
+        } catch {
+            Write-Output "Could not find system Python - installing with Chocolatey..." @info_colors
             choco install -y python --version=3.12.0
         }
-    } catch {
-        Write-Output "Could not find system Python - installing with Chocolatey..." @info_colors
-        choco install -y python --version=3.12.0
     }
 }
 

--- a/develop.ps1
+++ b/develop.ps1
@@ -24,7 +24,6 @@
         ANTLR version to install. Defaults to ANTLR 4.13.1.
     .PARAMETER release
         Flag - install packages for release, otherwise debug.
-
 #>
 
 param (

--- a/develop.ps1
+++ b/develop.ps1
@@ -4,7 +4,7 @@
     .DESCRIPTION
         Installs the following dependencies for Dissolve (separate and prior to Conan-managed packages):
             - Python 3.12 (unless stated otherwise)
-            - CMake 3.3
+            - CMake 3.x
             - ninja
             - pkgconfiglite
             - Qt6 <VERSION>

--- a/develop.ps1
+++ b/develop.ps1
@@ -27,7 +27,7 @@ param (
     [string]$qtVersion,
     [string]$antlrVersion = "4.13.1",
     [string]$forcePythonVersion,
-    [switch]$release = $false
+    [switch]$release = $false,
     [switch]$noPython = $false
 )
 

--- a/develop.ps1
+++ b/develop.ps1
@@ -3,7 +3,7 @@
         Script to install dependencies for Dissolve development environment in Visual Studio.
     .DESCRIPTION
         Installs the following dependencies for Dissolve (separate and prior to Conan-managed packages):
-            - Python 3.12
+            - Python 3.12 (unless stated otherwise)
             - CMake 3.3
             - ninja
             - pkgconfiglite
@@ -11,11 +11,15 @@
             - Freetype
             - FTGL
             - Antlr4 (Java backend)
-            - Java JDK
+            - Java JDK (latest)
         
         These packages are installed into a folder called 'dependencies'.
     .PARAMETER qtVersion
         Qt version to install. Defaults to existing system Qt6 installation if none specified.
+    .PARAMETER pythonPath
+        Path to a Python executable.
+    .PARAMETER forcePythonVersion
+        Force installation of a given Python version.
     .PARAMETER antlrVersion
         ANTLR version to install. Defaults to ANTLR 4.13.1.
     .PARAMETER release

--- a/develop.ps1
+++ b/develop.ps1
@@ -3,6 +3,10 @@
         Script to install dependencies for Dissolve development environment in Visual Studio.
     .DESCRIPTION
         Installs the following dependencies for Dissolve (separate and prior to Conan-managed packages):
+            - Python 3.12
+            - CMake 3.3
+            - ninja
+            - pkgconfiglite
             - Qt6 <VERSION>
             - Freetype
             - FTGL
@@ -21,7 +25,8 @@
 
 param (
     [string]$qtVersion,
-    [string]$antlrVersion = "4.13.1", 
+    [string]$antlrVersion = "4.13.1",
+    [string]$forcePythonVersion,
     [switch]$release = $false
 )
 
@@ -56,7 +61,8 @@ iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocola
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 
 Write-Host "Installing key dependencies with Chocolatey... " @info_colors
-choco install -y ninja pkgconfiglite cmake
+choco install -y ninja pkgconfiglite
+choco install -y cmake --version=3.30.1 --force
 
 # Find git, install if not found
 try {
@@ -68,18 +74,26 @@ try {
 }
 
 # Find python, install if not found
-try {
-    & "python" --version
-    Write-Output "Found system Python..." @info_colors
-    $pythonVersion = $(python -c "import sys; v = sys.version_info; print(v.major == 3, v.minor == 12)")
-    $versionParts = $pythonVersion -split " "
-    if (-not ($versionParts[0] -eq "True" -and $versionParts[1] -eq "True")) {
-        Write-Output "System Python is version $(python --version) and it is recommended to be == 3.12 - installing with Chocolatey..." @info_colors
+if (-not [string]::IsNullOrEmpty($forcePythonVersion))
+{
+    Write-Output "Installing requested Python version $forcePythonVersion..."
+    choco install -y python --version=$forcePythonVersion --force
+}
+else
+{
+    try {
+        & "python" --version
+        Write-Output "Found system Python..." @info_colors
+        $pythonVersion = $(python -c "import sys; v = sys.version_info; print(v.major == 3, v.minor == 12)")
+        $versionParts = $pythonVersion -split " "
+        if (-not ($versionParts[0] -eq "True" -and $versionParts[1] -eq "True")) {
+            Write-Output "System Python is version $(python --version) and it is recommended to be == 3.12 - installing with Chocolatey..." @info_colors
+            choco install -y python --version=3.12.0
+        }
+    } catch {
+        Write-Output "Could not find system Python - installing with Chocolatey..." @info_colors
         choco install -y python --version=3.12.0
     }
-} catch {
-    Write-Output "Could not find system Python - installing with Chocolatey..." @info_colors
-    choco install -y python --version=3.12.0
 }
 
 refreshenv

--- a/develop.ps1
+++ b/develop.ps1
@@ -324,11 +324,14 @@ try {
     $conanVersion = conan --version
     Write-Output "Found conan version $conanVersion..."
 } catch {
-    Write-Output "Could not find conan, adding Python scripts to path..."
+    Write-Output "Could not find conan, adding Python scripts to path..." @info_colors
     $scripts = & $python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
     $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
     [Environment]::SetEnvironmentVariable("PATH", "$scripts;$systemPath", [EnvironmentVariableTarget]::Machine)
     Write-Host "Python scripts path added to system PATH." @info_colors
+
+    $findConan = where.exe conan
+    Write-Output "Looking for conan - $findConan" @info_colors
 }
 
 conan profile new default --detect

--- a/develop.ps1
+++ b/develop.ps1
@@ -127,6 +127,9 @@ Write-Host "Installing Python packages... " @info_colors
 python -m pip install --upgrade pip
 python -m pip install aqtinstall conan==1.*
 
+$aqtVersion = aqt version 2>&1
+Write-Host "AQT Version output:`n$aqtVersion"
+
 $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
 
 [Environment]::SetEnvironmentVariable("PATH", "$(Join-Path -Path $projectDir -ChildPath "msvc-env\$pythonEnvSourceDir");$systemPath", [EnvironmentVariableTarget]::Machine)
@@ -140,7 +143,7 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
     $qtInstallationDir = Join-Path -Path $dependencies -ChildPath "qt"
     New-Item -ItemType Directory -Path $qtInstallationDir -ErrorAction SilentlyContinue
 
-    Write-Host "Installing Qt6, using aqt ($(aqt version))... " @info_colors
+    Write-Host "Installing Qt6... " @info_colors
     aqt install-qt --outputdir $qtInstallationDir windows desktop $qtVersion win64_msvc2019_64 -m all
 
     # Export Qt6_DIR to system environment variables

--- a/develop.ps1
+++ b/develop.ps1
@@ -319,6 +319,18 @@ Move-Item -Path $antlrOutput -Destination $antlrExePath
 Set-Location -Path $projectDir
 
 Write-Host "Setting up Conan profile... " @info_colors
+
+try {
+    $conanVersion = conan --version
+    Write-Output "Found conan version $conanVersion..."
+} catch {
+    Write-Output "Could not find conan, adding Python scripts to path..."
+    $scripts = & $python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
+    $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
+    [Environment]::SetEnvironmentVariable("PATH", "$scripts;$systemPath", [EnvironmentVariableTarget]::Machine)
+    Write-Host "Python scripts path added to system PATH." @info_colors
+}
+
 conan profile new default --detect
 conan profile update settings.compiler="Visual Studio" default
 conan profile update settings.compiler.version=17 default

--- a/develop.ps1
+++ b/develop.ps1
@@ -127,8 +127,8 @@ Write-Host "Installing Python packages... " @info_colors
 python -m pip install --upgrade pip
 python -m pip install aqtinstall conan==1.*
 
-$aqtVersion = aqt version 2>&1
-Write-Host "AQT Version output:`n$aqtVersion"
+$pythonVersion = python --version
+Write-Host "Python Version output:`n$pythonVersion"
 
 $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
 

--- a/develop.ps1
+++ b/develop.ps1
@@ -140,7 +140,7 @@ if (-not [string]::IsNullOrEmpty($qtVersion))
     $qtInstallationDir = Join-Path -Path $dependencies -ChildPath "qt"
     New-Item -ItemType Directory -Path $qtInstallationDir -ErrorAction SilentlyContinue
 
-    Write-Host "Installing Qt6... " @info_colors
+    Write-Host "Installing Qt6, using aqt ($(aqt version))... " @info_colors
     aqt install-qt --outputdir $qtInstallationDir windows desktop $qtVersion win64_msvc2019_64 -m all
 
     # Export Qt6_DIR to system environment variables

--- a/develop.ps1
+++ b/develop.ps1
@@ -95,7 +95,7 @@ else
             $pythonVersion = $(python -c "import sys; v = sys.version_info; print(v.major == 3, v.minor == 12)")
             $versionParts = $pythonVersion -split " "
             if (-not ($versionParts[0] -eq "True" -and $versionParts[1] -eq "True")) {
-                Write-Output "System Python is version $(python --version) and it is recommended to be == 3.12 - installing with Chocolatey..." @info_colors
+                Write-Output "System Python is version $(python --version) and it is recommended to be version == 3.12 - installing with Chocolatey..." @info_colors
                 choco install -y python --version=3.12.0
             }
         } catch {

--- a/develop.ps1
+++ b/develop.ps1
@@ -323,20 +323,21 @@ Write-Host "Setting up Conan profile... " @info_colors
 try {
     $conanVersion = conan --version
     Write-Output "Found conan version $conanVersion..."
+
+    $conan = "conan"
 } catch {
     Write-Output "Could not find conan, adding Python scripts to path..." @info_colors
     $scripts = & $python -c "import sysconfig; print(sysconfig.get_path('scripts'))"
     $systemPath = [Environment]::GetEnvironmentVariable("PATH", [EnvironmentVariableTarget]::Machine)
     [Environment]::SetEnvironmentVariable("PATH", "$scripts;$systemPath", [EnvironmentVariableTarget]::Machine)
-    Write-Host "Python scripts path added to system PATH." @info_colors
+    Write-Host "Python scripts path at location $scripts added to system PATH." @info_colors
 
-    $findConan = where.exe conan
-    Write-Output "Looking for conan - $findConan" @info_colors
+    $conan = "$scripts/conan.exe"
 }
 
-conan profile new default --detect
-conan profile update settings.compiler="Visual Studio" default
-conan profile update settings.compiler.version=17 default
+& $conan profile new default --detect
+& $conan profile update settings.compiler="Visual Studio" default
+& $conan profile update settings.compiler.version=17 default
 
 # Generate Cmake user presets JSON for MSVC Cmake configurations
 $out = Join-Path -Path $projectDir -ChildPath "build"

--- a/src/math/peaks.cpp
+++ b/src/math/peaks.cpp
@@ -123,6 +123,7 @@ std::vector<Peaks::Peak1D> Peaks::find(bool heightOrder)
 
 /*
  * Calculate the prominence of peaks.
+ * 
  * Prominence is defined by the height of the peak relative to a reference height.
  * This reference is determined by the heighest minimum of two intervals (bound by either the end of the data
  * or a higher data point), either side of the peak itself.


### PR DESCRIPTION
A couple of changes to ensure our `msvc` workflow stays in working order
- Downgrade MSVC (for Antlr)
- Python 3.11
- Wrestled with some path finding in the powershell script to get it to work in GitHub (still seems to work on local machine)
- `msvc` CI now tracks changes to the main Windows CI action, to try and catch changes to the build process more readily