### PR TITLE
feat: make the epsrManager count concencentration products factor instead

### DIFF
--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -109,7 +109,7 @@ class EPSRModule : public Module
      * Functions
      */
     private:
-    // Target Configuration (determined from target modules)
+    // Target Configuration (determined from target modules) and a function to return this for EPSRManager
     Configuration *targetConfiguration_{nullptr};
 
     private:
@@ -133,6 +133,8 @@ class EPSRModule : public Module
     void truncate(Data1D &data, double rMin, double rMax);
     // return vector of emirical potentials
     std::vector<std::tuple<std::shared_ptr<AtomType>, std::shared_ptr<AtomType>, Data1D>> empiricalPotentials();
+    // Return pointer to target configuration for EPSRManager
+    Configuration *targetConfiguration();
 
     /*
      * EPSR File I/O

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -8,6 +8,8 @@
 #include "modules/epsr/epsr.h"
 #include "templates/algorithms.h"
 
+Configuration *EPSRModule::targetConfiguration() { return targetConfiguration_; };
+
 // Create / update delta S(Q) information
 void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWrapper<const Array2D<Data1D>> optCalculatedSQ,
                                OptionalReferenceWrapper<const Array2D<Data1D>> optEstimatedSQ)

--- a/src/modules/epsrManager/process.cpp
+++ b/src/modules/epsrManager/process.cpp
@@ -39,17 +39,20 @@ Module::ExecutionResult EPSRManagerModule::process(ModuleContext &moduleContext)
     {
         auto *epsrModule = dynamic_cast<EPSRModule *>(module);
         auto eps = epsrModule->empiricalPotentials();
+        auto targetConfiguration = epsrModule->targetConfiguration();
+        auto atomTypeMix = targetConfiguration->atomTypePopulations();
 
         for (auto &&[at1, at2, potential] : eps)
         {
+            auto cicj = atomTypeMix.atomTypeData(at1)->get().fraction() * atomTypeMix.atomTypeData(at2)->get().fraction();
             auto key = EPSRManagerModule::pairKey(at1, at2);
             auto keyIt = newPotentials.potentialMap().find(key);
             if (keyIt == newPotentials.potentialMap().end())
-                newPotentials.potentialMap()[key] = {potential, 1, at1, at2};
+                newPotentials.potentialMap()[key] = {potential, cicj, at1, at2};
             else
             {
-                Interpolator::addInterpolated(potential, newPotentials.potentialMap()[key].potential, 1.0);
-                ++newPotentials.potentialMap()[key].count;
+                Interpolator::addInterpolated(potential, newPotentials.potentialMap()[key].potential, cicj);
+                newPotentials.potentialMap()[key].count += cicj;
             }
         }
     }


### PR DESCRIPTION
Need to make the count that we divide by the concentration product of the atom types in the configuration to see if it makes a difference for one of the Moonshine configurations.