### PR TITLE
feat: Node messenger

### DIFF
--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -27,7 +27,7 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  */
 
 // Add message to store
-void Node::postMessage(std::string_view message, MessageStatus status) { messages_[status].emplace_back(message); }
+void Node::postMessage(std::string message, MessageStatus status) { messages_[status].emplace_back(message); }
 
 // Message store vector
 const Node::MessageStore &Node::messages() const { return messages_; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -5,6 +5,7 @@
 #include "base/sysFunc.h"
 #include "nodes/edge.h"
 #include "nodes/graph.h"
+#include <algorithm>
 
 /*
  * Definition
@@ -27,7 +28,18 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  */
 
 // Message store vector
-const Node::MessageStore &Node::messages() const { return messages_; }
+const Node::MessageStore &Node::messages(MessageStatus status) const
+{
+    if (status != MessageStatus::Any)
+    {
+        MessageStore filtered;
+        std::copy_if(messages_.cbegin(), messages_.cend(), std::back_inserter(filtered),
+                     [status](const auto &entry) { return entry.first == status; });
+        return filtered;
+    }
+
+    return messages_;
+}
 
 /*
  * Inputs, Outputs & Options

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -25,11 +25,9 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
 /*
  * Node message
  */
+
 // Add message to store
-void Node::postMessage(std::string_view message, MessageStatus status)
-{
-    messages_.emplace_back(std::make_pair(status, message));
-}
+void Node::postMessage(std::string_view message, MessageStatus status) { messages_[status].emplace_back(message); }
 
 // Message store vector
 const Node::MessageStore &Node::messages() const { return messages_; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -23,6 +23,18 @@ void Node::setName(std::string_view newName)
 std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeName(this) : "UnparentedNode"; }
 
 /*
+ * Node message
+ */
+// Add message to store
+void Node::postMessage(std::string_view message, MessageStatus status)
+{
+    messages_.emplace_back(std::make_pair(status, message));
+}
+
+// Message store vector
+const Node::MessageStore& Node::messages() const { return messages_; }
+
+/*
  * Inputs, Outputs & Options
  */
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -27,7 +27,7 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  */
 
 // Add message to store
-void Node::postMessage(std::string message, MessageStatus status) { messages_[status].emplace_back(message); }
+void Node::postMessage(std::string message, MessageStatus status) { messages_.emplace_back(std::make_pair(status, message)); }
 
 // Message store vector
 const Node::MessageStore &Node::messages() const { return messages_; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -44,6 +44,9 @@ const Node::MessageStore &Node::messages(MessageStatus status) const
     return messages_;
 }
 
+// Print latest message
+void Node::echo() { std::cout << messages_.back().second << std::endl; }
+
 /*
  * Inputs, Outputs & Options
  */

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -32,7 +32,7 @@ void Node::postMessage(std::string_view message, MessageStatus status)
 }
 
 // Message store vector
-const Node::MessageStore& Node::messages() const { return messages_; }
+const Node::MessageStore &Node::messages() const { return messages_; }
 
 /*
  * Inputs, Outputs & Options

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -27,6 +27,9 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  * Node message
  */
 
+// Print latest message
+bool Node::echo_ = false;
+
 // Message store vector
 const Node::MessageStore &Node::messages(MessageStatus status) const
 {

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -31,17 +31,12 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
 bool Node::echo_ = false;
 
 // Message store vector
-const Node::MessageStore &Node::messages(MessageStatus status) const
-{
-    if (status != MessageStatus::Any)
-    {
-        MessageStore filtered;
-        std::copy_if(messages_.cbegin(), messages_.cend(), std::back_inserter(filtered),
-                     [status](const auto &entry) { return entry.first == status; });
-        return filtered;
-    }
+const Node::MessageStore &Node::messages() const { return messages_; }
 
-    return messages_;
+// Returns true if message with given status exists
+bool Node::hasMessages(MessageStatus status) const
+{
+    return std::any_of(messages_.cbegin(), messages_.cend(), [status](const auto &msg) { return msg.first == status; });
 }
 
 // Print latest message

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -26,9 +26,6 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  * Node message
  */
 
-// Add message to store
-void Node::postMessage(std::string message, MessageStatus status) { messages_.emplace_back(std::make_pair(status, message)); }
-
 // Message store vector
 const Node::MessageStore &Node::messages() const { return messages_; }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -50,6 +50,7 @@ class Node : public Serialisable<>
      */
     enum class MessageStatus
     {
+        Any,
         Info,
         Warn,
         Error,
@@ -78,7 +79,7 @@ class Node : public Serialisable<>
 
     public:
     // Message store vector
-    const MessageStore &messages() const;
+    const MessageStore &messages(MessageStatus status = MessageStatus::Any) const;
 
     /*
      * Processing & Validity

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -60,8 +60,21 @@ class Node : public Serialisable<>
     private:
     // Message store vector
     MessageStore messages_;
-    // Post message to store
-    void postMessage(std::string message, MessageStatus status = MessageStatus::Info);
+    // Node message format
+    template <typename... Args> static void message(std::format_string<Args...> format, Args... args)
+    {
+        messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args))));
+    }
+    // Node warn format
+    template <typename... Args> static void warn(std::format_string<Args...> format, Args... args)
+    {
+        messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args))));
+    }
+    // Node error format
+    template <typename... Args> static void error(std::format_string<Args...> format, Args... args)
+    {
+        messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args))));
+    }
 
     public:
     // Message store vector

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -55,7 +55,7 @@ class Node : public Serialisable<>
         Error,
         Exception
     };
-    using MessageStore = std::vector<std::pair<Node::MessageStatus, std::string_view>>;
+    using MessageStore = std::map<Node::MessageStatus, std::vector<std::string_view>>;
 
     private:
     // Message store vector

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -62,17 +62,17 @@ class Node : public Serialisable<>
     // Message store vector
     MessageStore messages_;
     // Node message format
-    template <typename... Args> static void message(std::format_string<Args...> format, Args... args)
+    template <typename... Args> void message(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args))));
     }
     // Node warn format
-    template <typename... Args> static void warn(std::format_string<Args...> format, Args... args)
+    template <typename... Args> void warn(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args))));
     }
     // Node error format
-    template <typename... Args> static void error(std::format_string<Args...> format, Args... args)
+    template <typename... Args> void error(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args))));
     }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -72,7 +72,7 @@ class Node : public Serialisable<>
         messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args)...)));
 
         if (echo_)
-            std::cout << messages_.back().second << std::endl;
+            echo();
     }
     // Node warn format
     template <typename... Args> void warn(std::format_string<Args...> format, Args... args)
@@ -80,7 +80,7 @@ class Node : public Serialisable<>
         messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args)...)));
 
         if (echo_)
-            std::cout << messages_.back().second << std::endl;
+            echo();
     }
     // Node error format
     template <typename... Args> void error(std::format_string<Args...> format, Args... args)
@@ -88,8 +88,10 @@ class Node : public Serialisable<>
         messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args)...)));
 
         if (echo_)
-            std::cout << messages_.back().second << std::endl;
+            echo();
     }
+    // Print latest message
+    void echo();
 
     public:
     // Message store vector

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -46,6 +46,28 @@ class Node : public Serialisable<>
     virtual std::string_view summary() const = 0;
 
     /*
+     * Node message
+     */
+    enum class MessageStatus
+    {
+        Info,
+        Warn,
+        Error,
+        Exception
+    };
+    using MessageStore = std::vector<std::pair<Node::MessageStatus, std::string_view>>;
+
+    private:
+    // Message store vector
+    MessageStore messages_;
+    // Post message to store
+    void postMessage(std::string_view message, MessageStatus status = MessageStatus::Info);
+
+    public:
+    // Message store vector
+    const MessageStore& messages() const;
+
+    /*
      * Processing & Validity
      */
     private:

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -65,7 +65,7 @@ class Node : public Serialisable<>
 
     public:
     // Message store vector
-    const MessageStore& messages() const;
+    const MessageStore &messages() const;
 
     /*
      * Processing & Validity

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -55,13 +55,13 @@ class Node : public Serialisable<>
         Error,
         Exception
     };
-    using MessageStore = std::map<Node::MessageStatus, std::vector<std::string_view>>;
+    using MessageStore = std::map<Node::MessageStatus, std::vector<std::string>>;
 
     private:
     // Message store vector
     MessageStore messages_;
     // Post message to store
-    void postMessage(std::string_view message, MessageStatus status = MessageStatus::Info);
+    void postMessage(std::string message, MessageStatus status = MessageStatus::Info);
 
     public:
     // Message store vector

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -52,7 +52,6 @@ class Node : public Serialisable<>
     // Enumeration for message status
     enum class MessageStatus
     {
-        Any,
         Info,
         Warn,
         Error
@@ -94,7 +93,9 @@ class Node : public Serialisable<>
 
     public:
     // Message store vector
-    const MessageStore &messages(MessageStatus status = MessageStatus::Any) const;
+    const MessageStore &messages() const;
+    // Returns true if message with given status exists
+    bool hasMessages(MessageStatus status) const;
 
     /*
      * Processing & Validity

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -48,6 +48,8 @@ class Node : public Serialisable<>
     /*
      * Node message
      */
+
+    // Enumeration for message status
     enum class MessageStatus
     {
         Any,
@@ -56,7 +58,10 @@ class Node : public Serialisable<>
         Error,
         Exception
     };
+
     using MessageStore = std::vector<std::pair<MessageStatus, std::string>>;
+    // Print latest message
+    static bool echo_;
 
     private:
     // Message store vector
@@ -65,16 +70,25 @@ class Node : public Serialisable<>
     template <typename... Args> void message(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args)...)));
+
+        if (echo_)
+            std::cout << messages_.back().second << std::endl;
     }
     // Node warn format
     template <typename... Args> void warn(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args)...)));
+
+        if (echo_)
+            std::cout << messages_.back().second << std::endl;
     }
     // Node error format
     template <typename... Args> void error(std::format_string<Args...> format, Args... args)
     {
         messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args)...)));
+
+        if (echo_)
+            std::cout << messages_.back().second << std::endl;
     }
 
     public:

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -55,8 +55,7 @@ class Node : public Serialisable<>
         Any,
         Info,
         Warn,
-        Error,
-        Exception
+        Error
     };
 
     using MessageStore = std::vector<std::pair<MessageStatus, std::string>>;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -64,17 +64,17 @@ class Node : public Serialisable<>
     // Node message format
     template <typename... Args> void message(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args))));
+        messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args)...)));
     }
     // Node warn format
     template <typename... Args> void warn(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args))));
+        messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args)...)));
     }
     // Node error format
     template <typename... Args> void error(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args))));
+        messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args)...)));
     }
 
     public:

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -55,7 +55,7 @@ class Node : public Serialisable<>
         Error,
         Exception
     };
-    using MessageStore = std::map<Node::MessageStatus, std::vector<std::string>>;
+    using MessageStore = std::vector<std::pair<MessageStatus, std::string>>;
 
     private:
     // Message store vector


### PR DESCRIPTION
This PR aims to capture the requirement for individual `Node` instances to hold a local record of messages, represented by the `MessageStore` type alias. I currently envisage each Node-local message to have a `MessageStatus` enum attributed to it (one of `Info`, `Warn`, `Error` or `Exception`) to allow us to differentiate between message levels.