### PR TITLE
build: Fix target OS version for OSX dependent libs

### DIFF
--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -13,6 +13,9 @@ on:
       msvcVersion:
         type: string
         required: true
+      osxRunner:
+        type: string
+        default: 'UNKNOWN'
       osxTargetDeploymentVersion:
         type: string
         default: 'UNKNOWN'
@@ -38,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-15, windows-latest ]
+        os: [ ${{ inputs.osxRunner }}, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'
@@ -89,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-15, windows-latest ]
+        os: [ ${{ inputs.osxRunner }}, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'

--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -13,6 +13,9 @@ on:
       msvcVersion:
         type: string
         required: true
+      osxTargetDeploymentVersion:
+        type: string
+        default: 'UNKNOWN'
       antlrVersion:
         type: string
         required: true
@@ -54,6 +57,7 @@ jobs:
         antlrVersion: ${{ inputs.antlrVersion }}
         conanHash: ${{ inputs.conanHash }}
         msvcVersion: ${{ inputs.msvcVersion }}
+        osxTargetDeploymentVersion: ${{ inputs.osxTargetDeploymentVersion }}
 
   BuildLinux:
     strategy:

--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ${{ inputs.osxRunner }}, windows-latest ]
+        os: [ "${{ inputs.osxRunner }}", windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'
@@ -92,7 +92,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ${{ inputs.osxRunner }}, windows-latest ]
+        os: [ "${{ inputs.osxRunner }}", windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'

--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-15, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest ]
+        os: [ macos-15, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -7,6 +7,9 @@ on:
       msvcVersion:
         type: string
         default: 14.41.17.11
+      osxTargetDeploymentVersion:
+        type: string
+        default: 13.3
       qtVersion:
         type: string
         default: 6.4.2
@@ -62,6 +65,9 @@ on:
       msvcVersion:
         description: "Version of MSVC required by the project"
         value: ${{ jobs.Checkout.outputs.msvcVersion }}
+      osxTargetDeploymentVersion:
+        description: "Minimum version of OSX to target for deployment"
+        value: ${{ jobs.Checkout.outputs.osxTargetDeploymentVersion }}
 
 jobs:
 
@@ -74,6 +80,7 @@ jobs:
       currentVersionPatch: ${{ steps.authVersion.outputs.currentVersionPatch }}
       currentShortHash: ${{ steps.authVersion.outputs.currentShortHash }}
       msvcVersion: ${{ steps.versions.outputs.msvcVersion }}
+      osxTargetDeploymentVersion: ${{ steps.versions.outputs.osxTargetDeploymentVersion }}
       qtVersion: ${{ steps.versions.outputs.qtVersion }}
       antlrVersion: ${{ steps.versions.outputs.antlrVersion }}
       hugoVersion: ${{ steps.versions.outputs.hugoVersion }}
@@ -106,6 +113,7 @@ jobs:
           echo "antlrVersion=${ANTLR_VERSION}" >> $GITHUB_OUTPUT
 
           echo "msvcVersion=${{ inputs.msvcVersion }}" >> $GITHUB_OUTPUT
+          echo "osxTargetDeploymentVersion=${{ inputs.osxTargetDeploymentVersion }}" >> $GITHUB_OUTPUT
 
       - name: Get Hashes
         id: hashes

--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -7,6 +7,9 @@ on:
       msvcVersion:
         type: string
         default: 14.41.17.11
+      osxRunner:
+        type: string
+        default: macos-15
       osxTargetDeploymentVersion:
         type: string
         default: 13.3
@@ -65,6 +68,9 @@ on:
       msvcVersion:
         description: "Version of MSVC required by the project"
         value: ${{ jobs.Checkout.outputs.msvcVersion }}
+      osxRunner:
+        description: "Runner target for OSX"
+        value: ${{ jobs.Checkout.outputs.osxRunner }}
       osxTargetDeploymentVersion:
         description: "Minimum version of OSX to target for deployment"
         value: ${{ jobs.Checkout.outputs.osxTargetDeploymentVersion }}
@@ -80,6 +86,7 @@ jobs:
       currentVersionPatch: ${{ steps.authVersion.outputs.currentVersionPatch }}
       currentShortHash: ${{ steps.authVersion.outputs.currentShortHash }}
       msvcVersion: ${{ steps.versions.outputs.msvcVersion }}
+      osxRunner: ${{ steps.versions.outputs.osxRunner }}
       osxTargetDeploymentVersion: ${{ steps.versions.outputs.osxTargetDeploymentVersion }}
       qtVersion: ${{ steps.versions.outputs.qtVersion }}
       antlrVersion: ${{ steps.versions.outputs.antlrVersion }}
@@ -113,6 +120,7 @@ jobs:
           echo "antlrVersion=${ANTLR_VERSION}" >> $GITHUB_OUTPUT
 
           echo "msvcVersion=${{ inputs.msvcVersion }}" >> $GITHUB_OUTPUT
+          echo "osxRunner=${{ inputs.osxRunner }}" >> $GITHUB_OUTPUT
           echo "osxTargetDeploymentVersion=${{ inputs.osxTargetDeploymentVersion }}" >> $GITHUB_OUTPUT
 
       - name: Get Hashes

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -28,6 +28,9 @@ inputs:
   benchmark:
     type: boolean
     default: false
+  osxTargetDeploymentVersion:
+    type: string
+    default: 'UNKNOWN'
   publishBenchmarks:
     type: boolean
     default: false
@@ -55,6 +58,7 @@ runs:
       conanHash: ${{ inputs.conanHash }}
       qtVersion: ${{ inputs.qtVersion }}
       antlrVersion: ${{ inputs.antlrVersion }}
+      targetDeploymentVersion: ${{ inputs.osxTargetDeploymentVersion }}
 
   - name: Build (Windows)
     if: runner.os == 'Windows'

--- a/.github/workflows/build/action.yml
+++ b/.github/workflows/build/action.yml
@@ -58,7 +58,7 @@ runs:
       conanHash: ${{ inputs.conanHash }}
       qtVersion: ${{ inputs.qtVersion }}
       antlrVersion: ${{ inputs.antlrVersion }}
-      targetDeploymentVersion: ${{ inputs.osxTargetDeploymentVersion }}
+      osxTargetDeploymentVersion: ${{ inputs.osxTargetDeploymentVersion }}
 
   - name: Build (Windows)
     if: runner.os == 'Windows'

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -4,7 +4,7 @@ description: Build on OSX
 inputs:
   threading:
     default: true
-  targetDeploymentVersion:
+  osxTargetDeploymentVersion:
     default: 13.3
   freeTypeArchive:
     default: https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.gz

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -94,7 +94,7 @@ runs:
     run: |
       set -ex
       mkdir freetype-build && cd freetype-build
-      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF  -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3
       cmake --build . --target install --config Release
 
   #
@@ -128,7 +128,7 @@ runs:
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
       export FREETYPE_DIR="${RUNNER_TEMP}/freetype-install"
-      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3
       cmake --build . --target install --config Release
 
   #

--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -4,6 +4,8 @@ description: Build on OSX
 inputs:
   threading:
     default: true
+  targetDeploymentVersion:
+    default: 13.3
   freeTypeArchive:
     default: https://download.savannah.gnu.org/releases/freetype/freetype-2.12.1.tar.gz
   ftglRepo:
@@ -94,7 +96,7 @@ runs:
     run: |
       set -ex
       mkdir freetype-build && cd freetype-build
-      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF  -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3
+      cmake ../freetype-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_DISABLE_FIND_PACKAGE_HarfBuzz:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BZip2:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_PNG:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_ZLIB:bool=true -DCMAKE_DISABLE_FIND_PACKAGE_BrotliDec:bool=true -DCMAKE_INSTALL_PREFIX:path=../freetype-install -DBUILD_SHARED_LIBS:bool=OFF  -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ inputs.targetDeploymentVersion }}
       cmake --build . --target install --config Release
 
   #
@@ -128,7 +130,7 @@ runs:
       INCLUDE="${RUNNER_TEMP}/freetype-latest;$INCLUDE"
       LIB="${RUNNER_TEMP}/freetype-install/lib;${RUNNER_TEMP}/freetype-install/bin;$LIB"
       export FREETYPE_DIR="${RUNNER_TEMP}/freetype-install"
-      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=13.3
+      cmake ../ftgl-latest -G Ninja -DCMAKE_BUILD_TYPE:STRING="Release" -DCMAKE_INSTALL_PREFIX:path=../ftgl-install -DBUILD_SHARED_LIBS:bool=OFF -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ inputs.targetDeploymentVersion }}
       cmake --build . --target install --config Release
 
   #
@@ -175,11 +177,11 @@ runs:
       conan config set storage.download_cache="${GITHUB_WORKSPACE}/.conancache"
 
       # Set minimum deployment target version
-      export MACOSX_DEPLOYMENT_TARGET=13.3
+      export MACOSX_DEPLOYMENT_TARGET=${{ inputs.targetDeploymentVersion }}
 
       # Build
       mkdir build && cd build
-      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../
+      cmake -G Ninja -DGUI:bool=true -DMULTI_THREADING:bool=${{ inputs.threading }} -DCONAN_GSL="OFF" -DJava_JAVA_EXECUTABLE:path=${JAVA_RUNTIME} -DANTLR_EXECUTABLE:string=$ANTLR_EXE -DQT_BASE_DIR=$QT_BASE_DIR ../ -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ inputs.targetDeploymentVersion }}
       cmake --build . --config Release
 
       # Copy over gsl libs so we can ship them with the bundle. Our exe is only linked to two of the four libs present, and this breaks the binary if we don't include them all in the package.

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -35,6 +35,7 @@ jobs:
       publishBenchmarks: true
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
+      osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -36,6 +36,7 @@ jobs:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
+      osxRunner: ${{ needs.Checkout.outputs.osxRunner }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -23,6 +23,7 @@ jobs:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
+      osxRunner: ${{ needs.Checkout.outputs.osxRunner }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -22,6 +22,7 @@ jobs:
     with:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
+      osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,6 +34,7 @@ jobs:
       benchmark: true
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
+      osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}
+      osxRunner: ${{ needs.Checkout.outputs.osxRunner }}
       qtVersion: ${{ needs.Checkout.outputs.qtVersion }}
       antlrVersion: ${{ needs.Checkout.outputs.antlrVersion }}
       conanHash: ${{ needs.Checkout.outputs.conanHash }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,8 +189,6 @@ endif(UNIX)
 
 # -- OSX
 if(APPLE)
-  set(CMAKE_OSX_DEPLOYMENT_TARGET 13.3)
-
   list(APPEND CMAKE_BUILD_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
   # Set some specific C++11 related options here (set_property below does not seem to persist)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")


### PR DESCRIPTION
This PR makes ANOTHER fix to the OSX builds. Building with `macos-latest` only gave a `macos-13` machine with AppleClang 15.0, and this seems to give a partly-working but mostly broken version of Dissolve. Specifying `macos-15` as the runner target appears to fix everything.