### PR TITLE
feat: Update node type checking, add node registry unit test

### DIFF
--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -35,9 +35,28 @@ std::string Graph::uniqueNodeName(const Node *node, std::string_view baseName) c
 }
 
 // Create node of specified type with the name provided
-Node *Graph::createNode(std::string_view type, std::string_view name)
+Node *Graph::createNode(std::string_view nodeType, std::string_view nodeName, bool strictTypeName)
 {
-    return addNode(NodeRegistry::produce(this, type), name.empty() ? type : name);
+    std::string newNodeType{nodeType};
+    if (strictTypeName)
+    {
+        if (!NodeRegistry::hasNodeType(nodeType))
+        {
+            Messenger::warn("Can't create a node of type '{}' as this type does not exist.\n", nodeType);
+            return nullptr;
+        }
+    }
+    else
+    {
+        newNodeType = NodeRegistry::getNodeTypeFuzzy(nodeType);
+        if (newNodeType.empty())
+        {
+            Messenger::warn("Can't create a node of type '{}' as neither this type nor a close match exists.\n", nodeType);
+            return nullptr;
+        }
+    }
+
+    return addNode(NodeRegistry::produce(this, newNodeType), nodeName.empty() ? newNodeType : nodeName);
 }
 
 // Add node to graph

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -53,7 +53,7 @@ class Graph : public Node
 
     public:
     // Create node of specified type with the name provided
-    Node *createNode(std::string_view type, std::string_view name = {});
+    Node *createNode(std::string_view type, std::string_view name = {}, bool strictTypeName = true);
     // Add node to graph
     Node *addNode(std::unique_ptr<Node> node, std::string_view name = {});
     // Get name of specified child node

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -55,6 +55,21 @@ bool NodeRegistry::hasNodeType(std::string_view nodeType)
     return producers_.contains(nodeType);
 }
 
+// Search for the supplied node type, returning strict node type if found
+std::string_view NodeRegistry::getNodeTypeFuzzy(std::string_view weakNodeType)
+{
+    instantiateNodeProducers();
+
+    // Case insensitive search for now - fuzzy search to be implemented at a later date
+    for (auto &&[nodeType, _] : producers_)
+    {
+        if (DissolveSys::sameString(weakNodeType, nodeType))
+            return nodeType;
+    }
+
+    return {};
+}
+
 // Produce a node of the given type with the specified Graph parent
 std::unique_ptr<Node> NodeRegistry::produce(Graph *parent, std::string_view nodeType)
 {

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -22,6 +22,8 @@ class NodeRegistry
     public:
     // Check whether the supplied node type is known
     static bool hasNodeType(std::string_view nodeType);
+    // Search for the supplied node type, returning strict node type if found
+    static std::string_view getNodeTypeFuzzy(std::string_view weakNodeType);
     // Produce a node of the given type with the specified Graph parent
     static std::unique_ptr<Node> produce(Graph *parent, std::string_view nodeType);
 };

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -94,4 +94,16 @@ TEST_F(GraphCoreTest, UniqueNaming)
     EXPECT_EQ(z_->name(), "z");
 }
 
+TEST_F(GraphCoreTest, NodeCreation)
+{
+    // Attempt to create a node type that doesn't exist
+    EXPECT_EQ(root_.createNode("NonexistentNodeType", "Bob"), nullptr);
+
+    // Wrong case in existing node type (should fail as createNode() defaults to requiring the strict node type)
+    EXPECT_EQ(root_.createNode("add", "Bob"), nullptr);
+
+    // Wrong case in existing node type (succeeds with non-strict type name checking)
+    EXPECT_NE(root_.createNode("add", "Bob", false), nullptr);
+}
+
 } // namespace UnitTest


### PR DESCRIPTION
A small PR to add a bit more unit test coverage, and start thinking about more relaxed determination of valid node type names.

Closes #2091.