### PR TITLE
feat: Better fuzzy search

### DIFF
--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -115,25 +115,14 @@ std::string Graph::uniqueNodeName(const Node *node, std::string_view baseName) c
 }
 
 // Create node of specified type with the name provided
-Node *Graph::createNode(std::string_view nodeType, std::string_view nodeName, bool strictTypeName)
+Node *Graph::createNode(std::string_view nodeType, std::string_view nodeName)
 {
     std::string newNodeType{nodeType};
-    if (strictTypeName)
+
+    if (!NodeRegistry::hasNodeType(nodeType))
     {
-        if (!NodeRegistry::hasNodeType(nodeType))
-        {
-            Messenger::warn("Can't create a node of type '{}' as this type does not exist.\n", nodeType);
-            return nullptr;
-        }
-    }
-    else
-    {
-        newNodeType = NodeRegistry::getNodeTypeFuzzy(nodeType);
-        if (newNodeType.empty())
-        {
-            Messenger::warn("Can't create a node of type '{}' as neither this type nor a close match exists.\n", nodeType);
-            return nullptr;
-        }
+        Messenger::warn("Can't create a node of type '{}' as this type does not exist.\n", nodeType);
+        return nullptr;
     }
 
     return addNode(NodeRegistry::produce(this, newNodeType), nodeName.empty() ? newNodeType : nodeName);

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -80,7 +80,7 @@ class Graph : public Node
 
     public:
     // Create node of specified type with the name provided
-    Node *createNode(std::string_view type, std::string_view name = {}, bool strictTypeName = true);
+    Node *createNode(std::string_view type, std::string_view name = {});
     // Add node to graph
     Node *addNode(std::unique_ptr<Node> node, std::string_view name = {});
     // Get name of specified child node

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -19,6 +19,8 @@
 #include "nodes/vec3Decomposition.h"
 #include <memory>
 
+using namespace std::string_literals;
+
 // Static Singletons
 std::map<std::string_view, NodeProducer> NodeRegistry::producers_;
 
@@ -66,7 +68,7 @@ std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view we
 
     std::vector<std::string_view> result;
 
-    auto fuzzy = std::string("*") + std::string(weakNodeType) + std::string("*");
+    auto fuzzy = "*"s + std::string(weakNodeType) + "*"s;
 
     // Case insensitive search for now - fuzzy search to be implemented at a later date
     for (auto &&[nodeType, _] : producers_)

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -66,10 +66,12 @@ std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view we
 
     std::vector<std::string_view> result;
 
+    auto fuzzy = std::string("*") + std::string(weakNodeType) + std::string("*");
+
     // Case insensitive search for now - fuzzy search to be implemented at a later date
     for (auto &&[nodeType, _] : producers_)
     {
-        if (DissolveSys::sameString(weakNodeType, nodeType))
+        if (DissolveSys::sameWildString(fuzzy, nodeType))
             result.emplace_back(nodeType);
     }
 

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -61,7 +61,7 @@ bool NodeRegistry::hasNodeType(std::string_view nodeType)
 }
 
 // Search for the supplied node type, returning strict node type if found
-std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view weakNodeType)
+std::vector<std::string_view> NodeRegistry::getNodeTypesFuzzy(std::string_view weakNodeType)
 {
     instantiateNodeProducers();
 
@@ -72,8 +72,7 @@ std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view we
 
     // Iterate over the keys of the map and include only the names
     // which match our fuzzy match
-    using namespace std::views;
-    auto range = producers_ | keys | filter(predicate);
+    auto range = producers_ | std::views::keys | std::views::filter(predicate);
 
     // Create a vector from the range
     return {range.begin(), range.end()};

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -18,8 +18,7 @@
 #include "nodes/vec3Assembly.h"
 #include "nodes/vec3Decomposition.h"
 #include <memory>
-
-using namespace std::string_literals;
+#include <ranges>
 
 // Static Singletons
 std::map<std::string_view, NodeProducer> NodeRegistry::producers_;
@@ -66,18 +65,18 @@ std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view we
 {
     instantiateNodeProducers();
 
-    std::vector<std::string_view> result;
+    using namespace std::string_literals;
 
-    auto fuzzy = "*"s + std::string(weakNodeType) + "*"s;
+    auto predicate = [weakNodeType](const auto nodeType)
+    { return DissolveSys::sameWildString("*"s + std::string(weakNodeType) + "*"s, nodeType); };
 
-    // Case insensitive search for now - fuzzy search to be implemented at a later date
-    for (auto &&[nodeType, _] : producers_)
-    {
-        if (DissolveSys::sameWildString(fuzzy, nodeType))
-            result.emplace_back(nodeType);
-    }
+    // Iterate over the keys of the map and include only the names
+    // which match our fuzzy match
+    using namespace std::views;
+    auto range = producers_ | keys | filter(predicate);
 
-    return result;
+    // Create a vector from the range
+    return {range.begin(), range.end()};
 }
 
 // Produce a node of the given type with the specified Graph parent

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -60,18 +60,20 @@ bool NodeRegistry::hasNodeType(std::string_view nodeType)
 }
 
 // Search for the supplied node type, returning strict node type if found
-std::string_view NodeRegistry::getNodeTypeFuzzy(std::string_view weakNodeType)
+std::vector<std::string_view> NodeRegistry::getNodeTypeFuzzy(std::string_view weakNodeType)
 {
     instantiateNodeProducers();
+
+    std::vector<std::string_view> result;
 
     // Case insensitive search for now - fuzzy search to be implemented at a later date
     for (auto &&[nodeType, _] : producers_)
     {
         if (DissolveSys::sameString(weakNodeType, nodeType))
-            return nodeType;
+            result.emplace_back(nodeType);
     }
 
-    return {};
+    return result;
 }
 
 // Produce a node of the given type with the specified Graph parent

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -5,6 +5,7 @@
 
 #include "node.h"
 #include <string>
+#include <vector>
 
 using NodeProducer = std::function<std::unique_ptr<Node>(Graph *parent)>;
 
@@ -23,7 +24,7 @@ class NodeRegistry
     // Check whether the supplied node type is known
     static bool hasNodeType(std::string_view nodeType);
     // Search for the supplied node type, returning strict node type if found
-    static std::string_view getNodeTypeFuzzy(std::string_view weakNodeType);
+    static std::vector<std::string_view> getNodeTypeFuzzy(std::string_view weakNodeType);
     // Produce a node of the given type with the specified Graph parent
     static std::unique_ptr<Node> produce(Graph *parent, std::string_view nodeType);
 };

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -24,7 +24,7 @@ class NodeRegistry
     // Check whether the supplied node type is known
     static bool hasNodeType(std::string_view nodeType);
     // Search for the supplied node type, returning strict node type if found
-    static std::vector<std::string_view> getNodeTypeFuzzy(std::string_view weakNodeType);
+    static std::vector<std::string_view> getNodeTypesFuzzy(std::string_view weakNodeType);
     // Produce a node of the given type with the specified Graph parent
     static std::unique_ptr<Node> produce(Graph *parent, std::string_view nodeType);
 };

--- a/src/nodes/registry.h
+++ b/src/nodes/registry.h
@@ -23,7 +23,8 @@ class NodeRegistry
     public:
     // Check whether the supplied node type is known
     static bool hasNodeType(std::string_view nodeType);
-    // Search for the supplied node type, returning strict node type if found
+    // Search for the supplied node type, returning all node types
+    // which match the selection
     static std::vector<std::string_view> getNodeTypesFuzzy(std::string_view weakNodeType);
     // Produce a node of the given type with the specified Graph parent
     static std::unique_ptr<Node> produce(Graph *parent, std::string_view nodeType);

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -103,7 +103,7 @@ TEST_F(GraphCoreTest, NodeCreation)
     EXPECT_EQ(root_.createNode("add", "Bob"), nullptr);
 
     // Wrong case in existing node type (succeeds with non-strict type name checking)
-    EXPECT_EQ(NodeRegistry::getNodeTypeFuzzy("prod")[0], "DotProduct");
+    EXPECT_EQ(NodeRegistry::getNodeTypesFuzzy("prod")[0], "DotProduct");
 }
 
 } // namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -103,7 +103,7 @@ TEST_F(GraphCoreTest, NodeCreation)
     EXPECT_EQ(root_.createNode("add", "Bob"), nullptr);
 
     // Wrong case in existing node type (succeeds with non-strict type name checking)
-    EXPECT_EQ(NodeRegistry::getNodeTypeFuzzy("add")[0], "Add");
+    EXPECT_EQ(NodeRegistry::getNodeTypeFuzzy("prod")[0], "DotProduct");
 }
 
 } // namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -3,7 +3,7 @@
 
 #include "nodes/add.h"
 #include "nodes/dissolve.h"
-#include "nodes/number.h"
+#include "nodes/registry.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -103,7 +103,7 @@ TEST_F(GraphCoreTest, NodeCreation)
     EXPECT_EQ(root_.createNode("add", "Bob"), nullptr);
 
     // Wrong case in existing node type (succeeds with non-strict type name checking)
-    EXPECT_NE(root_.createNode("add", "Bob", false), nullptr);
+    EXPECT_EQ(NodeRegistry::getNodeTypeFuzzy("add")[0], "Add");
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR improves the handling of fuzzy search for node names.  First, the `createNode` function now requires an exact value and has no logic to perform fuzzy searching.  Instead, the `getNodeTypeFuzzy` method has been upgraded to return a list of *all* of the matching node names (to eventually allow the user to select a name from the list).  It also does a slightly more advanced search allowing for substrings and case insensitivity.

I used the new C++20 ranges to handle collecting the list of names.  If this is too confusing, I can switch it over to a `for` loop.

Closes #2157