### PR TITLE
fix: Invalidated iterator error in Visual Studio build

### DIFF
--- a/src/classes/changeStore.cpp
+++ b/src/classes/changeStore.cpp
@@ -89,7 +89,6 @@ void ChangeStore::storeAndReset()
         if (item->hasMoved())
         {
             changes_.push_back(*item);
-            targetAtoms_.erase(item);
         }
     }
 


### PR DESCRIPTION
When debugging on MSVC, the method `ChangeStore::storeAndReset` errors out when iterating over target atoms due to an invalidated iterator error. This is caused by erasing the atoms while iterating over them. This PR aims to fix it by removing the `erase` call.