### PR TITLE
build: Remove SCARF preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -126,13 +126,6 @@
 	    "displayName": "CLI Debug Nix Build",
 	    "description": "The preset for a CLI debug build on a Nix system with tests",
 	    "inherits": ["base", "Debug", "nix"]
-	},
-
-        {
-            "name": "SCARF",
-            "displayName": "SCARF build",
-            "description": "Best setup for SCARF",
-	    "inherits" : ["MPI-Release"]
-        }
+	}
     ]
 }


### PR DESCRIPTION
The CMake preset "SCARF" depends on a now non-existent "MPI-Release", so is really redundant and should be removed. The effect of keeping it is that it interferes with CMake presets in Visual Studio, which can't load properly if there is anything wrong with the presets.