### PR TITLE
feat: Chiral nanotube and graphene sheet creator

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -79,9 +79,9 @@ add_library(
   copySpeciesTermsDialog.cpp
   copySpeciesTermsDialog.h
   copySpeciesTermsDialog.ui
-  createNanotubeSpeciesDialog.cpp
-  createNanotubeSpeciesDialog.h
-  createNanotubeSpeciesDialog.ui
+  createGrapheneSpeciesDialog.cpp
+  createGrapheneSpeciesDialog.h
+  createGrapheneSpeciesDialog.ui
   dataManagerDialog.cpp
   dataManagerDialog.h
   editSpeciesDialog.cpp

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -99,14 +99,14 @@ std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateGrapheneSpeciesDialog:
 
 // Get vector of atom keys from atom/neighbour map, sorted by position along indicated direction
 std::vector<SpeciesAtom *>
-CreateGrapheneSpeciesDialog::getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const
+CreateGrapheneSpeciesDialog::getSortedByY(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms) const
 {
     std::vector<SpeciesAtom *> sorted;
     for (auto &&[i, _] : atoms)
         sorted.push_back(i);
 
     std::sort(sorted.begin(), sorted.end(),
-              [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().get(dir) < b->r().get(dir); });
+              [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().y < b->r().y; });
 
     return sorted;
 }

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -105,8 +105,7 @@ CreateGrapheneSpeciesDialog::getSortedByY(const std::map<SpeciesAtom *, std::vec
     for (auto &&[i, _] : atoms)
         sorted.push_back(i);
 
-    std::sort(sorted.begin(), sorted.end(),
-              [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().y < b->r().y; });
+    std::sort(sorted.begin(), sorted.end(), [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().y < b->r().y; });
 
     return sorted;
 }

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -105,7 +105,7 @@ CreateGrapheneSpeciesDialog::getSortedByY(const std::map<SpeciesAtom *, std::vec
     for (auto &&[i, _] : atoms)
         sorted.push_back(i);
 
-    std::sort(sorted.begin(), sorted.end(), [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().y < b->r().y; });
+    std::sort(sorted.begin(), sorted.end(), [](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().y < b->r().y; });
 
     return sorted;
 }
@@ -237,7 +237,7 @@ void CreateGrapheneSpeciesDialog::regenerate()
             // Find all atoms which have two bonds spanning PBC of the box
             auto localCutoff = ui_.BondLengthSpin->value() * 1.01;
             const auto atoms = findDanglingAtoms(localCutoff);
-            auto sorted = getSorted(atoms, 1);
+            auto sorted = getSortedByY(atoms);
 
             // Pass 1 - Move all atoms along the PBC bond vectors
             while (!sorted.empty())

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#include "gui/createNanotubeSpeciesDialog.h"
+#include "gui/createGrapheneSpeciesDialog.h"
 #include "classes/empiricalFormula.h"
 #include "gui/helpers/comboPopulator.h"
 #include <numeric>
@@ -10,7 +10,7 @@
 const auto root3 = sqrt(3.0);
 const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
 
-CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissolve &dissolve)
+CreateGrapheneSpeciesDialog::CreateGrapheneSpeciesDialog(QWidget *parent, Dissolve &dissolve)
     : QDialog(parent), selectElementDialog_(this), dissolve_(dissolve)
 {
     ui_.setupUi(this);
@@ -38,7 +38,7 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
  */
 
 // Calculate parameters
-void CreateNanotubeSpeciesDialog::calculateParameters()
+void CreateGrapheneSpeciesDialog::calculateParameters()
 {
     /*
      * Procedure based on "Determination of the chiral indices (n,m) of carbon nanotubes by electron diffraction",
@@ -76,7 +76,7 @@ void CreateNanotubeSpeciesDialog::calculateParameters()
 }
 
 // Find dangling atoms, defined as those which have two bonds spanning PBC of the box
-std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateNanotubeSpeciesDialog::findDanglingAtoms(double localCutoff)
+std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateGrapheneSpeciesDialog::findDanglingAtoms(double localCutoff)
 {
     std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> atoms;
     for (auto &i : species_.atoms())
@@ -99,7 +99,7 @@ std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateNanotubeSpeciesDialog:
 
 // Get vector of atom keys from atom/neighbour map, sorted by position along indicated direction
 std::vector<SpeciesAtom *>
-CreateNanotubeSpeciesDialog::getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const
+CreateGrapheneSpeciesDialog::getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const
 {
     std::vector<SpeciesAtom *> sorted;
     for (auto &&[i, _] : atoms)
@@ -112,7 +112,7 @@ CreateNanotubeSpeciesDialog::getSorted(const std::map<SpeciesAtom *, std::vector
 }
 
 // Recursive branch function
-void CreateNanotubeSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac,
+void CreateGrapheneSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac,
                                                std::vector<SpeciesAtom *> &branch, double localCutoff) const
 {
     // Get PBC and non-PBC (local) bond partners for this atom and see what type of atom we have...
@@ -143,7 +143,7 @@ void CreateNanotubeSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, V
 }
 
 // Regenerate species
-void CreateNanotubeSpeciesDialog::regenerate()
+void CreateGrapheneSpeciesDialog::regenerate()
 {
     species_.clear();
 
@@ -339,7 +339,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
  */
 
 // Update all controls
-void CreateNanotubeSpeciesDialog::updateWidgets()
+void CreateGrapheneSpeciesDialog::updateWidgets()
 {
     Locker updateLock(widgetsUpdating_);
 
@@ -372,7 +372,7 @@ void CreateNanotubeSpeciesDialog::updateWidgets()
     ui_.StructureViewer->postRedisplay();
 }
 
-void CreateNanotubeSpeciesDialog::on_NSpin_valueChanged(int value)
+void CreateGrapheneSpeciesDialog::on_NSpin_valueChanged(int value)
 {
     if (widgetsUpdating_.isLocked())
         return;
@@ -385,14 +385,14 @@ void CreateNanotubeSpeciesDialog::on_NSpin_valueChanged(int value)
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_MSpin_valueChanged(int value)
+void CreateGrapheneSpeciesDialog::on_MSpin_valueChanged(int value)
 {
     calculateParameters();
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_ElementAButton_clicked(bool checked)
 {
     auto Z = selectElementDialog_.selectElement(zA_);
     if (Z == Elements::Unknown)
@@ -404,7 +404,7 @@ void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_ElementBButton_clicked(bool checked)
 {
     auto Z = selectElementDialog_.selectElement(zB_);
     if (Z == Elements::Unknown)
@@ -416,44 +416,36 @@ void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value)
+void CreateGrapheneSpeciesDialog::on_BondLengthSpin_valueChanged(double value)
 {
     calculateParameters();
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_CFactorSpin_valueChanged(int value)
+void CreateGrapheneSpeciesDialog::on_CFactorSpin_valueChanged(int value)
 {
     calculateParameters();
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_RollUpCheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_RollUpCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_PeriodicRadio_clicked(bool checked)
-{
-    if (widgetsUpdating_)
-        return;
-
-    regenerate();
-    updateWidgets();
-}
-
-void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_PeriodicRadio_clicked(bool checked)
 {
     if (widgetsUpdating_)
         return;
+
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
 {
     if (widgetsUpdating_)
         return;
@@ -461,25 +453,33 @@ void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TidyEndsCheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
+{
+    if (widgetsUpdating_)
+        return;
+    regenerate();
+    updateWidgets();
+}
+
+void CreateGrapheneSpeciesDialog::on_TidyEndsCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_RemoveBranchesCheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_RemoveBranchesCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TerminateCheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_TerminateCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TerminateElementButton_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_TerminateElementButton_clicked(bool checked)
 {
     auto Z = selectElementDialog_.selectElement(zB_);
     if (Z == Elements::Unknown)
@@ -491,25 +491,25 @@ void CreateNanotubeSpeciesDialog::on_TerminateElementButton_clicked(bool checked
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TerminateBondLengthSpin_valueChanged(double value)
+void CreateGrapheneSpeciesDialog::on_TerminateBondLengthSpin_valueChanged(double value)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TerminateACheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_TerminateACheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_TerminateBCheck_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_TerminateBCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
+void CreateGrapheneSpeciesDialog::on_OKButton_clicked(bool checked)
 {
     // Copy the species to the main Dissolve instance and set its new name
     auto *sp = dissolve_.coreData().copySpecies(&species_);
@@ -518,4 +518,4 @@ void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
     accept();
 }
 
-void CreateNanotubeSpeciesDialog::on_CancelButton_clicked(bool checked) { reject(); }
+void CreateGrapheneSpeciesDialog::on_CancelButton_clicked(bool checked) { reject(); }

--- a/src/gui/createGrapheneSpeciesDialog.h
+++ b/src/gui/createGrapheneSpeciesDialog.h
@@ -65,8 +65,8 @@ class CreateGrapheneSpeciesDialog : public QDialog
     void calculateParameters();
     // Find dangling atoms, defined as those which have two bonds spanning PBC of the box
     std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> findDanglingAtoms(double localCutoff);
-    // Get vector of atom keys from atom/neighbour map, sorted by position along indicated direction
-    std::vector<SpeciesAtom *> getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const;
+    // Get vector of atom keys from atom/neighbour map, sorted by position along y
+    std::vector<SpeciesAtom *> getSortedByY(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms) const;
     // Recursive branch function
     void extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac, std::vector<SpeciesAtom *> &branch,
                       double localCutoff) const;

--- a/src/gui/createGrapheneSpeciesDialog.h
+++ b/src/gui/createGrapheneSpeciesDialog.h
@@ -6,7 +6,7 @@
 #include "base/lock.h"
 #include "gui/models/cifAssemblyModel.h"
 #include "gui/selectElementDialog.h"
-#include "gui/ui_createNanotubeSpeciesDialog.h"
+#include "gui/ui_createGrapheneSpeciesDialog.h"
 #include "gui/wizard.h"
 #include "io/import/cif.h"
 #include "main/dissolve.h"
@@ -16,18 +16,18 @@
 class Dissolve;
 class Species;
 
-// Create Nanotube Species Dialog
-class CreateNanotubeSpeciesDialog : public QDialog
+// Create Graphene Species Dialog
+class CreateGrapheneSpeciesDialog : public QDialog
 {
     Q_OBJECT
 
     public:
-    CreateNanotubeSpeciesDialog(QWidget *parent, Dissolve &dissolve);
-    ~CreateNanotubeSpeciesDialog() = default;
+    CreateGrapheneSpeciesDialog(QWidget *parent, Dissolve &dissolve);
+    ~CreateGrapheneSpeciesDialog() = default;
 
     private:
     // Main form declaration
-    Ui::CreateNanotubeSpeciesDialog ui_;
+    Ui::CreateGrapheneSpeciesDialog ui_;
     // Temporary core data
     CoreData temporaryCoreData_;
 

--- a/src/gui/createGrapheneSpeciesDialog.ui
+++ b/src/gui/createGrapheneSpeciesDialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>CreateNanotubeSpeciesDialog</class>
- <widget class="QDialog" name="CreateNanotubeSpeciesDialog">
+ <class>CreateGrapheneSpeciesDialog</class>
+ <widget class="QDialog" name="CreateGrapheneSpeciesDialog">
   <property name="windowModality">
    <enum>Qt::ApplicationModal</enum>
   </property>
@@ -19,7 +19,7 @@
    </font>
   </property>
   <property name="windowTitle">
-   <string>Create Nanotube Species</string>
+   <string>Create Graphene Species</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <property name="spacing">
@@ -126,7 +126,7 @@
               <number>1000</number>
              </property>
              <property name="value">
-              <number>1</number>
+              <number>0</number>
              </property>
             </widget>
            </item>
@@ -522,7 +522,7 @@
               <string>Periodic</string>
              </property>
              <property name="checked">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
             </widget>
            </item>
@@ -539,7 +539,7 @@
               <string>Non-periodic</string>
              </property>
              <property name="checked">
-              <bool>true</bool>
+              <bool>false</bool>
              </property>
             </widget>
            </item>

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -6,6 +6,10 @@
 #include "gui/helpers/comboPopulator.h"
 #include <numeric>
 
+// Useful constants
+const auto root3 = sqrt(3.0);
+const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
+
 CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissolve &dissolve)
     : QDialog(parent), selectElementDialog_(this), dissolve_(dissolve)
 {
@@ -23,6 +27,8 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
 
     refreshLock.unlock();
 
+    calculateParameters();
+
     regenerate();
 }
 
@@ -30,87 +36,86 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
  * Data
  */
 
-// Regenerate species
-void CreateNanotubeSpeciesDialog::regenerate()
+// Calculate parameters
+void CreateNanotubeSpeciesDialog::calculateParameters()
 {
-    species_.clear();
-
     /*
      * Procedure based on "Determination of the chiral indices (n,m) of carbon nanotubes by electron diffraction",
      * Lu-Chan Qin, Phys. Chem. Chem. Phys. 2007, *9*, 31-48. https://doi.org/10.1039/B614121H
      */
 
-    const auto root3 = sqrt(3.0);
-    const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
-    const auto roll = ui_.RollUpCheck->isChecked();
-    const auto sheetZ = 10.0; // Default size of unit cell for sheet
-
     // Get n,m values for tube
-    const auto n = ui_.NSpin->value();
-    const auto m = ui_.MSpin->value();
+    n_ = ui_.NSpin->value();
+    m_ = ui_.MSpin->value();
 
     // Determine a0, the principal unit length of the structure, from the specified bond distance. See Figure 1a, noting that
     // a1 == a2 == a0.
     const auto r = ui_.BondLengthSpin->value();
-    const auto a0 = r * root3;
+    a0_ = r * root3;
 
     // Set principal vectors for reference
-    const auto va1 = Vec3<double>(a0, 0.0, 0.0);
-    const auto va2 = Vec3<double>(a0 * sin(oneSixthPi), a0 * cos(oneSixthPi), 0.0);
+    va1_ = Vec3<double>(a0_, 0.0, 0.0);
+    va2_ = Vec3<double>(a0_ * sin(oneSixthPi), a0_ * cos(oneSixthPi), 0.0);
 
     // Calculate repeat dimensions of the (n,m) sheet
     // -- A is magnitude of vecA (equation 1) and represents our X dimension
-    auto A = a0 * sqrt(n * n + m * m + n * m);
+    A_ = a0_ * sqrt(n_ * n_ + m_ * m_ + n_ * m_);
     // -- c is the magnitude of the vector perpendicular to vecA, along the tube axis, and represents our Y dimension
-    auto M = std::gcd(2 * n + m, n + 2 * m);
-    auto c = sqrt(3.0) * A / M;
+    const auto M = std::gcd(2 * n_ + m_, n_ + 2 * m_);
+    c_ = sqrt(3.0) * A_ / M;
 
     // Determine angle alpha, describing the tilt of the sheet away from va1 (equation 3)
-    auto alpha = atan((sqrt(3.0) * m) / (2 * n + m));
+    alpha_ = atan((sqrt(3.0) * m_) / (2 * n_ + m_));
 
     // The radius of the tube is then the circumference (== A) divided by 2PI
-    const auto radius = A / (2.0 * M_PI);
+    radius_ = A_ / (2.0 * M_PI);
 
-    // Scale the Y dimension of the system
-    auto cFactor = ui_.CFactorSpin->value();
+    dy_ = va2_.y / cos(alpha_);
+    H_ = round(c_ / dy_);
+}
+
+// Regenerate species
+void CreateNanotubeSpeciesDialog::regenerate()
+{
+    species_.clear();
+
+    const auto roll = ui_.RollUpCheck->isChecked();
 
     // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
     auto offset = Vec3<double>();
     if (roll)
     {
         // Create some extra space and set an offset so the tube is central in XZ
-        species_.createBox({radius * 3, c * cFactor, radius * 3}, {90, 90, 90});
-        offset = Vec3<double>(radius * 1.5, 0.0, radius * 1.5);
+        species_.createBox({radius_ * 3, c_, radius_ * 3}, {90, 90, 90});
+        offset = Vec3<double>(radius_ * 1.5, 0.0, radius_ * 1.5);
     }
     else
     {
-        species_.createBox({A, c * cFactor, sheetZ}, {90, 90, 90});
-        offset = Vec3<double>(0.0, 0.0, sheetZ * 0.5);
+        species_.createBox({A_, c_, sheetZ_}, {90, 90, 90});
+        offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
     }
 
     /*
      * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
      * Specifically, the innermost loop to translate the primary helix pair is originally stated to run over j (here 'i') from
      * 0 - (m-1) inclusive, but this does not generate the correct number of copies for most cases. Instead, the number of
-     * required helix copies 'H' is calculated from c and the rotated y component of va2.
+     * required helix copies 'H' is calculated from c and the rotated y component of va2 (see earlier).
      */
-    auto dy = va2.y / cos(alpha);
-    auto H = round(c * cFactor / dy);
-    for (auto j = 0; j <= n + m - 1; ++j)
+    for (auto j = 0; j <= n_ + m_ - 1; ++j)
     {
         // Primary helix atoms (equation 7)
-        auto x1j = j * a0 * cos(alpha);
-        auto y1j = -j * a0 * sin(alpha);
+        auto x1j = j * a0_ * cos(alpha_);
+        auto y1j = -j * a0_ * sin(alpha_);
 
         // Secondary helix atoms (equation 8)
-        auto x2j = x1j - (a0 / sqrt(3.0)) * cos(oneSixthPi - alpha);
-        auto y2j = y1j - (a0 / sqrt(3.0)) * sin(oneSixthPi - alpha);
+        auto x2j = x1j - (a0_ / sqrt(3.0)) * cos(oneSixthPi - alpha_);
+        auto y2j = y1j - (a0_ / sqrt(3.0)) * sin(oneSixthPi - alpha_);
 
         // Create H copies of the helix pairs
-        for (auto i = 0; i < H; ++i)
+        for (auto i = 0; i < H_; ++i)
         {
             // Generate translation vector for this copy (equation 9)
-            auto delta = Vec3<double>(-i * a0 * sin(oneSixthPi - alpha), i * a0 * cos(oneSixthPi - alpha), 0.0);
+            auto delta = Vec3<double>(-i * a0_ * sin(oneSixthPi - alpha_), i * a0_ * cos(oneSixthPi - alpha_), 0.0);
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
 
@@ -118,10 +123,10 @@ void CreateNanotubeSpeciesDialog::regenerate()
             {
                 // Wrap the X coordinate (== real position on circumference) onto a tube of radius 'radius', applying the
                 // offset we set earlier when creating the periodic box so as to put it in the centre of XZ.
-                species_.addAtom(zA_, species_.box()->fold(offset + Vec3<double>(radius * sin(2.0 * M_PI * r1.x / A), r1.y,
-                                                                                 radius * cos(2.0 * M_PI * r1.x / A))));
-                species_.addAtom(zB_, species_.box()->fold(offset + Vec3<double>(radius * sin(2.0 * M_PI * r2.x / A), r2.y,
-                                                                                 radius * cos(2.0 * M_PI * r2.x / A))));
+                species_.addAtom(zA_, species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y,
+                                                                                 radius_ * cos(2.0 * M_PI * r1.x / A_))));
+                species_.addAtom(zB_, species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y,
+                                                                                 radius_ * cos(2.0 * M_PI * r2.x / A_))));
             }
             else
             {
@@ -146,19 +151,6 @@ void CreateNanotubeSpeciesDialog::regenerate()
         species_.recalculateIntermolecularTerms(1.1);
         species_.removeBox();
     }
-
-    // Update the sheet properties
-    ui_.ALabel->setText(QString("%1 \u212B").arg(A, 0, 'f', 3));
-    ui_.CLabel->setText(QString("%1 \u212B").arg(c, 0, 'f', 3));
-    ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha * DEGRAD, 0, 'f', 3));
-    ui_.HLabel->setText(QString("%1\u00B0").arg(H));
-    ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius, 0, 'f', 3));
-
-    ui_.CellALabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().x, 0, 'f', 3));
-    ui_.CellBLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().y, 0, 'f', 3));
-    ui_.CellCLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().z, 0, 'f', 3));
-
-    updateWidgets();
 }
 
 /*
@@ -169,6 +161,18 @@ void CreateNanotubeSpeciesDialog::regenerate()
 void CreateNanotubeSpeciesDialog::updateWidgets()
 {
     Locker updateLock(widgetsUpdating_);
+
+    // Sheet properties
+    ui_.ALabel->setText(QString("%1 \u212B").arg(A_, 0, 'f', 3));
+    ui_.CLabel->setText(QString("%1 \u212B").arg(c_, 0, 'f', 3));
+    ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha_ * DEGRAD, 0, 'f', 3));
+    ui_.HLabel->setText(QString("%1\u00B0").arg(H_));
+    ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius_, 0, 'f', 3));
+
+    // Final cell properties
+    ui_.CellALabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().x, 0, 'f', 3));
+    ui_.CellBLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().y, 0, 'f', 3));
+    ui_.CellCLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().z, 0, 'f', 3));
 
     // Configuration information
     const auto *box = species_.box();
@@ -195,10 +199,17 @@ void CreateNanotubeSpeciesDialog::on_NSpin_valueChanged(int value)
     // MSpin's upper value is our current value
     ui_.MSpin->setMaximum(value);
 
+    calculateParameters();
     regenerate();
+    updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_MSpin_valueChanged(int value) { regenerate(); }
+void CreateNanotubeSpeciesDialog::on_MSpin_valueChanged(int value)
+{
+    calculateParameters();
+    regenerate();
+    updateWidgets();
+}
 
 void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
 {
@@ -208,6 +219,7 @@ void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
     zA_ = Z;
 
     regenerate();
+    updateWidgets();
 }
 
 void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
@@ -218,34 +230,29 @@ void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
     zB_ = Z;
 
     regenerate();
+    updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value) { regenerate(); }
-
-void CreateNanotubeSpeciesDialog::on_CFactorSpin_valueChanged(double value)
+void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value)
 {
-    // Determine whether the cFactor is whole
-    double cInt;
-    double cFrac = std::modf(value, &cInt);
-    auto canBePeriodic = cFrac < 0.001 || cFrac > 0.999;
-
-    // Update the output controls to reflect the choice of cFactor
-    Locker refreshLock(widgetsUpdating_);
-    ui_.PeriodicRadio->setEnabled(canBePeriodic);
-    if (!canBePeriodic && ui_.PeriodicRadio->isChecked())
-        ui_.NonPeriodicRadio->setChecked(true);
-    refreshLock.unlock();
-
+    calculateParameters();
     regenerate();
-};
+    updateWidgets();
+}
 
-void CreateNanotubeSpeciesDialog::on_RollUpCheck_clicked(bool checked) { regenerate(); }
+void CreateNanotubeSpeciesDialog::on_RollUpCheck_clicked(bool checked)
+{
+    regenerate();
+    updateWidgets();
+}
 
 void CreateNanotubeSpeciesDialog::on_PeriodicRadio_clicked(bool checked)
 {
     if (widgetsUpdating_)
         return;
+
     regenerate();
+    updateWidgets();
 }
 
 void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
@@ -253,6 +260,7 @@ void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
     if (widgetsUpdating_)
         return;
     regenerate();
+    updateWidgets();
 }
 
 void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
@@ -260,6 +268,7 @@ void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
     if (widgetsUpdating_)
         return;
     regenerate();
+    updateWidgets();
 }
 
 void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -54,49 +54,48 @@ void CreateNanotubeSpeciesDialog::regenerate()
     const auto r = ui_.BondLengthSpin->value();
     const auto nAxialRings = ui_.AxialRingLengthSpin->value();
 
-    const auto radialStep = (M_PI * 2.0) / ui_.RadialRingSizeSpin->value();
-    const auto radialHalfStep = radialStep * 0.5;
-    const auto ringRadialWidth = r * cos(30.0 / DEGRAD) * 2.0;
-    const auto ringAxialLayerStep = r * (cos(60.0 / DEGRAD) + 1.0);
-    const auto tubeRadius = ringRadialWidth / (2.0 * sin(M_PI / ui_.RadialRingSizeSpin->value()));
+    const auto a0 = 2.46;
+    const auto a1 = Vec3<double>(a0, 0.0, 0.0);
+    const auto a2 = Vec3<double>(a0*sin(M_PI/6.0), a0*cos(M_PI/6.0), 0.0);
+    const auto a3 = a2 - a1;
+    const auto n = 5;
+    const auto m = 2;
 
-    /*
-     *      B1--A2
-     *     /      \
-     *    A1       B2...
-     *     \      /
-     *      B1--A2
-     *
-     * Build up the nanotube in layers
-     */
-    auto radialOffset = 0.0;
-    for (auto axial = 0; axial < nAxialRings; ++axial)
+    auto vecA = a1 * n + a2 * m;
+    auto A = a0 * sqrt(n*n + m*m + n*m);
+    auto alpha = atan((sqrt(3.0) * m) / (2 * n + m));
+    const auto radius = A / (2.0 * M_PI);
+    std::cout << std::format("Helicity (alpha) = {}\n", alpha);
+
+    // TEST
+    auto M = 10;
+    auto nc = -((n + 2*m) / M);
+    auto mc = ((2*n + m) / M);
+
+    auto c = sqrt(3.0) * A / M;
+
+    std::cout << std::format("Rectangle dims are A = {} c = {}\n", A, c);
+
+    for (auto j = 0; j <= n + m -1; ++j)
     {
-        auto z = axial * ringAxialLayerStep;
-        // Create an AB layer
-        plotLayer(z, tubeRadius, radialStep, radialOffset, zA_, zB_);
-        radialOffset += radialHalfStep;
+        // Primary helix atoms
+        auto x1j = j * a0 * cos(alpha);
+        auto y1j = -j * a0 * sin(alpha);
+
+        // Secondary helix atoms
+        auto x2j = x1j - (a0 / sqrt(3.0)) * cos(M_PI/6.0 - alpha);
+        auto y2j = y1j - (a0 / sqrt(3.0)) * sin(M_PI/6.0-alpha);
+
+        for (auto i = 0; i < m; ++i)
+        {
+            auto delta = Vec3<double>(-i * a0 * sin(M_PI/6.0 - alpha), i * a0 * cos(M_PI/6.0 - alpha), 0.0);
+            auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
+            auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
+            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x / A)});
+            species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 * M_PI * r2.x / A)});
+        }
     }
 
-    // Terminate / make periodic
-    if (ui_.TypeCombo->currentIndex() == 0)
-    {
-        // Remove any existing unit cell
-        species_.removeBox();
-
-        // Add final terminating layer
-        plotLayer(nAxialRings * ringAxialLayerStep, tubeRadius, radialStep, nAxialRings * radialHalfStep, zA_, zB_);
-
-        // Add hydrogen termination layers
-        plotLayer(-1.0, tubeRadius, radialStep, 0.0, Elements::H, Elements::Unknown);
-        plotLayer(nAxialRings * ringAxialLayerStep + 1.0, tubeRadius, radialStep, nAxialRings * radialHalfStep,
-                  Elements::Unknown, Elements::H);
-    }
-    else
-    {
-        // Add on a suitable periodic box
-        species_.createBox({tubeRadius * 2.0 + 2.0, tubeRadius * 2.0 + 2.0, nAxialRings * ringAxialLayerStep}, {90, 90, 90});
-    }
 
     // Finalise the species
     species_.recalculateIntermolecularTerms(1.1);

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -74,6 +74,73 @@ void CreateNanotubeSpeciesDialog::calculateParameters()
     H_ = round(c_ / dy_);
 }
 
+// Find dangling atoms, defined as those which have two bonds spanning PBC of the box
+std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateNanotubeSpeciesDialog::findDanglingAtoms(double localCutoff)
+{
+    std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> atoms;
+    for (auto &i : species_.atoms())
+    {
+        // Find all bound partners which are across the unit cell
+        std::vector<SpeciesAtom *> pbcJ;
+        for (auto &b : i.bonds())
+        {
+            auto *j = b.get().partner(&i);
+            if ((i.r() - j->r()).magnitude() > localCutoff)
+                pbcJ.push_back(j);
+        }
+
+        if (pbcJ.size() == 2)
+            atoms[&i] = pbcJ;
+    }
+
+    return atoms;
+}
+
+// Get vector of atom keys from atom/neighbour map, sorted by position along indicated direction
+std::vector<SpeciesAtom *>
+CreateNanotubeSpeciesDialog::getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const
+{
+    std::vector<SpeciesAtom *> sorted;
+    for (auto &&[i, _] : atoms)
+        sorted.push_back(i);
+
+    std::sort(sorted.begin(), sorted.end(),
+              [dir](const SpeciesAtom *a, const SpeciesAtom *b) { return a->r().get(dir) < b->r().get(dir); });
+
+    return sorted;
+}
+
+// Recursive branch function
+void CreateNanotubeSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac,
+                                               std::vector<SpeciesAtom *> &branch, double localCutoff) const
+{
+    // Get PBC and non-PBC (local) bond partners for this atom and see what type of atom we have...
+    std::vector<SpeciesAtom *> pbcJ, localJ;
+    for (auto &b : i->bonds())
+    {
+        auto j = b.get().partner(i);
+        if ((i->r() - j->r()).magnitude() > localCutoff)
+            pbcJ.push_back(j);
+        else if (std::find(branch.begin(), branch.end(), j) == branch.end())
+            localJ.push_back(j);
+    }
+
+    // If all atoms are local this is a completely internally-bound atom, and we are done here.
+    if (pbcJ.size() == 0)
+        return;
+
+    // Add ourselves to the branch
+    branch.push_back(i);
+
+    // For all pbc atoms, increment the fractional direction
+    for (auto j : pbcJ)
+        vFrac += (box->getFractional(j->r()) - box->getFractional(i->r()));
+
+    // For local atoms, recurse into them if we haven't visited them already
+    for (auto j : localJ)
+        extendBranch(j, box, vFrac, branch, localCutoff);
+}
+
 // Regenerate species
 void CreateNanotubeSpeciesDialog::regenerate()
 {
@@ -95,7 +162,6 @@ void CreateNanotubeSpeciesDialog::regenerate()
         cellLengths = {A_, c_ * cFactor, sheetZ_};
         offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
     }
-    cellLengths.print();
     species_.createBox(cellLengths, {90, 90, 90});
 
     /*
@@ -128,10 +194,10 @@ void CreateNanotubeSpeciesDialog::regenerate()
             {
                 // Wrap the X coordinate (== real position on circumference) onto a tube of radius 'radius', applying the
                 // offset we set earlier when creating the periodic box so as to put it in the centre of XZ.
-                p1 = species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y,
-                                                                                 radius_ * cos(2.0 * M_PI * r1.x / A_)));
-                p2 = species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y,
-                                                                                 radius_ * cos(2.0 * M_PI * r2.x / A_)));
+                p1 = species_.box()->fold(
+                    offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y, radius_ * cos(2.0 * M_PI * r1.x / A_)));
+                p2 = species_.box()->fold(
+                    offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y, radius_ * cos(2.0 * M_PI * r2.x / A_)));
             }
             else
             {
@@ -147,7 +213,8 @@ void CreateNanotubeSpeciesDialog::regenerate()
                     add1 = (p1 - existing.r()).magnitude() > 0.1;
                 if (add2)
                     add2 = (p2 - existing.r()).magnitude() > 0.1;
-                if (!add1 && !add2) break;
+                if (!add1 && !add2)
+                    break;
             }
             if (add1)
                 species_.addAtom(zA_, p1);
@@ -167,110 +234,74 @@ void CreateNanotubeSpeciesDialog::regenerate()
 
         if (ui_.TidyEndsCheck->isChecked())
         {
-            // For any atom whose y coordinate is less than half the box B, or any x coordinate less than half the box A,
-            // translate it to the opposite side.
-
-            // // Pass over X
-            // for (auto &i : species_.atoms())
-            //     if (i.nBonds() == 1 && i.r().x < cellLengths.x*0.5)
-            //     {
-            //         i.setCoordinates(i.r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
-            //         // Check bound neighbour - if it has exactly two bonds then we need to move it as well
-            //         auto j =i.bonds().front().get().partner(&i);
-            //         if (j->nBonds() == 2)
-            //             j->setCoordinates(j->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
-            //     }
-            // species_.recalculateIntermolecularTerms(1.1);
-            //
-            // // Pass over Y
-            // for (auto &i : species_.atoms())
-            //     if (i.nBonds() == 1 && i.r().y < cellLengths.y*0.5)
-            //     {
-            //         i.setCoordinates(i.r() + Vec3<double>(0.0, cellLengths.y, 0.0));
-            //         // Check bound neighbour - if it has exactly two bonds then we need to move it as well
-            //         auto j =i.bonds().front().get().partner(&i);
-            //         if (j->nBonds() == 2)
-            //             j->setCoordinates(j->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
-            //     }
-
             // Find all atoms which have two bonds spanning PBC of the box
-            std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> atoms;
-            for (auto &i : species_.atoms())
+            auto localCutoff = ui_.BondLengthSpin->value() * 1.01;
+            const auto atoms = findDanglingAtoms(localCutoff);
+            auto sorted = getSorted(atoms, 1);
+
+            // Pass 1 - Move all atoms along the PBC bond vectors
+            while (!sorted.empty())
             {
-                // Find all bound partners which are across the unit cell
-                std::vector<SpeciesAtom *> pbcJ;
-                for (auto &b : i.bonds())
-                {
-                    auto *j = b.get().partner(&i);
-                    if ((i.r() - j->r()).magnitude() < 1.0)
-                        std::cout << std::format("!!! Atoms {} ({}) and {} ({}) overlap\n", i.index(), Elements::name(i.Z()), j->index(), Elements::name(j->Z()));
-                    if ((i.r() - j->r()).magnitude() > 1.44)
-                        pbcJ.push_back(j);
-                }
+                auto i = sorted.back();
+                auto &pbcJ = atoms.at(i);
 
-                if (pbcJ.size() == 2)
-                    atoms[&i] = pbcJ;
-            }
-            std::cout << std::format("There are {} atoms which have two periodic bonds.\n", atoms.size());
-
-            while (atoms.size() > 0)
-            {
-                auto &&[i, pbcJ] = *atoms.begin();
-
-                std::cout << std::format("-> Atom {} is at {},{},{}\n", i->index(), i->r().x, i->r().y, i->r().z);
                 // Determine the fractional average vector to the pbc atoms
                 Vec3<double> vFrac;
                 for (auto j : pbcJ)
-                    vFrac += species_.box()->getFractional(j->r()) -  species_.box()->getFractional(i->r());
-                vFrac.print();
+                    vFrac += species_.box()->getFractional(j->r()) - species_.box()->getFractional(i->r());
 
                 // Make this a sensible translation vector - divide elements by their abs value to make unitary and round
                 for (auto n = 0; n < 3; ++n)
                     vFrac[n] = fabs(vFrac[n]) < 0.5 ? 0.0 : round(vFrac[n] / fabs(vFrac[n]));
-                // vFrac.print();
                 vFrac.multiply(cellLengths);
-                // vFrac.print();
 
                 // Translate the atom
                 i->setCoordinates(i->r() + vFrac);
-                std::cout << std::format("-> new i.r() =  {},{},{}\n", i->r().x, i->r().y, i->r().z);
 
                 // Remove this atom from the vector, along with any that were in its pbc neighbour lists
                 for (auto j : pbcJ)
-                    if (atoms.contains(j))
-                        atoms.erase(j);
+                {
+                    auto it = std::ranges::find(sorted, j);
+                    if (it != sorted.end())
+                        sorted.erase(it);
+                }
 
-                atoms.erase(i);
-                //
-                // // Skip this atom
-                // if (!roll && i->r().x < cellLengths.x * 0.5)
-                // {
-                //     i->setCoordinates(i->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
-                //     // Check bound neighbour - if it has exactly two bonds then we need to move it as well
-                //     auto j = i->bonds().front().get().partner(i);
-                //     if (j->nBonds() == 2)
-                //         j->setCoordinates(j->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
-                // }
-                // else if (i->r().y < cellLengths.y * 0.5)
-                // {
-                //     i->setCoordinates(i->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
-                //     // Check bound neighbour - if it has exactly two bonds then we need to move it as well
-                //     auto j = i->bonds().front().get().partner(i);
-                //     if (j->nBonds() == 2)
-                //         j->setCoordinates(j->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
-                // }
-                //
-                // // Recalculate bonding
-                // species_.recalculateIntermolecularTerms(1.1);
-                //
-                // // Remove any atoms in the vector which now have more than one bond
-                // atoms.erase(std::remove_if(atoms.begin(), atoms.end(), [](const auto *j) { return j->nBonds() > 1; }),
-                //             atoms.end());
-                std::cout << std::format("There are now {} atoms to process.\n", atoms.size());
+                sorted.pop_back();
             }
+
+            // Pass 2 - We may have generated some "branches" inadvertently, so rebond, find any singly-bound atoms and check
+            auto branchEnd = findDanglingAtoms(localCutoff);
+            std::vector<int> indicesToRemove;
+            for (auto &&[i, _] : branchEnd)
+            {
+                // For this atom we will step along bonds until we find an atom with three non-PBC bonds - this marks a fully
+                // "internal" atom which does not need (and should not be) translated, and the end of the linear branch we're
+                // interested in. Along the way we maintain a fractional translation vector based on all PBC bonds we encounter
+                // which will inform the direction we might want to move the branch. Or we could just remove it.
+
+                Vec3<double> vFrac;
+                std::vector<SpeciesAtom *> branch;
+                extendBranch(i, species_.box(), vFrac, branch, localCutoff);
+                auto maxEl = vFrac.absMaxElement();
+                Vec3<double> tVec;
+                tVec.set(maxEl, round(vFrac.get(maxEl) / fabs(vFrac.get(maxEl))));
+                tVec.multiply(cellLengths);
+                ;
+
+                // Translate or remove the branch?
+                for (auto j : branch)
+                    if (ui_.RemoveBranchesCheck->isChecked())
+                        indicesToRemove.push_back(j->index());
+                    else
+                        j->setCoordinates(j->r() + tVec);
+            }
+
+            // Final tidy-up - remove any branch atoms if required
+            species_.removeAtoms(indicesToRemove);
         }
 
         species_.removeBox();
+        species_.recalculateIntermolecularTerms(1.1);
     }
     else
     {
@@ -388,6 +419,14 @@ void CreateNanotubeSpeciesDialog::on_PeriodicRadio_clicked(bool checked)
     updateWidgets();
 }
 
+void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
+{
+    if (widgetsUpdating_)
+        return;
+    regenerate();
+    updateWidgets();
+}
+
 void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
 {
     if (widgetsUpdating_)
@@ -402,10 +441,8 @@ void CreateNanotubeSpeciesDialog::on_TidyEndsCheck_clicked(bool checked)
     updateWidgets();
 }
 
-void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
+void CreateNanotubeSpeciesDialog::on_RemoveBranchesCheck_clicked(bool checked)
 {
-    if (widgetsUpdating_)
-        return;
     regenerate();
     updateWidgets();
 }

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -42,6 +42,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
 
     const auto root3 = sqrt(3.0);
     const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
+    const auto roll = ui_.RollUpCheck->isChecked();
 
     // Get n,m values for tube
     const auto n = ui_.NSpin->value();
@@ -68,7 +69,17 @@ void CreateNanotubeSpeciesDialog::regenerate()
 
     // The radius of the tube is then the circumference (== A) divided by 2PI
     const auto radius = A / (2.0 * M_PI);
-    std::cout << std::format("Helicity (alpha) = {} rad, {} degrees\n", alpha, alpha * DEGRAD);
+
+    // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
+    auto offset = Vec3<double>();
+    if (roll)
+    {
+        // Create some extra space and set an offset so the tube is central in XZ
+        species_.createBox({radius * 3, c, radius * 3}, {90, 90, 90});
+        offset = Vec3<double>(radius * 1.5, 0.0, radius * 1.5);
+    }
+    else
+        species_.createBox({A, c, 3.0}, {90, 90, 90});
 
     /*
      * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
@@ -78,7 +89,6 @@ void CreateNanotubeSpeciesDialog::regenerate()
      */
     auto dy = va2.y / cos(alpha);
     auto H = round(c / dy);
-    std::cout << std::format("Repeats H = {}, T/a0CosAlpha = {}, dy = {}\n", H, c / dy, dy);
     for (auto j = 0; j <= n + m - 1; ++j)
     {
         // Primary helix atoms (equation 7)
@@ -89,9 +99,6 @@ void CreateNanotubeSpeciesDialog::regenerate()
         auto x2j = x1j - (a0 / sqrt(3.0)) * cos(oneSixthPi - alpha);
         auto y2j = y1j - (a0 / sqrt(3.0)) * sin(oneSixthPi - alpha);
 
-        // Always create a unit cell for the system
-        species_.createBox({A, c, 3.0}, {90, 90, 90});
-
         // Create H copies of the helix pairs
         for (auto i = 0; i < H; ++i)
         {
@@ -100,21 +107,32 @@ void CreateNanotubeSpeciesDialog::regenerate()
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
 
-            // Fold into repeat rectangle A.c
-            r1 = fold(A, c, r1);
-            r2 = fold(A, c, r2);
-
-            species_.addAtom(zA_, species_.box()->fold(r1));
-            species_.addAtom(zB_, species_.box()->fold(r2));
-
-            //            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x
-            //            / A)}); species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 *
-            //            M_PI * r2.x / A)});
+            if (roll)
+            {
+                // Wrap the X coordinate (== real position on circumference) onto a tube of radius 'radius', applying the
+                // offset we set earlier when creating the periodic box so as to put it in the centre of XZ.
+                species_.addAtom(zA_, species_.box()->fold(offset + Vec3<double>(radius * sin(2.0 * M_PI * r1.x / A), r1.y,
+                                                                                 radius * cos(2.0 * M_PI * r1.x / A))));
+                species_.addAtom(zB_, species_.box()->fold(offset + Vec3<double>(radius * sin(2.0 * M_PI * r2.x / A), r2.y,
+                                                                                 radius * cos(2.0 * M_PI * r2.x / A))));
+            }
+            else
+            {
+                species_.addAtom(zA_, species_.box()->fold(r1));
+                species_.addAtom(zB_, species_.box()->fold(r2));
+            }
         }
     }
 
     // Finalise the species
     species_.recalculateIntermolecularTerms(1.1);
+
+    // Update the sheet properties
+    ui_.ALabel->setText(QString("%1 \u212B").arg(A, 0, 'f', 3));
+    ui_.CLabel->setText(QString("%1 \u212B").arg(c, 0, 'f', 3));
+    ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha * DEGRAD, 0, 'f', 3));
+    ui_.HLabel->setText(QString("%1\u00B0").arg(H));
+    ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius, 0, 'f', 3));
 
     updateWidgets();
 }
@@ -177,6 +195,10 @@ void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
 
     regenerate();
 }
+
+void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value) { regenerate(); }
+
+void CreateNanotubeSpeciesDialog::on_RollCheck_clicked(bool checked) { regenerate(); }
 
 void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
 {

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -80,18 +80,19 @@ void CreateNanotubeSpeciesDialog::regenerate()
     species_.clear();
 
     const auto roll = ui_.RollUpCheck->isChecked();
+    const auto cFactor = ui_.CFactorSpin->value();
 
     // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
     auto offset = Vec3<double>();
     if (roll)
     {
         // Create some extra space and set an offset so the tube is central in XZ
-        species_.createBox({radius_ * 3, c_, radius_ * 3}, {90, 90, 90});
+        species_.createBox({radius_ * 3, c_ * cFactor, radius_ * 3}, {90, 90, 90});
         offset = Vec3<double>(radius_ * 1.5, 0.0, radius_ * 1.5);
     }
     else
     {
-        species_.createBox({A_, c_, sheetZ_}, {90, 90, 90});
+        species_.createBox({A_, c_ * cFactor, sheetZ_}, {90, 90, 90});
         offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
     }
 
@@ -111,8 +112,8 @@ void CreateNanotubeSpeciesDialog::regenerate()
         auto x2j = x1j - (a0_ / sqrt(3.0)) * cos(oneSixthPi - alpha_);
         auto y2j = y1j - (a0_ / sqrt(3.0)) * sin(oneSixthPi - alpha_);
 
-        // Create H copies of the helix pairs
-        for (auto i = 0; i < H_; ++i)
+        // Create H copies of the helix pairs, multiplied by the extension factor along C
+        for (auto i = 0; i < H_ * cFactor; ++i)
         {
             // Generate translation vector for this copy (equation 9)
             auto delta = Vec3<double>(-i * a0_ * sin(oneSixthPi - alpha_), i * a0_ * cos(oneSixthPi - alpha_), 0.0);
@@ -164,9 +165,9 @@ void CreateNanotubeSpeciesDialog::updateWidgets()
 
     // Sheet properties
     ui_.ALabel->setText(QString("%1 \u212B").arg(A_, 0, 'f', 3));
-    ui_.CLabel->setText(QString("%1 \u212B").arg(c_, 0, 'f', 3));
+    ui_.CLabel->setText(QString("%1 (%2) \u212B").arg(c_, 0, 'f', 3).arg(c_ * ui_.CFactorSpin->value(), 0, 'f', 3));
     ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha_ * DEGRAD, 0, 'f', 3));
-    ui_.HLabel->setText(QString("%1\u00B0").arg(H_));
+    ui_.HLabel->setText(QString("%1 (%2)").arg(H_).arg(H_ * ui_.CFactorSpin->value()));
     ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius_, 0, 'f', 3));
 
     // Final cell properties
@@ -240,6 +241,13 @@ void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value)
     updateWidgets();
 }
 
+void CreateNanotubeSpeciesDialog::on_CFactorSpin_valueChanged(int value)
+{
+    calculateParameters();
+    regenerate();
+    updateWidgets();
+}
+
 void CreateNanotubeSpeciesDialog::on_RollUpCheck_clicked(bool checked)
 {
     regenerate();
@@ -281,24 +289,3 @@ void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
 }
 
 void CreateNanotubeSpeciesDialog::on_CancelButton_clicked(bool checked) { reject(); }
-
-void CreateNanotubeSpeciesDialog::on_TypeCombo_currentIndexChanged(int index)
-{
-    Locker refreshLock(widgetsUpdating_);
-
-    //    // Limit tube axial length depending on mode requested
-    //    if (index == 0)
-    //    {
-    //        ui_.AxialRingLengthSpin->setSingleStep(1);
-    //        ui_.AxialRingLengthSpin->setMinimum(1);
-    //    }
-    //    else
-    //    {
-    //        ui_.AxialRingLengthSpin->setSingleStep(2);
-    //        ui_.AxialRingLengthSpin->setMinimum(2);
-    //    }
-
-    refreshLock.unlock();
-
-    regenerate();
-}

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -43,6 +43,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
     const auto root3 = sqrt(3.0);
     const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
     const auto roll = ui_.RollUpCheck->isChecked();
+    const auto sheetZ = 10.0; // Default size of unit cell for sheet
 
     // Get n,m values for tube
     const auto n = ui_.NSpin->value();
@@ -70,16 +71,22 @@ void CreateNanotubeSpeciesDialog::regenerate()
     // The radius of the tube is then the circumference (== A) divided by 2PI
     const auto radius = A / (2.0 * M_PI);
 
+    // Scale the Y dimension of the system
+    auto cFactor = ui_.CFactorSpin->value();
+
     // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
     auto offset = Vec3<double>();
     if (roll)
     {
         // Create some extra space and set an offset so the tube is central in XZ
-        species_.createBox({radius * 3, c, radius * 3}, {90, 90, 90});
+        species_.createBox({radius * 3, c * cFactor, radius * 3}, {90, 90, 90});
         offset = Vec3<double>(radius * 1.5, 0.0, radius * 1.5);
     }
     else
-        species_.createBox({A, c, 3.0}, {90, 90, 90});
+    {
+        species_.createBox({A, c * cFactor, sheetZ}, {90, 90, 90});
+        offset = Vec3<double>(0.0, 0.0, sheetZ * 0.5);
+    }
 
     /*
      * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
@@ -88,7 +95,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
      * required helix copies 'H' is calculated from c and the rotated y component of va2.
      */
     auto dy = va2.y / cos(alpha);
-    auto H = round(c / dy);
+    auto H = round(c * cFactor / dy);
     for (auto j = 0; j <= n + m - 1; ++j)
     {
         // Primary helix atoms (equation 7)
@@ -125,7 +132,20 @@ void CreateNanotubeSpeciesDialog::regenerate()
     }
 
     // Finalise the species
-    species_.recalculateIntermolecularTerms(1.1);
+    if (ui_.PeriodicRadio->isChecked())
+    {
+        species_.recalculateIntermolecularTerms(1.1);
+    }
+    else if (ui_.NonPeriodicRadio->isChecked())
+    {
+        species_.removeBox();
+        species_.recalculateIntermolecularTerms(1.1);
+    }
+    else
+    {
+        species_.recalculateIntermolecularTerms(1.1);
+        species_.removeBox();
+    }
 
     // Update the sheet properties
     ui_.ALabel->setText(QString("%1 \u212B").arg(A, 0, 'f', 3));
@@ -133,6 +153,10 @@ void CreateNanotubeSpeciesDialog::regenerate()
     ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha * DEGRAD, 0, 'f', 3));
     ui_.HLabel->setText(QString("%1\u00B0").arg(H));
     ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius, 0, 'f', 3));
+
+    ui_.CellALabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().x, 0, 'f', 3));
+    ui_.CellBLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().y, 0, 'f', 3));
+    ui_.CellCLabel->setText(QString("%1 \u212B").arg(species_.box()->axisLengths().z, 0, 'f', 3));
 
     updateWidgets();
 }
@@ -198,7 +222,45 @@ void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
 
 void CreateNanotubeSpeciesDialog::on_BondLengthSpin_valueChanged(double value) { regenerate(); }
 
-void CreateNanotubeSpeciesDialog::on_RollCheck_clicked(bool checked) { regenerate(); }
+void CreateNanotubeSpeciesDialog::on_CFactorSpin_valueChanged(double value)
+{
+    // Determine whether the cFactor is whole
+    double cInt;
+    double cFrac = std::modf(value, &cInt);
+    auto canBePeriodic = cFrac < 0.001 || cFrac > 0.999;
+
+    // Update the output controls to reflect the choice of cFactor
+    Locker refreshLock(widgetsUpdating_);
+    ui_.PeriodicRadio->setEnabled(canBePeriodic);
+    if (!canBePeriodic && ui_.PeriodicRadio->isChecked())
+        ui_.NonPeriodicRadio->setChecked(true);
+    refreshLock.unlock();
+
+    regenerate();
+};
+
+void CreateNanotubeSpeciesDialog::on_RollUpCheck_clicked(bool checked) { regenerate(); }
+
+void CreateNanotubeSpeciesDialog::on_PeriodicRadio_clicked(bool checked)
+{
+    if (widgetsUpdating_)
+        return;
+    regenerate();
+}
+
+void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
+{
+    if (widgetsUpdating_)
+        return;
+    regenerate();
+}
+
+void CreateNanotubeSpeciesDialog::on_PseudoPeriodicRadio_clicked(bool checked)
+{
+    if (widgetsUpdating_)
+        return;
+    regenerate();
+}
 
 void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
 {

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -19,6 +19,7 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
 
     ui_.ElementAButton->setText(QString::fromStdString(std::string(Elements::symbol(zA_))));
     ui_.ElementBButton->setText(QString::fromStdString(std::string(Elements::symbol(zB_))));
+    ui_.TerminateElementButton->setText(QString::fromStdString(std::string(Elements::symbol(zTerminate_))));
 
     ui_.MSpin->setMaximum(ui_.NSpin->value());
 
@@ -302,6 +303,29 @@ void CreateNanotubeSpeciesDialog::regenerate()
 
         species_.removeBox();
         species_.recalculateIntermolecularTerms(1.1);
+
+        // Terminate?
+        if (ui_.TerminateCheck->isChecked())
+        {
+            auto rT = ui_.TerminateBondLengthSpin->value();
+            auto excludeA = !ui_.TerminateACheck->isChecked();
+            auto excludeB = !ui_.TerminateBCheck->isChecked();
+
+            // Any atom with just two bonds can be terminated
+            for (auto &i : species_.atoms())
+            {
+                if ((i.nBonds() != 2) || (excludeA && i.Z() == zA_) || (excludeB && i.Z() == zB_))
+                    continue;
+
+                // Get average bond vector
+                auto v = (i.r() - i.bond(0).partner(&i)->r()) + (i.r() - i.bond(1).partner(&i)->r());
+                v.normalise();
+
+                species_.addAtom(zTerminate_, i.r() + v * rT);
+            }
+
+            species_.recalculateIntermolecularTerms(1.1);
+        }
     }
     else
     {
@@ -374,6 +398,7 @@ void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
     if (Z == Elements::Unknown)
         return;
     zA_ = Z;
+    ui_.ElementAButton->setText(QString::fromStdString(std::string(Elements::symbol(zA_))));
 
     regenerate();
     updateWidgets();
@@ -385,6 +410,7 @@ void CreateNanotubeSpeciesDialog::on_ElementBButton_clicked(bool checked)
     if (Z == Elements::Unknown)
         return;
     zB_ = Z;
+    ui_.ElementBButton->setText(QString::fromStdString(std::string(Elements::symbol(zB_))));
 
     regenerate();
     updateWidgets();
@@ -442,6 +468,42 @@ void CreateNanotubeSpeciesDialog::on_TidyEndsCheck_clicked(bool checked)
 }
 
 void CreateNanotubeSpeciesDialog::on_RemoveBranchesCheck_clicked(bool checked)
+{
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TerminateCheck_clicked(bool checked)
+{
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TerminateElementButton_clicked(bool checked)
+{
+    auto Z = selectElementDialog_.selectElement(zB_);
+    if (Z == Elements::Unknown)
+        return;
+    zTerminate_ = Z;
+    ui_.TerminateElementButton->setText(QString::fromStdString(std::string(Elements::symbol(zTerminate_))));
+
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TerminateBondLengthSpin_valueChanged(double value)
+{
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TerminateACheck_clicked(bool checked)
+{
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TerminateBCheck_clicked(bool checked)
 {
     regenerate();
     updateWidgets();

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -16,6 +16,8 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
     ui_.ElementAButton->setText(QString::fromStdString(std::string(Elements::symbol(zA_))));
     ui_.ElementBButton->setText(QString::fromStdString(std::string(Elements::symbol(zB_))));
 
+    ui_.MSpin->setMaximum(ui_.NSpin->value());
+
     // Set display configuration
     ui_.StructureViewer->setSpecies(&species_);
 
@@ -33,69 +35,84 @@ void CreateNanotubeSpeciesDialog::regenerate()
 {
     species_.clear();
 
-    const auto r = ui_.BondLengthSpin->value();
+    /*
+     * Procedure based on "Determination of the chiral indices (n,m) of carbon nanotubes by electron diffraction",
+     * Lu-Chan Qin, Phys. Chem. Chem. Phys. 2007, *9*, 31-48. https://doi.org/10.1039/B614121H
+     */
 
-    const auto a0 = 2.46;
-    const auto a1 = Vec3<double>(a0, 0.0, 0.0);
-    const auto a2 = Vec3<double>(a0*sin(M_PI/6.0), a0*cos(M_PI/6.0), 0.0);
+    const auto root3 = sqrt(3.0);
+    const auto oneSixthPi = M_PI / 6.0; // == 30 degrees
+
+    // Get n,m values for tube
     const auto n = ui_.NSpin->value();
-    a2.print();
     const auto m = ui_.MSpin->value();
 
-    auto A = a0 * sqrt(n*n + m*m + n*m);
-    auto alpha = atan((sqrt(3.0) * m) / (2 * n + m));
-    const auto radius = A / (2.0 * M_PI);
-    std::cout << std::format("Helicity (alpha) = {} rad, {} degrees\n", alpha, alpha*DEGRAD);
+    // Determine a0, the principal unit length of the structure, from the specified bond distance. See Figure 1a, noting that
+    // a1 == a2 == a0.
+    const auto r = ui_.BondLengthSpin->value();
+    const auto a0 = r * root3;
 
-    // TEST
+    // Set principal vectors for reference
+    const auto va1 = Vec3<double>(a0, 0.0, 0.0);
+    const auto va2 = Vec3<double>(a0 * sin(oneSixthPi), a0 * cos(oneSixthPi), 0.0);
+
+    // Calculate repeat dimensions of the (n,m) sheet
+    // -- A is magnitude of vecA (equation 1) and represents our X dimension
+    auto A = a0 * sqrt(n * n + m * m + n * m);
+    // -- c is the magnitude of the vector perpendicular to vecA, along the tube axis, and represents our Y dimension
     auto M = std::gcd(2 * n + m, n + 2 * m);
-//    auto nc = -((n + 2*m) / M);
-//    auto mc = ((2*n + m) / M);
-//    auto vecAPerp = a1 * nc + a2 * mc;
-//    auto Aperp = a0 * sqrt(nc*nc + mc*mc + nc*mc);
-//
     auto c = sqrt(3.0) * A / M;
 
-    std::cout << std::format("Rectangle dims are A = {} c = {}\n", A, c);
-    auto d = std::gcd(n,m);
-    auto acc = a0 / sqrt(3.0);
-    auto T = 3.0 * acc * sqrt(n*n + n*m + m*m);
-    T /= (n-m)%(3*d) == 0 ? 3 * d : d;
-    std::cout << std::format("T = {}, acc = {}, d = {}\n", T, acc, d);
+    // Determine angle alpha, describing the tilt of the sheet away from va1 (equation 3)
+    auto alpha = atan((sqrt(3.0) * m) / (2 * n + m));
 
-    species_.createBox({A, T, 3.0}, {90,90,90});
+    // The radius of the tube is then the circumference (== A) divided by 2PI
+    const auto radius = A / (2.0 * M_PI);
+    std::cout << std::format("Helicity (alpha) = {} rad, {} degrees\n", alpha, alpha * DEGRAD);
 
-    // Generate the full coordinates
-    auto dy = a2.y/cos(alpha);
-    auto H = round(T / dy);
-    std::cout << std::format("Repeats H = {}, T/a0CosAlpha = {}, dy = {}\n", H, T / dy, dy);
-    for (auto j = 0; j <= n + m -1; ++j)
+    // TEST
+
+    //    std::cout << std::format("Rectangle dims are A = {} c = {}\n", A, c);
+    //    auto d = std::gcd(n,m);
+    //    auto acc = a0 / sqrt(3.0);
+    //    auto T = 3.0 * acc * sqrt(n*n + n*m + m*m);
+    //    T /= (n-m)%(3*d) == 0 ? 3 * d : d;
+    //    std::cout << std::format("T = {}, acc = {}, d = {}\n", T, acc, d);
+
+    species_.createBox({A, c, 3.0}, {90, 90, 90});
+
+    /*
+     * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
+     * Specifically, the innermost loop to translate the primary helix pair is originally stated to run over j (here 'i') from
+     * 0 - (m-1) inclusive, but this does not generate the correct number of copies for most cases. Instead, the number of
+     * required helix copies 'H' is calculated from c and the rotated y component of va2.
+     */
+    auto dy = va2.y / cos(alpha);
+    auto H = round(c / dy);
+    std::cout << std::format("Repeats H = {}, T/a0CosAlpha = {}, dy = {}\n", H, c / dy, dy);
+    for (auto j = 0; j <= n + m - 1; ++j)
     {
-        // Primary helix atoms
+        // Primary helix atoms (equation 7)
         auto x1j = j * a0 * cos(alpha);
         auto y1j = -j * a0 * sin(alpha);
 
-        // Secondary helix atoms
-        auto x2j = x1j - (a0 / sqrt(3.0)) * cos(M_PI/6.0 - alpha);
-        auto y2j = y1j - (a0 / sqrt(3.0)) * sin(M_PI/6.0-alpha);
+        // Secondary helix atoms (equation 8)
+        auto x2j = x1j - (a0 / sqrt(3.0)) * cos(oneSixthPi - alpha);
+        auto y2j = y1j - (a0 / sqrt(3.0)) * sin(oneSixthPi - alpha);
 
+        // Create H copies of the helix pairs (equation 9)
         for (auto i = 0; i < H; ++i)
         {
-            auto delta = Vec3<double>(-i * a0 * sin(M_PI/6.0 - alpha), i * a0 * cos(M_PI/6.0 - alpha), 0.0);
+            auto delta = Vec3<double>(-i * a0 * sin(oneSixthPi - alpha), i * a0 * cos(oneSixthPi - alpha), 0.0);
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
 
-            // Map negative y values back into their positive periodic image
-//            if (r1.y < 0.0)
-//                r1.y += T * d;
-//            if (r2.y < 0.0)
-//                r2.y += T * d;
+            species_.addAtom(Elements::C, species_.box()->fold(r1));
+            species_.addAtom(Elements::N, species_.box()->fold(r2));
 
-                species_.addAtom(Elements::C,     species_.box()->fold(r1));
-                species_.addAtom(Elements::N,     species_.box()->fold(r2));
-
-//            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x / A)});
-//            species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 * M_PI * r2.x / A)});
+            //            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x
+            //            / A)}); species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 *
+            //            M_PI * r2.x / A)});
         }
     }
 
@@ -179,17 +196,17 @@ void CreateNanotubeSpeciesDialog::on_TypeCombo_currentIndexChanged(int index)
 {
     Locker refreshLock(widgetsUpdating_);
 
-//    // Limit tube axial length depending on mode requested
-//    if (index == 0)
-//    {
-//        ui_.AxialRingLengthSpin->setSingleStep(1);
-//        ui_.AxialRingLengthSpin->setMinimum(1);
-//    }
-//    else
-//    {
-//        ui_.AxialRingLengthSpin->setSingleStep(2);
-//        ui_.AxialRingLengthSpin->setMinimum(2);
-//    }
+    //    // Limit tube axial length depending on mode requested
+    //    if (index == 0)
+    //    {
+    //        ui_.AxialRingLengthSpin->setSingleStep(1);
+    //        ui_.AxialRingLengthSpin->setMinimum(1);
+    //    }
+    //    else
+    //    {
+    //        ui_.AxialRingLengthSpin->setSingleStep(2);
+    //        ui_.AxialRingLengthSpin->setMinimum(2);
+    //    }
 
     refreshLock.unlock();
 

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -70,17 +70,6 @@ void CreateNanotubeSpeciesDialog::regenerate()
     const auto radius = A / (2.0 * M_PI);
     std::cout << std::format("Helicity (alpha) = {} rad, {} degrees\n", alpha, alpha * DEGRAD);
 
-    // TEST
-
-    //    std::cout << std::format("Rectangle dims are A = {} c = {}\n", A, c);
-    //    auto d = std::gcd(n,m);
-    //    auto acc = a0 / sqrt(3.0);
-    //    auto T = 3.0 * acc * sqrt(n*n + n*m + m*m);
-    //    T /= (n-m)%(3*d) == 0 ? 3 * d : d;
-    //    std::cout << std::format("T = {}, acc = {}, d = {}\n", T, acc, d);
-
-    species_.createBox({A, c, 3.0}, {90, 90, 90});
-
     /*
      * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
      * Specifically, the innermost loop to translate the primary helix pair is originally stated to run over j (here 'i') from
@@ -100,15 +89,23 @@ void CreateNanotubeSpeciesDialog::regenerate()
         auto x2j = x1j - (a0 / sqrt(3.0)) * cos(oneSixthPi - alpha);
         auto y2j = y1j - (a0 / sqrt(3.0)) * sin(oneSixthPi - alpha);
 
-        // Create H copies of the helix pairs (equation 9)
+        // Always create a unit cell for the system
+        species_.createBox({A, c, 3.0}, {90, 90, 90});
+
+        // Create H copies of the helix pairs
         for (auto i = 0; i < H; ++i)
         {
+            // Generate translation vector for this copy (equation 9)
             auto delta = Vec3<double>(-i * a0 * sin(oneSixthPi - alpha), i * a0 * cos(oneSixthPi - alpha), 0.0);
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
 
-            species_.addAtom(Elements::C, species_.box()->fold(r1));
-            species_.addAtom(Elements::N, species_.box()->fold(r2));
+            // Fold into repeat rectangle A.c
+            r1 = fold(A, c, r1);
+            r2 = fold(A, c, r2);
+
+            species_.addAtom(zA_, species_.box()->fold(r1));
+            species_.addAtom(zB_, species_.box()->fold(r2));
 
             //            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x
             //            / A)}); species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 *

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -4,6 +4,7 @@
 #include "gui/createNanotubeSpeciesDialog.h"
 #include "classes/empiricalFormula.h"
 #include "gui/helpers/comboPopulator.h"
+#include <numeric>
 
 CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissolve &dissolve)
     : QDialog(parent), selectElementDialog_(this), dissolve_(dissolve)
@@ -37,25 +38,37 @@ void CreateNanotubeSpeciesDialog::regenerate()
     const auto a0 = 2.46;
     const auto a1 = Vec3<double>(a0, 0.0, 0.0);
     const auto a2 = Vec3<double>(a0*sin(M_PI/6.0), a0*cos(M_PI/6.0), 0.0);
-    const auto a3 = a2 - a1;
     const auto n = ui_.NSpin->value();
+    a2.print();
     const auto m = ui_.MSpin->value();
 
-    auto vecA = a1 * n + a2 * m;
     auto A = a0 * sqrt(n*n + m*m + n*m);
     auto alpha = atan((sqrt(3.0) * m) / (2 * n + m));
     const auto radius = A / (2.0 * M_PI);
-    std::cout << std::format("Helicity (alpha) = {}\n", alpha);
+    std::cout << std::format("Helicity (alpha) = {} rad, {} degrees\n", alpha, alpha*DEGRAD);
 
     // TEST
-    auto M = 10;
-    auto nc = -((n + 2*m) / M);
-    auto mc = ((2*n + m) / M);
-
+    auto M = std::gcd(2 * n + m, n + 2 * m);
+//    auto nc = -((n + 2*m) / M);
+//    auto mc = ((2*n + m) / M);
+//    auto vecAPerp = a1 * nc + a2 * mc;
+//    auto Aperp = a0 * sqrt(nc*nc + mc*mc + nc*mc);
+//
     auto c = sqrt(3.0) * A / M;
 
     std::cout << std::format("Rectangle dims are A = {} c = {}\n", A, c);
+    auto d = std::gcd(n,m);
+    auto acc = a0 / sqrt(3.0);
+    auto T = 3.0 * acc * sqrt(n*n + n*m + m*m);
+    T /= (n-m)%(3*d) == 0 ? 3 * d : d;
+    std::cout << std::format("T = {}, acc = {}, d = {}\n", T, acc, d);
 
+    species_.createBox({A, T, 3.0}, {90,90,90});
+
+    // Generate the full coordinates
+    auto dy = a2.y/cos(alpha);
+    auto H = round(T / dy);
+    std::cout << std::format("Repeats H = {}, T/a0CosAlpha = {}, dy = {}\n", H, T / dy, dy);
     for (auto j = 0; j <= n + m -1; ++j)
     {
         // Primary helix atoms
@@ -66,16 +79,25 @@ void CreateNanotubeSpeciesDialog::regenerate()
         auto x2j = x1j - (a0 / sqrt(3.0)) * cos(M_PI/6.0 - alpha);
         auto y2j = y1j - (a0 / sqrt(3.0)) * sin(M_PI/6.0-alpha);
 
-        for (auto i = 0; i < m; ++i)
+        for (auto i = 0; i < H; ++i)
         {
             auto delta = Vec3<double>(-i * a0 * sin(M_PI/6.0 - alpha), i * a0 * cos(M_PI/6.0 - alpha), 0.0);
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
-            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x / A)});
-            species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 * M_PI * r2.x / A)});
+
+            // Map negative y values back into their positive periodic image
+//            if (r1.y < 0.0)
+//                r1.y += T * d;
+//            if (r2.y < 0.0)
+//                r2.y += T * d;
+
+                species_.addAtom(Elements::C,     species_.box()->fold(r1));
+                species_.addAtom(Elements::N,     species_.box()->fold(r2));
+
+//            species_.addAtom(Elements::C, {radius*sin(2.0 * M_PI * r1.x / A) , r1.y, radius* cos(2.0 * M_PI * r1.x / A)});
+//            species_.addAtom(Elements::N, {radius*sin(2.0 * M_PI * r2.x / A) , r2.y, radius * cos(2.0 * M_PI * r2.x / A)});
         }
     }
-
 
     // Finalise the species
     species_.recalculateIntermolecularTerms(1.1);

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -95,7 +95,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
         cellLengths = {A_, c_ * cFactor, sheetZ_};
         offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
     }
-
+    cellLengths.print();
     species_.createBox(cellLengths, {90, 90, 90});
 
     /*
@@ -104,7 +104,7 @@ void CreateNanotubeSpeciesDialog::regenerate()
      * 0 - (m-1) inclusive, but this does not generate the correct number of copies for most cases. Instead, the number of
      * required helix copies 'H' is calculated from c and the rotated y component of va2 (see earlier).
      */
-    for (auto j = 0; j <= n_ + m_ - 1; ++j)
+    for (auto j = 0; j < n_ + m_; ++j)
     {
         // Primary helix atoms (equation 7)
         auto x1j = j * a0_ * cos(alpha_);
@@ -122,20 +122,37 @@ void CreateNanotubeSpeciesDialog::regenerate()
             auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
             auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
 
+            // Get new helix pair coordinates
+            Vec3<double> p1, p2;
             if (roll)
             {
                 // Wrap the X coordinate (== real position on circumference) onto a tube of radius 'radius', applying the
                 // offset we set earlier when creating the periodic box so as to put it in the centre of XZ.
-                species_.addAtom(zA_, species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y,
-                                                                                 radius_ * cos(2.0 * M_PI * r1.x / A_))));
-                species_.addAtom(zB_, species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y,
-                                                                                 radius_ * cos(2.0 * M_PI * r2.x / A_))));
+                p1 = species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y,
+                                                                                 radius_ * cos(2.0 * M_PI * r1.x / A_)));
+                p2 = species_.box()->fold(offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y,
+                                                                                 radius_ * cos(2.0 * M_PI * r2.x / A_)));
             }
             else
             {
-                species_.addAtom(zA_, species_.box()->fold(r1));
-                species_.addAtom(zB_, species_.box()->fold(r2));
+                p1 = species_.box()->fold(r1);
+                p2 = species_.box()->fold(r2);
             }
+
+            // Check for overlaps with existing atoms - easier and more efficient to do this now as we go.
+            auto add1 = true, add2 = true;
+            for (auto &existing : species_.atoms())
+            {
+                if (add1)
+                    add1 = (p1 - existing.r()).magnitude() > 0.1;
+                if (add2)
+                    add2 = (p2 - existing.r()).magnitude() > 0.1;
+                if (!add1 && !add2) break;
+            }
+            if (add1)
+                species_.addAtom(zA_, p1);
+            if (add2)
+                species_.addAtom(zB_, p2);
         }
     }
 
@@ -183,8 +200,13 @@ void CreateNanotubeSpeciesDialog::regenerate()
                 // Find all bound partners which are across the unit cell
                 std::vector<SpeciesAtom *> pbcJ;
                 for (auto &b : i.bonds())
-                    if ((i.r() - b.get().partner(&i)->r()).magnitude() > 1.44)
-                        pbcJ.push_back(b.get().partner(&i));
+                {
+                    auto *j = b.get().partner(&i);
+                    if ((i.r() - j->r()).magnitude() < 1.0)
+                        std::cout << std::format("!!! Atoms {} ({}) and {} ({}) overlap\n", i.index(), Elements::name(i.Z()), j->index(), Elements::name(j->Z()));
+                    if ((i.r() - j->r()).magnitude() > 1.44)
+                        pbcJ.push_back(j);
+                }
 
                 if (pbcJ.size() == 2)
                     atoms[&i] = pbcJ;
@@ -199,18 +221,15 @@ void CreateNanotubeSpeciesDialog::regenerate()
                 // Determine the fractional average vector to the pbc atoms
                 Vec3<double> vFrac;
                 for (auto j : pbcJ)
-                {
                     vFrac += species_.box()->getFractional(j->r()) -  species_.box()->getFractional(i->r());
-                    std::cout << std::format("-> partner {} is at {},{},{}\n", j->index(), j->r().x, j->r().y, j->r().z);
-                }
                 vFrac.print();
 
                 // Make this a sensible translation vector - divide elements by their abs value to make unitary and round
                 for (auto n = 0; n < 3; ++n)
                     vFrac[n] = fabs(vFrac[n]) < 0.5 ? 0.0 : round(vFrac[n] / fabs(vFrac[n]));
-                vFrac.print();
+                // vFrac.print();
                 vFrac.multiply(cellLengths);
-                vFrac.print();
+                // vFrac.print();
 
                 // Translate the atom
                 i->setCoordinates(i->r() + vFrac);

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -27,39 +27,19 @@ CreateNanotubeSpeciesDialog::CreateNanotubeSpeciesDialog(QWidget *parent, Dissol
  * Data
  */
 
-// Plot an AB atom layer
-void CreateNanotubeSpeciesDialog::plotLayer(double z, double tubeRadius, double radialStep, double radialOffset,
-                                            Elements::Element zA, Elements::Element zB)
-{
-    for (auto radial = 0; radial < ui_.RadialRingSizeSpin->value(); ++radial)
-    {
-        auto angle = radial * radialStep + radialOffset;
-
-        if (zA != Elements::Unknown)
-            species_.addAtom(zA, {tubeRadius * cos(angle), tubeRadius * sin(angle), z});
-
-        angle += radialStep * 0.5;
-
-        if (zB != Elements::Unknown)
-            species_.addAtom(
-                zB, {tubeRadius * cos(angle), tubeRadius * sin(angle), z + ui_.BondLengthSpin->value() * cos(60.0 / DEGRAD)});
-    }
-}
-
 // Regenerate species
 void CreateNanotubeSpeciesDialog::regenerate()
 {
     species_.clear();
 
     const auto r = ui_.BondLengthSpin->value();
-    const auto nAxialRings = ui_.AxialRingLengthSpin->value();
 
     const auto a0 = 2.46;
     const auto a1 = Vec3<double>(a0, 0.0, 0.0);
     const auto a2 = Vec3<double>(a0*sin(M_PI/6.0), a0*cos(M_PI/6.0), 0.0);
     const auto a3 = a2 - a1;
-    const auto n = 5;
-    const auto m = 2;
+    const auto n = ui_.NSpin->value();
+    const auto m = ui_.MSpin->value();
 
     auto vecA = a1 * n + a2 * m;
     auto A = a0 * sqrt(n*n + m*m + n*m);
@@ -129,22 +109,18 @@ void CreateNanotubeSpeciesDialog::updateWidgets()
     ui_.StructureViewer->postRedisplay();
 }
 
-void CreateNanotubeSpeciesDialog::on_AxialRingLengthSpin_valueChanged(int value)
+void CreateNanotubeSpeciesDialog::on_NSpin_valueChanged(int value)
 {
     if (widgetsUpdating_.isLocked())
         return;
 
-    // Clamp to even numbers if type == Periodic
-    if (ui_.TypeCombo->currentIndex() == 1)
-    {
-        Locker refreshLock(widgetsUpdating_);
-        ui_.AxialRingLengthSpin->setValue(2 * (ui_.AxialRingLengthSpin->value() / 2));
-    }
+    // MSpin's upper value is our current value
+    ui_.MSpin->setMaximum(value);
 
     regenerate();
 }
 
-void CreateNanotubeSpeciesDialog::on_RadialRingSizeSpin_valueChanged(int value) { regenerate(); }
+void CreateNanotubeSpeciesDialog::on_MSpin_valueChanged(int value) { regenerate(); }
 
 void CreateNanotubeSpeciesDialog::on_ElementAButton_clicked(bool checked)
 {
@@ -170,7 +146,7 @@ void CreateNanotubeSpeciesDialog::on_OKButton_clicked(bool checked)
 {
     // Copy the species to the main Dissolve instance and set its new name
     auto *sp = dissolve_.coreData().copySpecies(&species_);
-    sp->setName(std::format("Nanotube-{}x{}", ui_.AxialRingLengthSpin->value(), ui_.RadialRingSizeSpin->value()));
+    sp->setName(std::format("Nanotube-({},{})", ui_.NSpin->value(), ui_.MSpin->value()));
 
     accept();
 }
@@ -181,17 +157,17 @@ void CreateNanotubeSpeciesDialog::on_TypeCombo_currentIndexChanged(int index)
 {
     Locker refreshLock(widgetsUpdating_);
 
-    // Limit tube axial length depending on mode requested
-    if (index == 0)
-    {
-        ui_.AxialRingLengthSpin->setSingleStep(1);
-        ui_.AxialRingLengthSpin->setMinimum(1);
-    }
-    else
-    {
-        ui_.AxialRingLengthSpin->setSingleStep(2);
-        ui_.AxialRingLengthSpin->setMinimum(2);
-    }
+//    // Limit tube axial length depending on mode requested
+//    if (index == 0)
+//    {
+//        ui_.AxialRingLengthSpin->setSingleStep(1);
+//        ui_.AxialRingLengthSpin->setMinimum(1);
+//    }
+//    else
+//    {
+//        ui_.AxialRingLengthSpin->setSingleStep(2);
+//        ui_.AxialRingLengthSpin->setMinimum(2);
+//    }
 
     refreshLock.unlock();
 

--- a/src/gui/createNanotubeSpeciesDialog.cpp
+++ b/src/gui/createNanotubeSpeciesDialog.cpp
@@ -83,18 +83,20 @@ void CreateNanotubeSpeciesDialog::regenerate()
     const auto cFactor = ui_.CFactorSpin->value();
 
     // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
-    auto offset = Vec3<double>();
+    auto offset = Vec3<double>(), cellLengths = Vec3<double>();
     if (roll)
     {
         // Create some extra space and set an offset so the tube is central in XZ
-        species_.createBox({radius_ * 3, c_ * cFactor, radius_ * 3}, {90, 90, 90});
+        cellLengths = {radius_ * 3, c_ * cFactor, radius_ * 3};
         offset = Vec3<double>(radius_ * 1.5, 0.0, radius_ * 1.5);
     }
     else
     {
-        species_.createBox({A_, c_ * cFactor, sheetZ_}, {90, 90, 90});
+        cellLengths = {A_, c_ * cFactor, sheetZ_};
         offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
     }
+
+    species_.createBox(cellLengths, {90, 90, 90});
 
     /*
      * Generate the full coordinates of the sheet. This process is based on equations 7 - 9, but does not follow it precisely.
@@ -144,8 +146,112 @@ void CreateNanotubeSpeciesDialog::regenerate()
     }
     else if (ui_.NonPeriodicRadio->isChecked())
     {
-        species_.removeBox();
         species_.recalculateIntermolecularTerms(1.1);
+
+        if (ui_.TidyEndsCheck->isChecked())
+        {
+            // For any atom whose y coordinate is less than half the box B, or any x coordinate less than half the box A,
+            // translate it to the opposite side.
+
+            // // Pass over X
+            // for (auto &i : species_.atoms())
+            //     if (i.nBonds() == 1 && i.r().x < cellLengths.x*0.5)
+            //     {
+            //         i.setCoordinates(i.r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
+            //         // Check bound neighbour - if it has exactly two bonds then we need to move it as well
+            //         auto j =i.bonds().front().get().partner(&i);
+            //         if (j->nBonds() == 2)
+            //             j->setCoordinates(j->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
+            //     }
+            // species_.recalculateIntermolecularTerms(1.1);
+            //
+            // // Pass over Y
+            // for (auto &i : species_.atoms())
+            //     if (i.nBonds() == 1 && i.r().y < cellLengths.y*0.5)
+            //     {
+            //         i.setCoordinates(i.r() + Vec3<double>(0.0, cellLengths.y, 0.0));
+            //         // Check bound neighbour - if it has exactly two bonds then we need to move it as well
+            //         auto j =i.bonds().front().get().partner(&i);
+            //         if (j->nBonds() == 2)
+            //             j->setCoordinates(j->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
+            //     }
+
+            // Find all atoms which have two bonds spanning PBC of the box
+            std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> atoms;
+            for (auto &i : species_.atoms())
+            {
+                // Find all bound partners which are across the unit cell
+                std::vector<SpeciesAtom *> pbcJ;
+                for (auto &b : i.bonds())
+                    if ((i.r() - b.get().partner(&i)->r()).magnitude() > 1.44)
+                        pbcJ.push_back(b.get().partner(&i));
+
+                if (pbcJ.size() == 2)
+                    atoms[&i] = pbcJ;
+            }
+            std::cout << std::format("There are {} atoms which have two periodic bonds.\n", atoms.size());
+
+            while (atoms.size() > 0)
+            {
+                auto &&[i, pbcJ] = *atoms.begin();
+
+                std::cout << std::format("-> Atom {} is at {},{},{}\n", i->index(), i->r().x, i->r().y, i->r().z);
+                // Determine the fractional average vector to the pbc atoms
+                Vec3<double> vFrac;
+                for (auto j : pbcJ)
+                {
+                    vFrac += species_.box()->getFractional(j->r()) -  species_.box()->getFractional(i->r());
+                    std::cout << std::format("-> partner {} is at {},{},{}\n", j->index(), j->r().x, j->r().y, j->r().z);
+                }
+                vFrac.print();
+
+                // Make this a sensible translation vector - divide elements by their abs value to make unitary and round
+                for (auto n = 0; n < 3; ++n)
+                    vFrac[n] = fabs(vFrac[n]) < 0.5 ? 0.0 : round(vFrac[n] / fabs(vFrac[n]));
+                vFrac.print();
+                vFrac.multiply(cellLengths);
+                vFrac.print();
+
+                // Translate the atom
+                i->setCoordinates(i->r() + vFrac);
+                std::cout << std::format("-> new i.r() =  {},{},{}\n", i->r().x, i->r().y, i->r().z);
+
+                // Remove this atom from the vector, along with any that were in its pbc neighbour lists
+                for (auto j : pbcJ)
+                    if (atoms.contains(j))
+                        atoms.erase(j);
+
+                atoms.erase(i);
+                //
+                // // Skip this atom
+                // if (!roll && i->r().x < cellLengths.x * 0.5)
+                // {
+                //     i->setCoordinates(i->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
+                //     // Check bound neighbour - if it has exactly two bonds then we need to move it as well
+                //     auto j = i->bonds().front().get().partner(i);
+                //     if (j->nBonds() == 2)
+                //         j->setCoordinates(j->r() + Vec3<double>(cellLengths.x, 0.0, 0.0));
+                // }
+                // else if (i->r().y < cellLengths.y * 0.5)
+                // {
+                //     i->setCoordinates(i->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
+                //     // Check bound neighbour - if it has exactly two bonds then we need to move it as well
+                //     auto j = i->bonds().front().get().partner(i);
+                //     if (j->nBonds() == 2)
+                //         j->setCoordinates(j->r() + Vec3<double>(0.0, cellLengths.y, 0.0));
+                // }
+                //
+                // // Recalculate bonding
+                // species_.recalculateIntermolecularTerms(1.1);
+                //
+                // // Remove any atoms in the vector which now have more than one bond
+                // atoms.erase(std::remove_if(atoms.begin(), atoms.end(), [](const auto *j) { return j->nBonds() > 1; }),
+                //             atoms.end());
+                std::cout << std::format("There are now {} atoms to process.\n", atoms.size());
+            }
+        }
+
+        species_.removeBox();
     }
     else
     {
@@ -267,6 +373,12 @@ void CreateNanotubeSpeciesDialog::on_NonPeriodicRadio_clicked(bool checked)
 {
     if (widgetsUpdating_)
         return;
+    regenerate();
+    updateWidgets();
+}
+
+void CreateNanotubeSpeciesDialog::on_TidyEndsCheck_clicked(bool checked)
+{
     regenerate();
     updateWidgets();
 }

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -41,8 +41,28 @@ class CreateNanotubeSpeciesDialog : public QDialog
     Elements::Element zA_{Elements::Element::C}, zB_{Elements::Element::N};
     // Generated nanotube species
     Species species_;
+    // Chirality parameters
+    int n_{0}, m_{0};
+    // Sheet width (A) and height (c)
+    double A_{0.0}, c_{0.0};
+    // Representative unit length
+    double a0_{0.0};
+    // Principal vectors
+    Vec3<double> va1_, va2_;
+    // Angle between principal vector va1 and the sheet vector
+    double alpha_{0.0};
+    // Radius of resulting tube
+    double radius_{0.0};
+    // Delta along y between helices
+    double dy_{0.0};
+    // Number of helices required
+    int H_{0};
+    // Default size of unit cell for sheet
+    const double sheetZ_{10.0};
 
     private:
+    // Calculate parameters
+    void calculateParameters();
     // Regenerate species
     void regenerate();
 
@@ -66,9 +86,7 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void on_ElementAButton_clicked(bool checked);
     void on_ElementBButton_clicked(bool checked);
     void on_BondLengthSpin_valueChanged(double value);
-    void on_TypeCombo_currentIndexChanged(int index);
     // Sheet Transforms
-    void on_CFactorSpin_valueChanged(double value);
     void on_RollUpCheck_clicked(bool checked);
     // Output Options
     void on_PeriodicRadio_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -43,9 +43,6 @@ class CreateNanotubeSpeciesDialog : public QDialog
     Species species_;
 
     private:
-    // Plot an AB atom layer
-    void plotLayer(double z, double tubeRadius, double radialStep, double radialOffset, Elements::Element zA,
-                   Elements::Element zB);
     // Regenerate species
     void regenerate();
 
@@ -63,8 +60,8 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void updateWidgets();
 
     private Q_SLOTS:
-    void on_AxialRingLengthSpin_valueChanged(int value);
-    void on_RadialRingSizeSpin_valueChanged(int value);
+    void on_NSpin_valueChanged(int value);
+    void on_MSpin_valueChanged(int value);
     void on_ElementAButton_clicked(bool checked);
     void on_ElementBButton_clicked(bool checked);
     void on_TypeCombo_currentIndexChanged(int index);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -60,11 +60,15 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void updateWidgets();
 
     private Q_SLOTS:
+    // Sheet Definition
     void on_NSpin_valueChanged(int value);
     void on_MSpin_valueChanged(int value);
     void on_ElementAButton_clicked(bool checked);
     void on_ElementBButton_clicked(bool checked);
+    void on_BondLengthSpin_valueChanged(double value);
     void on_TypeCombo_currentIndexChanged(int index);
+    // Sheet Transforms
+    void on_RollCheck_clicked(bool checked);
     // Dialog
     void on_OKButton_clicked(bool checked);
     void on_CancelButton_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -92,6 +92,7 @@ class CreateNanotubeSpeciesDialog : public QDialog
     // Output Options
     void on_PeriodicRadio_clicked(bool checked);
     void on_NonPeriodicRadio_clicked(bool checked);
+    void on_TidyEndsCheck_clicked(bool checked);
     void on_PseudoPeriodicRadio_clicked(bool checked);
     // Dialog
     void on_OKButton_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -87,6 +87,7 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void on_ElementBButton_clicked(bool checked);
     void on_BondLengthSpin_valueChanged(double value);
     // Sheet Transforms
+    void on_CFactorSpin_valueChanged(int value);
     void on_RollUpCheck_clicked(bool checked);
     // Output Options
     void on_PeriodicRadio_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -63,6 +63,13 @@ class CreateNanotubeSpeciesDialog : public QDialog
     private:
     // Calculate parameters
     void calculateParameters();
+    // Find dangling atoms, defined as those which have two bonds spanning PBC of the box
+    std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> findDanglingAtoms(double localCutoff);
+    // Get vector of atom keys from atom/neighbour map, sorted by position along indicated direction
+    std::vector<SpeciesAtom *> getSorted(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms, int dir) const;
+    // Recursive branch function
+    void extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac, std::vector<SpeciesAtom *> &branch,
+                      double localCutoff) const;
     // Regenerate species
     void regenerate();
 
@@ -91,9 +98,10 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void on_RollUpCheck_clicked(bool checked);
     // Output Options
     void on_PeriodicRadio_clicked(bool checked);
+    void on_PseudoPeriodicRadio_clicked(bool checked);
     void on_NonPeriodicRadio_clicked(bool checked);
     void on_TidyEndsCheck_clicked(bool checked);
-    void on_PseudoPeriodicRadio_clicked(bool checked);
+    void on_RemoveBranchesCheck_clicked(bool checked);
     // Dialog
     void on_OKButton_clicked(bool checked);
     void on_CancelButton_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -68,7 +68,12 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void on_BondLengthSpin_valueChanged(double value);
     void on_TypeCombo_currentIndexChanged(int index);
     // Sheet Transforms
-    void on_RollCheck_clicked(bool checked);
+    void on_CFactorSpin_valueChanged(double value);
+    void on_RollUpCheck_clicked(bool checked);
+    // Output Options
+    void on_PeriodicRadio_clicked(bool checked);
+    void on_NonPeriodicRadio_clicked(bool checked);
+    void on_PseudoPeriodicRadio_clicked(bool checked);
     // Dialog
     void on_OKButton_clicked(bool checked);
     void on_CancelButton_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.h
+++ b/src/gui/createNanotubeSpeciesDialog.h
@@ -38,7 +38,7 @@ class CreateNanotubeSpeciesDialog : public QDialog
     // Main Dissolve object
     Dissolve &dissolve_;
     // Elements in nanotube
-    Elements::Element zA_{Elements::Element::C}, zB_{Elements::Element::N};
+    Elements::Element zA_{Elements::Element::C}, zB_{Elements::Element::N}, zTerminate_{Elements::H};
     // Generated nanotube species
     Species species_;
     // Chirality parameters
@@ -102,6 +102,11 @@ class CreateNanotubeSpeciesDialog : public QDialog
     void on_NonPeriodicRadio_clicked(bool checked);
     void on_TidyEndsCheck_clicked(bool checked);
     void on_RemoveBranchesCheck_clicked(bool checked);
+    void on_TerminateCheck_clicked(bool checked);
+    void on_TerminateElementButton_clicked(bool checked);
+    void on_TerminateBondLengthSpin_valueChanged(double value);
+    void on_TerminateACheck_clicked(bool checked);
+    void on_TerminateBCheck_clicked(bool checked);
     // Dialog
     void on_OKButton_clicked(bool checked);
     void on_CancelButton_clicked(bool checked);

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>1227</width>
-    <height>790</height>
+    <height>769</height>
    </rect>
   </property>
   <property name="font">
@@ -110,57 +110,6 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
-            <widget class="QLabel" name="label_2">
-             <property name="text">
-              <string>Element A</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Element B</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_4">
-             <property name="text">
-              <string>Bond Length</string>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QPushButton" name="ElementAButton">
-             <property name="text">
-              <string>ElementA</string>
-             </property>
-            </widget>
-           </item>
-           <item row="3" column="1">
-            <widget class="QPushButton" name="ElementBButton">
-             <property name="text">
-              <string>ElementB</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QDoubleSpinBox" name="BondLengthSpin">
-             <property name="decimals">
-              <number>3</number>
-             </property>
-             <property name="minimum">
-              <double>0.100000000000000</double>
-             </property>
-             <property name="singleStep">
-              <double>0.010000000000000</double>
-             </property>
-             <property name="value">
-              <double>1.420000000000000</double>
-             </property>
-            </widget>
-           </item>
            <item row="1" column="0">
             <widget class="QLabel" name="label_5">
              <property name="text">
@@ -178,6 +127,57 @@
              </property>
              <property name="value">
               <number>0</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>Element A</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QPushButton" name="ElementAButton">
+             <property name="text">
+              <string>ElementA</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>Element B</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QPushButton" name="ElementBButton">
+             <property name="text">
+              <string>ElementB</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_4">
+             <property name="text">
+              <string>Bond Length</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QDoubleSpinBox" name="BondLengthSpin">
+             <property name="decimals">
+              <number>3</number>
+             </property>
+             <property name="minimum">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.420000000000000</double>
              </property>
             </widget>
            </item>
@@ -202,6 +202,117 @@
              </item>
             </widget>
            </item>
+           <item row="6" column="0" colspan="2">
+            <widget class="Line" name="line_2">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
+             </property>
+             <property name="text">
+              <string>A</string>
+             </property>
+            </widget>
+           </item>
+           <item row="7" column="1">
+            <widget class="QLabel" name="ALabel">
+             <property name="toolTip">
+              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Axial length of sheet along the y direction</string>
+             </property>
+             <property name="text">
+              <string>c</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
+             </property>
+             <property name="text">
+              <string>ɑ</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Number of repeated translations of the primary helix required</string>
+             </property>
+             <property name="text">
+              <string>H</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="1">
+            <widget class="QLabel" name="CLabel">
+             <property name="toolTip">
+              <string>Axial length of sheet along the y direction</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
+            <widget class="QLabel" name="AlphaLabel">
+             <property name="toolTip">
+              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="10" column="1">
+            <widget class="QLabel" name="HLabel">
+             <property name="toolTip">
+              <string>Number of repeated translations of the primary helix required</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>
@@ -210,10 +321,7 @@
           <property name="title">
            <string>Sheet Transforms</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="spacing">
-            <number>4</number>
-           </property>
+          <layout class="QFormLayout" name="formLayout_3">
            <property name="leftMargin">
             <number>4</number>
            </property>
@@ -226,7 +334,17 @@
            <property name="bottomMargin">
             <number>4</number>
            </property>
-           <item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_16">
+             <property name="toolTip">
+              <string>Factor by which to scale c, resulting in longer sheets / tubes along y. Note that setting this to a non-integer number prevents creation of a periodic species.</string>
+             </property>
+             <property name="text">
+              <string>c Factor</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" colspan="2">
             <widget class="QCheckBox" name="RollUpCheck">
              <property name="toolTip">
               <string>Whether to roll up the sheet about the y axis to form a nanotube</string>
@@ -236,13 +354,61 @@
              </property>
             </widget>
            </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_11">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Radius, if rolled into a nanotube</string>
+             </property>
+             <property name="text">
+              <string>Radius</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="RadiusLabel">
+             <property name="toolTip">
+              <string>Radius, if rolled into a nanotube</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QDoubleSpinBox" name="CFactorSpin">
+             <property name="toolTip">
+              <string>Factor by which to scale c, resulting in longer sheets / tubes along y. Note that setting this to a non-integer number prevents creation of a periodic species.</string>
+             </property>
+             <property name="minimum">
+              <double>0.500000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1000.000000000000000</double>
+             </property>
+             <property name="value">
+              <double>1.000000000000000</double>
+             </property>
+            </widget>
+           </item>
           </layout>
          </widget>
         </item>
         <item>
-         <widget class="QGroupBox" name="SheetPropertiesGroup">
+         <widget class="QGroupBox" name="CellPropertiesGroup">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="title">
-           <string>Sheet Properties</string>
+           <string>Cell Properties</string>
           </property>
           <layout class="QFormLayout" name="formLayout">
            <property name="horizontalSpacing">
@@ -264,102 +430,140 @@
             <number>4</number>
            </property>
            <item row="0" column="0">
-            <widget class="QLabel" name="label_7">
-             <property name="toolTip">
-              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
+            <widget class="QLabel" name="label_13">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
              </property>
              <property name="text">
               <string>A</string>
              </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="ALabel">
-             <property name="toolTip">
-              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
-             </property>
-             <property name="text">
-              <string>0</string>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
            <item row="1" column="0">
-            <widget class="QLabel" name="label_8">
-             <property name="toolTip">
-              <string>Axial length of sheet along the y direction</string>
+            <widget class="QLabel" name="label_12">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
              </property>
              <property name="text">
-              <string>c</string>
+              <string>B</string>
              </property>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QLabel" name="CLabel">
-             <property name="toolTip">
-              <string>Axial length of sheet along the y direction</string>
-             </property>
-             <property name="text">
-              <string>0</string>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
              </property>
             </widget>
            </item>
            <item row="2" column="0">
-            <widget class="QLabel" name="label_9">
-             <property name="toolTip">
-              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
+            <widget class="QLabel" name="label_14">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
              </property>
              <property name="text">
-              <string>ɑ</string>
+              <string>C</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="CellALabel">
+             <property name="text">
+              <string>0.0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="CellBLabel">
+             <property name="text">
+              <string>0.0</string>
              </property>
             </widget>
            </item>
            <item row="2" column="1">
-            <widget class="QLabel" name="AlphaLabel">
-             <property name="toolTip">
-              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
-             </property>
+            <widget class="QLabel" name="CellCLabel">
              <property name="text">
-              <string>0</string>
+              <string>0.0</string>
              </property>
             </widget>
            </item>
-           <item row="3" column="0">
-            <widget class="QLabel" name="label_10">
-             <property name="toolTip">
-              <string>Number of repeated translations of the primary helix required</string>
-             </property>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="OutputOptionsGroup">
+          <property name="title">
+           <string>Output Options</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <widget class="QRadioButton" name="PeriodicRadio">
              <property name="text">
-              <string>H</string>
+              <string>Periodic</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
              </property>
             </widget>
            </item>
-           <item row="3" column="1">
-            <widget class="QLabel" name="HLabel">
-             <property name="toolTip">
-              <string>Number of repeated translations of the primary helix required</string>
-             </property>
+           <item>
+            <widget class="QRadioButton" name="NonPeriodicRadio">
              <property name="text">
-              <string>0</string>
+              <string>Non-periodic</string>
+             </property>
+             <property name="checked">
+              <bool>false</bool>
              </property>
             </widget>
            </item>
-           <item row="4" column="0">
-            <widget class="QLabel" name="label_11">
-             <property name="toolTip">
-              <string>Radius, if rolled into a nanotube</string>
-             </property>
+           <item>
+            <widget class="QRadioButton" name="PseudoPeriodicRadio">
              <property name="text">
-              <string>Radius</string>
-             </property>
-            </widget>
-           </item>
-           <item row="4" column="1">
-            <widget class="QLabel" name="RadiusLabel">
-             <property name="toolTip">
-              <string>Radius, if rolled into a nanotube</string>
-             </property>
-             <property name="text">
-              <string>0</string>
+              <string>Pseudo-periodic</string>
              </property>
             </widget>
            </item>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -181,35 +181,14 @@
              </property>
             </widget>
            </item>
-           <item row="5" column="0">
-            <widget class="QLabel" name="label_6">
-             <property name="text">
-              <string>Type</string>
-             </property>
-            </widget>
-           </item>
-           <item row="5" column="1">
-            <widget class="QComboBox" name="TypeCombo">
-             <item>
-              <property name="text">
-               <string>Terminated</string>
-              </property>
-             </item>
-             <item>
-              <property name="text">
-               <string>Periodic</string>
-              </property>
-             </item>
-            </widget>
-           </item>
-           <item row="6" column="0" colspan="2">
+           <item row="5" column="0" colspan="2">
             <widget class="Line" name="line_2">
              <property name="orientation">
               <enum>Qt::Horizontal</enum>
              </property>
             </widget>
            </item>
-           <item row="7" column="0">
+           <item row="6" column="0">
             <widget class="QLabel" name="label_7">
              <property name="font">
               <font>
@@ -225,7 +204,7 @@
              </property>
             </widget>
            </item>
-           <item row="7" column="1">
+           <item row="6" column="1">
             <widget class="QLabel" name="ALabel">
              <property name="toolTip">
               <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
@@ -235,7 +214,7 @@
              </property>
             </widget>
            </item>
-           <item row="8" column="0">
+           <item row="7" column="0">
             <widget class="QLabel" name="label_8">
              <property name="font">
               <font>
@@ -251,7 +230,17 @@
              </property>
             </widget>
            </item>
-           <item row="9" column="0">
+           <item row="7" column="1">
+            <widget class="QLabel" name="CLabel">
+             <property name="toolTip">
+              <string>Axial length of sheet along the y direction</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="8" column="0">
             <widget class="QLabel" name="label_9">
              <property name="font">
               <font>
@@ -267,33 +256,7 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="0">
-            <widget class="QLabel" name="label_10">
-             <property name="font">
-              <font>
-               <pointsize>10</pointsize>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="toolTip">
-              <string>Number of repeated translations of the primary helix required</string>
-             </property>
-             <property name="text">
-              <string>H</string>
-             </property>
-            </widget>
-           </item>
            <item row="8" column="1">
-            <widget class="QLabel" name="CLabel">
-             <property name="toolTip">
-              <string>Axial length of sheet along the y direction</string>
-             </property>
-             <property name="text">
-              <string>0</string>
-             </property>
-            </widget>
-           </item>
-           <item row="9" column="1">
             <widget class="QLabel" name="AlphaLabel">
              <property name="toolTip">
               <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
@@ -303,10 +266,26 @@
              </property>
             </widget>
            </item>
-           <item row="10" column="1">
+           <item row="9" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="font">
+              <font>
+               <pointsize>10</pointsize>
+               <bold>true</bold>
+              </font>
+             </property>
+             <property name="toolTip">
+              <string>Number of repeated translations of the primary helix required (adjusted value in brackets)</string>
+             </property>
+             <property name="text">
+              <string>H</string>
+             </property>
+            </widget>
+           </item>
+           <item row="9" column="1">
             <widget class="QLabel" name="HLabel">
              <property name="toolTip">
-              <string>Number of repeated translations of the primary helix required</string>
+              <string>Number of repeated translations of the primary helix required (adjusted value in brackets)</string>
              </property>
              <property name="text">
               <string>0</string>
@@ -334,17 +313,7 @@
            <property name="bottomMargin">
             <number>4</number>
            </property>
-           <item row="0" column="0">
-            <widget class="QLabel" name="label_16">
-             <property name="toolTip">
-              <string>Factor by which to scale c, resulting in longer sheets / tubes along y. Note that setting this to a non-integer number prevents creation of a periodic species.</string>
-             </property>
-             <property name="text">
-              <string>c Factor</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" colspan="2">
+           <item row="0" column="0" colspan="2">
             <widget class="QCheckBox" name="RollUpCheck">
              <property name="toolTip">
               <string>Whether to roll up the sheet about the y axis to form a nanotube</string>
@@ -354,7 +323,7 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="1" column="0">
             <widget class="QLabel" name="label_11">
              <property name="font">
               <font>
@@ -370,29 +339,13 @@
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="1" column="1">
             <widget class="QLabel" name="RadiusLabel">
              <property name="toolTip">
               <string>Radius, if rolled into a nanotube</string>
              </property>
              <property name="text">
               <string>0</string>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="1">
-            <widget class="QDoubleSpinBox" name="CFactorSpin">
-             <property name="toolTip">
-              <string>Factor by which to scale c, resulting in longer sheets / tubes along y. Note that setting this to a non-integer number prevents creation of a periodic species.</string>
-             </property>
-             <property name="minimum">
-              <double>0.500000000000000</double>
-             </property>
-             <property name="maximum">
-              <double>1000.000000000000000</double>
-             </property>
-             <property name="value">
-              <double>1.000000000000000</double>
              </property>
             </widget>
            </item>
@@ -888,7 +841,6 @@
   <tabstop>ElementAButton</tabstop>
   <tabstop>ElementBButton</tabstop>
   <tabstop>BondLengthSpin</tabstop>
-  <tabstop>TypeCombo</tabstop>
   <tabstop>CancelButton</tabstop>
   <tabstop>OKButton</tabstop>
   <tabstop>CurrentBoxToolButton</tabstop>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -313,7 +313,7 @@
            <property name="bottomMargin">
             <number>4</number>
            </property>
-           <item row="0" column="0" colspan="2">
+           <item row="1" column="0" colspan="2">
             <widget class="QCheckBox" name="RollUpCheck">
              <property name="toolTip">
               <string>Whether to roll up the sheet about the y axis to form a nanotube</string>
@@ -323,7 +323,7 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="0">
+           <item row="2" column="0">
             <widget class="QLabel" name="label_11">
              <property name="font">
               <font>
@@ -339,13 +339,36 @@
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="2" column="1">
             <widget class="QLabel" name="RadiusLabel">
              <property name="toolTip">
               <string>Radius, if rolled into a nanotube</string>
              </property>
              <property name="text">
               <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_6">
+             <property name="toolTip">
+              <string>Multiplier for the sheet along the c axis</string>
+             </property>
+             <property name="text">
+              <string>c Factor</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QSpinBox" name="CFactorSpin">
+             <property name="toolTip">
+              <string>Multiplier for the sheet along the c axis</string>
+             </property>
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>100</number>
              </property>
             </widget>
            </item>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>1227</width>
-    <height>769</height>
+    <height>835</height>
    </rect>
   </property>
   <property name="font">
@@ -588,6 +588,94 @@
                   <string>Remove branches</string>
                  </property>
                 </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="TerminateCheck">
+                 <property name="text">
+                  <string>Terminate?</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <item>
+                  <spacer name="horizontalSpacer_4">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeType">
+                    <enum>QSizePolicy::Fixed</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item>
+                  <layout class="QFormLayout" name="formLayout_4">
+                   <item row="0" column="0">
+                    <widget class="QLabel" name="label_15">
+                     <property name="text">
+                      <string>Element</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="0" column="1">
+                    <widget class="QPushButton" name="TerminateElementButton">
+                     <property name="text">
+                      <string>ElementA</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="0">
+                    <widget class="QLabel" name="label_16">
+                     <property name="text">
+                      <string>Bond Length</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="1" column="1">
+                    <widget class="QDoubleSpinBox" name="TerminateBondLengthSpin">
+                     <property name="decimals">
+                      <number>3</number>
+                     </property>
+                     <property name="minimum">
+                      <double>0.100000000000000</double>
+                     </property>
+                     <property name="singleStep">
+                      <double>0.010000000000000</double>
+                     </property>
+                     <property name="value">
+                      <double>1.000000000000000</double>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="2" column="0" colspan="2">
+                    <widget class="QCheckBox" name="TerminateACheck">
+                     <property name="text">
+                      <string>Terminate A</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item row="3" column="0" colspan="2">
+                    <widget class="QCheckBox" name="TerminateBCheck">
+                     <property name="text">
+                      <string>Terminate B</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
                </item>
               </layout>
              </item>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -67,11 +67,29 @@
          <number>0</number>
         </property>
         <item>
-         <widget class="QGroupBox" name="InputFileGroup">
+         <widget class="QGroupBox" name="SheetDefinitionGroup">
           <property name="title">
-           <string>Nanotube Properties</string>
+           <string>Sheet Definition</string>
           </property>
           <layout class="QFormLayout" name="formLayout_2">
+           <property name="horizontalSpacing">
+            <number>4</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
            <item row="0" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
@@ -135,8 +153,11 @@
              <property name="minimum">
               <double>0.100000000000000</double>
              </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
              <property name="value">
-              <double>1.390000000000000</double>
+              <double>1.420000000000000</double>
              </property>
             </widget>
            </item>
@@ -179,6 +200,167 @@
                <string>Periodic</string>
               </property>
              </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="SheetTransformsGroup">
+          <property name="title">
+           <string>Sheet Transforms</string>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <property name="spacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="RollUpCheck">
+             <property name="toolTip">
+              <string>Whether to roll up the sheet about the y axis to form a nanotube</string>
+             </property>
+             <property name="text">
+              <string>Roll</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QGroupBox" name="SheetPropertiesGroup">
+          <property name="title">
+           <string>Sheet Properties</string>
+          </property>
+          <layout class="QFormLayout" name="formLayout">
+           <property name="horizontalSpacing">
+            <number>4</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>4</number>
+           </property>
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <property name="topMargin">
+            <number>4</number>
+           </property>
+           <property name="rightMargin">
+            <number>4</number>
+           </property>
+           <property name="bottomMargin">
+            <number>4</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_7">
+             <property name="toolTip">
+              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
+             </property>
+             <property name="text">
+              <string>A</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="ALabel">
+             <property name="toolTip">
+              <string>Sheet repeat dimension along x, or circumference if rolled into a tube</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="label_8">
+             <property name="toolTip">
+              <string>Axial length of sheet along the y direction</string>
+             </property>
+             <property name="text">
+              <string>c</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="CLabel">
+             <property name="toolTip">
+              <string>Axial length of sheet along the y direction</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QLabel" name="label_9">
+             <property name="toolTip">
+              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
+             </property>
+             <property name="text">
+              <string>ɑ</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="AlphaLabel">
+             <property name="toolTip">
+              <string>Angle alpha between principal vector a1 and the x axis of the repeat unit cell</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="0">
+            <widget class="QLabel" name="label_10">
+             <property name="toolTip">
+              <string>Number of repeated translations of the primary helix required</string>
+             </property>
+             <property name="text">
+              <string>H</string>
+             </property>
+            </widget>
+           </item>
+           <item row="3" column="1">
+            <widget class="QLabel" name="HLabel">
+             <property name="toolTip">
+              <string>Number of repeated translations of the primary helix required</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QLabel" name="label_11">
+             <property name="toolTip">
+              <string>Radius, if rolled into a nanotube</string>
+             </property>
+             <property name="text">
+              <string>Radius</string>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="1">
+            <widget class="QLabel" name="RadiusLabel">
+             <property name="toolTip">
+              <string>Radius, if rolled into a nanotube</string>
+             </property>
+             <property name="text">
+              <string>0</string>
+             </property>
             </widget>
            </item>
           </layout>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -500,7 +500,7 @@
           <property name="title">
            <string>Output Options</string>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
+          <layout class="QVBoxLayout" name="verticalLayout_2">
            <property name="spacing">
             <number>4</number>
            </property>
@@ -523,6 +523,13 @@
              </property>
              <property name="checked">
               <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QRadioButton" name="PseudoPeriodicRadio">
+             <property name="text">
+              <string>Pseudo-periodic</string>
              </property>
             </widget>
            </item>
@@ -555,26 +562,36 @@
               </spacer>
              </item>
              <item>
-              <widget class="QCheckBox" name="TidyEndsCheck">
-               <property name="toolTip">
-                <string>Tidy the ends of non-periodic sheets, moving dangling atoms to leave complete rings</string>
+              <layout class="QVBoxLayout" name="verticalLayout">
+               <property name="spacing">
+                <number>4</number>
                </property>
-               <property name="text">
-                <string>Tidy Ends</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
+               <item>
+                <widget class="QCheckBox" name="TidyEndsCheck">
+                 <property name="toolTip">
+                  <string>Tidy the ends of non-periodic sheets, moving dangling atoms to leave complete rings</string>
+                 </property>
+                 <property name="text">
+                  <string>Tidy Ends</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QCheckBox" name="RemoveBranchesCheck">
+                 <property name="toolTip">
+                  <string>Whether to remove any remaining branches rather than try to translate them into a meaningful position (requires Tidy Ends)</string>
+                 </property>
+                 <property name="text">
+                  <string>Remove branches</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
              </item>
             </layout>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="PseudoPeriodicRadio">
-             <property name="text">
-              <string>Pseudo-periodic</string>
-             </property>
-            </widget>
            </item>
           </layout>
          </widget>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -87,6 +87,9 @@
              <property name="maximum">
               <number>1000</number>
              </property>
+             <property name="value">
+              <number>5</number>
+             </property>
             </widget>
            </item>
            <item row="2" column="0">
@@ -493,6 +496,18 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>NSpin</tabstop>
+  <tabstop>MSpin</tabstop>
+  <tabstop>ElementAButton</tabstop>
+  <tabstop>ElementBButton</tabstop>
+  <tabstop>BondLengthSpin</tabstop>
+  <tabstop>TypeCombo</tabstop>
+  <tabstop>CancelButton</tabstop>
+  <tabstop>OKButton</tabstop>
+  <tabstop>CurrentBoxToolButton</tabstop>
+  <tabstop>AtomPopulationToolButton</tabstop>
+ </tabstops>
  <resources>
   <include location="main.qrc"/>
  </resources>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -75,12 +75,12 @@
            <item row="0" column="0">
             <widget class="QLabel" name="label">
              <property name="text">
-              <string>Axial Ring Length</string>
+              <string>N</string>
              </property>
             </widget>
            </item>
            <item row="0" column="1">
-            <widget class="QSpinBox" name="AxialRingLengthSpin">
+            <widget class="QSpinBox" name="NSpin">
              <property name="minimum">
               <number>1</number>
              </property>
@@ -140,17 +140,20 @@
            <item row="1" column="0">
             <widget class="QLabel" name="label_5">
              <property name="text">
-              <string>Radial Ring Size</string>
+              <string>M</string>
              </property>
             </widget>
            </item>
            <item row="1" column="1">
-            <widget class="QSpinBox" name="RadialRingSizeSpin">
+            <widget class="QSpinBox" name="MSpin">
              <property name="minimum">
-              <number>5</number>
+              <number>0</number>
              </property>
              <property name="maximum">
               <number>1000</number>
+             </property>
+             <property name="value">
+              <number>0</number>
              </property>
             </widget>
            </item>

--- a/src/gui/createNanotubeSpeciesDialog.ui
+++ b/src/gui/createNanotubeSpeciesDialog.ui
@@ -126,7 +126,7 @@
               <number>1000</number>
              </property>
              <property name="value">
-              <number>0</number>
+              <number>1</number>
              </property>
             </widget>
            </item>
@@ -522,7 +522,7 @@
               <string>Periodic</string>
              </property>
              <property name="checked">
-              <bool>true</bool>
+              <bool>false</bool>
              </property>
             </widget>
            </item>
@@ -532,9 +532,42 @@
               <string>Non-periodic</string>
              </property>
              <property name="checked">
-              <bool>false</bool>
+              <bool>true</bool>
              </property>
             </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout">
+             <item>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Fixed</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="TidyEndsCheck">
+               <property name="toolTip">
+                <string>Tidy the ends of non-periodic sheets, moving dangling atoms to leave complete rings</string>
+               </property>
+               <property name="text">
+                <string>Tidy Ends</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </item>
            <item>
             <widget class="QRadioButton" name="PseudoPeriodicRadio">

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -166,7 +166,7 @@ class DissolveWindow : public QMainWindow
     void on_SpeciesCreateAtomicAction_triggered(bool checked);
     void on_SpeciesCreateDrawAction_triggered(bool checked);
     void on_SpeciesCreateFromExistingAction_triggered(bool checked);
-    void on_SpeciesCreateNanotubeAction_triggered(bool checked);
+    void on_SpeciesCreateGrapheneAction_triggered(bool checked);
     void on_SpeciesImportFromDissolveAction_triggered(bool checked);
     void on_SpeciesImportFromXYZAction_triggered(bool checked);
     void on_SpeciesImportLigParGenAction_triggered(bool checked);

--- a/src/gui/gui.ui
+++ b/src/gui/gui.ui
@@ -139,7 +139,7 @@
      <x>0</x>
      <y>0</y>
      <width>819</width>
-     <height>23</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="SessionMenu">
@@ -236,7 +236,7 @@
      <addaction name="SpeciesCreateDrawAction"/>
      <addaction name="SpeciesCreateFromExistingAction"/>
      <addaction name="separator"/>
-     <addaction name="SpeciesCreateNanotubeAction"/>
+     <addaction name="SpeciesCreateGrapheneAction"/>
     </widget>
     <widget class="QMenu" name="SpeciesImportMenu">
      <property name="font">
@@ -853,9 +853,9 @@
     <string>Create Empty</string>
    </property>
   </action>
-  <action name="SpeciesCreateNanotubeAction">
+  <action name="SpeciesCreateGrapheneAction">
    <property name="text">
-    <string>&amp;Nanotube...</string>
+    <string>&amp;Sheet / Nanotube...</string>
    </property>
   </action>
  </widget>

--- a/src/gui/menu_species.cpp
+++ b/src/gui/menu_species.cpp
@@ -5,7 +5,7 @@
 #include "classes/species.h"
 #include "gui/addForcefieldTermsDialog.h"
 #include "gui/copySpeciesTermsDialog.h"
-#include "gui/createNanotubeSpeciesDialog.h"
+#include "gui/createGrapheneSpeciesDialog.h"
 #include "gui/editSpeciesDialog.h"
 #include "gui/gui.h"
 #include "gui/importCIFDialog.h"
@@ -94,11 +94,11 @@ void DissolveWindow::on_SpeciesCreateFromExistingAction_triggered(bool checked)
         dissolve_.coreData().removeSpecies(newSpecies);
 }
 
-void DissolveWindow::on_SpeciesCreateNanotubeAction_triggered(bool checked)
+void DissolveWindow::on_SpeciesCreateGrapheneAction_triggered(bool checked)
 {
-    CreateNanotubeSpeciesDialog createNanotubeSpeciesDialog(this, dissolve_);
+    CreateGrapheneSpeciesDialog createGrapheneSpeciesDialog(this, dissolve_);
 
-    if (createNanotubeSpeciesDialog.exec() == QDialog::Accepted)
+    if (createGrapheneSpeciesDialog.exec() == QDialog::Accepted)
     {
         // Fully update GUI
         setModified();


### PR DESCRIPTION
This PR replaces the previous simplistic nanotube creation with one which implements the proper (n,m) system. It will also generate plain graphene sheets, periodic or not.

## TODO
- [x] Rename dialog
- [x] H-termination
- [x] TIdy up tube ends in non-periodic generation
- [x] Extension of tubes / sheets along Y in integer multiples of _c_
- [x] Fix - generating one layer of overlapping atoms?