### PR TITLE
feat: Generalise method for node data serialisation

### DIFF
--- a/src/classes/atomType.h
+++ b/src/classes/atomType.h
@@ -71,7 +71,7 @@ class AtomType : public Serialisable<>
     bool sameParametersAs(const AtomType *other, bool checkCharge = false);
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -169,7 +169,7 @@ class Box : public Serialisable<>
     Vector3 scaleFactors(double requestedVolume, const std::array<bool, 3> &scalableAxes = {true, true, true}) const;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -260,7 +260,7 @@ class Configuration : public Serialisable<const CoreData &>
     double getEnergyGradient() const;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Write through specified LineParser

--- a/src/classes/dataSource.h
+++ b/src/classes/dataSource.h
@@ -114,7 +114,7 @@ template <typename DataType> class DataSource : public Serialisable<const CoreDa
     const DataType &data() const { return data_; }
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     bool deserialise(LineParser &parser, int startArg, const CoreData &coreData)

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -392,7 +392,7 @@ void PairPotential::setAdditionalPotential(Data1D &newUAdditional)
 }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -189,7 +189,7 @@ class PairPotential : Serialisable<>
     static constexpr double CoulConvert = 1389.35444426359172669289;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/classes/pairPotentialOverride.cpp
+++ b/src/classes/pairPotentialOverride.cpp
@@ -45,7 +45,7 @@ InteractionPotential<Functions1D> &PairPotentialOverride::interactionPotential()
 const InteractionPotential<Functions1D> &PairPotentialOverride::interactionPotential() const { return interactionPotential_; }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -52,7 +52,7 @@ class PairPotentialOverride : public Serialisable<>
     const InteractionPotential<Functions1D> &interactionPotential() const;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/generator/nodeValue.h
+++ b/src/generator/nodeValue.h
@@ -106,7 +106,7 @@ class Vector3NodeValue : public Serialisable<std::vector<std::shared_ptr<Express
     NodeValue x, y, z;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/generator/parameters.cpp
+++ b/src/generator/parameters.cpp
@@ -29,7 +29,7 @@ bool ParametersGeneratorNode::prepare(const GeneratorContext &generatorContext) 
 bool ParametersGeneratorNode::execute(const GeneratorContext &generatorContext) { return true; }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/generator/parameters.h
+++ b/src/generator/parameters.h
@@ -33,7 +33,7 @@ class ParametersGeneratorNode : public GeneratorNode
     bool execute(const GeneratorContext &generatorContext) override;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -171,7 +171,7 @@ class Dissolve : public Serialisable<>
     void printTiming();
 
     /*
-     * I/O
+     * Serialisation
      */
     private:
     // Filename of current input file

--- a/src/math/sampledDouble.cpp
+++ b/src/math/sampledDouble.cpp
@@ -155,3 +155,9 @@ bool SampledDouble::deserialise(LineParser &parser)
 
 // Write data through specified LineParser
 bool SampledDouble::serialise(LineParser &parser) const { return parser.writeLineF("{}  {}  {}\n", mean_, count_, m2_); }
+
+// Express as a serialisable value
+SerialisedValue SampledDouble::serialise() const { return {}; }
+
+// Read values from a serialisable value
+void SampledDouble::deserialise(const SerialisedValue &node){};

--- a/src/math/sampledDouble.cpp
+++ b/src/math/sampledDouble.cpp
@@ -157,7 +157,12 @@ bool SampledDouble::deserialise(LineParser &parser)
 bool SampledDouble::serialise(LineParser &parser) const { return parser.writeLineF("{}  {}  {}\n", mean_, count_, m2_); }
 
 // Express as a serialisable value
-SerialisedValue SampledDouble::serialise() const { return {}; }
+SerialisedValue SampledDouble::serialise() const { return {{"mean", mean_}, {"count", count_}, {"m2", m2_}}; }
 
 // Read values from a serialisable value
-void SampledDouble::deserialise(const SerialisedValue &node){};
+void SampledDouble::deserialise(const SerialisedValue &value)
+{
+    mean_ = toml::find<double>(value, "mean");
+    count_ = toml::find<int>(value, "count");
+    m2_ = toml::find<double>(value, "m2");
+};

--- a/src/math/sampledDouble.h
+++ b/src/math/sampledDouble.h
@@ -3,13 +3,15 @@
 
 #pragma once
 
+#include "base/serialiser.h"
+
 // Forward Declarations
 class CoreData;
 class LineParser;
 class ProcessPool;
 
 // Double value with sampling
-class SampledDouble
+class SampledDouble : public Serialisable<>
 {
     public:
     SampledDouble();
@@ -56,11 +58,15 @@ class SampledDouble
     void operator/=(double factor);
 
     /*
-     * Serialisation
+     * I/O
      */
     public:
     // Read data through specified LineParser
     bool deserialise(LineParser &parser);
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
+    // Express as a serialisable value
+    SerialisedValue serialise() const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/sampledDouble.h
+++ b/src/math/sampledDouble.h
@@ -58,7 +58,7 @@ class SampledDouble : public Serialisable<>
     void operator/=(double factor);
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Read data through specified LineParser

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -491,7 +491,7 @@ double Vector3::angleInRadians(const Vector3 &to) const { return acos(normalised
 double Vector3::angleInDegrees(const Vector3 &to) const { return DissolveMath::toDegrees(angleInRadians(to)); }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -134,7 +134,7 @@ class Vector3 : public Serialisable<>
     double angleInDegrees(const Vector3 &to) const;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/math/vector3i.cpp
+++ b/src/math/vector3i.cpp
@@ -341,7 +341,7 @@ void Vector3i::swap(int a, int b)
 }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/math/vector3i.h
+++ b/src/math/vector3i.h
@@ -109,7 +109,7 @@ class Vector3i : public Serialisable<>
     void swap(int a, int b);
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/nodes/atomicMC/atomicMC.h
+++ b/src/nodes/atomicMC/atomicMC.h
@@ -45,4 +45,13 @@ class AtomicMCNode : public Node
     private:
     // Run main processing
     NodeConstants::ProcessResult process() override;
+
+    /*
+     * Serialisation
+     */
+    protected:
+    // Express persistent data within the supplied serialisable value
+    virtual void serialisePersistentData(SerialisedValue &value) const;
+    // Retrieve persistent data from the supplied serialisable value
+    virtual void deserialisePersistentData(const SerialisedValue &value);
 };

--- a/src/nodes/atomicMC/atomicMC.h
+++ b/src/nodes/atomicMC/atomicMC.h
@@ -45,13 +45,4 @@ class AtomicMCNode : public Node
     private:
     // Run main processing
     NodeConstants::ProcessResult process() override;
-
-    /*
-     * Serialisation
-     */
-    protected:
-    // Express persistent data within the supplied serialisable value
-    virtual void serialisePersistentData(SerialisedValue &value) const;
-    // Retrieve persistent data from the supplied serialisable value
-    virtual void deserialisePersistentData(const SerialisedValue &value);
 };

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -124,16 +124,3 @@ NodeConstants::ProcessResult AtomicMCNode::process()
 
     return NodeConstants::ProcessResult::Success;
 }
-
-/*
- * Serialisation
- */
-
-// Express persistent data within the supplied serialisable value
-void AtomicMCNode::serialisePersistentData(SerialisedValue &value) const { value["stepSize"] = stepSize_; }
-
-// Retrieve persistent data from the supplied serialisable value
-void AtomicMCNode::deserialisePersistentData(const SerialisedValue &value)
-{
-    stepSize_ = toml::find<double>(value, "stepSize");
-}

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -124,3 +124,19 @@ NodeConstants::ProcessResult AtomicMCNode::process()
 
     return NodeConstants::ProcessResult::Success;
 }
+
+/*
+ * Serialisation
+ */
+
+// Express persistent data within the supplied serialisable value
+void AtomicMCNode::serialisePersistentData(SerialisedValue &value) const
+{
+    value["stepSize"] = stepSize_;
+}
+
+// Retrieve persistent data from the supplied serialisable value
+void AtomicMCNode::deserialisePersistentData(const SerialisedValue &value)
+{
+    stepSize_ = toml::find<double>(value, "stepSize");
+}

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -130,10 +130,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
  */
 
 // Express persistent data within the supplied serialisable value
-void AtomicMCNode::serialisePersistentData(SerialisedValue &value) const
-{
-    value["stepSize"] = stepSize_;
-}
+void AtomicMCNode::serialisePersistentData(SerialisedValue &value) const { value["stepSize"] = stepSize_; }
 
 // Retrieve persistent data from the supplied serialisable value
 void AtomicMCNode::deserialisePersistentData(const SerialisedValue &value)

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -170,7 +170,7 @@ std::string EdgeDefinition::asString() const
 }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -75,7 +75,7 @@ class Edge : public Serialisable<>
     void forceNextPull();
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/nodes/gr/gr.cpp
+++ b/src/nodes/gr/gr.cpp
@@ -22,7 +22,13 @@ GRNode::GRNode(Graph *parentGraph) : Node(parentGraph)
     addOption<GRNode::PartialsMethod>("Method", "Calculation method for partial radial distribution functions",
                                       partialsMethod_);
     addOptionalPointerOutput<PartialSet>("UnweightedGR", "Unweighted partials for target configuration", unweightedGR_);
+
+    // Flag serialisable data
+//    addOptionalSerialisable("stepSize", unweightedGR_);
+    optionalSerialisables_["unweightedGR"] = unweightedGR_;
+
 }
+
 
 // Return enum option info for NormalisationType
 EnumOptions<GRNode::PartialsMethod> GRNode::partialsMethods()

--- a/src/nodes/gr/gr.cpp
+++ b/src/nodes/gr/gr.cpp
@@ -27,10 +27,10 @@ GRNode::GRNode(Graph *parentGraph) : Node(parentGraph)
     SampledDouble x;
     std::optional<SampledDouble> y;
     double z;
-    std::make_shared<SerialisableClass>("dasds", x);
-//    addSerialisable("testShit", x);
-//    addSerialisable("testShit2", y);
-//    addSerialisable("testShit3", z);
+    std::make_shared<SerialisableClass<SampledDouble>>("dasds", x);
+    addSerialisable("testShit", x);
+    addSerialisable("testShit2", y);
+    addSerialisable("testShit3", z);
 }
 
 // Return enum option info for NormalisationType

--- a/src/nodes/gr/gr.cpp
+++ b/src/nodes/gr/gr.cpp
@@ -22,15 +22,6 @@ GRNode::GRNode(Graph *parentGraph) : Node(parentGraph)
     addOption<GRNode::PartialsMethod>("Method", "Calculation method for partial radial distribution functions",
                                       partialsMethod_);
     addOptionalPointerOutput<PartialSet>("UnweightedGR", "Unweighted partials for target configuration", unweightedGR_);
-
-    // Flag serialisable data
-    SampledDouble x;
-    std::optional<SampledDouble> y;
-    double z;
-    std::make_shared<SerialisableClass<SampledDouble>>("dasds", x);
-    addSerialisable("testShit", x);
-    addSerialisable("testShit2", y);
-    addSerialisable("testShit3", z);
 }
 
 // Return enum option info for NormalisationType

--- a/src/nodes/gr/gr.cpp
+++ b/src/nodes/gr/gr.cpp
@@ -24,11 +24,14 @@ GRNode::GRNode(Graph *parentGraph) : Node(parentGraph)
     addOptionalPointerOutput<PartialSet>("UnweightedGR", "Unweighted partials for target configuration", unweightedGR_);
 
     // Flag serialisable data
-//    addOptionalSerialisable("stepSize", unweightedGR_);
-    optionalSerialisables_["unweightedGR"] = unweightedGR_;
-
+    SampledDouble x;
+    std::optional<SampledDouble> y;
+    double z;
+    std::make_shared<SerialisableClass>("dasds", x);
+//    addSerialisable("testShit", x);
+//    addSerialisable("testShit2", y);
+//    addSerialisable("testShit3", z);
 }
-
 
 // Return enum option info for NormalisationType
 EnumOptions<GRNode::PartialsMethod> GRNode::partialsMethods()

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -246,7 +246,7 @@ std::string Graph::location() const
 }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express as a serialisable value

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -104,7 +104,7 @@ class Graph : public Node
     std::string location() const;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialisable value

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -23,7 +23,7 @@ std::string_view InputsNode::summary() const { return "Maps graph inputs to loca
 NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::ProcessResult::Success; }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Is it appropriate to bother serialising this node?

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -29,7 +29,7 @@ class InputsNode : public Node
     NodeConstants::ProcessResult process() override;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Is it appropriate to bother serialising this node?

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -320,10 +320,10 @@ SampledDouble Node::timing() const { return timing_; }
  */
 
 // Express persistent data within the supplied serialisable value
-void Node::putPersistentData(SerialisedValue &value) { }
+void Node::putPersistentData(SerialisedValue &value) {}
 
 // Retrieve persistent data from the supplied serialisable value
-void getPersistentData(const SerialisedValue &value) { }
+void Node::getPersistentData(const SerialisedValue &value) {}
 
 // Express as a serialisable value
 SerialisedValue Node::serialise() const
@@ -365,10 +365,9 @@ SerialisedValue Node::serialiseData() const
 {
     SerialisedValue result;
     result["timing"] = timing_.serialise();
+
+    return result;
 }
 
 // Read persistent data from a serialisable value
-void Node::deserialiseData(const SerialisedValue &node)
-{
-
-}
+void Node::deserialiseData(const SerialisedValue &node) {}

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -361,10 +361,8 @@ SerialisedValue Node::serialiseData() const
     result["timing"] = timing_.serialise();
 
     for (auto &[key, serialisable] : serialisables_)
-    {
         if (serialisable->canSerialise())
             result[key] = serialisable->serialise();
-    }
 
     return result;
 }
@@ -375,8 +373,6 @@ void Node::deserialiseData(const SerialisedValue &node)
     timing_.deserialise(node.at("timing"));
 
     for (auto &[key, serialisable] : serialisables_)
-    {
         if (node.contains(key))
             serialisable->deserialise(node.at(key));
-    }
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -319,12 +319,6 @@ SampledDouble Node::timing() const { return timing_; }
  * Serialisation
  */
 
-// Express persistent data within the supplied serialisable value
-void Node::serialisePersistentData(SerialisedValue &value) const {}
-
-// Retrieve persistent data from the supplied serialisable value
-void Node::deserialisePersistentData(const SerialisedValue &value) {}
-
 // Express as a serialisable value
 SerialisedValue Node::serialise() const
 {
@@ -366,7 +360,11 @@ SerialisedValue Node::serialiseData() const
     SerialisedValue result;
     result["timing"] = timing_.serialise();
 
-    serialisePersistentData(result);
+    for (auto &[key, serialisable] : serialisables_)
+    {
+        if (serialisable->canSerialise())
+            result[key] = serialisable->serialise();
+    }
 
     return result;
 }
@@ -376,5 +374,9 @@ void Node::deserialiseData(const SerialisedValue &node)
 {
     timing_.deserialise(node.at("timing"));
 
-    deserialisePersistentData(node);
+    for (auto &[key, serialisable] : serialisables_)
+    {
+        if (node.contains(key))
+            serialisable->deserialise(node.at(key));
+    }
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -316,7 +316,7 @@ void Node::clearData() {}
 SampledDouble Node::timing() const { return timing_; }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Express persistent data within the supplied serialisable value

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -320,10 +320,10 @@ SampledDouble Node::timing() const { return timing_; }
  */
 
 // Express persistent data within the supplied serialisable value
-void Node::putPersistentData(SerialisedValue &value) {}
+void Node::serialisePersistentData(SerialisedValue &value) const {}
 
 // Retrieve persistent data from the supplied serialisable value
-void Node::getPersistentData(const SerialisedValue &value) {}
+void Node::deserialisePersistentData(const SerialisedValue &value) {}
 
 // Express as a serialisable value
 SerialisedValue Node::serialise() const
@@ -366,8 +366,15 @@ SerialisedValue Node::serialiseData() const
     SerialisedValue result;
     result["timing"] = timing_.serialise();
 
+    serialisePersistentData(result);
+
     return result;
 }
 
 // Read persistent data from a serialisable value
-void Node::deserialiseData(const SerialisedValue &node) {}
+void Node::deserialiseData(const SerialisedValue &node)
+{
+    timing_.deserialise(node.at("timing"));
+
+    deserialisePersistentData(node);
+}

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -312,9 +312,18 @@ DissolveGraph *Node::dissolveGraph() { return parentGraph_->dissolveGraph(); }
 // Clear any local data
 void Node::clearData() {}
 
+// Return timing information (in seconds) for this Module
+SampledDouble Node::timing() const { return timing_; }
+
 /*
  * I/O
  */
+
+// Express persistent data within the supplied serialisable value
+void Node::putPersistentData(SerialisedValue &value) { }
+
+// Retrieve persistent data from the supplied serialisable value
+void getPersistentData(const SerialisedValue &value) { }
 
 // Express as a serialisable value
 SerialisedValue Node::serialise() const
@@ -349,4 +358,17 @@ void Node::deserialise(const SerialisedValue &node)
               else
                   Messenger::exception("Node {} does not contain an option {}", name(), k);
           });
+}
+
+// Express persistent data as a serialisable value
+SerialisedValue Node::serialiseData() const
+{
+    SerialisedValue result;
+    result["timing"] = timing_.serialise();
+}
+
+// Read persistent data from a serialisable value
+void Node::deserialiseData(const SerialisedValue &node)
+{
+
 }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -292,7 +292,7 @@ class Node : public Serialisable<>
     // Flag a persistent serialisable quantity
     template <typename DataClass> void addSerialisable(std::string_view key, DataClass &data)
     {
-        serialisables_[std::string(key)] = std::make_shared<SerialisableClass>(key, data);
+        serialisables_[std::string(key)] = std::make_shared<SerialisableClass<DataClass>>(key, data);
     }
     // Express as a serialisable value
     SerialisedValue serialise() const override;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -268,13 +268,25 @@ class Node : public Serialisable<>
     /*
      * Data
      */
+    private:
+    // Accumulated timing information (in seconds) for this Module
+    SampledDouble timing_;
+
     public:
     // Clear any local data
     virtual void clearData();
+    // Return timing information (in seconds) for this Module
+    SampledDouble timing() const;
 
     /*
      * I/O
      */
+    protected:
+    // Express persistent data within the supplied serialisable value
+    virtual void putPersistentData(SerialisedValue &value);
+    // Retrieve persistent data from the supplied serialisable value
+    virtual void getPersistentData(const SerialisedValue &value);
+
     public:
     // Is it appropriate to bother serialising this node?
     virtual bool shouldSerialise() const { return true; }
@@ -282,4 +294,8 @@ class Node : public Serialisable<>
     SerialisedValue serialise() const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
+    // Express persistent data as a serialisable value
+    SerialisedValue serialiseData() const;
+    // Read persistent data from a serialisable value
+    void deserialiseData(const SerialisedValue &node);
 };

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -283,20 +283,17 @@ class Node : public Serialisable<>
      * Serialisation
      */
     protected:
-    // Persistent data Serialisables
-    std::map<std::string, std::reference_wrapper<Serialisable>> serialisables_;
-    // Optional persistent data Serialisables
-    std::map<std::string, std::reference_wrapper<std::optional<Serialisable>>> optionalSerialisables_;
-
-    protected:
-    // Express persistent data within the supplied serialisable value
-    virtual void serialisePersistentData(SerialisedValue &value) const;
-    // Retrieve persistent data from the supplied serialisable value
-    virtual void deserialisePersistentData(const SerialisedValue &value);
+    // Persistent data serialisables
+    std::map<std::string, std::shared_ptr<SerialisableData>> serialisables_;
 
     public:
     // Is it appropriate to bother serialising this node?
     virtual bool shouldSerialise() const { return true; }
+    // Flag a persistent serialisable quantity
+    template <typename DataClass> void addSerialisable(std::string_view key, DataClass &data)
+    {
+        serialisables_[std::string(key)] = std::make_shared<SerialisableClass>(key, data);
+    }
     // Express as a serialisable value
     SerialisedValue serialise() const override;
     // Read values from a serialisable value

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -283,9 +283,9 @@ class Node : public Serialisable<>
      */
     protected:
     // Express persistent data within the supplied serialisable value
-    virtual void putPersistentData(SerialisedValue &value);
+    virtual void serialisePersistentData(SerialisedValue &value) const;
     // Retrieve persistent data from the supplied serialisable value
-    virtual void getPersistentData(const SerialisedValue &value);
+    virtual void deserialisePersistentData(const SerialisedValue &value);
 
     public:
     // Is it appropriate to bother serialising this node?

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -279,7 +279,7 @@ class Node : public Serialisable<>
     SampledDouble timing() const;
 
     /*
-     * I/O
+     * Serialisation
      */
     protected:
     // Express persistent data within the supplied serialisable value

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -8,6 +8,7 @@
 #include "module/module.h"
 #include "nodes/constants.h"
 #include "nodes/parameter.h"
+#include "nodes/serialisableData.h"
 #include <map>
 #include <string>
 #include <vector>
@@ -281,6 +282,12 @@ class Node : public Serialisable<>
     /*
      * Serialisation
      */
+    protected:
+    // Persistent data Serialisables
+    std::map<std::string, std::reference_wrapper<Serialisable>> serialisables_;
+    // Optional persistent data Serialisables
+    std::map<std::string, std::reference_wrapper<std::optional<Serialisable>>> optionalSerialisables_;
+
     protected:
     // Express persistent data within the supplied serialisable value
     virtual void serialisePersistentData(SerialisedValue &value) const;

--- a/src/nodes/outputs.cpp
+++ b/src/nodes/outputs.cpp
@@ -38,7 +38,7 @@ void OutputsNode::setUpdateRequired()
 }
 
 /*
- * I/O
+ * Serialisation
  */
 
 // Is it appropriate to bother serialising this node?

--- a/src/nodes/outputs.h
+++ b/src/nodes/outputs.h
@@ -33,7 +33,7 @@ class OutputsNode : public Node
     void setUpdateRequired() override;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Is it appropriate to bother serialising this node?

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -152,7 +152,7 @@ class ParameterBase : public Serialisable<>
     virtual ParameterLink createParameterLink(std::string_view newName, std::string_view newDescription = "") const = 0;
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialised value
@@ -399,7 +399,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     };
 
     /*
-     * I/O
+     * Serialisation
      */
     public:
     // Express as a serialised value

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/serialiser.h"
+#include "templates/algorithms.h"
+
+// Base type for serialisable data
+class SerialisableData
+{
+    public:
+    SerialisableData(std::string_view key);
+    virtual ~SerialisableData() = default;
+
+    /*
+     * Definition
+     */
+    protected:
+    // Key for the data
+    std::string key_;
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Return whether there is data to serialise
+    virtual bool canSerialise() const { return false; }
+    // Express as a serialised value
+    virtual SerialisedValue serialise() const { return {}; }
+    // Read from a serialised value
+    virtual void deserialise(const SerialisedValue &node){};
+};
+
+// Primary type for a SerialisableClass to a specific DataClass
+template <typename DataClass> class SerialisableClass : public SerialisableData
+{
+    public:
+    SerialisableClass(std::string_view key, DataClass &targetData)
+        requires(is_optional<DataClass> && std::is_base_of_v<Serialisable<>, typename DataClass::value_type>)
+        : SerialisableData(key), data_(targetData), dataSerialiser_([&]() { return data_.value().serialise(); }),
+          dataDeserialiser_(
+              [&](const SerialisedValue &value)
+              {
+                  targetData = typename DataClass::value_type();
+                  data_->deserialise(value);
+              }),
+          dataChecker_([&]() { return targetData.has_value(); })
+    {
+    }
+    SerialisableClass(std::string_view key, DataClass &value)
+        requires(std::is_pod_v<DataClass>)
+        : SerialisableData(key), data_(value), dataSerialiser_(
+                                                   [&]()
+                                                   {
+                                                       SerialisedValue value;
+                                                       value = data_;
+                                                       return value;
+                                                   }),
+          dataDeserialiser_(
+              [&](const SerialisedValue &value)
+              {
+                  if constexpr (std::is_floating_point_v<DataClass>)
+                      data_ = value.as_floating();
+                  else if constexpr (std::is_integral_v<DataClass>)
+                      data_ = value.as_integer();
+              })
+    {
+    }
+    SerialisableClass(std::string_view key, DataClass &value)
+        requires(std::is_base_of_v<Serialisable<>, DataClass>)
+        : SerialisableData(key), data_(value)
+    {
+    }
+    ~SerialisableClass() override = default;
+
+    /*
+     * Data
+     */
+    protected:
+    // Reference to target data
+    DataClass &data_;
+    // Serialiser for target data
+    using DataSerialiser = std::function<SerialisedValue()>;
+    DataSerialiser dataSerialiser_{[&]() { return data_.serialise(); }};
+    // Deserialiser for target data
+    using DataDeserialiser = std::function<void(const SerialisedValue &value)>;
+    DataDeserialiser dataDeserialiser_{[&](const SerialisedValue &value) { data_.deserialise(value); }};
+    // Value checker for data, returning whether there is actually data to write
+    using ValueChecker = std::function<bool()>;
+    ValueChecker dataChecker_{[&]() { return true; }};
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Return whether there is data to serialise
+    bool canSerialise() const override { return dataChecker_(); }
+    // Express as a serialised value
+    SerialisedValue serialise() const override { return dataSerialiser_(); };
+    // Read from a serialised value
+    void deserialise(const SerialisedValue &node) override { dataDeserialiser_(node); }
+};

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -49,7 +49,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     {
     }
     SerialisableClass(std::string_view key, DataClass &value)
-        requires(std::is_pod_v<DataClass>)
+        requires(std::is_trivial_v<DataClass>)
         : SerialisableData(key), data_(value), dataSerialiser_(
                                                    [&]()
                                                    {

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -10,7 +10,7 @@
 class SerialisableData
 {
     public:
-    SerialisableData(std::string_view key);
+    SerialisableData(std::string_view key) : key_(key) {}
     virtual ~SerialisableData() = default;
 
     /*

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -29,7 +29,7 @@ class SerialisableData
     // Express as a serialised value
     virtual SerialisedValue serialise() const { return {}; }
     // Read from a serialised value
-    virtual void deserialise(const SerialisedValue &node){};
+    virtual void deserialise(const SerialisedValue &node) {};
 };
 
 // Primary type for a SerialisableClass to a specific DataClass

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -302,3 +302,5 @@ template <class Class, class Lam> std::string joinStrings(Class range, std::stri
 // Template functions to determine if a given class derives from a specific base
 template <class T, template <class...> class U> inline constexpr bool is_instance_of_v = std::false_type{};
 template <template <class...> class U, class... Vs> inline constexpr bool is_instance_of_v<U<Vs...>, U> = std::true_type{};
+template<typename>   constexpr bool is_optional = false;
+template<typename T> constexpr bool is_optional<std::optional<T>> = true;

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -302,5 +302,5 @@ template <class Class, class Lam> std::string joinStrings(Class range, std::stri
 // Template functions to determine if a given class derives from a specific base
 template <class T, template <class...> class U> inline constexpr bool is_instance_of_v = std::false_type{};
 template <template <class...> class U, class... Vs> inline constexpr bool is_instance_of_v<U<Vs...>, U> = std::true_type{};
-template<typename>   constexpr bool is_optional = false;
-template<typename T> constexpr bool is_optional<std::optional<T>> = true;
+template <typename> constexpr bool is_optional = false;
+template <typename T> constexpr bool is_optional<std::optional<T>> = true;


### PR DESCRIPTION
Just a draft for now so you can see where this is going and comment before it goes too far!  I took inspiration from my recent use of `requires` in the vector parameter PR to implement a general way of flagging data which should be serialised because it is "restart" or "persistent" data.  Reasons for doing it in this way are:

1. It makes it trivially easy to flag what data get saved / restored from a `Node` - just call `addSerialisable()` with the name (key) of the data as it appears in the TOML and the object you want serialised.
2. Different types of data - PODs, classes derived from `Serialisable`, `Serialisable`s contained within `std::optional`s - can all be handled without requiring multiple function definitions or overloads.
3. (De)serialisation can be handled automatically from within the `Node`.
4. Keys for data are defined once, rather than requiring it to be written e.g. once in `serialise()` and once in `deserialise()` is one was going to go the manual route.

This approach will require that all classes to be serialised derive from `Serialisable`, but many currently don't (e.g. `PartialSet`) so this will encompass most of the work past this point.

## Dependents
- [x] #2206
- [x] #2209
- [x] #2213
- [x] #2216