### PR TITLE
chore: Added concurrency group to the pr workflow to automatically cancel previous low priority workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,10 @@ on:
     - '.github/ISSUE_TEMPLATE/**'
     - 'README.md'
 
+concurrency:
+  group: pull-request-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
 
   Checkout:


### PR DESCRIPTION
I am adding [concurrency groups](https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency#example-concurrency-groups) to the **pr** workflow to automatically cancel the previous workflows if commits are pushed in quick succession. This is because the runtime of the PR checks is over 3.5 hours (see [link](https://github.com/disorderedmaterials/dissolve/actions/runs/16524256074/usage)) and we should not be running them unnecessarily.

I recently saw that metrics of actions are now available on [GitHub](https://github.com/disorderedmaterials/dissolve/actions/metrics/usage). As the **pr.yml** is the action that has the highest runtime across the runners, hopefully this change will make development more sustainable. And we can track the reduction in **total jobs runs** and **total minutes** next month.

<img width="744" height="420" alt="image" src="https://github.com/user-attachments/assets/7fcc75b4-ec03-4a9f-9323-dd82eb56323c" />

