### PR TITLE
build: Fix bad syntax in release pipeline.

### DIFF
--- a/.github/workflows/detect_release.yml
+++ b/.github/workflows/detect_release.yml
@@ -8,8 +8,9 @@ on:
 
 jobs:
 
+  # Note: github.event.pull_request.merged is a true bool, so do not quote the value to test.
   Checkout:
-    if: github.event.pull_request.merged == 'true' && startsWith(github.event.pull_request.title, '[Release]')
+    if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Release]')
     uses: "./.github/workflows/_checkout.yml"
     secrets: inherit
     with:


### PR DESCRIPTION
Our `detect_release.yml` currently does not run - potentially the culprit is a recent change to the `if:` test in the workflow.  Until it is merged and I try and push a new release it's hard to say for certain though!