### PR TITLE
build: Fix MacOS installer for the nth time

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -156,6 +156,7 @@ runs:
       Qt6_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos/lib/cmake/Qt6
       QT_BASE_DIR=${{ runner.temp }}/qt/${{ inputs.qtVersion }}/macos
       export FTGL_DIR="${RUNNER_TEMP}/ftgl-install"
+      export FREETYPE_DIR="${RUNNER_TEMP}/freetype-install"
 
       # Find ANTLR4
       ANTLR_EXE="${{ runner.temp }}/antlr-${{ inputs.antlrVersion }}-complete.jar"

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -93,7 +93,7 @@ runs:
     run: |
       set -ex
       mkdir freetype-build && cd freetype-build
-      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DBUILD_SHARED_LIBS:STRING=ON -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF
       cmake --build . --target install --config Release
 
   #

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -35,6 +35,7 @@ runs:
       set -ex
       brew update-reset
       brew install gsl
+      brew uninstall --ignore-dependencies freetype
 
   - name: Get ANTLR
     working-directory: ${{ runner.temp }}

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -25,9 +25,12 @@ runs:
       name: osx-${{ runner.arch }}-build-artifacts
       path: ${{ github.workspace }}/build
 
-  - name: Install Python Dependencies
+  - name: Install Dependencies
     shell: bash
     run: |
+      set -ex
+      brew update-reset
+      brew install gsl
       pip3 install dmgbuild biplist --break-system-packages
 
   - name: Install Custom Dependencies

--- a/.github/workflows/package/osx/action.yml
+++ b/.github/workflows/package/osx/action.yml
@@ -32,11 +32,6 @@ runs:
       brew update-reset
       brew install gsl
       pip3 install dmgbuild biplist --break-system-packages
-
-  - name: Install Custom Dependencies
-    shell: bash
-    run: |
-      set -ex
       wget https://raw.githubusercontent.com/disorderedmaterials/scripts/master/prep-dmg
       chmod u+x ./prep-dmg
 


### PR DESCRIPTION
A PR to address failing MacOS packages. The culprit was the Freetype library: the Homebrew-derived version was being included rather than the one we deliberately build ourselves.