### PR TITLE
refactor: Handle creation of any type of parameter link

### DIFF
--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -75,7 +75,7 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
         // The target node is a Graph: create a parameter link from the sourceOutput and from it a mapped input
         auto graphNode = dynamic_cast<Graph *>(targetNode);
         auto link = sourceOutput->createParameterLink(definition.targetInput);
-        if (!graphNode->addMappedInput(link.inputParameter, link.outputParameter))
+        if (!graphNode->addProxyInput(link.inputParameter, link.outputParameter))
         {
             Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
             return {};
@@ -87,7 +87,7 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
         // The target node is the parent Graph's own Outputs node, so create a parameter link from the sourceOutput and from it
         // a mapped output
         auto link = sourceOutput->createParameterLink(definition.targetInput);
-        if (!parent->addMappedOutput(link.inputParameter, link.outputParameter))
+        if (!parent->addProxyOutput(link.inputParameter, link.outputParameter))
         {
             Messenger::error("Failed to add mapped output '{}'.\n", definition.targetInput);
             return {};

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -72,14 +72,27 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     std::shared_ptr<ParameterBase> targetInput{nullptr};
     if (dynamic_cast<Graph *>(targetNode))
     {
-        // The target node is a Graph: create a mapped input
+        // The target node is a Graph: create a parameter link from the sourceOutput and from it a mapped input
         auto graphNode = dynamic_cast<Graph *>(targetNode);
-        targetInput = graphNode->createMappedInput(definition.targetInput, sourceOutput->type());
+        auto link = sourceOutput->createParameterLink(definition.targetInput);
+        if (!graphNode->addMappedInput(link.inputParameter, link.outputParameter))
+        {
+            Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
+            return {};
+        }
+        targetInput = link.inputParameter;
     }
     else if (dynamic_cast<OutputsNode *>(targetNode))
     {
-        // The target node is the parent Graph's own Outputs node, so create a mapped output
-        targetInput = parent->createMappedOutput(definition.targetInput, sourceOutput->type());
+        // The target node is the parent Graph's own Outputs node, so create a parameter link from the sourceOutput and from it
+        // a mapped output
+        auto link = sourceOutput->createParameterLink(definition.targetInput);
+        if (!parent->addMappedOutput(link.inputParameter, link.outputParameter))
+        {
+            Messenger::error("Failed to add mapped output '{}'.\n", definition.targetInput);
+            return {};
+        }
+        targetInput = link.inputParameter;
     }
     else
         targetInput = targetNode->findInput(definition.targetInput);

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -83,61 +83,18 @@ void Graph::setUpdateRequired()
  * Inputs, Outputs, and Options
  */
 
-// Create and return mapped input
-std::shared_ptr<ParameterBase> Graph::createMappedInput(std::string_view inputName, std::type_index typeIndex)
+// Add supplied mapped input, setting ownership of the nodes appropriately
+bool Graph::addMappedInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
 {
-    std::shared_ptr<ParameterBase> inputParameter;
-
-    // Check first that the inputName doesn't exist in our inputs_ (implicitly this carries for InputNode's outputs_)
-    if (findInput(inputName))
-    {
-        Messenger::error("Can't create mapped input as one named '{}' already exists in the Graph.", inputName);
-        return {};
-    }
-
-    // TODO Convert to Factory
-    if (typeIndex == std::type_index(typeid(Number)))
-    {
-        // Create a parameter holder object with the correct type
-        auto proxy = std::make_shared<ParameterHolder<Number>>();
-        parameterHolders_.emplace_back(proxy);
-
-        // Create an input on ourself, linked to the proxy data
-        inputParameter = addInput(inputName, "", proxy->data);
-
-        // Create a companion output on our Inputs node, again linked to the proxy data
-        mappedInputs_->addOutput(inputName, "", proxy->data);
-    }
-
-    return inputParameter;
+    // We (the Graph) own the input and the mappedInputs_ owns the output
+    return ownParameter(input) && mappedInputs_->ownParameter(output, true);
 }
 
-// Create mapped output, returning the relevant input (rather than the output)
-std::shared_ptr<ParameterBase> Graph::createMappedOutput(std::string_view outputName, std::type_index typeIndex)
+// Add supplied mapped output, setting ownership of the nodes appropriately
+bool Graph::addMappedOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
 {
-    // Check first that the inputName doesn't exist in our outputs_ (implicitly this carries for OutputNode's inputs_)
-    if (findOutput(outputName))
-    {
-        Messenger::error("Can't create mapped output as one named '{}' already exists in the Graph.", outputName);
-        return {};
-    }
-
-    std::shared_ptr<ParameterBase> outputParameter;
-    // TODO Convert to Factory
-    if (typeIndex == std::type_index(typeid(Number)))
-    {
-        // Create n parameter holder object with the correct type
-        auto proxy = std::make_shared<ParameterHolder<Number>>();
-        parameterHolders_.emplace_back(proxy);
-
-        // Create an output on ourself, linked to the proxy data
-        addOutput(outputName, "", proxy->data);
-
-        // Create a companion input on our Outputs node, again linked to the proxy data
-        outputParameter = mappedOutputs_->addInput(outputName, "", proxy->data);
-    }
-
-    return outputParameter;
+    // We (the Graph) own the output and the mappedOutputs_ owns the input
+    return mappedOutputs_->ownParameter(input) && ownParameter(output, true);
 }
 
 /*

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -9,8 +9,8 @@
 
 Graph::Graph(Graph *parentGraph) : Node(parentGraph)
 {
-    mappedInputs_ = dynamic_cast<InputsNode *>(addNode(std::make_unique<InputsNode>(this), "Inputs"));
-    mappedOutputs_ = dynamic_cast<OutputsNode *>(addNode(std::make_unique<OutputsNode>(this), "Outputs"));
+    proxyInputs_ = dynamic_cast<InputsNode *>(addNode(std::make_unique<InputsNode>(this), "Inputs"));
+    proxyOutputs_ = dynamic_cast<OutputsNode *>(addNode(std::make_unique<OutputsNode>(this), "Outputs"));
 }
 
 /*
@@ -38,7 +38,7 @@ NodeConstants::ProcessResult Graph::process()
      */
 
     // Pull outputs first
-    auto outputsResult = mappedOutputs_->run();
+    auto outputsResult = proxyOutputs_->run();
     if (outputsResult == NodeConstants::ProcessResult::Failed)
         return outputsResult;
 
@@ -72,8 +72,8 @@ void Graph::setUpdateRequired()
     if (!isUpToDate())
         return;
 
-    // Propagate changes through mappedInputs_
-    mappedInputs_->setUpdateRequired();
+    // Propagate changes through proxyInputs_
+    proxyInputs_->setUpdateRequired();
 
     // Call base class function to set flag and propagate through outputs
     Node::setUpdateRequired();
@@ -83,18 +83,18 @@ void Graph::setUpdateRequired()
  * Inputs, Outputs, and Options
  */
 
-// Add supplied mapped input, setting ownership of the nodes appropriately
-bool Graph::addMappedInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
+// Add supplied proxy input, setting ownership of the parameters appropriately
+bool Graph::addProxyInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
 {
-    // We (the Graph) own the input and the mappedInputs_ owns the output
-    return ownParameter(input) && mappedInputs_->ownParameter(output, true);
+    // We (the Graph) own the input and the proxyInputs_ owns the output
+    return ownParameter(input) && proxyInputs_->ownParameter(output, true);
 }
 
-// Add supplied mapped output, setting ownership of the nodes appropriately
-bool Graph::addMappedOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
+// Add supplied proxy output, setting ownership of the parameters appropriately
+bool Graph::addProxyOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
 {
-    // We (the Graph) own the output and the mappedOutputs_ owns the input
-    return mappedOutputs_->ownParameter(input) && ownParameter(output, true);
+    // We (the Graph) own the output and the proxyOutputs_ owns the input
+    return proxyOutputs_->ownParameter(input) && ownParameter(output, true);
 }
 
 /*

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -16,18 +16,6 @@ class EdgeDefinition;
 class InputsNode;
 class OutputsNode;
 
-// Parameter Holder Base
-class ParameterHolderBase
-{
-};
-
-// Parameter Holder
-template <class T> class ParameterHolder : public ParameterHolderBase
-{
-    public:
-    T data;
-};
-
 // Graph
 class Graph : public Node
 {
@@ -59,17 +47,15 @@ class Graph : public Node
      * Inputs, Outputs, and Options
      */
     private:
-    // Parameter holders for dynamic input / output variables
-    std::vector<std::shared_ptr<ParameterHolderBase>> parameterHolders_;
     // Mapped input and output nodes
     InputsNode *mappedInputs_{nullptr};
     OutputsNode *mappedOutputs_{nullptr};
 
     public:
-    // Create and return mapped input
-    std::shared_ptr<ParameterBase> createMappedInput(std::string_view inputName, std::type_index typeIndex);
-    // Create mapped output, returning the relevant input (rather than the output)
-    std::shared_ptr<ParameterBase> createMappedOutput(std::string_view outputName, std::type_index typeIndex);
+    // Add supplied mapped input, setting ownership of the nodes appropriately
+    bool addMappedInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
+    // Add supplied mapped output, setting ownership of the nodes appropriately
+    bool addMappedOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
 
     /*
      * Nodes and Edges

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -47,15 +47,15 @@ class Graph : public Node
      * Inputs, Outputs, and Options
      */
     private:
-    // Mapped input and output nodes
-    InputsNode *mappedInputs_{nullptr};
-    OutputsNode *mappedOutputs_{nullptr};
+    // Proxy input and output nodes
+    InputsNode *proxyInputs_{nullptr};
+    OutputsNode *proxyOutputs_{nullptr};
 
     public:
-    // Add supplied mapped input, setting ownership of the nodes appropriately
-    bool addMappedInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
-    // Add supplied mapped output, setting ownership of the nodes appropriately
-    bool addMappedOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
+    // Add supplied proxy input, setting ownership of the parameters appropriately
+    bool addProxyInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
+    // Add supplied proxy output, setting ownership of the parameters appropriately
+    bool addProxyOutput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output);
 
     /*
      * Nodes and Edges

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -43,70 +43,6 @@ bool Node::hasMessages(MessageStatus status) const
 void Node::echo() { std::cout << messages_.back().second << std::endl; }
 
 /*
- * Inputs, Outputs & Options
- */
-
-// Link edge, returning whether we accept it
-bool Node::linkEdge(Edge *edge)
-{
-
-    // The supplied Edge was created via our parent Graph, but we will still check to see whether we accept it
-    if (&edge->targetNode() == this)
-    {
-        // We are the target node, so we will double-check the specified input to see if it can accept the connection
-        // Simple check at present, we accept at most one connection per input, so if one already exists we complain
-        if (inputEdges_.contains(edge->targetInput().name()))
-            return Messenger::error("Node '{}' refusing to accept Edge connecting to input '{}' as one already exists.\n",
-                                    name(), edge->targetInput().name());
-
-        // All good, so add the input to our list
-        inputEdges_[edge->targetInput().name()] = edge;
-
-        // Adding an Edge to an input always invalidates the target
-        invalidate();
-    }
-    else if (&edge->sourceNode() == this)
-    {
-        // We are the source node - add the outgoing edge to our list
-        outputEdges_[edge->sourceOutput().name()] = edge;
-    }
-    else
-        return Messenger::error("Node '{}' is neither the source nor the target for the supplied Edge.\n", name());
-
-    return true;
-}
-
-// Unlink edge
-void Node::unlinkEdge(Edge *edge)
-{
-    // If we are the Edge's targetNode_ then we should have its pointer in inputEdges_
-    if (&edge->targetNode() == this)
-    {
-        auto it = std::find_if(inputEdges_.begin(), inputEdges_.end(),
-                               [edge](const auto &inputEdge) { return edge == inputEdge.second; });
-        if (it == inputEdges_.end())
-            Messenger::error("Tried to unlink an incoming edge to target node '{}' which knew nothing about it.\n", name());
-        else
-        {
-            inputEdges_.erase(it);
-            invalidate();
-        }
-    }
-    else if (&edge->sourceNode() == this)
-    {
-        // We are the source node for the edge...
-        auto it = std::find_if(outputEdges_.begin(), outputEdges_.end(),
-                               [edge](const auto &outputEdge) { return edge == outputEdge.second; });
-        if (it == outputEdges_.end())
-            Messenger::error("Tried to unlink an outgoing edge from source node '{}' which knew nothing about it.\n", name());
-        else
-            outputEdges_.erase(it);
-    }
-    else
-        Messenger::error("Node '{}' is neither the source nor the target for the Edge being unlinked.\n", name());
-}
-
-/*
  * Processing & Validity
  */
 
@@ -201,8 +137,85 @@ NodeConstants::ProcessResult Node::run()
 NodeConstants::ProcessResult Node::process() { return NodeConstants::ProcessResult::Failed; }
 
 /*
- * Inputs, Outputs, and Options
+ * Inputs, Outputs & Options
  */
+
+// Link edge, returning whether we accept it
+bool Node::linkEdge(Edge *edge)
+{
+
+    // The supplied Edge was created via our parent Graph, but we will still check to see whether we accept it
+    if (&edge->targetNode() == this)
+    {
+        // We are the target node, so we will double-check the specified input to see if it can accept the connection
+        // Simple check at present, we accept at most one connection per input, so if one already exists we complain
+        if (inputEdges_.contains(edge->targetInput().name()))
+            return Messenger::error("Node '{}' refusing to accept Edge connecting to input '{}' as one already exists.\n",
+                                    name(), edge->targetInput().name());
+
+        // All good, so add the input to our list
+        inputEdges_[edge->targetInput().name()] = edge;
+
+        // Adding an Edge to an input always invalidates the target
+        invalidate();
+    }
+    else if (&edge->sourceNode() == this)
+    {
+        // We are the source node - add the outgoing edge to our list
+        outputEdges_[edge->sourceOutput().name()] = edge;
+    }
+    else
+        return Messenger::error("Node '{}' is neither the source nor the target for the supplied Edge.\n", name());
+
+    return true;
+}
+
+// Unlink edge
+void Node::unlinkEdge(Edge *edge)
+{
+    // If we are the Edge's targetNode_ then we should have its pointer in inputEdges_
+    if (&edge->targetNode() == this)
+    {
+        auto it = std::find_if(inputEdges_.begin(), inputEdges_.end(),
+                               [edge](const auto &inputEdge) { return edge == inputEdge.second; });
+        if (it == inputEdges_.end())
+            Messenger::error("Tried to unlink an incoming edge to target node '{}' which knew nothing about it.\n", name());
+        else
+        {
+            inputEdges_.erase(it);
+            invalidate();
+        }
+    }
+    else if (&edge->sourceNode() == this)
+    {
+        // We are the source node for the edge...
+        auto it = std::find_if(outputEdges_.begin(), outputEdges_.end(),
+                               [edge](const auto &outputEdge) { return edge == outputEdge.second; });
+        if (it == outputEdges_.end())
+            Messenger::error("Tried to unlink an outgoing edge from source node '{}' which knew nothing about it.\n", name());
+        else
+            outputEdges_.erase(it);
+    }
+    else
+        Messenger::error("Node '{}' is neither the source nor the target for the Edge being unlinked.\n", name());
+}
+
+// Own supplied parameter
+bool Node::ownParameter(std::shared_ptr<ParameterBase> &parameter, bool isOutput)
+{
+    if ((!isOutput && findInput(parameter->name())) || (isOutput && findOutput(parameter->name())))
+        return Messenger::error("Parameter '{}' cannot be owned as it conflicts with an existing input or output.\n",
+                                parameter->name());
+
+    parameter->setParent(this);
+
+    if (isOutput)
+        outputs_.emplace(parameter->name(), parameter);
+    else
+        inputs_.emplace(parameter->name(), parameter);
+
+    return true;
+}
 
 // Return named input parameter if it exists
 std::shared_ptr<ParameterBase> Node::findInput(std::string_view name) const

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -153,7 +153,8 @@ class Node : public Serialisable<>
             Messenger::exception("Option '{}' already exists, and can't be added again.", optionName);
 
         auto param =
-            options_.emplace(std::make_pair(optionName, new Parameter<T>(this, optionName, description, data))).first->second;
+            options_.emplace(std::make_pair(optionName, std::make_shared<Parameter<T>>(this, optionName, description, data)))
+                .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
     }
@@ -165,7 +166,8 @@ class Node : public Serialisable<>
             Messenger::exception("Input parameter '{}' already exists, and can't be added again.", inputName);
 
         auto param =
-            inputs_.emplace(std::make_pair(inputName, new Parameter<T>(this, inputName, description, data))).first->second;
+            inputs_.emplace(std::make_pair(inputName, std::make_shared<Parameter<T>>(this, inputName, description, data)))
+                .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
     }
@@ -179,8 +181,8 @@ class Node : public Serialisable<>
             Messenger::exception("Input parameter '{}' already exists, and can't be added again.", inputName);
 
         auto param = inputs_
-                         .emplace(std::make_pair(
-                             inputName, new BoundedParameter<T>(this, inputName, description, data, lower, upper, step)))
+                         .emplace(std::make_pair(inputName, std::make_shared<BoundedParameter<T>>(this, inputName, description,
+                                                                                                  data, lower, upper, step)))
                          .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
@@ -193,10 +195,11 @@ class Node : public Serialisable<>
         if (findInput(inputName))
             Messenger::exception("Input parameter '{}' already exists, and can't be added again.", inputName);
 
-        auto param = inputs_
-                         .emplace(std::make_pair(inputName, new BoundedOptionalParameter<T>(this, inputName, description, data,
-                                                                                            lower, textWhenNull, upper, step)))
-                         .first->second;
+        auto param =
+            inputs_
+                .emplace(std::make_pair(inputName, std::make_shared<BoundedOptionalParameter<T>>(
+                                                       this, inputName, description, data, lower, textWhenNull, upper, step)))
+                .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
     }
@@ -208,7 +211,8 @@ class Node : public Serialisable<>
             Messenger::exception("Output parameter '{}' already exists, and can't be added again.", outputName);
 
         auto param =
-            outputs_.emplace(std::make_pair(outputName, new Parameter<T>(this, outputName, description, data))).first->second;
+            outputs_.emplace(std::make_pair(outputName, std::make_shared<Parameter<T>>(this, outputName, description, data)))
+                .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Output);
         return param;
     }
@@ -220,12 +224,15 @@ class Node : public Serialisable<>
         if (findOutput(outputName))
             Messenger::exception("Output parameter '{}' already exists, and can't be added again.", outputName);
 
-        auto param =
-            outputs_.emplace(std::make_pair(outputName, new PointerParameter<T>(this, outputName, description, object)))
-                .first->second;
+        auto param = outputs_
+                         .emplace(std::make_pair(outputName,
+                                                 std::make_shared<PointerParameter<T>>(this, outputName, description, object)))
+                         .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Output);
         return param;
     }
+    // Own supplied parameter
+    bool ownParameter(std::shared_ptr<ParameterBase> &parameter, bool isOutput = false);
     // Return named input parameter if it exists
     std::shared_ptr<ParameterBase> findInput(std::string_view inputName) const;
     // Return input parameters

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -13,6 +13,9 @@ ParameterBase::ParameterBase(Node *parent, std::string_view name, std::string_vi
  * Definition
  */
 
+// Set node parent
+void ParameterBase::setParent(Node *parent) { parent_ = parent; }
+
 // Return the parameter name
 std::string_view ParameterBase::name() const { return name_; }
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -13,8 +13,32 @@
 
 // Forward Declarations
 class Node;
+class ParameterBase;
 template <typename T> class Parameter;
 template <typename T> class PointerParameter;
+
+// Parameter Proxy Base
+class ParameterProxyBase
+{
+};
+
+// Parameter Proxy
+template <class T> class ParameterProxy : public ParameterProxyBase
+{
+    public:
+    T data;
+};
+
+// Parameter Link Data
+struct ParameterLink
+{
+    // Parameter proxy
+    std::shared_ptr<ParameterProxyBase> proxy;
+    // Input parameter side
+    std::shared_ptr<ParameterBase> inputParameter;
+    // Output parameter side
+    std::shared_ptr<ParameterBase> outputParameter;
+};
 
 // Base type for all parameter templates to inherit from
 class ParameterBase : public Serialisable<>
@@ -47,6 +71,8 @@ class ParameterBase : public Serialisable<>
     Flags<ParameterBase::ParameterFlags> flags_;
 
     public:
+    // Set node parent
+    void setParent(Node *parent);
     // Return the parameter name
     std::string_view name() const;
     // Return the parameter description
@@ -63,6 +89,10 @@ class ParameterBase : public Serialisable<>
     /*
      * Data
      */
+    protected:
+    // Parameter link data proxies
+    std::vector<std::shared_ptr<ParameterProxyBase>> proxies_;
+
     public:
     // Return whether the contained data represents the default value
     virtual bool isDefault() const { return true; };
@@ -83,6 +113,8 @@ class ParameterBase : public Serialisable<>
         auto cast2 = static_cast<Parameter<T> *>(this);
         return cast2->shared_from_this();
     }
+    // Create a parameter link (input - data proxy - output) for the derived class type
+    virtual ParameterLink createParameterLink(std::string_view parameterName, std::string_view parameterDescription = "") = 0;
 
     /*
      * I/O
@@ -143,6 +175,23 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
             return false;
         set(upcasted->get());
         return true;
+    }
+    // Create a parameter link (input - data proxy - output) for this parameter type
+    ParameterLink createParameterLink(std::string_view newName, std::string_view newDescription) override
+    {
+        // Create a parameter holder object with the same type as ours and add it to the proxies_ storage
+        auto proxy = std::make_shared<ParameterProxy<T>>();
+        proxies_.emplace_back(proxy);
+
+        // Create an input and an output Parameter linked to the proxy data
+        auto inputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy->data);
+        inputParameter->setFlags(ParameterBase::ParameterFlags::Input);
+
+        // Create a companion input on our Outputs node, again linked to the proxy data
+        auto outputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy->data);
+        outputParameter->setFlags(ParameterBase::ParameterFlags::Output);
+
+        return {proxy, inputParameter, outputParameter};
     }
 
     // Helper templates for handling serialisation

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -90,8 +90,8 @@ class ParameterBase : public Serialisable<>
      * Data
      */
     protected:
-    // Parameter link data proxies
-    std::vector<std::shared_ptr<ParameterProxyBase>> proxies_;
+    // Parameter proxy data (if a ParameterLink)
+    std::shared_ptr<ParameterProxyBase> proxyData_;
 
     public:
     // Return whether the contained data represents the default value
@@ -114,7 +114,7 @@ class ParameterBase : public Serialisable<>
         return cast2->shared_from_this();
     }
     // Create a parameter link (input - data proxy - output) for the derived class type
-    virtual ParameterLink createParameterLink(std::string_view parameterName, std::string_view parameterDescription = "") = 0;
+    virtual ParameterLink createParameterLink(std::string_view newName, std::string_view newDescription = "") const = 0;
 
     /*
      * I/O
@@ -133,6 +133,12 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
     Parameter(Node *parent, std::string_view name, std::string_view description, T &value)
         : ParameterBase(parent, name, description, std::type_index(typeid(T))), data_(value), default_(value)
     {
+    }
+    Parameter(Node *parent, std::string_view name, std::string_view description, std::shared_ptr<ParameterProxy<T>> &proxy)
+        : ParameterBase(parent, name, description, std::type_index(typeid(T))), data_(proxy->data), default_(proxy->data)
+    {
+        // Store the proxy data smart pointer to preserve the lifetime of the data
+        proxyData_ = proxy;
     }
     virtual ~Parameter() = default;
 
@@ -177,18 +183,17 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         return true;
     }
     // Create a parameter link (input - data proxy - output) for this parameter type
-    ParameterLink createParameterLink(std::string_view newName, std::string_view newDescription) override
+    ParameterLink createParameterLink(std::string_view newName, std::string_view newDescription) const override
     {
         // Create a parameter holder object with the same type as ours and add it to the proxies_ storage
         auto proxy = std::make_shared<ParameterProxy<T>>();
-        proxies_.emplace_back(proxy);
 
         // Create an input and an output Parameter linked to the proxy data
-        auto inputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy->data);
+        auto inputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy);
         inputParameter->setFlags(ParameterBase::ParameterFlags::Input);
 
         // Create a companion input on our Outputs node, again linked to the proxy data
-        auto outputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy->data);
+        auto outputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy);
         outputParameter->setFlags(ParameterBase::ParameterFlags::Output);
 
         return {proxy, inputParameter, outputParameter};

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -32,7 +32,7 @@ template <class T> class ParameterProxy : public ParameterProxyBase
 // Parameter Link Data
 struct ParameterLink
 {
-    // Parameter proxy
+    // Parameter data proxy
     std::shared_ptr<ParameterProxyBase> proxy;
     // Input parameter side
     std::shared_ptr<ParameterBase> inputParameter;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -17,13 +17,8 @@ class ParameterBase;
 template <typename T> class Parameter;
 template <typename T> class PointerParameter;
 
-// Parameter Proxy Base
-class ParameterProxyBase
-{
-};
-
 // Parameter Proxy
-template <class T> class ParameterProxy : public ParameterProxyBase
+template <class T> class ParameterProxy
 {
     public:
     T data;
@@ -32,8 +27,6 @@ template <class T> class ParameterProxy : public ParameterProxyBase
 // Parameter Link Data
 struct ParameterLink
 {
-    // Parameter data proxy
-    std::shared_ptr<ParameterProxyBase> proxy;
     // Input parameter side
     std::shared_ptr<ParameterBase> inputParameter;
     // Output parameter side
@@ -89,10 +82,6 @@ class ParameterBase : public Serialisable<>
     /*
      * Data
      */
-    protected:
-    // Parameter proxy data (if a ParameterLink)
-    std::shared_ptr<ParameterProxyBase> proxyData_;
-
     public:
     // Return whether the contained data represents the default value
     virtual bool isDefault() const { return true; };
@@ -150,6 +139,8 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
     T &data_;
     // Initial value
     const T default_;
+    // Parameter proxy data (if a ParameterLink)
+    std::shared_ptr<ParameterProxy<T>> proxyData_;
 
     public:
     // Set the parameter value
@@ -196,7 +187,7 @@ template <typename T> class Parameter : public ParameterBase, public std::enable
         auto outputParameter = std::make_shared<Parameter<T>>(nullptr, newName, newDescription, proxy);
         outputParameter->setFlags(ParameterBase::ParameterFlags::Output);
 
-        return {proxy, inputParameter, outputParameter};
+        return {inputParameter, outputParameter};
     }
 
     // Helper templates for handling serialisation


### PR DESCRIPTION
Here we implement the ability to create parameter links between graphs / nodes / subgraphs without knowledge of the underlying data type being linked, and no factory method.