### PR TITLE
feat: Optional bounded Number

### DIFF
--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -80,12 +80,12 @@ bool Number::operator<=(const Number &other) const
 
 bool Number::operator>(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return b < a; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return a > b; }, value_, other.value_);
 }
 
 bool Number::operator>=(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return b <= a; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return a >= b; }, value_, other.value_);
 }
 
 /*

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -138,8 +138,7 @@ std::optional<double> Number::doubleMin()
     if (!hasBounds())
         return {};
 
-    auto min = asDouble(min_.value());
-    return min;
+    return asDouble(min_.value());
 }
 
 // Return optional integer lower bound

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -117,44 +117,50 @@ double Number::asDouble(NumberVariant n) const
 // Set from other Number
 void Number::set(const Number &other) { value_ = other.value_; }
 
-// Return whether the number has bounds
-bool Number::hasBounds() const { return min_.has_value() && max_.has_value(); }
+// Return whether the number has lower bound
+bool Number::hasLowerBound() const { return min_.has_value(); }
+
+// Return whether the number has upper bound
+bool Number::hasUpperBound() const { return min_.has_value(); }
 
 // Return optional double upper bound
 std::optional<double> Number::doubleMax()
 {
-    if (!hasBounds())
-        return {};
+    if (hasUpperBound())
+        return asDouble(max_.value());
 
-    return asDouble(max_.value());
+    return {};
 }
 
 // Return optional integer upper bound
 std::optional<int> Number::integerMax()
 {
-    if (!hasBounds())
-        return {};
+    if (hasUpperBound())
+        return asInteger(max_.value());
 
-    return asInteger(max_.value());
+    return {};
 }
 
 // Return optional double lower bound
 std::optional<double> Number::doubleMin()
 {
-    if (!hasBounds())
-        return {};
+    if (hasLowerBound())
+        return asDouble(min_.value());
 
-    return asDouble(min_.value());
+    return {};
 }
 
 // Return optional integer lower bound
 std::optional<int> Number::integerMin()
 {
-    if (!hasBounds())
-        return {};
+    if (hasLowerBound())
+        return asInteger(min_.value());
 
-    return asInteger(min_.value());
+    return {};
 }
+
+// Return whether the number has bounds
+bool Number::isBounded() const { return hasLowerBound() && hasUpperBound(); }
 
 // Return whether the contained value is an integer
 bool Number::isInteger() const { return isInteger(value_); }

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -142,7 +142,7 @@ std::optional<double> Number::doubleMin()
     return min;
 }
 
-// Return optional integer lowe bound
+// Return optional integer lower bound
 std::optional<int> Number::integerMin()
 {
     if (!hasBounds())

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -34,7 +34,7 @@ Number::Number(double value, std::optional<double> min, std::optional<double> ma
 
 Number &Number::operator=(const Number &other)
 {
-    value_ = other.value_;
+    set(other);
     return *this;
 }
 
@@ -46,6 +46,7 @@ Number Number::operator+(const Number &other) const
 Number &Number::operator+=(const Number &other)
 {
     std::visit([](auto &a, auto b) { a += b; }, value_, other.value_);
+    set(value_);
     return *this;
 }
 
@@ -57,6 +58,7 @@ Number Number::operator-(const Number &other) const
 Number &Number::operator-=(const Number &other)
 {
     std::visit([](auto &a, auto b) { a -= b; }, value_, other.value_);
+    set(value_);
     return *this;
 }
 
@@ -68,6 +70,7 @@ Number Number::operator*(const Number &other) const
 Number &Number::operator*=(const Number &other)
 {
     std::visit([](auto &a, auto b) { a *= b; }, value_, other.value_);
+    set(value_);
     return *this;
 }
 
@@ -79,6 +82,7 @@ Number Number::operator/(const Number &other) const
 Number &Number::operator/=(const Number &other)
 {
     std::visit([](auto &a, auto b) { a /= b; }, value_, other.value_);
+    set(value_);
     return *this;
 }
 
@@ -89,6 +93,18 @@ bool Number::operator!=(const Number &other) const { return value_ != other.valu
 /*
  * Data
  */
+
+// Impose limit on Number
+Number::NumberVariant Number::limit(Number n) const
+{
+    if (hasLowerBound() && n.value_ < min_)
+        return min_.value();
+
+    if (hasUpperBound() && n.value_ > max_)
+        return max_.value();
+
+    return n.value_;
+}
 
 // Return whether the contained value is an integer
 bool Number::isInteger(NumberVariant n) const { return std::holds_alternative<int>(n); }
@@ -115,7 +131,7 @@ double Number::asDouble(NumberVariant n) const
 }
 
 // Set from other Number
-void Number::set(const Number &other) { value_ = other.value_; }
+void Number::set(const Number &other) { value_ = limit(other.value_); }
 
 // Return whether the number has lower bound
 bool Number::hasLowerBound() const { return min_.has_value(); }

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -90,6 +90,26 @@ bool Number::operator==(const Number &other) const { return value_ == other.valu
 
 bool Number::operator!=(const Number &other) const { return value_ != other.value_; }
 
+bool Number::operator<(const Number& other) const
+{
+    return std::visit([](auto a, auto b) -> bool { return { a < b }; }, value_, other.value_);
+}
+
+bool Number::operator<=(const Number& other) const
+{
+    return std::visit([](auto a, auto b) -> bool { return { a <= b }; }, value_, other.value_);
+}
+
+bool Number::operator>(const Number& other) const
+{
+    return std::visit([](auto a, auto b) -> bool { return { b < a }; }, value_, other.value_);
+}
+
+bool Number::operator>=(const Number& other) const
+{
+    return std::visit([](auto a, auto b) -> bool { return { b <= a }; }, value_, other.value_);
+}
+
 /*
  * Data
  */
@@ -97,10 +117,10 @@ bool Number::operator!=(const Number &other) const { return value_ != other.valu
 // Impose limit on Number
 Number::NumberVariant Number::limit(Number n) const
 {
-    if (hasLowerBound() && n.value_ < min_)
+    if (hasLowerBound() && n < Number(min_.value()))
         return min_.value();
 
-    if (hasUpperBound() && n.value_ > max_)
+    if (hasUpperBound() && n > Number(max_.value()))
         return max_.value();
 
     return n.value_;

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -70,22 +70,22 @@ bool Number::operator!=(const Number &other) const { return value_ != other.valu
 
 bool Number::operator<(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return {a < b}; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return a < b; }, value_, other.value_);
 }
 
 bool Number::operator<=(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return {a <= b}; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return a <= b; }, value_, other.value_);
 }
 
 bool Number::operator>(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return {b < a}; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return b < a; }, value_, other.value_);
 }
 
 bool Number::operator>=(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return {b <= a}; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return b <= a; }, value_, other.value_);
 }
 
 /*

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -10,6 +10,10 @@ Number::Number(int value) : value_(value) {}
 
 Number::Number(double value) : value_(value) {}
 
+//Number::Number(int value, std::optional<int> min, std::optional<int> max) : value_(value), min_(min), max_(max) {}
+
+//Number::Number(double value, std::optional<double> min, std::optional<double> max) : value_(value), min_(min), max_(max) {}
+
 Number &Number::operator=(const Number &other)
 {
     value_ = other.value_;
@@ -68,32 +72,90 @@ bool Number::operator!=(const Number &other) const { return value_ != other.valu
  * Data
  */
 
-// Set from other Number
-void Number::set(const Number &other) { value_ = other.value_; }
-
 // Return whether the contained value is an integer
-bool Number::isInteger() const { return std::holds_alternative<int>(value_); }
+bool Number::isInteger(NumberVariant n) const { return std::holds_alternative<int>(n); }
 
 // Return whether the contained value is a double
-bool Number::isDouble() const { return std::holds_alternative<double>(value_); }
+bool Number::isDouble(NumberVariant n) const { return std::holds_alternative<double>(n); }
 
 // Return contained value as integer
-int Number::asInteger() const
+int Number::asInteger(NumberVariant n) const
 {
-    if (std::holds_alternative<int>(value_))
-        return std::get<int>(value_);
+    if (isInteger(n))
+        return std::get<int>(n);
     else
-        return int(std::get<double>(value_));
+        return int(std::get<double>(n));
 }
 
 // Return contained value as double
-double Number::asDouble() const
+double Number::asDouble(NumberVariant n) const
 {
-    if (std::holds_alternative<int>(value_))
-        return double(std::get<int>(value_));
+    if (isInteger(n))
+        return double(std::get<int>(n));
     else
-        return std::get<double>(value_);
+        return std::get<double>(n);
 }
+
+// Set from other Number
+void Number::set(const Number &other)
+{
+    if (other.hasBounds())
+        min_ = other.min_, max_ = other.max_;
+
+    value_ = other.value_;
+}
+
+// Return whether the number has bounds
+bool Number::hasBounds() const { return min_.has_value() && max_.has_value(); }
+
+// Return optional double upper bound
+std::optional<double> Number::doubleMax()
+{
+    if (!hasBounds())
+        return {};
+
+    return asDouble(max_.value());
+}
+
+// Return optional integer upper bound
+std::optional<int> Number::integerMax()
+{
+    if (!hasBounds())
+        return {};
+
+    return asInteger(max_.value());
+}
+
+// Return optional double lower bound
+std::optional<double> Number::doubleMin()
+{
+    if (!hasBounds())
+        return {};
+
+    auto min = asDouble(min_.value());
+    return min;
+}
+
+// Return optional integer lowe bound
+std::optional<int> Number::integerMin()
+{
+    if (!hasBounds())
+        return {};
+
+    return asInteger(min_.value());
+}
+
+// Return whether the contained value is an integer
+bool Number::isInteger() const { return isInteger(value_); }
+
+// Return whether the contained value is a double
+bool Number::isDouble() const { return isDouble(value_); }
+
+// Return contained value as integer
+int Number::asInteger() const { return asInteger(value_); }
+
+// Return contained value as double
+double Number::asDouble() const { return asDouble(value_); }
 
 // Return value represented as a string
 std::string Number::asString(bool addQuotesIfRequired) const

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -137,7 +137,7 @@ void Number::set(const Number &other) { value_ = limit(other.value_); }
 bool Number::hasLowerBound() const { return min_.has_value(); }
 
 // Return whether the number has upper bound
-bool Number::hasUpperBound() const { return min_.has_value(); }
+bool Number::hasUpperBound() const { return max_.has_value(); }
 
 // Return optional double upper bound
 std::optional<double> Number::doubleMax()

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -10,14 +10,16 @@ Number::Number(int value) : value_(value) {}
 
 Number::Number(double value) : value_(value) {}
 
-Number::Number(int value, std::optional<int> min, std::optional<int> max)
-    : value_(value), min_(std::optional<NumberVariant>(min.value())), max_(std::optional<NumberVariant>(max.value()))
+Number::Number(int value, int min, int max) : value_(value)
 {
+    min_ = std::optional<Number::NumberVariant>(min);
+    max_ = std::optional<Number::NumberVariant>(max);
 }
 
-Number::Number(double value, std::optional<double> min, std::optional<double> max)
-    : value_(value), min_(std::optional<NumberVariant>(min.value())), max_(std::optional<NumberVariant>(max.value()))
+Number::Number(double value, double min, double max) : value_(value)
 {
+    min_ = std::optional<Number::NumberVariant>(min);
+    max_ = std::optional<Number::NumberVariant>(max);
 }
 
 Number &Number::operator=(const Number &other)

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -10,9 +10,15 @@ Number::Number(int value) : value_(value) {}
 
 Number::Number(double value) : value_(value) {}
 
-//Number::Number(int value, std::optional<int> min, std::optional<int> max) : value_(value), min_(min), max_(max) {}
+Number::Number(int value, std::optional<int> min, std::optional<int> max)
+    : value_(value), min_(std::optional<NumberVariant>(min.value())), max_(std::optional<NumberVariant>(max.value()))
+{
+}
 
-//Number::Number(double value, std::optional<double> min, std::optional<double> max) : value_(value), min_(min), max_(max) {}
+Number::Number(double value, std::optional<double> min, std::optional<double> max)
+    : value_(value), min_(std::optional<NumberVariant>(min.value())), max_(std::optional<NumberVariant>(max.value()))
+{
+}
 
 Number &Number::operator=(const Number &other)
 {

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -137,41 +137,11 @@ bool Number::hasLowerBound() const { return min_.has_value(); }
 // Return whether the number has upper bound
 bool Number::hasUpperBound() const { return max_.has_value(); }
 
-// Return optional double upper bound
-std::optional<double> Number::doubleMax()
-{
-    if (hasUpperBound())
-        return asDouble(max_.value());
+// Return optional lower bound
+std::optional<Number::NumberVariant> Number::min() const { return min_; }
 
-    return {};
-}
-
-// Return optional integer upper bound
-std::optional<int> Number::integerMax()
-{
-    if (hasUpperBound())
-        return asInteger(max_.value());
-
-    return {};
-}
-
-// Return optional double lower bound
-std::optional<double> Number::doubleMin()
-{
-    if (hasLowerBound())
-        return asDouble(min_.value());
-
-    return {};
-}
-
-// Return optional integer lower bound
-std::optional<int> Number::integerMin()
-{
-    if (hasLowerBound())
-        return asInteger(min_.value());
-
-    return {};
-}
+// Return optional upper bound
+std::optional<Number::NumberVariant> Number::max() const { return max_; }
 
 // Return whether the number has bounds
 bool Number::isBounded() const { return hasLowerBound() && hasUpperBound(); }

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -6,31 +6,9 @@
 
 Number::Number(const std::variant<int, double> &value) : value_(value) {}
 
-Number::Number(int value, std::optional<int> min, std::optional<int> max) : value_(value)
-{
-    if (min && min.has_value())
-    {
-        min_ = min;
-    }
+Number::Number(int value, std::optional<int> min, std::optional<int> max) : value_(value), min_(min), max_(max) {}
 
-    if (max && max.has_value())
-    {
-        max_ = max;
-    }
-}
-
-Number::Number(double value, std::optional<double> min, std::optional<double> max) : value_(value)
-{
-    if (min && min.has_value())
-    {
-        min_ = min;
-    }
-
-    if (max && max.has_value())
-    {
-        max_ = max;
-    }
-}
+Number::Number(double value, std::optional<double> min, std::optional<double> max) : value_(value), min_(min), max_(max) {}
 
 Number &Number::operator=(const Number &other)
 {

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -90,24 +90,24 @@ bool Number::operator==(const Number &other) const { return value_ == other.valu
 
 bool Number::operator!=(const Number &other) const { return value_ != other.value_; }
 
-bool Number::operator<(const Number& other) const
+bool Number::operator<(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return { a < b }; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return {a < b}; }, value_, other.value_);
 }
 
-bool Number::operator<=(const Number& other) const
+bool Number::operator<=(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return { a <= b }; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return {a <= b}; }, value_, other.value_);
 }
 
-bool Number::operator>(const Number& other) const
+bool Number::operator>(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return { b < a }; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return {b < a}; }, value_, other.value_);
 }
 
-bool Number::operator>=(const Number& other) const
+bool Number::operator>=(const Number &other) const
 {
-    return std::visit([](auto a, auto b) -> bool { return { b <= a }; }, value_, other.value_);
+    return std::visit([](auto a, auto b) -> bool { return {b <= a}; }, value_, other.value_);
 }
 
 /*

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -6,20 +6,30 @@
 
 Number::Number(const std::variant<int, double> &value) : value_(value) {}
 
-Number::Number(int value) : value_(value) {}
-
-Number::Number(double value) : value_(value) {}
-
-Number::Number(int value, int min, int max) : value_(value)
+Number::Number(int value, std::optional<int> min, std::optional<int> max) : value_(value)
 {
-    min_ = std::optional<Number::NumberVariant>(min);
-    max_ = std::optional<Number::NumberVariant>(max);
+    if (min && min.has_value())
+    {
+        min_ = min;
+    }
+
+    if (max && max.has_value())
+    {
+        max_ = max;
+    }
 }
 
-Number::Number(double value, double min, double max) : value_(value)
+Number::Number(double value, std::optional<double> min, std::optional<double> max) : value_(value)
 {
-    min_ = std::optional<Number::NumberVariant>(min);
-    max_ = std::optional<Number::NumberVariant>(max);
+    if (min && min.has_value())
+    {
+        min_ = min;
+    }
+
+    if (max && max.has_value())
+    {
+        max_ = max;
+    }
 }
 
 Number &Number::operator=(const Number &other)
@@ -105,13 +115,7 @@ double Number::asDouble(NumberVariant n) const
 }
 
 // Set from other Number
-void Number::set(const Number &other)
-{
-    if (other.hasBounds())
-        min_ = other.min_, max_ = other.max_;
-
-    value_ = other.value_;
-}
+void Number::set(const Number &other) { value_ = other.value_; }
 
 // Return whether the number has bounds
 bool Number::hasBounds() const { return min_.has_value() && max_.has_value(); }

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -29,6 +29,10 @@ class Number : public Serialisable<>
     Number &operator--();
     bool operator==(const Number &value) const;
     bool operator!=(const Number &value) const;
+    bool operator<(const Number& other) const;
+    bool operator<=(const Number& other) const;
+    bool operator>(const Number& other) const;
+    bool operator>=(const Number& other) const;
 
     /*
      * Data

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -15,8 +15,8 @@ class Number : public Serialisable<>
     Number(const NumberVariant &value = {0});
     Number(int value);
     Number(double value);
-    Number(int value, std::optional<int> min, std::optional<int> max);
-    Number(double value, std::optional<double> min, std::optional<double> max);
+    Number(int value, int min, int max);
+    Number(double value, double min, double max);
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -54,8 +54,12 @@ class Number : public Serialisable<>
     public:
     // Set from other Number
     void set(const Number &other);
+    // Return whether the number has lower bound
+    bool hasLowerBound() const;
+    // Return whether the number has upper bound
+    bool hasUpperBound() const;
     // Return whether the number has bounds
-    bool hasBounds() const;
+    bool isBounded() const;
     // Return optional double upper bound
     std::optional<double> doubleMax();
     // Return optional integer lower bound

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -13,8 +13,8 @@ class Number : public Serialisable<>
     public:
     using NumberVariant = std::variant<int, double>;
     Number(const NumberVariant &value = {0});
-    Number(int value, std::optional<int> min, std::optional<int> max);
-    Number(double value, std::optional<double> min, std::optional<double> max);
+    Number(int value, std::optional<int> min = {}, std::optional<int> max = {});
+    Number(double value, std::optional<double> min = {}, std::optional<double> max = {});
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -29,10 +29,10 @@ class Number : public Serialisable<>
     Number &operator--();
     bool operator==(const Number &value) const;
     bool operator!=(const Number &value) const;
-    bool operator<(const Number& other) const;
-    bool operator<=(const Number& other) const;
-    bool operator>(const Number& other) const;
-    bool operator>=(const Number& other) const;
+    bool operator<(const Number &other) const;
+    bool operator<=(const Number &other) const;
+    bool operator>(const Number &other) const;
+    bool operator>=(const Number &other) const;
 
     /*
      * Data

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -15,8 +15,8 @@ class Number : public Serialisable<>
     Number(const NumberVariant &value = {0});
     Number(int value);
     Number(double value);
-    //Number(int value, std::optional<int> min = {}, std::optional<int> max = {});
-    //Number(double value, std::optional<double> min = {}, std::optional<double> max = {});
+    Number(int value, std::optional<int> min = {}, std::optional<int> max = {});
+    Number(double value, std::optional<double> min = {}, std::optional<double> max = {});
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -13,10 +13,8 @@ class Number : public Serialisable<>
     public:
     using NumberVariant = std::variant<int, double>;
     Number(const NumberVariant &value = {0});
-    Number(int value);
-    Number(double value);
-    Number(int value, int min, int max);
-    Number(double value, double min, double max);
+    Number(int value, std::optional<int> min, std::optional<int> max);
+    Number(double value, std::optional<double> min, std::optional<double> max);
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -15,8 +15,8 @@ class Number : public Serialisable<>
     Number(const NumberVariant &value = {0});
     Number(int value);
     Number(double value);
-    Number(int value, std::optional<int> min = {}, std::optional<int> max = {});
-    Number(double value, std::optional<double> min = {}, std::optional<double> max = {});
+    Number(int value, std::optional<int> min, std::optional<int> max);
+    Number(double value, std::optional<double> min, std::optional<double> max);
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "base/serialiser.h"
+#include <optional>
 #include <variant>
 
 // Node Number
@@ -14,6 +15,8 @@ class Number : public Serialisable<>
     Number(const NumberVariant &value = {0});
     Number(int value);
     Number(double value);
+    //Number(int value, std::optional<int> min = {}, std::optional<int> max = {});
+    //Number(double value, std::optional<double> min = {}, std::optional<double> max = {});
     ~Number() = default;
     Number &operator=(const Number &other);
     Number operator+(const Number &other) const;
@@ -35,10 +38,34 @@ class Number : public Serialisable<>
     protected:
     // Value
     NumberVariant value_;
+    // Lower bound
+    std::optional<NumberVariant> min_;
+    // Upper bound
+    std::optional<NumberVariant> max_;
+
+    private:
+    // Return whether the contained value is an integer
+    bool isInteger(NumberVariant n) const;
+    // Return whether the contained value is a double
+    bool isDouble(NumberVariant n) const;
+    // Return contained value as integer
+    int asInteger(NumberVariant n) const;
+    // Return contained value as double
+    double asDouble(NumberVariant n) const;
 
     public:
     // Set from other Number
     void set(const Number &other);
+    // Return whether the number has bounds
+    bool hasBounds() const;
+    // Return optional double upper bound
+    std::optional<double> doubleMax();
+    // Return optional integer lower bound
+    std::optional<int> integerMax();
+    // Return optional double lower bound
+    std::optional<double> doubleMin();
+    // Return optional integer upper bound
+    std::optional<int> integerMin();
     // Return whether the contained value is an integer
     bool isInteger() const;
     // Return whether the contained value is a double

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -66,14 +66,10 @@ class Number : public Serialisable<>
     bool hasUpperBound() const;
     // Return whether the number has bounds
     bool isBounded() const;
-    // Return optional double upper bound
-    std::optional<double> doubleMax();
-    // Return optional integer lower bound
-    std::optional<int> integerMax();
-    // Return optional double lower bound
-    std::optional<double> doubleMin();
-    // Return optional integer upper bound
-    std::optional<int> integerMin();
+    // Return optional min
+    std::optional<Number::NumberVariant> min() const;
+    // Return optional max
+    std::optional<Number::NumberVariant> max() const;
     // Return whether the contained value is an integer
     bool isInteger() const;
     // Return whether the contained value is a double

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -42,6 +42,8 @@ class Number : public Serialisable<>
     std::optional<NumberVariant> max_;
 
     private:
+    // Impose limit on Number
+    Number::NumberVariant limit(Number n) const;
     // Return whether the contained value is an integer
     bool isInteger(NumberVariant n) const;
     // Return whether the contained value is a double

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -50,7 +50,7 @@ TEST(NumberTest, Construction)
     EXPECT_FALSE(f.hasLowerBound());
 
     // Construct bounded number with undefined upper bound
-    Number h(10, 5, {});
+    Number h(10, 5);
     EXPECT_FALSE(f.hasUpperBound());
 }
 

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -49,7 +49,7 @@ TEST(NumberTest, Construction)
     Number g(10, {}, 20);
     EXPECT_FALSE(f.hasLowerBound());
 
-    // Construct bounded number with undefined upper bounds
+    // Construct bounded number with undefined upper bound
     Number h(10, 5, {});
     EXPECT_FALSE(f.hasUpperBound());
 }

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -325,17 +325,14 @@ TEST(NumberTest, BoundedMultiply)
 
     // Multiplication of any other combination results in a double
     b = 10.0;
-    auto res1 = a * b;
     EXPECT_TRUE((a * b).isDouble());
     EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
     
     a = 5.0;
-    auto res2 = a * b;
     EXPECT_TRUE((a * b).isDouble());
     EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
 
     b = 10;
-    auto res3 = a * b;
     EXPECT_TRUE((a * b).isDouble());
     EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
 }

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -49,11 +49,11 @@ TEST(NumberTest, BoundedConstruction)
     EXPECT_FALSE(c.isBounded());
 
     // Construct bounded number with undefined lower bound
-    Number c(10, {}, 20);
+    Number d(10, {}, 20);
     EXPECT_FALSE(c.hasLowerBound());
 
     // Construct bounded number with undefined upper bound
-    Number c(10, 5);
+    Number e(10, 5);
     EXPECT_FALSE(c.hasUpperBound());
 }
 

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -24,34 +24,37 @@ TEST(NumberTest, Construction)
     Number c(1.234);
     EXPECT_TRUE(c.isDouble());
     EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
+}
 
+TEST(NumberTest, BoundedConstruction)
+{
     // Construct bounded number from integer
-    Number d(10, 5, 20);
-    EXPECT_TRUE(d.isBounded());
-    EXPECT_TRUE(d.isInteger());
-    EXPECT_EQ(d.asInteger(), 10);
-    EXPECT_EQ(d.integerMin().value(), 5);
-    EXPECT_EQ(d.integerMax().value(), 20);
+    Number a(10, 5, 20);
+    EXPECT_TRUE(a.isBounded());
+    EXPECT_TRUE(a.isInteger());
+    EXPECT_EQ(a.asInteger(), 10);
+    EXPECT_EQ(a.integerMin().value(), 5);
+    EXPECT_EQ(a.integerMax().value(), 20);
 
     // Construct bounded number from double
-    Number e(1.234, 1.0, 2.0);
-    EXPECT_TRUE(e.isBounded());
-    EXPECT_TRUE(e.isDouble());
-    EXPECT_DOUBLE_EQ(e.asDouble(), 1.234);
-    EXPECT_DOUBLE_EQ(e.doubleMin().value(), 1.0);
-    EXPECT_DOUBLE_EQ(e.doubleMax().value(), 2.0);
+    Number b(1.234, 1.0, 2.0);
+    EXPECT_TRUE(b.isBounded());
+    EXPECT_TRUE(b.isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 1.234);
+    EXPECT_DOUBLE_EQ(b.doubleMin().value(), 1.0);
+    EXPECT_DOUBLE_EQ(b.doubleMax().value(), 2.0);
 
     // Construct bounded number with undefined bounds
-    Number f(10);
-    EXPECT_FALSE(f.isBounded());
+    Number c(10);
+    EXPECT_FALSE(c.isBounded());
 
     // Construct bounded number with undefined lower bound
-    Number g(10, {}, 20);
-    EXPECT_FALSE(f.hasLowerBound());
+    Number c(10, {}, 20);
+    EXPECT_FALSE(c.hasLowerBound());
 
     // Construct bounded number with undefined upper bound
-    Number h(10, 5);
-    EXPECT_FALSE(f.hasUpperBound());
+    Number c(10, 5);
+    EXPECT_FALSE(c.hasUpperBound());
 }
 
 TEST(NumberTest, Assignment)
@@ -74,6 +77,29 @@ TEST(NumberTest, Assignment)
     EXPECT_DOUBLE_EQ(b.asDouble(), 5.0);
 }
 
+TEST(NumberTest, BoundedAssignment)
+{
+    // Assignment from other Number with upper bound
+    Number a(5, {}, 7);
+    Number b(3);
+    a = b;
+    EXPECT_TRUE(a.isInteger());
+    EXPECT_TRUE(a.hasUpperBound());
+    EXPECT_FALSE(a.hasLowerBound());
+    EXPECT_FALSE(a.integerMin());
+    EXPECT_EQ(a.asInteger(), 7);
+
+    // Assignment from other Number with lower bound
+    Number c(0.5, 1.5);
+    Number d(2);
+    c = d;
+    EXPECT_TRUE(c.isDouble());
+    EXPECT_TRUE(c.hasLowerBound());
+    EXPECT_FALSE(c.hasUpperBound());
+    EXPECT_FALSE(a.doubleMax());
+    EXPECT_EQ(c.asDouble(), 1.5);
+}
+
 TEST(NumberTest, Addition)
 {
     // Addition of two integers must result in an integer
@@ -93,6 +119,18 @@ TEST(NumberTest, Addition)
     EXPECT_DOUBLE_EQ((a + b).asDouble(), a.asDouble() + b.asDouble());
 }
 
+TEST(NumberTest, BoundedAddition)
+{
+    // Addition of two integers must not exceed the upper bound
+    Number a(5, {}, 10), b(10);
+    EXPECT_FALSE(a.integerMin());
+    EXPECT_EQ((a + b).asInteger(), 10);
+
+    // Addition of any other combination results in a double
+    b = 10.0;
+    EXPECT_DOUBLE_EQ((a + b).asDouble(), 10.0);
+}
+
 TEST(NumberTest, AdditionAssignment)
 {
     // Addition of anything to an integer maintains the integer type
@@ -108,6 +146,25 @@ TEST(NumberTest, AdditionAssignment)
     EXPECT_DOUBLE_EQ(a.asDouble(), 3.0);
     EXPECT_TRUE((a += 2.0).isDouble());
     EXPECT_DOUBLE_EQ(a.asDouble(), 5.0);
+}
+
+TEST(NumberTest, BoundedAdditionAssignment)
+{
+    // Addition of anything to an integer maintains the integer type
+    Number a(1, {}, 2);
+    EXPECT_FALSE(a.integerMin());
+    EXPECT_TRUE((a += 2).isInteger());
+    EXPECT_EQ(a.asInteger(), 2);
+    EXPECT_TRUE((a += 2.0).isInteger());
+    EXPECT_DOUBLE_EQ(a.asInteger(), 2);
+
+    // Addition to a double always results in a double
+    Number b(1.0, {}, 2.0);
+    EXPECT_FALSE(a.doubleMin());
+    EXPECT_TRUE((b += 2).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
+    EXPECT_TRUE((b += 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
 }
 
 TEST(NumberTest, Subtraction)
@@ -129,6 +186,18 @@ TEST(NumberTest, Subtraction)
     EXPECT_DOUBLE_EQ((a - b).asDouble(), a.asDouble() - b.asDouble());
 }
 
+TEST(NumberTest, BoundedSubtraction)
+{
+    // Subtraction of two integers must not exceed the upper bound
+    Number a(5, 2), b(10);
+    EXPECT_FALSE(a.integerMax());
+    EXPECT_EQ((a - b).asInteger(), 2);
+
+    // Subtraction of any other combination results in a double
+    b = 10.0;
+    EXPECT_DOUBLE_EQ((a - b).asDouble(), 2.0);
+}
+
 TEST(NumberTest, SubtractionAssignment)
 {
     // Subtraction of anything from an integer maintains the integer type
@@ -144,6 +213,25 @@ TEST(NumberTest, SubtractionAssignment)
     EXPECT_DOUBLE_EQ(a.asDouble(), -1.0);
     EXPECT_TRUE((a -= 2.0).isDouble());
     EXPECT_DOUBLE_EQ(a.asDouble(), -3.0);
+}
+
+TEST(NumberTest, BoundedSubtractionAssignment)
+{
+    // Subtraction of anything to an integer maintains the integer type
+    Number a(1, 0);
+    EXPECT_FALSE(a.integerMin());
+    EXPECT_TRUE((a -= 2).isInteger());
+    EXPECT_EQ(a.asInteger(), 2);
+    EXPECT_TRUE((a -= 2.0).isInteger());
+    EXPECT_DOUBLE_EQ(a.asInteger(), 0);
+
+    // Subtraction to a double always results in a double
+    Number b(1.0, 0.5);
+    EXPECT_FALSE(a.doubleMin());
+    EXPECT_TRUE((b -= 2).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 0.5);
+    EXPECT_TRUE((b -= 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 0.5);
 }
 
 TEST(NumberTest, Multiply)
@@ -168,6 +256,30 @@ TEST(NumberTest, Multiply)
     EXPECT_DOUBLE_EQ((a * b).asDouble(), a.asDouble() * b.asDouble());
 }
 
+TEST(NumberTest, BoundedMultiply)
+{
+    // Multiplication of two integers must result in an integer
+    Number a(5, {}, 10), b(10);
+    EXPECT_FALSE(a.hasLowerBound());
+    EXPECT_FALSE(b.isBounded());
+    EXPECT_TRUE((a * b).isInteger());
+    EXPECT_EQ((a * b).asInteger(), 10);
+
+    // Multiplication of any other combination results in a double
+    b = 10.0;
+
+    EXPECT_TRUE((a * b).isDouble());
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+    a = 5.0;
+
+    EXPECT_TRUE((a * b).isDouble());
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+    b = 10;
+
+    EXPECT_TRUE((a * b).isDouble());
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+}
+
 TEST(NumberTest, MultiplyAssignment)
 {
     // Multiplication of anything with an integer maintains the integer type
@@ -183,6 +295,24 @@ TEST(NumberTest, MultiplyAssignment)
     EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
     EXPECT_TRUE((a *= 2.0).isDouble());
     EXPECT_DOUBLE_EQ(a.asDouble(), 4.0);
+}
+
+TEST(NumberTest, BoundedMultiplyAssignment)
+{
+    // Multiplication of anything with an integer maintains the integer type
+    Number a(1, {}, 2);
+    EXPECT_FALSE(a.hasLowerBound());
+    EXPECT_TRUE((a *= 2).isInteger());
+    EXPECT_EQ(a.asInteger(), 2);
+    EXPECT_TRUE((a *= 2.0).isInteger());
+    EXPECT_DOUBLE_EQ(a.asInteger(), 2);
+
+    // Multiplication of a double always results in a double
+    Number a(1.0, {}, 2.0);
+    EXPECT_TRUE((a *= 2).isDouble());
+    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
+    EXPECT_TRUE((a *= 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
 }
 
 TEST(NumberTest, Division)
@@ -204,6 +334,25 @@ TEST(NumberTest, Division)
     EXPECT_DOUBLE_EQ((a / b).asDouble(), a.asDouble() / b.asDouble());
 }
 
+TEST(NumberTest, BoundedDivision)
+{
+    // Division of two integers must result in an integer
+    Number a(5, 2), b(10);
+    EXPECT_TRUE((a / b).isInteger());
+    EXPECT_EQ((a / b).asInteger(), 2);
+
+    // Addition of any other combination results in a double
+    b = 10.0;
+    EXPECT_TRUE((a / b).isDouble());
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+    a = 5.0;
+    EXPECT_TRUE((a / b).isDouble());
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+    b = 10;
+    EXPECT_TRUE((a / b).isDouble());
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+}
+
 TEST(NumberTest, DivisionAssignment)
 {
     // Division of an integer by anything maintains the integer type
@@ -221,4 +370,20 @@ TEST(NumberTest, DivisionAssignment)
     EXPECT_DOUBLE_EQ(a.asDouble(), 0.5);
 }
 
+TEST(NumberTest, BoundedDivisionAssignment)
+{
+    // Division of an integer by anything maintains the integer type
+    Number a(2, 2);
+    EXPECT_TRUE((a /= 2).isInteger());
+    EXPECT_EQ(a.asInteger(), 2);
+    EXPECT_TRUE((a /= 2.0).isInteger());
+    EXPECT_DOUBLE_EQ(a.asInteger(), 2);
+
+    // Division of a double always results in a double
+    Number a(2.0, 2.0);
+    EXPECT_TRUE((a /= 2).isDouble());
+    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
+    EXPECT_TRUE((a /= 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
+}
 } // namespace UnitTest

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -308,11 +308,11 @@ TEST(NumberTest, BoundedMultiplyAssignment)
     EXPECT_DOUBLE_EQ(a.asInteger(), 2);
 
     // Multiplication of a double always results in a double
-    Number a(1.0, {}, 2.0);
-    EXPECT_TRUE((a *= 2).isDouble());
-    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
-    EXPECT_TRUE((a *= 2.0).isDouble());
-    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
+    Number b(1.0, {}, 2.0);
+    EXPECT_TRUE((b *= 2).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
+    EXPECT_TRUE((b *= 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
 }
 
 TEST(NumberTest, Division)
@@ -380,10 +380,10 @@ TEST(NumberTest, BoundedDivisionAssignment)
     EXPECT_DOUBLE_EQ(a.asInteger(), 2);
 
     // Division of a double always results in a double
-    Number a(2.0, 2.0);
-    EXPECT_TRUE((a /= 2).isDouble());
-    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
-    EXPECT_TRUE((a /= 2.0).isDouble());
-    EXPECT_DOUBLE_EQ(a.asDouble(), 2.0);
+    Number b(2.0, 2.0);
+    EXPECT_TRUE((b /= 2).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
+    EXPECT_TRUE((b /= 2.0).isDouble());
+    EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
 }
 } // namespace UnitTest

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -81,7 +81,7 @@ TEST(NumberTest, BoundedAssignment)
 {
     // Assignment from other Number with upper bound
     Number a(5, {}, 7);
-    Number b(3);
+    Number b(30);
     a = b;
     EXPECT_TRUE(a.isInteger());
     EXPECT_TRUE(a.hasUpperBound());

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -96,70 +96,70 @@ TEST(NumberTest, BoundedAssignment)
 
 TEST(NumberTest, BLessThanA)
 {
-    // Int greater than int
+    // Int less than int
     Number a(5), b(2);
     EXPECT_TRUE(b < a);
 
-    // Int greater than double
+    // Double less than int
     b = 2.0;
     EXPECT_TRUE(b < a);
 
-    // Double greater than double
+    // Double less than double
     a = 5.0;
     EXPECT_TRUE(b < a);
 
-    // Upper bounded int greater than unbounded int
+    // Unbounded int less than upper bounded int
     Number c(5, {}, 10), d(2);
     EXPECT_TRUE(d < c);
 
-    // Upper bounded int greater than unbounded double
+    // Unbounded double less than upper bounded int
     d = 2.0;
     EXPECT_TRUE(d < c);
 
-    // Lower bounded int greater than unbounded double
+    // Unbounded double less than lower bounded int
     Number e(5, 2), f(2);
     EXPECT_TRUE(f < e);
 
-    // Lower bounded int greater than unbounded double
+    // Unbounded double less than lower bounded int
     f = 2.0;
     EXPECT_TRUE(f < e);
 
-    // Bounded int greater than bounded double
+    // Bounded double less than bounded int
     Number g(5, 2, 10), h(2.0, 1.0, 20.0);
     EXPECT_FALSE(g < h);
 }
 
 TEST(NumberTest, AGreaterThanB)
 {
-    // Int less than int
+    // Int greater than int
     Number a(5), b(2);
     EXPECT_TRUE(a > b);
 
-    // Int less than double
+    // Int greater than double
     b = 2.0;
     EXPECT_TRUE(a > b);
 
-    // Double less than double
+    // Double greater than double
     a = 5.0;
     EXPECT_TRUE(a > b);
 
-    // Upper bounded int less than unbounded int
+    // Upper bounded int greater than unbounded int
     Number c(5, {}, 10), d(2);
     EXPECT_TRUE(c > d);
 
-    // Upper bounded int less than unbounded double
+    // Upper bounded int greater than unbounded double
     d = 2.0;
     EXPECT_TRUE(c > d);
 
-    // Lower bounded int less than unbounded double
+    // Lower bounded int greater than unbounded double
     Number e(5, 2), f(2);
     EXPECT_TRUE(e > f);
 
-    // Lower bounded int less than unbounded double
+    // Lower bounded int greater than unbounded double
     f = 2.0;
     EXPECT_TRUE(e > f);
 
-    // Bounded int less than bounded double
+    // Bounded int greater than bounded double
     Number g(5, 2, 10), h(2.0, 1.0, 20.0);
     EXPECT_FALSE(h > g);
 }

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -79,25 +79,89 @@ TEST(NumberTest, Assignment)
 
 TEST(NumberTest, BoundedAssignment)
 {
-    // Assignment from other Number with upper bound
+    // Construct left and right Numbers
     Number a(5, {}, 7);
     Number b(30);
+
+    // Assignment from other Number with upper bound
     a = b;
-    EXPECT_TRUE(a.isInteger());
-    EXPECT_TRUE(a.hasUpperBound());
-    EXPECT_FALSE(a.hasLowerBound());
-    EXPECT_FALSE(a.integerMin());
     EXPECT_EQ(a.asInteger(), 7);
 
     // Assignment from other Number with lower bound
     Number c(0.5, 0.2);
     Number d(0.15);
     c = d;
-    EXPECT_TRUE(c.isDouble());
-    EXPECT_TRUE(c.hasLowerBound());
-    EXPECT_FALSE(c.hasUpperBound());
-    EXPECT_DOUBLE_EQ(c.doubleMax(), 0.2);
     EXPECT_DOUBLE_EQ(c.asDouble(), 0.2);
+}
+
+TEST(NumberTest, BLessThanA)
+{
+    // Int greater than int
+    Number a(5), b(2);
+    EXPECT_TRUE(b < a);
+
+    // Int greater than double
+    b = 2.0;
+    EXPECT_TRUE(b < a);
+
+    // Double greater than double
+    a = 5.0;
+    EXPECT_TRUE(b < a);
+
+    // Upper bounded int greater than unbounded int
+    Number c(5, {}, 10), d(2);
+    EXPECT_TRUE(d < c);
+
+    // Upper bounded int greater than unbounded double
+    d = 2.0;
+    EXPECT_TRUE(d < c);
+
+    // Lower bounded int greater than unbounded double
+    Number e(5, 2), f(2);
+    EXPECT_TRUE(f < e);
+
+    // Lower bounded int greater than unbounded double
+    f = 2.0;
+    EXPECT_TRUE(f < e);
+
+    // Bounded int greater than bounded double
+    Number g(5, 2, 10), h(2.0, 1.0, 20.0);
+    EXPECT_FALSE(g < h);
+}
+
+TEST(NumberTest, AGreaterThanB)
+{
+    // Int less than int
+    Number a(5), b(2);
+    EXPECT_TRUE(a > b);
+
+    // Int less than double
+    b = 2.0;
+    EXPECT_TRUE(a > b);
+
+    // Double less than double
+    a = 5.0;
+    EXPECT_TRUE(a > b);
+
+    // Upper bounded int less than unbounded int
+    Number c(5, {}, 10), d(2);
+    EXPECT_TRUE(c > d);
+
+    // Upper bounded int less than unbounded double
+    d = 2.0;
+    EXPECT_TRUE(c > d);
+
+    // Lower bounded int less than unbounded double
+    Number e(5, 2), f(2);
+    EXPECT_TRUE(e > f);
+
+    // Lower bounded int less than unbounded double
+    f = 2.0;
+    EXPECT_TRUE(e > f);
+
+    // Bounded int less than bounded double
+    Number g(5, 2, 10), h(2.0, 1.0, 20.0);
+    EXPECT_FALSE(h > g);
 }
 
 TEST(NumberTest, Addition)
@@ -123,12 +187,11 @@ TEST(NumberTest, BoundedAddition)
 {
     // Addition of two integers must not exceed the upper bound
     Number a(5, {}, 10), b(10);
-    EXPECT_FALSE(a.integerMin());
-    EXPECT_EQ((a + b).asInteger(), 10);
+    EXPECT_EQ((a + b).asInteger(), 15);
 
     // Addition of any other combination results in a double
     b = 10.0;
-    EXPECT_DOUBLE_EQ((a + b).asDouble(), 10.0);
+    EXPECT_DOUBLE_EQ((a + b).asDouble(), 15.0);
 }
 
 TEST(NumberTest, AdditionAssignment)
@@ -152,7 +215,6 @@ TEST(NumberTest, BoundedAdditionAssignment)
 {
     // Addition of anything to an integer maintains the integer type
     Number a(1, {}, 2);
-    EXPECT_FALSE(a.integerMin());
     EXPECT_TRUE((a += 2).isInteger());
     EXPECT_EQ(a.asInteger(), 2);
     EXPECT_TRUE((a += 2.0).isInteger());
@@ -160,7 +222,6 @@ TEST(NumberTest, BoundedAdditionAssignment)
 
     // Addition to a double always results in a double
     Number b(1.0, {}, 2.0);
-    EXPECT_FALSE(a.doubleMin());
     EXPECT_TRUE((b += 2).isDouble());
     EXPECT_DOUBLE_EQ(b.asDouble(), 2.0);
     EXPECT_TRUE((b += 2.0).isDouble());
@@ -190,12 +251,11 @@ TEST(NumberTest, BoundedSubtraction)
 {
     // Subtraction of two integers must not exceed the upper bound
     Number a(5, 2), b(10);
-    EXPECT_FALSE(a.integerMax());
-    EXPECT_EQ((a - b).asInteger(), 2);
+    EXPECT_EQ((a - b).asInteger(), -5);
 
     // Subtraction of any other combination results in a double
     b = 10.0;
-    EXPECT_DOUBLE_EQ((a - b).asDouble(), 2.0);
+    EXPECT_DOUBLE_EQ((a - b).asDouble(), -5.0);
 }
 
 TEST(NumberTest, SubtractionAssignment)
@@ -219,15 +279,15 @@ TEST(NumberTest, BoundedSubtractionAssignment)
 {
     // Subtraction of anything to an integer maintains the integer type
     Number a(1, 0);
-    EXPECT_FALSE(a.integerMin());
+    EXPECT_TRUE(a.integerMin());
     EXPECT_TRUE((a -= 2).isInteger());
-    EXPECT_EQ(a.asInteger(), 2);
+    EXPECT_EQ(a.asInteger(), 0);
     EXPECT_TRUE((a -= 2.0).isInteger());
     EXPECT_DOUBLE_EQ(a.asInteger(), 0);
 
     // Subtraction to a double always results in a double
     Number b(1.0, 0.5);
-    EXPECT_FALSE(a.doubleMin());
+    EXPECT_TRUE(a.doubleMin());
     EXPECT_TRUE((b -= 2).isDouble());
     EXPECT_DOUBLE_EQ(b.asDouble(), 0.5);
     EXPECT_TRUE((b -= 2.0).isDouble());
@@ -260,24 +320,24 @@ TEST(NumberTest, BoundedMultiply)
 {
     // Multiplication of two integers must result in an integer
     Number a(5, {}, 10), b(10);
-    EXPECT_FALSE(a.hasLowerBound());
-    EXPECT_FALSE(b.isBounded());
     EXPECT_TRUE((a * b).isInteger());
-    EXPECT_EQ((a * b).asInteger(), 10);
+    EXPECT_EQ((a * b).asInteger(), 50);
 
     // Multiplication of any other combination results in a double
     b = 10.0;
-
+    auto res1 = a * b;
     EXPECT_TRUE((a * b).isDouble());
-    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
+    
     a = 5.0;
-
+    auto res2 = a * b;
     EXPECT_TRUE((a * b).isDouble());
-    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
+
     b = 10;
-
+    auto res3 = a * b;
     EXPECT_TRUE((a * b).isDouble());
-    EXPECT_DOUBLE_EQ((a * b).asDouble(), 10);
+    EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
 }
 
 TEST(NumberTest, MultiplyAssignment)
@@ -339,18 +399,18 @@ TEST(NumberTest, BoundedDivision)
     // Division of two integers must result in an integer
     Number a(5, 2), b(10);
     EXPECT_TRUE((a / b).isInteger());
-    EXPECT_EQ((a / b).asInteger(), 2);
+    EXPECT_EQ((a / b).asInteger(), a.asInteger() / b.asInteger());
 
     // Addition of any other combination results in a double
     b = 10.0;
     EXPECT_TRUE((a / b).isDouble());
-    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), a.asDouble() / b.asDouble());
     a = 5.0;
     EXPECT_TRUE((a / b).isDouble());
-    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), a.asDouble() / b.asDouble());
     b = 10;
     EXPECT_TRUE((a / b).isDouble());
-    EXPECT_DOUBLE_EQ((a / b).asDouble(), 2.0);
+    EXPECT_DOUBLE_EQ((a / b).asDouble(), a.asDouble() / b.asDouble());
 }
 
 TEST(NumberTest, DivisionAssignment)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -327,7 +327,7 @@ TEST(NumberTest, BoundedMultiply)
     b = 10.0;
     EXPECT_TRUE((a * b).isDouble());
     EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);
-    
+
     a = 5.0;
     EXPECT_TRUE((a * b).isDouble());
     EXPECT_DOUBLE_EQ((a * b).asDouble(), 50);

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -90,14 +90,14 @@ TEST(NumberTest, BoundedAssignment)
     EXPECT_EQ(a.asInteger(), 7);
 
     // Assignment from other Number with lower bound
-    Number c(0.5, 1.5);
-    Number d(2);
+    Number c(0.5, 0.2);
+    Number d(0.15);
     c = d;
     EXPECT_TRUE(c.isDouble());
     EXPECT_TRUE(c.hasLowerBound());
     EXPECT_FALSE(c.hasUpperBound());
-    EXPECT_FALSE(a.doubleMax());
-    EXPECT_EQ(c.asDouble(), 1.5);
+    EXPECT_DOUBLE_EQ(c.doubleMax(), 0.2);
+    EXPECT_DOUBLE_EQ(c.asDouble(), 0.2);
 }
 
 TEST(NumberTest, Addition)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -35,15 +35,23 @@ TEST(NumberTest, Construction)
 
     // Construct bounded number from double
     Number e(1.234, 1.0, 2.0);
-    EXPECT_TRUE(e.hasBounds());
+    EXPECT_TRUE(e.isBounded());
     EXPECT_TRUE(e.isDouble());
     EXPECT_DOUBLE_EQ(e.asDouble(), 1.234);
     EXPECT_DOUBLE_EQ(e.doubleMin().value(), 1.0);
     EXPECT_DOUBLE_EQ(e.doubleMax().value(), 2.0);
 
-    // Construct bounded number with invalid bounds
+    // Construct bounded number with undefined bounds
     Number f(10);
-    EXPECT_FALSE(f.hasBounds());
+    EXPECT_FALSE(f.isBounded());
+
+    // Construct bounded number with undefined lower bound
+    Number g(10, {}, 20);
+    EXPECT_FALSE(f.hasLowerBound());
+
+    // Construct bounded number with undefined upper bounds
+    Number h(10, 5, {});
+    EXPECT_FALSE(f.hasUpperBound());
 }
 
 TEST(NumberTest, Assignment)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -27,7 +27,7 @@ TEST(NumberTest, Construction)
 
     // Construct bounded number from integer
     Number d(10, 5, 20);
-    EXPECT_TRUE(d.hasBounds());
+    EXPECT_TRUE(d.isBounded());
     EXPECT_TRUE(d.isInteger());
     EXPECT_EQ(d.asInteger(), 10);
     EXPECT_EQ(d.integerMin().value(), 5);

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -26,24 +26,24 @@ TEST(NumberTest, Construction)
     EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
 
     // Construct bounded number from integer
-    Number b(10, 5, 20);
-    EXPECT_TRUE(c.hasBounds());
-    EXPECT_TRUE(c.isInteger());
-    EXPECT_EQ(c.asInteger(), 10);
-    EXPECT_EQ(c.integerMin().value(), 5);
-    EXPECT_EQ(c.integerMax().value(), 20);
+    Number d(10, 5, 20);
+    EXPECT_TRUE(d.hasBounds());
+    EXPECT_TRUE(d.isInteger());
+    EXPECT_EQ(d.asInteger(), 10);
+    EXPECT_EQ(d.integerMin().value(), 5);
+    EXPECT_EQ(d.integerMax().value(), 20);
 
     // Construct bounded number from double
-    Number c(1.234, 1.0, 2.0);
-    EXPECT_TRUE(c.hasBounds());
-    EXPECT_TRUE(c.isDouble());
-    EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
-    EXPECT_DOUBLE_EQ(c.doubleMin().value(), 1.0);
-    EXPECT_DOUBLE_EQ(c.doubleMax().value(), 2.0);
+    Number e(1.234, 1.0, 2.0);
+    EXPECT_TRUE(e.hasBounds());
+    EXPECT_TRUE(e.isDouble());
+    EXPECT_DOUBLE_EQ(e.asDouble(), 1.234);
+    EXPECT_DOUBLE_EQ(e.doubleMin().value(), 1.0);
+    EXPECT_DOUBLE_EQ(e.doubleMax().value(), 2.0);
 
     // Construct bounded number with invalid bounds
-    Number c(10);
-    EXPECT_FALSE(c.hasBounds());
+    Number f(10);
+    EXPECT_FALSE(f.hasBounds());
 }
 
 TEST(NumberTest, Assignment)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -359,9 +359,9 @@ TEST(NumberTest, BoundedMultiplyAssignment)
     // Multiplication of anything with an integer maintains the integer type
     Number a(1, {}, 2);
     EXPECT_FALSE(a.hasLowerBound());
-    EXPECT_TRUE((a *= 2).isInteger());
+    EXPECT_TRUE((a *= 4).isInteger());
     EXPECT_EQ(a.asInteger(), 2);
-    EXPECT_TRUE((a *= 2.0).isInteger());
+    EXPECT_TRUE((a *= 4.0).isInteger());
     EXPECT_DOUBLE_EQ(a.asInteger(), 2);
 
     // Multiplication of a double always results in a double

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -24,6 +24,22 @@ TEST(NumberTest, Construction)
     Number c(1.234);
     EXPECT_TRUE(c.isDouble());
     EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
+
+    // Construct bounded number from integer
+    Number b(10, 5, 20);
+    EXPECT_TRUE(c.hasBounds());
+    EXPECT_TRUE(c.isInteger());
+    EXPECT_EQ(c.asInteger(), 10);
+    EXPECT_EQ(c.integerMin().value(), 5);
+    EXPECT_EQ(c.integerMax().value(), 20);
+
+    // Construct bounded number from double
+    Number c(1.234, 1.0, 2.0);
+    EXPECT_TRUE(c.hasBounds());
+    EXPECT_TRUE(c.isDouble());
+    EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
+    EXPECT_DOUBLE_EQ(c.doubleMin().value(), 1.0);
+    EXPECT_DOUBLE_EQ(c.doubleMax().value(), 2.0);
 }
 
 TEST(NumberTest, Assignment)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -40,6 +40,10 @@ TEST(NumberTest, Construction)
     EXPECT_DOUBLE_EQ(c.asDouble(), 1.234);
     EXPECT_DOUBLE_EQ(c.doubleMin().value(), 1.0);
     EXPECT_DOUBLE_EQ(c.doubleMax().value(), 2.0);
+
+    // Construct bounded number with invalid bounds
+    Number c(10);
+    EXPECT_FALSE(c.hasBounds());
 }
 
 TEST(NumberTest, Assignment)

--- a/tests/nodes/number.cpp
+++ b/tests/nodes/number.cpp
@@ -33,17 +33,16 @@ TEST(NumberTest, BoundedConstruction)
     EXPECT_TRUE(a.isBounded());
     EXPECT_TRUE(a.isInteger());
     EXPECT_EQ(a.asInteger(), 10);
-    EXPECT_EQ(a.integerMin().value(), 5);
-    EXPECT_EQ(a.integerMax().value(), 20);
+    EXPECT_EQ(std::get<int>(a.min().value()), 5);
+    EXPECT_EQ(std::get<int>(a.max().value()), 20);
 
     // Construct bounded number from double
     Number b(1.234, 1.0, 2.0);
     EXPECT_TRUE(b.isBounded());
     EXPECT_TRUE(b.isDouble());
     EXPECT_DOUBLE_EQ(b.asDouble(), 1.234);
-    EXPECT_DOUBLE_EQ(b.doubleMin().value(), 1.0);
-    EXPECT_DOUBLE_EQ(b.doubleMax().value(), 2.0);
-
+    EXPECT_DOUBLE_EQ(std::get<double>(b.min().value()), 1.0);
+    EXPECT_DOUBLE_EQ(std::get<double>(b.max().value()), 2.0);
     // Construct bounded number with undefined bounds
     Number c(10);
     EXPECT_FALSE(c.isBounded());
@@ -279,7 +278,7 @@ TEST(NumberTest, BoundedSubtractionAssignment)
 {
     // Subtraction of anything to an integer maintains the integer type
     Number a(1, 0);
-    EXPECT_TRUE(a.integerMin());
+    EXPECT_TRUE(a.min());
     EXPECT_TRUE((a -= 2).isInteger());
     EXPECT_EQ(a.asInteger(), 0);
     EXPECT_TRUE((a -= 2.0).isInteger());
@@ -287,7 +286,6 @@ TEST(NumberTest, BoundedSubtractionAssignment)
 
     // Subtraction to a double always results in a double
     Number b(1.0, 0.5);
-    EXPECT_TRUE(a.doubleMin());
     EXPECT_TRUE((b -= 2).isDouble());
     EXPECT_DOUBLE_EQ(b.asDouble(), 0.5);
     EXPECT_TRUE((b -= 2.0).isDouble());


### PR DESCRIPTION
Storing numeric upper and lower bounds in `Number` should alleviate the need for methods like `addBoundedInput<Number>`

- [x] Still a question of how to handle operators for bounded `Number` (i.e. do we blindly apply the operators to the bounds as well as `value_`, or do we need to consider whether `other` and `this` actually both have bounds)
- [ ] Refactor nodes to utilise bounded `Number` instead of `addBoundedInput`