### PR TITLE
build:Upgrade clang-format version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ stamp-h1
 ui_*
 moc_*
 *.kdev4
+/.cache/
 build/
 build-*/
 *.exe

--- a/flake.lock
+++ b/flake.lock
@@ -182,32 +182,32 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1731797254,
-        "narHash": "sha256-df3dJApLPhd11AlueuoN0Q4fHo/hagP75LlM5K1sz9g=",
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e8c38b73aeb218e27163376a2d617e61a2ad9b59",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "outdated": {
       "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "lastModified": 1754292888,
+        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.05",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -198,16 +198,16 @@
     },
     "outdated": {
       "locked": {
-        "lastModified": 1754292888,
-        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
-    outdated.url = "github:NixOS/nixpkgs/nixos-21.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    outdated.url = "github:NixOS/nixpkgs/nixos-25.05";
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
   };
@@ -141,7 +141,7 @@
           name = "dissolve-shell";
           buildInputs = base_libs pkgs ++ gui_libs system pkgs
             ++ check_libs pkgs ++ (with pkgs; [
-              clang-tools
+              llvmPackages_20.clang-tools
 
               (onedpl pkgs)
 
@@ -165,15 +165,15 @@
             export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS
             export LIBGL_DRIVERS_PATH=${
               pkgs.lib.makeSearchPathOutput "lib" "lib/dri"
-              [ pkgs.mesa.drivers ]
+              [ pkgs.mesa ]
             }
             export LIBVA_DRIVERS_PATH=${
               pkgs.lib.makeSearchPathOutput "out" "lib/dri"
-              [ pkgs.mesa.drivers ]
+              [ pkgs.mesa ]
             }
-            export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
+            export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json
             export LD_LIBRARY_PATH=${
-              pkgs.lib.makeLibraryPath [ pkgs.mesa.drivers ]
+              pkgs.lib.makeLibraryPath [ pkgs.mesa ]
             }:${
               pkgs.lib.makeSearchPathOutput "lib" "lib/vdpau" [ pkgs.libvdpau ]
             }:${

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
-    outdated.url = "github:NixOS/nixpkgs/nixos-25.05";
+    outdated.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
   };
@@ -39,24 +39,24 @@
           pugixml
           (toml pkgs)
         ];
-      gui_libs = system: pkgs:
-        with pkgs; [
-          glib
-          freetype
-          ftgl
-          libGL.dev
-          libglvnd
-          libglvnd.dev
-          qt6.qt3d
-          qt6.qtbase
-          qt6.qtbase.dev
-          qt6.qtquick3d
-          qt6.qtsvg
-          qt6.qtshadertools
-          qt6.qttools
-          qt6.qtdeclarative
-          qt6.qtdeclarative.dev
-          qt6.wrapQtAppsHook
+      gui_libs = system: pkgs: qt:
+        [
+          pkgs.glib
+          pkgs.freetype
+          pkgs.ftgl
+          pkgs.libGL.dev
+          pkgs.libglvnd
+          pkgs.libglvnd.dev
+          qt.qt3d
+          qt.qtbase
+          qt.qtbase.dev
+          qt.qtquick3d
+          qt.qtsvg
+          qt.qtshadertools
+          qt.qttools
+          qt.qtdeclarative
+          qt.qtdeclarative.dev
+          qt.wrapQtAppsHook
         ];
       check_libs = pkgs: with pkgs; [ gtest ];
 
@@ -64,7 +64,9 @@
 
       let
         pkgs = import nixpkgs { inherit system; };
+        old = import outdated { inherit system; };
         nixGL = import nixGL-src { inherit pkgs; };
+        qt = old.qt6;
         dissolve = { gui ? false, threading ? true, checks ? true
           , benchmarks ? false }:
           pkgs.stdenv.mkDerivation ({
@@ -75,7 +77,7 @@
               name = "dissolve-src";
             };
             buildInputs = base_libs pkgs
-              ++ pkgs.lib.optionals gui (gui_libs system pkgs)
+              ++ pkgs.lib.optionals gui (gui_libs system pkgs qt)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optionals threading [
                 pkgs.tbb_2021_11
@@ -139,7 +141,7 @@
 
         devShells.default = pkgs.mkShell {
           name = "dissolve-shell";
-          buildInputs = base_libs pkgs ++ gui_libs system pkgs
+          buildInputs = base_libs pkgs ++ gui_libs system pkgs qt
             ++ check_libs pkgs ++ (with pkgs; [
               llvmPackages_20.clang-tools
 
@@ -156,7 +158,7 @@
               gdb
               gtk3
               nixGL.nixGLIntel
-              qt6.qttools
+              qt.qttools
               tbb_2021_11
               valgrind
               weggli
@@ -179,19 +181,19 @@
             }:${
               pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]
             }"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
-            # export QT_PLUGIN_PATH="${pkgs.qt6.qt3d}/lib/qt-6/plugins:${pkgs.qt6.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
-            export QT_PLUGIN_PATH="${pkgs.qt6.qtquick3d}/lib/qt-6/plugins:${pkgs.qt6.qt3d}/lib/qt-6/plugins:${pkgs.qt6.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
+            # export QT_PLUGIN_PATH="${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
+            export QT_PLUGIN_PATH="${qt.qtquick3d}/lib/qt-6/plugins:${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
           '';
 
           CMAKE_CXX_COMPILER_LAUNCHER = "${pkgs.ccache}/bin/ccache";
           CMAKE_C_COMPILER_LAUNCHER = "${pkgs.ccache}/bin/ccache";
           CMAKE_CXX_FLAGS_DEBUG = "-g -O0";
           CXXL = "${pkgs.stdenv.cc.cc.lib}";
-          Qt6Quick3D_DIR = "${pkgs.qt6.qtquick3d}/lib/";
+          Qt6Quick3D_DIR = "${qt.qtquick3d}/lib/";
           QML_IMPORT_PATH =
-            "${pkgs.qt6.qtquick3d}/lib/qt-6/qml:${pkgs.qt6.qtdeclarative}/lib/qt-6/qml/";
+            "${qt.qtquick3d}/lib/qt-6/qml:${qt.qtdeclarative}/lib/qt-6/qml/";
           QML2_IMPORT_PATH =
-            "$\${pkgs.qt6.qtquick3d}/lib/qt-6/qml:{pkgs.qt6.qtdeclarative}/lib/qt-6/qml/";
+            "$\${qt.qtquick3d}/lib/qt-6/qml:{qt.qtdeclarative}/lib/qt-6/qml/";
         };
 
         apps = {

--- a/src/base/cbor.cpp
+++ b/src/base/cbor.cpp
@@ -41,8 +41,7 @@ void bs_advance(ByteSource &bs, size_t step)
 uint8_t bs_peek(ByteSource &bs)
 {
     return std::visit(overloaded{[](std::ranges::subrange<std::vector<uint8_t>::iterator> &source) -> uint8_t
-                                 { return *source.begin(); },
-                                 [](std::ifstream &source) -> uint8_t { return source.peek(); }},
+                                 { return *source.begin(); }, [](std::ifstream &source) -> uint8_t { return source.peek(); }},
                       bs);
 };
 

--- a/src/base/enumOptions.h
+++ b/src/base/enumOptions.h
@@ -55,8 +55,7 @@ template <class E> class EnumOptions : public EnumOptionsBase
     // Return whether specified option keyword is valid
     bool isValid(std::string_view keyword) const
     {
-        return std::find_if(options_.cbegin(), options_.cend(),
-                            [keyword](auto &option)
+        return std::find_if(options_.cbegin(), options_.cend(), [keyword](auto &option)
                             { return DissolveSys::sameString(keyword, option.keyword()); }) != options_.end();
     }
 

--- a/src/base/sysFunc.cpp
+++ b/src/base/sysFunc.cpp
@@ -227,8 +227,7 @@ std::string DissolveSys::niceName(std::string_view original)
 {
     std::string s{original};
 
-    std::replace_if(
-        s.begin(), s.end(), [](auto &c) { return " /\\#*$"sv.find(c) != std::string::npos; }, '_');
+    std::replace_if(s.begin(), s.end(), [](auto &c) { return " /\\#*$"sv.find(c) != std::string::npos; }, '_');
 
     return s;
 }
@@ -346,8 +345,7 @@ std::vector<std::string_view> DissolveSys::splitString(std::string_view str, std
 // Double any of the supplied characters in the string
 std::string DissolveSys::doubleChars(const std::string_view s, const std::string_view charsToDouble)
 {
-    std::string result(s.length() + std::count_if(s.begin(), s.end(),
-                                                  [charsToDouble](const char c)
+    std::string result(s.length() + std::count_if(s.begin(), s.end(), [charsToDouble](const char c)
                                                   { return charsToDouble.find(c) != std::string::npos; }),
                        ' ');
     auto pos = 0;

--- a/src/base/sysFunc.h
+++ b/src/base/sysFunc.h
@@ -80,11 +80,10 @@ class DissolveSys
 
         // Iterate until we find an unused name
         auto suffix = 0;
-        while (std::find_if(objects.begin(), objects.end(),
-                            [nameFunction, &uniqueName](const auto &object) {
-                                return !nameFunction(object).empty() &&
-                                       DissolveSys::sameString(nameFunction(object), uniqueName);
-                            }) != objects.end())
+        while (std::find_if(
+                   objects.begin(), objects.end(), [nameFunction, &uniqueName](const auto &object)
+                   { return !nameFunction(object).empty() && DissolveSys::sameString(nameFunction(object), uniqueName); }) !=
+               objects.end())
             uniqueName = std::format("{}{:02d}", base, ++suffix);
 
         return uniqueName;

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -91,8 +91,7 @@ void AtomType::deserialise(SerialisedValue node)
     Z_ = toml::find<Elements::Element>(node, "z");
     charge_ = toml::find_or<double>(node, "charge", 0.0);
     Serialisable::optionalOn(
-        node, "form",
-        [this](const auto node)
+        node, "form", [this](const auto node)
         { interactionPotential_.setForm(ShortRangeFunctions::forms().enumeration(std::string(node.as_string()))); });
 
     Serialisable::optionalOn(node, "parameters",

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -92,8 +92,7 @@ std::vector<const AtomType *> Configuration::atomTypeVector() const
 // Return the total charge of the Configuration
 double Configuration::totalCharge(bool ppIncludeCoulomb) const
 {
-    return std::accumulate(speciesPopulations_.begin(), speciesPopulations_.end(), 0.0,
-                           [&](const auto &acc, auto &spPop)
+    return std::accumulate(speciesPopulations_.begin(), speciesPopulations_.end(), 0.0, [&](const auto &acc, auto &spPop)
                            { return acc + spPop.first->totalCharge(ppIncludeCoulomb) * spPop.second; });
 }
 

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -581,8 +581,8 @@ Configuration *CoreData::addConfiguration()
     auto &newConfiguration = configurations_.emplace_back(std::make_unique<Configuration>());
 
     // Create a suitable unique name
-    newConfiguration->setName(DissolveSys::uniqueName(
-        "NewConfiguration", configurations_, [&](const auto &cfg) { return newConfiguration == cfg ? "" : cfg->name(); }));
+    newConfiguration->setName(DissolveSys::uniqueName("NewConfiguration", configurations_, [&](const auto &cfg)
+                                                      { return newConfiguration == cfg ? "" : cfg->name(); }));
 
     return newConfiguration.get();
 }
@@ -703,17 +703,13 @@ SerialisedValue CoreData::Masters::serialise() const
 // Read values from a serialisable value
 void CoreData::Masters::deserialise(const SerialisedValue &node)
 {
-    Serialisable::toMap(node, "bonds",
-                        [this](const std::string &name, const SerialisedValue &bond)
+    Serialisable::toMap(node, "bonds", [this](const std::string &name, const SerialisedValue &bond)
                         { bonds.emplace_back(std::make_unique<MasterBond>(name))->deserialise(bond); });
-    Serialisable::toMap(node, "angles",
-                        [this](const std::string &name, const SerialisedValue &angle)
+    Serialisable::toMap(node, "angles", [this](const std::string &name, const SerialisedValue &angle)
                         { angles.emplace_back(std::make_unique<MasterAngle>(name))->deserialise(angle); });
-    Serialisable::toMap(node, "torsions",
-                        [this](const std::string &name, const SerialisedValue &torsion)
+    Serialisable::toMap(node, "torsions", [this](const std::string &name, const SerialisedValue &torsion)
                         { torsions.emplace_back(std::make_unique<MasterTorsion>(name))->deserialise(torsion); });
-    Serialisable::toMap(node, "impropers",
-                        [this](const std::string &name, const SerialisedValue &improper)
+    Serialisable::toMap(node, "impropers", [this](const std::string &name, const SerialisedValue &improper)
                         { impropers.emplace_back(std::make_unique<MasterImproper>(name))->deserialise(improper); });
     return;
 }

--- a/src/classes/distributor.cpp
+++ b/src/classes/distributor.cpp
@@ -174,8 +174,7 @@ bool Distributor::canHardLock(int cellIndex) const
     auto *cell = cellArray_.cell(cellIndex);
 
     // For the specified Cell to be hard lockable its neighbours must not be HardLocked
-    if (std::find_if(cellArray_.neighbours(*cell).begin(), cellArray_.neighbours(*cell).end(),
-                     [&](const auto &nbr)
+    if (std::find_if(cellArray_.neighbours(*cell).begin(), cellArray_.neighbours(*cell).end(), [&](const auto &nbr)
                      { return cellLocks_[nbr.cell.index()] == HardLocked; }) != cellArray_.neighbours(*cell).end())
         return false;
 

--- a/src/classes/isotopeMix.cpp
+++ b/src/classes/isotopeMix.cpp
@@ -16,8 +16,7 @@
 double IsotopeMix::isolatedBoundCoherent(const AtomType *atomType) const
 {
     const auto &isotopes = mix_.value(atomType);
-    return std::accumulate(isotopes.begin(), isotopes.end(), 0.0,
-                           [](const auto acc, const auto &isotope)
+    return std::accumulate(isotopes.begin(), isotopes.end(), 0.0, [](const auto acc, const auto &isotope)
                            { return acc + isotope.second * Sears91::boundCoherent(isotope.first); }) /
            std::accumulate(isotopes.begin(), isotopes.end(), 0.0,
                            [](const auto acc, const auto &isotope) { return acc + isotope.second; });

--- a/src/classes/kVector.cpp
+++ b/src/classes/kVector.cpp
@@ -72,8 +72,7 @@ void KVector::calculateIntensities(std::vector<BraggReflection> &reflections)
     auto &braggReflection = reflections[braggReflectionIndex_];
     braggReflection.addKVectors(halfSphereNorm);
     dissolve::for_each_pair(
-        ParallelPolicies::par, cosTerms_.size(),
-        [&](auto i, auto j)
+        ParallelPolicies::par, cosTerms_.size(), [&](auto i, auto j)
         { braggReflection.addIntensity(i, j, (cosTerms_[i] * cosTerms_[j] + sinTerms_[i] * sinTerms_[j]) * halfSphereNorm); });
 }
 

--- a/src/classes/pairPotentialOverride.cpp
+++ b/src/classes/pairPotentialOverride.cpp
@@ -77,14 +77,12 @@ void PairPotentialOverride::deserialise(const SerialisedValue &node)
     matchI_ = toml::find<std::string>(node, "matchI");
     matchJ_ = toml::find<std::string>(node, "matchJ");
 
-    Serialisable::optionalOn(node, "type",
-                             [this](const auto node)
+    Serialisable::optionalOn(node, "type", [this](const auto node)
                              { type_ = pairPotentialOverrideTypes().enumeration(std::string(node.as_string())); });
 
-    Serialisable::optionalOn(node, "form",
-                             [this](const auto node) {
-                                 interactionPotential_.setForm(Functions1D::forms().enumeration(std::string(node.as_string())));
-                             });
+    Serialisable::optionalOn(
+        node, "form", [this](const auto node)
+        { interactionPotential_.setForm(Functions1D::forms().enumeration(std::string(node.as_string()))); });
 
     Serialisable::optionalOn(node, "parameters",
                              [this](const auto node)

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -226,8 +226,8 @@ SerialisedValue Species::serialise() const
 // Read values from a serialisable value
 void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
-    Serialisable::toVector(
-        node, "atoms", [this, &coreData](const SerialisedValue &atom) { atoms_.emplace_back().deserialise(atom, coreData); });
+    Serialisable::toVector(node, "atoms", [this, &coreData](const SerialisedValue &atom)
+                           { atoms_.emplace_back().deserialise(atom, coreData); });
     if (node.contains("forcefield"))
         forcefield_ = ForcefieldLibrary::forcefield(toml::find<std::string>(node, "forcefield"));
 
@@ -273,7 +273,6 @@ void Species::deserialise(const SerialisedValue &node, CoreData &coreData)
                             isotopologues_.back()->deserialise(iso, coreData);
                         });
 
-    Serialisable::toMap(node, "sites",
-                        [this, &coreData](const std::string &name, const SerialisedValue &site)
+    Serialisable::toMap(node, "sites", [this, &coreData](const std::string &name, const SerialisedValue &site)
                         { sites_.emplace_back(std::make_unique<SpeciesSite>(this, name))->deserialise(site, coreData); });
 }

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -19,7 +19,7 @@ class Species;
 template <class Intra, class Functions> class SpeciesIntra : public Serialisable<>
 {
     public:
-    explicit SpeciesIntra(typename Functions::Form form) : interactionPotential_(form){};
+    explicit SpeciesIntra(typename Functions::Form form) : interactionPotential_(form) {};
     virtual ~SpeciesIntra() = default;
     SpeciesIntra(const SpeciesIntra &source) : interactionPotential_(source.interactionPotential_.form()) { (*this) = source; }
     SpeciesIntra(SpeciesIntra &&source) = delete;

--- a/src/classes/speciesRing.cpp
+++ b/src/classes/speciesRing.cpp
@@ -5,7 +5,7 @@
 #include "classes/speciesAtom.h"
 #include "data/elements.h"
 
-SpeciesRing::SpeciesRing(const std::vector<const SpeciesAtom *> &atoms) : atoms_(atoms){};
+SpeciesRing::SpeciesRing(const std::vector<const SpeciesAtom *> &atoms) : atoms_(atoms) {};
 
 bool SpeciesRing::operator==(const SpeciesRing &other) const
 {

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -392,8 +392,7 @@ bool SpeciesSite::generateInstances()
 
                     // Check if the fragment we have found is unique.
                     std::sort(matchedAtomIndices.begin(), matchedAtomIndices.end());
-                    if (std::find_if(instances_.begin(), instances_.end(),
-                                     [&](const auto &instance)
+                    if (std::find_if(instances_.begin(), instances_.end(), [&](const auto &instance)
                                      { return matchedAtomIndices == instance.allIndices(); }) != instances_.end())
                         continue;
 
@@ -448,8 +447,7 @@ const std::vector<SpeciesSiteInstance> &SpeciesSite::instances() const { return 
 Vector3 SpeciesSite::centreOfGeometry(const std::vector<int> &indices) const
 {
     const auto ref = parent_->atom(indices.front()).r();
-    return std::accumulate(std::next(indices.begin()), indices.end(), ref,
-                           [&ref, this](const auto &acc, const auto idx)
+    return std::accumulate(std::next(indices.begin()), indices.end(), ref, [&ref, this](const auto &acc, const auto idx)
                            { return acc + parent_->box()->minimumImage(parent_->atom(idx).r(), ref); }) /
            indices.size();
 }

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -86,27 +86,25 @@ void Species::removeAtoms(std::vector<int> indices)
     impropers_.clear();
 
     // Detach & remove any bond terms that involve any of the supplied atom
-    auto it = std::remove_if(bonds_.begin(), bonds_.end(),
-                             [&indices](auto &bond)
-                             {
-                                 if (std::find_if(indices.begin(), indices.end(),
-                                                  [&bond](const auto i) {
-                                                      return (bond.i()->index() == i || bond.j()->index() == i);
-                                                  }) != indices.end())
-                                 {
-                                     bond.detach();
-                                     return true;
-                                 }
-                                 else
-                                     return false;
-                             });
+    auto it =
+        std::remove_if(bonds_.begin(), bonds_.end(),
+                       [&indices](auto &bond)
+                       {
+                           if (std::find_if(indices.begin(), indices.end(), [&bond](const auto i)
+                                            { return (bond.i()->index() == i || bond.j()->index() == i); }) != indices.end())
+                           {
+                               bond.detach();
+                               return true;
+                           }
+                           else
+                               return false;
+                       });
     if (it != bonds_.end())
         bonds_.erase(it, bonds_.end());
 
     // Now remove the atoms
-    auto atomIt =
-        std::remove_if(atoms_.begin(), atoms_.end(),
-                       [&](const auto &i) { return std::find(indices.begin(), indices.end(), i.index()) != indices.end(); });
+    auto atomIt = std::remove_if(atoms_.begin(), atoms_.end(), [&](const auto &i)
+                                 { return std::find(indices.begin(), indices.end(), i.index()) != indices.end(); });
     atoms_.erase(atomIt, atoms_.end());
     renumberAtoms();
 
@@ -264,8 +262,7 @@ int Species::atomSelectionVersion() const { return atomSelectionVersion_; }
 // Return total atomic mass of Species
 double Species::mass() const
 {
-    return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
-                           [](const auto acc, const auto &i)
+    return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i)
                            { return acc + (i.isPresence(SpeciesAtom::Presence::Physical) ? AtomicMass::mass(i.Z()) : 0.0); });
 }
 
@@ -297,8 +294,8 @@ int Species::simplifyAtomTypes()
     for (auto it = std::next(atoms_.begin()); it != atoms_.end(); ++it)
     {
         // Search all used atom types looking for a match, up to the current one
-        auto matchingIt = std::find_if(
-            atoms_.begin(), it, [&](auto &i) { return i.atomType() && i.atomType()->sameParametersAs(it->atomType().get()); });
+        auto matchingIt = std::find_if(atoms_.begin(), it, [&](auto &i)
+                                       { return i.atomType() && i.atomType()->sameParametersAs(it->atomType().get()); });
         if (matchingIt == it)
             continue;
 
@@ -325,8 +322,7 @@ void Species::setAtomCharge(SpeciesAtom *i, double q)
 double Species::totalCharge(bool useAtomTypes) const
 {
     if (useAtomTypes)
-        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
-                               [](const auto acc, const auto &i)
+        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i)
                                { return acc + (i.atomType() ? i.atomType()->charge() : 0.0); });
     else
         return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,

--- a/src/classes/species_site.cpp
+++ b/src/classes/species_site.cpp
@@ -50,8 +50,7 @@ std::string Species::uniqueSiteName(std::string_view base, const SpeciesSite *ex
 // Search for SpeciesSite by name
 const SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *exclude) const
 {
-    auto it = std::find_if(sites_.begin(), sites_.end(),
-                           [name, exclude](const auto &site)
+    auto it = std::find_if(sites_.begin(), sites_.end(), [name, exclude](const auto &site)
                            { return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name()))); });
     if (it != sites_.end())
         return (*it).get();
@@ -60,8 +59,7 @@ const SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *e
 }
 SpeciesSite *Species::findSite(std::string_view name, const SpeciesSite *exclude)
 {
-    auto it = std::find_if(sites_.begin(), sites_.end(),
-                           [name, exclude](const auto &site)
+    auto it = std::find_if(sites_.begin(), sites_.end(), [name, exclude](const auto &site)
                            { return ((site.get() != exclude) && (DissolveSys::sameString(name, site->name()))); });
     if (it != sites_.end())
         return (*it).get();

--- a/src/data/ff/library.cpp
+++ b/src/data/ff/library.cpp
@@ -98,9 +98,8 @@ std::vector<std::shared_ptr<Forcefield>> &ForcefieldLibrary::forcefields()
 // Return named Forcefield, if it exists
 std::shared_ptr<Forcefield> ForcefieldLibrary::forcefield(std::string_view name)
 {
-    auto it =
-        std::find_if(forcefields().begin(), forcefields().end(),
-                     [&name](const std::shared_ptr<Forcefield> &ff) { return DissolveSys::sameString(ff->name(), name); });
+    auto it = std::find_if(forcefields().begin(), forcefields().end(), [&name](const std::shared_ptr<Forcefield> &ff)
+                           { return DissolveSys::sameString(ff->name(), name); });
     if (it == forcefields().end())
         return nullptr;
 

--- a/src/data/formFactors_WK1995.cpp
+++ b/src/data/formFactors_WK1995.cpp
@@ -1130,9 +1130,8 @@ OptionalReferenceWrapper<const FormFactorData> wk1995Data(Elements::Element Z, i
                                                                {0.550447, 3.581973, 14.357388, 96.064972, 0.052450},
                                                                3.005326}};
 
-    auto it =
-        std::find_if(wk1995.cbegin(), wk1995.cend(),
-                     [&](const FormFactorData_WK1995 &data) { return data.Z() == Z && data.formalCharge() == formalCharge; });
+    auto it = std::find_if(wk1995.cbegin(), wk1995.cend(), [&](const FormFactorData_WK1995 &data)
+                           { return data.Z() == Z && data.formalCharge() == formalCharge; });
     if (it == wk1995.end())
         return {};
     return *it;

--- a/src/data/spaceGroups.cpp
+++ b/src/data/spaceGroups.cpp
@@ -592,7 +592,8 @@ SpaceGroups::SpaceGroupId findByHermannMauginnSymbol(std::string_view hmSymbol, 
     // If the provided HM symbol contains a colon already, or the supplied code is empty, do a plain search.
     auto it = hmSymbol.find(':') != std::string::npos
                   ? std::find_if(symbols_.begin(), symbols_.end(),
-                                 [cleanedHMSymbol](const auto &sg) {
+                                 [cleanedHMSymbol](const auto &sg)
+                                 {
                                      return sg.hermannMauginnSymbol() == cleanedHMSymbol ||
                                             sg.condensedHermannMauginnSymbol() == cleanedHMSymbol;
                                  })
@@ -616,8 +617,7 @@ SpaceGroups::SpaceGroupId findByHermannMauginnSymbol(std::string_view hmSymbol, 
 // Find space group from supplied International Tables index and (optional) code
 SpaceGroups::SpaceGroupId findByInternationalTablesIndex(int itIndex, std::string_view code)
 {
-    auto it = std::find_if(symbols_.begin(), symbols_.end(),
-                           [itIndex, code](const auto &sg)
+    auto it = std::find_if(symbols_.begin(), symbols_.end(), [itIndex, code](const auto &sg)
                            { return sg.internationalTableIndex() == itIndex && (code.empty() || sg.code() == code); });
     return it == symbols_.end() ? SpaceGroupId::NoSpaceGroup : it->id();
 }

--- a/src/expression/expression.cpp
+++ b/src/expression/expression.cpp
@@ -33,8 +33,7 @@ void Expression::operator=(const Expression &source)
 // Add local variable
 std::shared_ptr<ExpressionVariable> Expression::addLocalVariable(std::string_view name)
 {
-    if (std::find_if(localVariables_.begin(), localVariables_.end(),
-                     [name](const auto &var)
+    if (std::find_if(localVariables_.begin(), localVariables_.end(), [name](const auto &var)
                      { return DissolveSys::sameString(name, var->baseName()); }) != localVariables_.end())
         Messenger::exception("Tried to create local variable '{}' in Expression, but it already exists.\n", name);
 

--- a/src/gui/addConfigurationDialog.cpp
+++ b/src/gui/addConfigurationDialog.cpp
@@ -84,9 +84,8 @@ bool AddConfigurationDialog::progressionAllowed(int index) const
     {
         // Must have at least one species, and not more than one periodic species
         auto selection = ui_.TargetSpeciesWidget->selection();
-        if (selection.size() == 0 ||
-            std::count_if(selection.begin(), selection.end(),
-                          [](const auto *sp) { return sp->box()->type() != Box::BoxType::NonPeriodic; }) > 1)
+        if (selection.size() == 0 || std::count_if(selection.begin(), selection.end(), [](const auto *sp)
+                                                   { return sp->box()->type() != Box::BoxType::NonPeriodic; }) > 1)
             return false;
     }
     else if (index == AddConfigurationDialog::BoxGeometryPage)

--- a/src/gui/getModuleLayerNameDialog.cpp
+++ b/src/gui/getModuleLayerNameDialog.cpp
@@ -43,11 +43,9 @@ void GetModuleLayerNameDialog::on_NameEdit_textChanged(const QString text)
         nameValid = false;
     else
     {
-        nameValid = std::none_of(layers_.begin(), layers_.end(),
-                                 [text, this](const auto &layer) {
-                                     return this->moduleLayer_ != layer.get() &&
-                                            DissolveSys::sameString(layer->name(), qPrintable(text));
-                                 });
+        nameValid = std::none_of(
+            layers_.begin(), layers_.end(), [text, this](const auto &layer)
+            { return this->moduleLayer_ != layer.get() && DissolveSys::sameString(layer->name(), qPrintable(text)); });
     }
 
     // Update indicator

--- a/src/gui/keywordWidgets/isotopologueSet.cpp
+++ b/src/gui/keywordWidgets/isotopologueSet.cpp
@@ -127,8 +127,7 @@ void IsotopologueSetKeywordWidget::updateSummaryText()
     auto nNatural = 0;
     for (const auto &topes : keyword_->data().isotopologues())
         // Check if this is a completely "natural" specification
-        if (std::count_if(topes.mix().begin(), topes.mix().end(),
-                          [&topes](const auto &isoWeight)
+        if (std::count_if(topes.mix().begin(), topes.mix().end(), [&topes](const auto &isoWeight)
                           { return isoWeight.first == topes.species()->naturalIsotopologue(); }) == topes.mix().size())
         {
             text += std::format("{}{}[Natural]", text.empty() ? "" : ", ", topes.species()->name());
@@ -141,8 +140,7 @@ void IsotopologueSetKeywordWidget::updateSummaryText()
                                     topes.mix().begin()->first->name());
             else
                 text += std::format("{}{}[{}]", text.empty() ? "" : ", ", topes.species()->name(),
-                                    joinStrings(topes.mix(), ", ",
-                                                [](const auto &isoWeight)
+                                    joinStrings(topes.mix(), ", ", [](const auto &isoWeight)
                                                 { return std::format("{}={}", isoWeight.first->name(), isoWeight.second); }));
         }
 

--- a/src/gui/keywordWidgets/producers.h
+++ b/src/gui/keywordWidgets/producers.h
@@ -56,9 +56,8 @@ class KeywordWidgetProducer
     }
     template <class K> void registerNullProducer()
     {
-        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData) {
-            return WidgetKeywordProduct{nullptr, nullptr};
-        };
+        producers_[typeid(K *)] = [&](KeywordBase *keyword, const CoreData &coreData)
+        { return WidgetKeywordProduct{nullptr, nullptr}; };
     }
     // Produce object of specified type
     std::pair<QWidget *, KeywordWidgetBase *> produce(KeywordBase *keyword, CoreData &coreData) const;

--- a/src/gui/keywordWidgets/speciesSiteVector.cpp
+++ b/src/gui/keywordWidgets/speciesSiteVector.cpp
@@ -71,7 +71,7 @@ void SpeciesSiteVectorKeywordWidget::updateSummaryText()
     if (keyword_->data().empty())
         setSummaryText("<None>");
     else
-        setSummaryText(QString::fromStdString(
-            joinStrings(keyword_->data(), ", ",
-                        [](const auto &site) { return std::format("{} ({})", site->name(), site->parent()->name()); })));
+        setSummaryText(
+            QString::fromStdString(joinStrings(keyword_->data(), ", ", [](const auto &site)
+                                               { return std::format("{} ({})", site->name(), site->parent()->name()); })));
 }

--- a/src/gui/models/moduleModel.cpp
+++ b/src/gui/models/moduleModel.cpp
@@ -11,8 +11,7 @@ void ModuleModel::setData(const std::vector<Module *> &modules)
     if (checkedItems_)
     {
         auto it =
-            std::remove_if(checkedItems_->get().begin(), checkedItems_->get().end(),
-                           [&](const auto *m)
+            std::remove_if(checkedItems_->get().begin(), checkedItems_->get().end(), [&](const auto *m)
                            { return std::find(modules_->get().begin(), modules_->get().end(), m) == modules_->get().end(); });
         if (it != checkedItems_->get().end())
             checkedItems_->get().erase(it, checkedItems_->get().end());

--- a/src/gui/models/nodeGraph/enumRegistry.cpp
+++ b/src/gui/models/nodeGraph/enumRegistry.cpp
@@ -4,6 +4,7 @@
 #include "enumRegistry.h"
 #include "data/structureFactors.h"
 #include "gui/models/nodeGraph/enumOptionsModel.h"
+#include "math/averaging.h"
 #include "math/windowFunction.h"
 #include "nodes/gr/gr.h"
 #include "nodes/md/md.h"

--- a/src/gui/models/weightedModuleModel.cpp
+++ b/src/gui/models/weightedModuleModel.cpp
@@ -11,8 +11,7 @@ void WeightedModuleModel::setData(const std::vector<Module *> &modules)
     if (weightedItems_)
     {
         auto it = std::remove_if(
-            weightedItems_->get().begin(), weightedItems_->get().end(),
-            [&](const auto &item)
+            weightedItems_->get().begin(), weightedItems_->get().end(), [&](const auto &item)
             { return std::find(modules_->get().begin(), modules_->get().end(), item.first) == modules_->get().end(); });
         if (it != weightedItems_->get().end())
             weightedItems_->get().erase(it, weightedItems_->get().end());

--- a/src/gui/speciesEditor.cpp
+++ b/src/gui/speciesEditor.cpp
@@ -94,8 +94,8 @@ void SpeciesEditor::updateStatusBar()
 
     // Set / update empirical formula for the Species and its current atom selection
     auto selection = sp->selectedAtoms();
-    ui_.FormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
-        sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
+    ui_.FormulaLabel->setText(
+        QString::fromStdString(EmpiricalFormula::formula(sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
     ui_.SelectionLabel->setText(selection.empty() ? "--"
                                                   : QString::fromStdString(EmpiricalFormula::formula(
                                                         selection, [](const auto &i) { return i->Z(); }, true)));

--- a/src/gui/speciesTab.cpp
+++ b/src/gui/speciesTab.cpp
@@ -142,8 +142,8 @@ void SpeciesTab::updateControls()
     ui_.CurrentBoxFrame->setToolTip(boxInfo);
     updateDensityLabel();
 
-    ui_.EmpiricalFormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
-        species_->atoms(), [](const auto &i) { return i.Z(); }, true)));
+    ui_.EmpiricalFormulaLabel->setText(
+        QString::fromStdString(EmpiricalFormula::formula(species_->atoms(), [](const auto &i) { return i.Z(); }, true)));
 
     // Charges
     updateTotalCharges();

--- a/src/gui/speciesTab_isotopologues.cpp
+++ b/src/gui/speciesTab_isotopologues.cpp
@@ -65,9 +65,9 @@ void SpeciesTab::on_IsotopologuesTree_customContextMenuRequested(const QPoint &p
 
         // Set a unique name for the new isotopologue
         auto newIso = isos_.data(newIndex, Qt::UserRole).value<Isotopologue *>();
-        isos_.setData(newIndex, QString::fromStdString(DissolveSys::uniqueName(
-                                    iso->name(), species_->isotopologues(),
-                                    [newIso](const auto &oldIso) { return newIso == oldIso.get() ? "" : oldIso->name(); })));
+        isos_.setData(newIndex, QString::fromStdString(
+                                    DissolveSys::uniqueName(iso->name(), species_->isotopologues(), [newIso](const auto &oldIso)
+                                                            { return newIso == oldIso.get() ? "" : oldIso->name(); })));
 
         auto row = 0;
         for (const auto &[atomType, tope] : iso->isotopes())

--- a/src/gui/speciesWidget.cpp
+++ b/src/gui/speciesWidget.cpp
@@ -63,8 +63,8 @@ void SpeciesWidget::updateStatusBar()
     if (sp)
     {
         auto selection = sp->selectedAtoms();
-        ui_.FormulaLabel->setText(QString::fromStdString(EmpiricalFormula::formula(
-            sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
+        ui_.FormulaLabel->setText(
+            QString::fromStdString(EmpiricalFormula::formula(sp->atoms(), [](const auto &i) { return i.Z(); }, true)));
         ui_.SelectionLabel->setText(!selection.empty() ? QString::fromStdString(EmpiricalFormula::formula(
                                                              selection, [](const auto &i) { return i->Z(); }, true))
                                                        : "--");

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -396,11 +396,9 @@ bool CIFHandler::hasBondDistances() const { return !bondingPairs_.empty(); }
 // Return whether a bond distance is defined for the specified label pair
 std::optional<double> CIFHandler::bondDistance(std::string_view labelI, std::string_view labelJ) const
 {
-    auto it = std::find_if(bondingPairs_.begin(), bondingPairs_.end(),
-                           [labelI, labelJ](const auto &bp) {
-                               return (bp.labelI() == labelI && bp.labelJ() == labelJ) ||
-                                      (bp.labelI() == labelJ && bp.labelJ() == labelI);
-                           });
+    auto it = std::find_if(
+        bondingPairs_.begin(), bondingPairs_.end(), [labelI, labelJ](const auto &bp)
+        { return (bp.labelI() == labelI && bp.labelJ() == labelJ) || (bp.labelI() == labelJ && bp.labelJ() == labelI); });
     if (it != bondingPairs_.end())
         return it->r();
     return std::nullopt;

--- a/src/io/import/cifClasses.cpp
+++ b/src/io/import/cifClasses.cpp
@@ -11,7 +11,7 @@
  */
 
 CIFSymmetryAtom::CIFSymmetryAtom(std::string_view label, Elements::Element Z, Vector3 rFrac, double occ)
-    : label_{label}, Z_(Z), rFrac_(rFrac), occupancy_(occ){};
+    : label_{label}, Z_(Z), rFrac_(rFrac), occupancy_(occ) {};
 
 // Return label (from _atom_site_label)
 std::string_view CIFSymmetryAtom::label() const { return label_; }
@@ -30,7 +30,7 @@ double CIFSymmetryAtom::occupancy() const { return occupancy_; }
  */
 
 CIFBondingPair::CIFBondingPair(std::string_view labelI, std::string_view labelJ, double r)
-    : labelI_{labelI}, labelJ_{labelJ}, r_(r){};
+    : labelI_{labelI}, labelJ_{labelJ}, r_(r) {};
 
 // Return labels of involved atom i (from _geom_bond_atom_site_label_1)
 std::string_view CIFBondingPair::labelI() const { return labelI_; }

--- a/src/items/list.cpp
+++ b/src/items/list.cpp
@@ -97,9 +97,8 @@ void GenericList::renamePrefix(std::string_view oldPrefix, std::string_view newP
     auto delimitedPrefix = std::format("{}//", oldPrefix);
     do
     {
-        auto it =
-            std::find_if(items_.begin(), items_.end(),
-                         [delimitedPrefix](const auto &item) { return DissolveSys::startsWith(item.first, delimitedPrefix); });
+        auto it = std::find_if(items_.begin(), items_.end(), [delimitedPrefix](const auto &item)
+                               { return DissolveSys::startsWith(item.first, delimitedPrefix); });
         if (it == items_.end())
             break;
 

--- a/src/kernels/energy.h
+++ b/src/kernels/energy.h
@@ -50,7 +50,7 @@ class EnergyResult
 {
     public:
     EnergyResult(PairPotentialEnergyValue pp = {}, double geom = 0.0, double ext = 0.0)
-        : total_(pp.total() + geom + ext), geometry_(geom), extended_(ext), pairPotential_(pp){};
+        : total_(pp.total() + geom + ext), geometry_(geom), extended_(ext), pairPotential_(pp) {};
 
     private:
     // Components

--- a/src/kernels/geometry.cpp
+++ b/src/kernels/geometry.cpp
@@ -333,8 +333,7 @@ double GeometryKernel::totalGeometryEnergy(const Atom &i) const
 
     // Add energy from SpeciesAngle terms
     intraEnergy += std::accumulate(
-        spAtom->angles().begin(), spAtom->angles().end(), 0.0,
-        [this, &mol](const auto acc, const SpeciesAngle &angle)
+        spAtom->angles().begin(), spAtom->angles().end(), 0.0, [this, &mol](const auto acc, const SpeciesAngle &angle)
         { return acc + angleEnergy(angle, *mol.atom(angle.indexI()), *mol.atom(angle.indexJ()), *mol.atom(angle.indexK())); });
 
     // Add energy from SpeciesTorsion terms

--- a/src/keywords/atomTypeVector.cpp
+++ b/src/keywords/atomTypeVector.cpp
@@ -34,8 +34,7 @@ bool AtomTypeVectorKeyword::deserialise(LineParser &parser, int startArg, const 
     for (auto n = startArg; n < parser.nArgs(); ++n)
     {
         // Do we recognise the AtomType?
-        auto it = std::find_if(coreData.atomTypes().begin(), coreData.atomTypes().end(),
-                               [&parser, n](const auto atomType)
+        auto it = std::find_if(coreData.atomTypes().begin(), coreData.atomTypes().end(), [&parser, n](const auto atomType)
                                { return DissolveSys::sameString(atomType->name(), parser.argsv(n)); });
         if (it == coreData.atomTypes().end())
             return Messenger::error("Unrecognised AtomType '{}' given to '{}' keyword.\n", parser.argsv(n), name());
@@ -87,8 +86,7 @@ void AtomTypeVectorKeyword::deserialise(const SerialisedValue &node, const CoreD
              [this, &coreData](const auto &item)
              {
                  auto it = std::find_if(
-                     coreData.atomTypes().begin(), coreData.atomTypes().end(),
-                     [&item](const auto atomType)
+                     coreData.atomTypes().begin(), coreData.atomTypes().end(), [&item](const auto atomType)
                      { return DissolveSys::sameString(atomType->name(), std::string_view(std::string(item.as_string()))); });
                  if (it == coreData.atomTypes().end())
                      throw toml::type_error(std::format("Unrecognised AtomType '{}' given to '{}' keyword.\n",

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -73,7 +73,7 @@ class KeywordBase : public Serialisable<CoreData const &>
     // Express as a serialisable value
     virtual SerialisedValue serialise() const override = 0;
     // Read values from a serialisable value
-    virtual void deserialise(const SerialisedValue &node, const CoreData &coreData) override{};
+    virtual void deserialise(const SerialisedValue &node, const CoreData &coreData) override {};
 
     /*
      * Keyword Types

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -12,7 +12,7 @@
 class ModuleKeywordBase : public KeywordBase
 {
     public:
-    explicit ModuleKeywordBase(ModuleTypes::ModuleType moduleType) : KeywordBase(typeid(this)), moduleType_(moduleType){};
+    explicit ModuleKeywordBase(ModuleTypes::ModuleType moduleType) : KeywordBase(typeid(this)), moduleType_(moduleType) {};
     ~ModuleKeywordBase() override = default;
 
     /*

--- a/src/keywords/moduleVector.cpp
+++ b/src/keywords/moduleVector.cpp
@@ -52,9 +52,8 @@ bool ModuleVectorKeyword::deserialise(LineParser &parser, int startArg, const Co
             return Messenger::error("No Module named '{}' exists.\n", parser.argsv(n));
 
         // Check the module's type if we can
-        if (!moduleTypes_.empty() &&
-            std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(),
-                         [module](const auto &type) { return type == module->type(); }) == moduleTypes_.cend())
+        if (!moduleTypes_.empty() && std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &type)
+                                                  { return type == module->type(); }) == moduleTypes_.cend())
             return Messenger::error("Module '{}' is of type '{}', and is not relevant to keyword '{}' (allowed types = {}).\n",
                                     parser.argsv(n), ModuleTypes::moduleType(module->type()), name(),
                                     joinStrings(moduleTypes_, ", ", [](auto m) { return ModuleTypes::moduleType(m); }));
@@ -107,9 +106,8 @@ void ModuleVectorKeyword::deserialise(const SerialisedValue &node, const CoreDat
                      throw toml::type_error(std::format("No Module named '{}' exists.\n", title), item.location());
 
                  // Check the module's type if we can
-                 if (!moduleTypes_.empty() &&
-                     std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(),
-                                  [module](const auto &s) { return s == module->type(); }) == moduleTypes_.cend())
+                 if (!moduleTypes_.empty() && std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &s)
+                                                           { return s == module->type(); }) == moduleTypes_.cend())
                      throw toml::type_error(
                          std::format("Module '{}' is of type '{}', and is not relevant to keyword '{}' (allowed types = {}).\n",
                                      title, ModuleTypes::moduleType(module->type()), name(),

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -98,10 +98,8 @@ void SpeciesSiteVectorKeyword::removeReferencesTo(SpeciesSite *spSite)
 // Express as a serialisable value
 SerialisedValue SpeciesSiteVectorKeyword::serialise() const
 {
-    return fromVector(data_,
-                      [](const auto item) -> SerialisedValue {
-                          return {{"site", item->name()}, {"species", item->parent()->name()}};
-                      });
+    return fromVector(data_, [](const auto item) -> SerialisedValue
+                      { return {{"site", item->name()}, {"species", item->parent()->name()}}; });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -33,13 +33,13 @@ class KeywordStore
         for (const auto &section : sections_)
             for (const auto &group : section.groups())
             {
-                auto it = std::remove_if(allKeywords_.begin(), allKeywords_.end(),
-                                         [&](const auto *k)
-                                         {
-                                             return std::find_if(group.keywords().begin(), group.keywords().end(),
-                                                                 [k](const auto &kd)
-                                                                 { return k == kd.first; }) != group.keywords().end();
-                                         });
+                auto it =
+                    std::remove_if(allKeywords_.begin(), allKeywords_.end(),
+                                   [&](const auto *k)
+                                   {
+                                       return std::find_if(group.keywords().begin(), group.keywords().end(), [k](const auto &kd)
+                                                           { return k == kd.first; }) != group.keywords().end();
+                                   });
                 allKeywords_.erase(it, allKeywords_.end());
             }
     }

--- a/src/keywords/weightedModuleVector.cpp
+++ b/src/keywords/weightedModuleVector.cpp
@@ -44,9 +44,8 @@ bool WeightedModuleVectorKeyword::deserialise(LineParser &parser, int startArg, 
     auto weight = parser.hasArg(startArg + 1) ? parser.argd(startArg + 1) : 1.0;
 
     // Check the module's type if we can
-    if (!moduleTypes_.empty() &&
-        std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(),
-                     [module](const auto &type) { return type == module->type(); }) == moduleTypes_.cend())
+    if (!moduleTypes_.empty() && std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &type)
+                                              { return type == module->type(); }) == moduleTypes_.cend())
         return Messenger::error("Module '{}' is of type '{}', and is not relevant to keyword '{}' (allowed types = {}).\n",
                                 module->name(), ModuleTypes::moduleType(module->type()), name(),
                                 joinStrings(moduleTypes_, ", ", [](auto m) { return ModuleTypes::moduleType(m); }));
@@ -85,10 +84,8 @@ void WeightedModuleVectorKeyword::removeReferencesTo(Module *module)
 // Express as a serialisable value
 SerialisedValue WeightedModuleVectorKeyword::serialise() const
 {
-    return fromVector(data_,
-                      [](const auto &item) -> SerialisedValue {
-                          return {{"target", item.first->name()}, {"weight", item.second}};
-                      });
+    return fromVector(data_, [](const auto &item) -> SerialisedValue
+                      { return {{"target", item.first->name()}, {"weight", item.second}}; });
 }
 
 // Read values from a serialisable value
@@ -103,9 +100,8 @@ void WeightedModuleVectorKeyword::deserialise(const SerialisedValue &node, const
                      throw toml::type_error(std::format("No Module named '{}' exists.\n", moduleName), item.location());
 
                  // Check the module's type if we can
-                 if (!moduleTypes_.empty() &&
-                     std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(),
-                                  [module](const auto &s) { return s == module->type(); }) == moduleTypes_.cend())
+                 if (!moduleTypes_.empty() && std::find_if(moduleTypes_.cbegin(), moduleTypes_.cend(), [module](const auto &s)
+                                                           { return s == module->type(); }) == moduleTypes_.cend())
                      throw toml::type_error(
                          std::format("Module '{}' is of type '{}', and is not relevant to keyword '{}' (allowed types = {}).\n",
                                      moduleName, ModuleTypes::moduleType(module->type()), name(),

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -197,8 +197,7 @@ void Dissolve::deserialisePairPotentials(const SerialisedValue &node)
     PairPotential::setShortRangeTruncationScheme(PairPotential::shortRangeTruncationSchemes().deserialise(
         toml::find_or<std::string>(node, "shortRangeTruncation", "Shifted")));
 
-    toMap(node, "atomTypes",
-          [this](const std::string &name, const auto &data)
+    toMap(node, "atomTypes", [this](const std::string &name, const auto &data)
           { coreData().atomTypes().emplace_back(std::make_unique<AtomType>(name))->deserialise(data); });
 
     useCombinationRules_ = toml::find_or<bool>(node, "useCombinationRules", true);
@@ -234,8 +233,7 @@ void Dissolve::deserialise(const SerialisedValue &originalNode)
                            [this](const auto node) { coreData_.addPairPotentialOverride()->deserialise(node); });
     Serialisable::optionalOn(node, "master", [this](const auto node) { coreData_.deserialiseMaster(node); });
 
-    toMap(node, "species",
-          [this](const std::string &name, const SerialisedValue &data)
+    toMap(node, "species", [this](const std::string &name, const SerialisedValue &data)
           { coreData_.species().emplace_back(std::make_unique<Species>(name))->deserialise(data, coreData_); });
 
     toMap(node, "configurations",

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -373,7 +373,8 @@ const std::map<Functions1D::Form, Function1DDefinition> &functions1D()
          */
         functions[Functions1D::Form::ShiftedCoulomb] =
             Function1DDefinition({"q1", "q2", "range"},
-                                 [](double x, double omega, const std::vector<double> &params) {
+                                 [](double x, double omega, const std::vector<double> &params)
+                                 {
                                      return PairPotential::CoulConvert * params[0] * params[1] *
                                             (1.0 / x + x / (params[2] * params[2]) - 2.0 / params[2]);
                                  });

--- a/src/math/peaks.cpp
+++ b/src/math/peaks.cpp
@@ -75,7 +75,8 @@ std::vector<Peaks::Peak1D> Peaks::top(std::size_t n, std::vector<Peaks::Peak1D> 
     for (const auto &peak : peaks)
     {
         bool withinRadius = std::any_of(isolatedPeaks.begin(), isolatedPeaks.end(),
-                                        [this, &peak](const auto &p) {
+                                        [this, &peak](const auto &p)
+                                        {
                                             return (p.index != peak.index) && ((p.valueAt > peak.valueAt - isolation_) &&
                                                                                (p.valueAt < peak.valueAt + isolation_));
                                         });

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <stdexcept>
 
-Vector3::Vector3(const double xx, const double yy, const double zz) : x(xx), y(yy), z(zz){};
+Vector3::Vector3(const double xx, const double yy, const double zz) : x(xx), y(yy), z(zz) {};
 
 /*
  * Set / adjust / retrieve

--- a/src/math/vector3i.cpp
+++ b/src/math/vector3i.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 #include <stdexcept>
 
-Vector3i::Vector3i(const int xx, const int yy, const int zz) : x(xx), y(yy), z(zz){};
+Vector3i::Vector3i(const int xx, const int yy, const int zz) : x(xx), y(yy), z(zz) {};
 
 /*
  * Set / adjust / retrieve

--- a/src/module/groups.cpp
+++ b/src/module/groups.cpp
@@ -41,9 +41,8 @@ const std::vector<std::string> &ModuleGroups::allowedModuleTypes() const { retur
 ModuleGroup *ModuleGroups::addModule(Module *module, std::string_view groupName)
 {
     // Does the specified group exist?
-    auto moduleGroup =
-        std::find_if(groups_.begin(), groups_.end(),
-                     [groupName](auto &moduleGroup) { return DissolveSys::sameString(moduleGroup->name(), groupName); });
+    auto moduleGroup = std::find_if(groups_.begin(), groups_.end(), [groupName](auto &moduleGroup)
+                                    { return DissolveSys::sameString(moduleGroup->name(), groupName); });
 
     if (moduleGroup == groups_.end())
     {

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -232,8 +232,7 @@ Module::ExecutionResult Module::checkConfigurationTargets(GenericList &processin
     else if (!executeIfTargetsUnchanged_)
     {
         // Targets are the same - are _all_ versions different?
-        if (std::any_of(currentTargets.begin(), currentTargets.end(),
-                        [&](const auto *currentTarget)
+        if (std::any_of(currentTargets.begin(), currentTargets.end(), [&](const auto *currentTarget)
                         { return lastProcessedConfigurations_[currentTarget] == currentTarget->version(); }))
         {
             Messenger::warn("One or more target configurations have not changed since module '{}' was last run, so it "

--- a/src/modules/angle/process.cpp
+++ b/src/modules/angle/process.cpp
@@ -172,7 +172,8 @@ Module::ExecutionResult AngleModule::process(Dissolve &dissolve)
     DataOperator2D normaliserDAngleAB(normalisedDAngleAB);
     // Normalise by value / sin(y) / sin(yDelta)
     normaliserDAngleAB.operate(
-        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value) {
+        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+        {
             return (symmetric_ ? value : value * 2.0) / sin(DissolveMath::toRadians(y)) / sin(DissolveMath::toRadians(yDelta));
         });
     // Normalise by A site population
@@ -190,7 +191,8 @@ Module::ExecutionResult AngleModule::process(Dissolve &dissolve)
     DataOperator2D normaliserDAngleBC(normalisedDAngleBC);
     // Normalise by value / sin(y) / sin(yDelta)
     normaliserDAngleBC.operate(
-        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value) {
+        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+        {
             return (symmetric_ ? value : value * 2.0) / sin(DissolveMath::toRadians(y)) / sin(DissolveMath::toRadians(yDelta));
         });
     // Normalise by A site population

--- a/src/modules/axisAngle/process.cpp
+++ b/src/modules/axisAngle/process.cpp
@@ -97,7 +97,8 @@ Module::ExecutionResult AxisAngleModule::process(Dissolve &dissolve)
     DataOperator2D dAxisAngleNormaliser(dAxisAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
     dAxisAngleNormaliser.operate(
-        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value) {
+        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+        {
             return (symmetric_ ? value : value * 2.0) / sin(DissolveMath::toRadians(y)) / sin(DissolveMath::toRadians(yDelta));
         });
     // Normalise by A site population

--- a/src/modules/bragg/gui/braggWidgetFuncs.cpp
+++ b/src/modules/bragg/gui/braggWidgetFuncs.cpp
@@ -106,8 +106,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
                 std::vector<std::string> columnHeaders;
                 columnHeaders.reserve(typeVector.size() * (typeVector.size() + 1) / 2);
                 dissolve::for_each_pair(
-                    ParallelPolicies::seq, typeVector,
-                    [&](int i, auto &popI, int j, auto &popJ)
+                    ParallelPolicies::seq, typeVector, [&](int i, auto &popI, int j, auto &popJ)
                     { columnHeaders.emplace_back(std::format("{}-{}", popI.first->name(), popJ.first->name())); });
 
                 braggModel_.setIntensityHeaders(columnHeaders);

--- a/src/modules/dAngle/process.cpp
+++ b/src/modules/dAngle/process.cpp
@@ -120,7 +120,8 @@ Module::ExecutionResult DAngleModule::process(Dissolve &dissolve)
     DataOperator2D dAngleNormaliser(dAngleNormalised);
     // Normalise by value / sin(y) / sin(yDelta)
     dAngleNormaliser.operate(
-        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value) {
+        [&](const auto &x, const auto &xDelta, const auto &y, const auto &yDelta, const auto &value)
+        {
             return (symmetric_ ? value : value * 2.0) / sin(DissolveMath::toRadians(y)) / sin(DissolveMath::toRadians(yDelta));
         });
     // Normalise by A site population

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -187,25 +187,21 @@ double EnergyModule::intraMolecularEnergy(const Species *sp)
     const Box *box = sp->box();
 
     // Loop over bonds
-    energy += std::accumulate(sp->bonds().begin(), sp->bonds().end(), 0.0,
-                              [box](const auto acc, const auto &b)
+    energy += std::accumulate(sp->bonds().begin(), sp->bonds().end(), 0.0, [box](const auto acc, const auto &b)
                               { return acc + b.energy(box->minimumDistance(b.j()->r(), b.i()->r())); });
 
     // Loop over angles
-    energy += std::accumulate(sp->angles().begin(), sp->angles().end(), 0.0,
-                              [box](const auto acc, const auto &a)
+    energy += std::accumulate(sp->angles().begin(), sp->angles().end(), 0.0, [box](const auto acc, const auto &a)
                               { return acc + a.energy(box->angleInRadians(a.i()->r(), a.j()->r(), a.k()->r())); });
 
     // Loop over torsions
-    energy += std::accumulate(sp->torsions().begin(), sp->torsions().end(), 0.0,
-                              [box](const auto acc, const auto &t) {
-                                  return acc + t.energy(box->torsionInRadians(t.i()->r(), t.j()->r(), t.k()->r(), t.l()->r()));
-                              });
+    energy +=
+        std::accumulate(sp->torsions().begin(), sp->torsions().end(), 0.0, [box](const auto acc, const auto &t)
+                        { return acc + t.energy(box->torsionInRadians(t.i()->r(), t.j()->r(), t.k()->r(), t.l()->r())); });
 
     // Loop over impropers
     energy += std::accumulate(
-        sp->impropers().begin(), sp->impropers().end(), 0.0,
-        [box](const auto acc, const auto &imp)
+        sp->impropers().begin(), sp->impropers().end(), 0.0, [box](const auto acc, const auto &imp)
         { return acc + imp.energy(box->torsionInRadians(imp.i()->r(), imp.j()->r(), imp.k()->r(), imp.l()->r())); });
 
     return energy;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -217,10 +217,8 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     // Create storage for our summed UnweightedSQ
     auto &calculatedUnweightedSQ = moduleData.realise<Array2D<Data1D>>("UnweightedSQ", name_, GenericItem::InRestartFileFlag);
     calculatedUnweightedSQ.initialise(nAtomTypes, nAtomTypes, true);
-    dissolve::for_each_pair(ParallelPolicies::par, atomTypes,
-                            [&](int i, auto at1, int j, auto at2) {
-                                calculatedUnweightedSQ[{i, j}].setTag(std::format("{}-{}", at1->name(), at2->name()));
-                            });
+    dissolve::for_each_pair(ParallelPolicies::par, atomTypes, [&](int i, auto at1, int j, auto at2)
+                            { calculatedUnweightedSQ[{i, j}].setTag(std::format("{}-{}", at1->name(), at2->name())); });
 
     // Is our scattering matrix fully set-up and just requiring updated data?
     auto scatteringMatrixSetUp = scatteringMatrix_.nReferenceData() != 0;

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -539,8 +539,7 @@ bool GRModule::sumUnweightedGR(GenericList &processingData, std::string_view tar
     }
 
     // Calculate overall density of combined system
-    double rho0 = std::accumulate(configWeights.begin(), configWeights.end(), 0.0,
-                                  [totalWeight](double acc, auto pair)
+    double rho0 = std::accumulate(configWeights.begin(), configWeights.end(), 0.0, [totalWeight](double acc, auto pair)
                                   { return acc + pair.second / totalWeight / pair.first->atomicDensity().value(); });
     rho0 = 1.0 / rho0;
 

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
+#define _USE_MATH_DEFINES
+#include <math.h>
 #include <ranges>
 
 #include "classes/atom.h"

--- a/src/nodes/energy/helpers.cpp
+++ b/src/nodes/energy/helpers.cpp
@@ -173,25 +173,21 @@ double EnergyNode::intraMolecularEnergy(const Species *sp)
     const Box *box = sp->box();
 
     // Loop over bonds
-    energy += std::accumulate(sp->bonds().begin(), sp->bonds().end(), 0.0,
-                              [box](const auto acc, const auto &b)
+    energy += std::accumulate(sp->bonds().begin(), sp->bonds().end(), 0.0, [box](const auto acc, const auto &b)
                               { return acc + b.energy(box->minimumDistance(b.j()->r(), b.i()->r())); });
 
     // Loop over angles
-    energy += std::accumulate(sp->angles().begin(), sp->angles().end(), 0.0,
-                              [box](const auto acc, const auto &a)
+    energy += std::accumulate(sp->angles().begin(), sp->angles().end(), 0.0, [box](const auto acc, const auto &a)
                               { return acc + a.energy(box->angleInRadians(a.i()->r(), a.j()->r(), a.k()->r())); });
 
     // Loop over torsions
-    energy += std::accumulate(sp->torsions().begin(), sp->torsions().end(), 0.0,
-                              [box](const auto acc, const auto &t) {
-                                  return acc + t.energy(box->torsionInRadians(t.i()->r(), t.j()->r(), t.k()->r(), t.l()->r()));
-                              });
+    energy +=
+        std::accumulate(sp->torsions().begin(), sp->torsions().end(), 0.0, [box](const auto acc, const auto &t)
+                        { return acc + t.energy(box->torsionInRadians(t.i()->r(), t.j()->r(), t.k()->r(), t.l()->r())); });
 
     // Loop over impropers
     energy += std::accumulate(
-        sp->impropers().begin(), sp->impropers().end(), 0.0,
-        [box](const auto acc, const auto &imp)
+        sp->impropers().begin(), sp->impropers().end(), 0.0, [box](const auto acc, const auto &imp)
         { return acc + imp.energy(box->torsionInRadians(imp.i()->r(), imp.j()->r(), imp.k()->r(), imp.l()->r())); });
 
     return energy;

--- a/src/nodes/gr/helpers.cpp
+++ b/src/nodes/gr/helpers.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
+#define _USE_MATH_DEFINES
 #include "classes/atom.h"
 #include "classes/atomType.h"
 #include "classes/box.h"
@@ -13,6 +14,7 @@
 #include "nodes/gr/gr.h"
 #include "templates/algorithms.h"
 #include "templates/combinable.h"
+#include <math.h>
 #include <tuple>
 
 /*

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -33,4 +33,4 @@ bool InputsNode::shouldSerialise() const { return false; }
 SerialisedValue InputsNode::serialise() const { return {}; }
 
 // Read values from a serialisable value
-void InputsNode::deserialise(const SerialisedValue &node){};
+void InputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/nodes/outputs.cpp
+++ b/src/nodes/outputs.cpp
@@ -48,4 +48,4 @@ bool OutputsNode::shouldSerialise() const { return false; }
 SerialisedValue OutputsNode::serialise() const { return {}; }
 
 // Read values from a serialisable value
-void OutputsNode::deserialise(const SerialisedValue &node){};
+void OutputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -30,8 +30,8 @@ template <typename T> class EarlyReturn
 
     public:
     using inner = T;
-    EarlyReturn(Type t = Type::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v){};
-    EarlyReturn(const T &val) : type_(Type::Return), value_(val){};
+    EarlyReturn(Type t = Type::Continue, std::optional<T> v = std::nullopt) : type_(t), value_(v) {};
+    EarlyReturn(const T &val) : type_(Type::Return), value_(val) {};
     Type type() const { return type_; }
     std::optional<T> value() const { return value_; }
 };
@@ -82,7 +82,7 @@ template <class Lam> auto for_each_pair_early(int count, Lam lambda, bool half =
 template <typename... Args> class ZipIterator
 {
     public:
-    ZipIterator(std::tuple<Args...> args) : source_(std::move(args)){};
+    ZipIterator(std::tuple<Args...> args) : source_(std::move(args)) {};
     bool operator!=(ZipIterator<Args...> other)
     {
         return std::apply(

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -130,11 +130,8 @@ template <typename ValueClass> class DoubleKeyedMap
         auto nElements = keyedObjects.size();
         result.initialise(nElements, nElements, mirroredAreEquivalent_);
         dissolve::for_each_pair(
-            ParallelPolicies::seq, keyedObjects,
-            [&](int i, const auto &itemI, int j, const auto &itemJ) {
-                result[{i, j}] = find(keyGetter(itemI), keyGetter(itemJ));
-            },
-            mirroredAreEquivalent_);
+            ParallelPolicies::seq, keyedObjects, [&](int i, const auto &itemI, int j, const auto &itemJ)
+            { result[{i, j}] = find(keyGetter(itemI), keyGetter(itemJ)); }, mirroredAreEquivalent_);
         return result;
     }
 };

--- a/src/templates/orderedMap.h
+++ b/src/templates/orderedMap.h
@@ -41,7 +41,7 @@ template <typename Key, typename Value> class OrderedMap
 
     public:
     // Constructors
-    OrderedMap(){};
+    OrderedMap() {};
     // Constructor from an iterator off a std::map or std::unorderedmap
     template <typename Iter> OrderedMap(Iter begin, Iter end)
     {

--- a/tests/algorithms/array3DIterator.cpp
+++ b/tests/algorithms/array3DIterator.cpp
@@ -20,9 +20,7 @@ TEST(Array3DIteratorTest, ForEach)
     Array3DIterator it(sizeX, sizeY, sizeZ, 0);
 
     dissolve::for_each_triplet(ParallelPolicies::par, it.begin(), it.end(),
-                               [&](auto triplet, auto x1, auto y1, auto z1) {
-                                   arr[triplet] = {Vector3i{x1, y1, z1}, true};
-                               });
+                               [&](auto triplet, auto x1, auto y1, auto z1) { arr[triplet] = {Vector3i{x1, y1, z1}, true}; });
     for (x = 0; x < sizeX; ++x)
         for (y = 0; y < sizeY; ++y)
             for (z = 0; z < sizeZ; ++z)

--- a/tests/algorithms/pairIterator.cpp
+++ b/tests/algorithms/pairIterator.cpp
@@ -32,11 +32,7 @@ void for_each_test(bool unordered)
 
     int sum = 0;
     dissolve::for_each_pair(
-        ParallelPolicies::seq, size,
-        [&sum, &store](const auto i, const auto j) {
-            sum += store[{i, j}];
-        },
-        unordered);
+        ParallelPolicies::seq, size, [&sum, &store](const auto i, const auto j) { sum += store[{i, j}]; }, unordered);
 
     EXPECT_EQ(total, sum);
 }

--- a/tests/algorithms/sysFunc.cpp
+++ b/tests/algorithms/sysFunc.cpp
@@ -9,7 +9,7 @@ namespace UnitTest
 {
 struct NameObject
 {
-    NameObject(std::string newName) : name(std::move(newName)){};
+    NameObject(std::string newName) : name(std::move(newName)) {};
     std::string name;
 };
 TEST(SysFunc, StringManipulation)

--- a/tests/classes/speciesSite.cpp
+++ b/tests/classes/speciesSite.cpp
@@ -12,7 +12,7 @@ namespace UnitTest
 class SpeciesSiteTest : public ::testing::Test
 {
     public:
-    SpeciesSiteTest(){};
+    SpeciesSiteTest() {};
 
     void testVector(const Vector3 &u, const Vector3 &v)
     {

--- a/tests/gui/addForcefieldTerms.cpp
+++ b/tests/gui/addForcefieldTerms.cpp
@@ -16,7 +16,7 @@ class AddForcefieldDialogModelTest : public ::testing::Test
     AddForcefieldDialogModelTest() = default;
 
     protected:
-    void SetUp() override{};
+    void SetUp() override {};
 };
 
 TEST_F(AddForcefieldDialogModelTest, benzene)

--- a/tests/gui/modifyCharges.cpp
+++ b/tests/gui/modifyCharges.cpp
@@ -20,7 +20,7 @@ class ModifyChargesModelTest : public ::testing::Test
     ModifyChargesModelTest() = default;
 
     protected:
-    void SetUp() override{};
+    void SetUp() override {};
 };
 
 TEST_F(ModifyChargesModelTest, Scale)


### PR DESCRIPTION
This PR accomplishes the following chores

- [x] Upgrade the nixpkgs version to 25.05 (from 24.05)
- [x] Remove the outdated container builder
- [x] Upgrade clang-format to version 20.1.6
- [x] Reformat source to match new clang format

As a quick reminder on the container builder, there was a bug in singularity that caused it to fail on the CI.  We had worked around it by using an old version of singularity from before when the bug was created.  However, I am now checking whether the bug has been cleared and we can use a more recent singularity version.