### PR TITLE
refactor: Convert XRayWeights to use keying

### DIFF
--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -122,16 +122,7 @@ Array2D<double> ScatteringMatrix::matrix(double q) const
         auto col = 0;
         for (auto [i, j] : typePairs_)
         {
-            auto ffi = XRayFormFactors::formFactorData(weights.formFactors(), i->Z());
-            if (!ffi)
-                Messenger::exception("No form factor data available for element {} in dataset {}.", Elements::name(i->Z()),
-                                     XRayFormFactors::xRayFormFactorData().keyword(weights.formFactors()));
-            auto ffj = XRayFormFactors::formFactorData(weights.formFactors(), j->Z());
-            if (!ffj)
-                Messenger::exception("No form factor data available for element {} in dataset {}.", Elements::name(j->Z()),
-                                     XRayFormFactors::xRayFormFactorData().keyword(weights.formFactors()));
-
-            m[{row, col}] *= ffi->get().magnitude(q) * ffj->get().magnitude(q) / normFactor;
+            m[{row, col}] *= weights.formFactorProduct(i, j, q) / normFactor;
 
             ++col;
         }
@@ -410,23 +401,23 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
     const auto rowIndex = A_.nRows() - 1;
 
     // Set coefficients in A_
-    auto success = for_each_pair_early(dataWeights.typeFractions(),
-                                       [&](int indexI, auto &fracI, int indexJ, auto &fracJ) -> EarlyReturn<bool>
-                                       {
-                                           auto colIndex = columnIndex(fracI.first, fracJ.first);
-                                           if (colIndex == -1)
-                                               return Messenger::error(
-                                                   "Weights associated to reference data contain one or more unknown AtomTypes "
-                                                   "('{}' and/or '{}').\n",
-                                                   fracI.first->name(), fracJ.first->name());
+    auto success = for_each_pair_early(
+        dataWeights.typeFractions(),
+        [&](int indexI, auto &fracI, int indexJ, auto &fracJ) -> EarlyReturn<bool>
+        {
+            auto colIndex = columnIndex(fracI.first, fracJ.first);
+            if (colIndex == -1)
+                return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
+                                        "('{}' and/or '{}').\n",
+                                        fracI.first->name(), fracJ.first->name());
 
-                                           // Now have the local column index of the AtomType pair in our matrix A_.
-                                           // Since this is X-ray data, we will just store the product of the concentration
-                                           // weights and the factor
-                                           A_[{rowIndex, colIndex}] = dataWeights.preFactor(indexI, indexJ) * factor;
+            // Now have the local column index of the AtomType pair in our matrix A_.
+            // Since this is X-ray data, we will just store the product of the concentration
+            // weights and the factor
+            A_[{rowIndex, colIndex}] = dataWeights.preFactors().get({fracI.first->name(), fracJ.first->name()}) * factor;
 
-                                           return EarlyReturn<bool>::Continue;
-                                       });
+            return EarlyReturn<bool>::Continue;
+        });
     if (!success.value_or(true))
         return false;
 

--- a/src/classes/xRayWeights.cpp
+++ b/src/classes/xRayWeights.cpp
@@ -148,7 +148,7 @@ double XRayWeights::boundCoherentAverageOfSquares(double Q) const
                            [&, Q](auto acc, const auto &typePop)
                            {
                                auto mag = formFactorData_.at(typePop.first).get().magnitude(Q);
-                               return acc + typePop.second * mag * mag;
+                               return acc + typePop.second * pow(mag, 2);
                            });
 }
 

--- a/src/classes/xRayWeights.cpp
+++ b/src/classes/xRayWeights.cpp
@@ -75,15 +75,6 @@ XRayFormFactors::XRayFormFactorData XRayWeights::formFactors() const { return fo
 // Return atom type fractions
 const KeyedVector<const AtomType *, double> &XRayWeights::typeFractions() const { return typeFractions_; }
 
-// Return concentration product for type i
-double XRayWeights::concentration(int typeIndexI) const { return concentrations_[typeIndexI]; }
-
-// Return concentration product for types i and j
-double XRayWeights::concentrationProduct(int typeIndexI, int typeIndexJ) const
-{
-    return concentrationProducts_[{typeIndexI, typeIndexJ}];
-}
-
 // Return pre-factor for types i and j
 double XRayWeights::preFactor(int typeIndexI, int typeIndexJ) const { return preFactors_[{typeIndexI, typeIndexJ}]; }
 

--- a/src/classes/xRayWeights.cpp
+++ b/src/classes/xRayWeights.cpp
@@ -115,8 +115,7 @@ std::vector<double> XRayWeights::weight(const AtomType *i, const AtomType *j, co
 // Calculate and return Q-dependent average squared scattering (<b>**2) for supplied Q value
 double XRayWeights::boundCoherentSquareOfAverage(double Q) const
 {
-    auto result = std::accumulate(typeFractions_.begin(), typeFractions_.end(), 0.0,
-                                  [&, Q](auto acc, const auto &typePop)
+    auto result = std::accumulate(typeFractions_.begin(), typeFractions_.end(), 0.0, [&, Q](auto acc, const auto &typePop)
                                   { return acc + typePop.second * formFactorData_.at(typePop.first).get().magnitude(Q); });
     return result * result;
 }

--- a/src/classes/xRayWeights.cpp
+++ b/src/classes/xRayWeights.cpp
@@ -13,12 +13,10 @@ bool XRayWeights::setUp(const std::vector<std::pair<const Species *, double>> &s
                         XRayFormFactors::XRayFormFactorData formFactors)
 {
     typeFractions_.clear();
-    concentrations_.clear();
     concentrationProducts_.clear();
     preFactors_.clear();
 
     // Calculate fractional type weights
-    typeFractions_.clear();
     auto sum = 0.0;
     for (auto &[species, speciesPopulation] : speciesPopulations)
         for (const auto &[atomType, atomTypePopulation] : species->atomTypePopulations())
@@ -32,59 +30,53 @@ bool XRayWeights::setUp(const std::vector<std::pair<const Species *, double>> &s
         value /= sum;
 
     // Retrieve form factor data for the current atom types
-    formFactors_ = formFactors;
     formFactorData_.clear();
 
     for (auto &[atomType, fraction] : typeFractions_)
     {
         // Try to retrieve form factor data for this atom type (element, formal charge [TODO])
-        auto data = XRayFormFactors::formFactorData(formFactors_, atomType->Z());
+        auto data = XRayFormFactors::formFactorData(formFactors, atomType->Z());
         if (!data)
             return Messenger::error("No form factor data present for element {} (formal charge {}) in x-ray data set '{}'.\n",
                                     Elements::symbol(atomType->Z()), 0,
-                                    XRayFormFactors::xRayFormFactorData().keyword(formFactors_));
+                                    XRayFormFactors::xRayFormFactorData().keyword(formFactors));
 
-        formFactorData_.push_back(*data);
+        formFactorData_.emplace(atomType, *data);
     }
 
     // Set up weights matrices
     auto nTypes = typeFractions_.size();
-    concentrations_.clear();
-    concentrations_.resize(nTypes);
-    concentrationProducts_.initialise(nTypes, nTypes, true);
-    preFactors_.initialise(nTypes, nTypes, true);
+    concentrationProducts_.clear(true);
+    preFactors_.clear(true);
 
     // Determine atomic concentration products and full pre-factor
     dissolve::for_each_pair(ParallelPolicies::seq, typeFractions_,
                             [&](int indexI, const auto &popI, int indexJ, const auto &popJ)
                             {
+                                DoubleKeyedMapKey key{popI.first->name(), popJ.first->name()};
                                 auto ci = popI.second;
                                 auto cj = popJ.second;
 
-                                concentrations_.at(indexI) = ci;
-                                concentrationProducts_[{indexI, indexJ}] = ci * cj;
-                                preFactors_[{indexI, indexJ}] = ci * cj * (indexI == indexJ ? 1 : 2);
+                                concentrationProducts_.set(key, ci * cj);
+                                preFactors_.set(key, ci * cj * (indexI == indexJ ? 1 : 2));
                             });
 
     return true;
 }
 
-// Return X-Ray form factors being used
-XRayFormFactors::XRayFormFactorData XRayWeights::formFactors() const { return formFactors_; }
-
 // Return atom type fractions
 const KeyedVector<const AtomType *, double> &XRayWeights::typeFractions() const { return typeFractions_; }
 
 // Return pre-factor for types i and j
-double XRayWeights::preFactor(int typeIndexI, int typeIndexJ) const { return preFactors_[{typeIndexI, typeIndexJ}]; }
+const DoubleKeyedMap<double> &XRayWeights::preFactors() const { return preFactors_; }
 
 // Return form factor for type i over supplied Q values
-std::vector<double> XRayWeights::formFactor(int typeIndexI, const std::vector<double> &Q) const
+std::vector<double> XRayWeights::formFactor(const AtomType *i, const std::vector<double> &Q) const
 {
     // Initialise results array
     std::vector<double> fiq(Q.size());
 
-    auto &fi = formFactorData_[typeIndexI].get();
+    auto &fi = formFactorData_.at(i).get();
 
     for (auto n = 0; n < Q.size(); ++n)
         fiq[n] = fi.magnitude(Q[n]);
@@ -93,26 +85,26 @@ std::vector<double> XRayWeights::formFactor(int typeIndexI, const std::vector<do
 }
 
 // Return form factor product for types i and j at specified Q value
-double XRayWeights::formFactorProduct(int typeIndexI, int typeIndexJ, double Q) const
+double XRayWeights::formFactorProduct(const AtomType *i, const AtomType *j, double Q) const
 {
-    return formFactorData_[typeIndexI].get().magnitude(Q) * formFactorData_[typeIndexJ].get().magnitude(Q);
+    return formFactorData_.at(i).get().magnitude(Q) * formFactorData_.at(j).get().magnitude(Q);
 }
 
 // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
-double XRayWeights::weight(int typeIndexI, int typeIndexJ, double Q) const
+double XRayWeights::weight(const AtomType *i, const AtomType *j, double Q) const
 {
-    return preFactors_[{typeIndexI, typeIndexJ}] * formFactorProduct(typeIndexI, typeIndexJ, Q);
+    return preFactors_[{i->name(), j->name()}] * formFactorProduct(i, j, Q);
 }
 
 // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
-std::vector<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const std::vector<double> &Q) const
+std::vector<double> XRayWeights::weight(const AtomType *i, const AtomType *j, const std::vector<double> &Q) const
 {
     // Initialise results array
     std::vector<double> fijq(Q.size());
 
-    auto &fi = formFactorData_[typeIndexI].get();
-    auto &fj = formFactorData_[typeIndexJ].get();
-    auto preFactor = preFactors_[{typeIndexI, typeIndexJ}];
+    auto &fi = formFactorData_.at(i).get();
+    auto &fj = formFactorData_.at(j).get();
+    auto preFactor = preFactors_.get(i->name(), j->name());
 
     std::transform(Q.begin(), Q.end(), fijq.begin(),
                    [preFactor, &fi, &fj](auto q) { return fi.magnitude(q) * fj.magnitude(q) * preFactor; });
@@ -123,8 +115,9 @@ std::vector<double> XRayWeights::weight(int typeIndexI, int typeIndexJ, const st
 // Calculate and return Q-dependent average squared scattering (<b>**2) for supplied Q value
 double XRayWeights::boundCoherentSquareOfAverage(double Q) const
 {
-    auto result = std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0.0,
-                                     std::plus<>(), [Q](auto con, auto form) { return con * form.get().magnitude(Q); });
+    auto result = std::accumulate(typeFractions_.begin(), typeFractions_.end(), 0.0,
+                                  [&, Q](auto acc, const auto &typePop)
+                                  { return acc + typePop.second * formFactorData_.at(typePop.first).get().magnitude(Q); });
     return result * result;
 }
 
@@ -134,13 +127,12 @@ std::vector<double> XRayWeights::boundCoherentSquareOfAverage(const std::vector<
     // Initialise results array
     std::vector<double> bbar(Q.size(), 0.0);
 
-    for (auto typeI = 0; typeI < typeFractions_.size(); ++typeI)
+    for (auto &[atomType, fraction] : typeFractions_)
     {
-        const double ci = concentrations_[typeI];
-        auto &fi = formFactorData_[typeI].get();
+        auto &fi = formFactorData_.at(atomType).get();
 
         std::transform(Q.begin(), Q.end(), bbar.begin(), bbar.begin(),
-                       [ci, &fi](auto q, auto b) { return b + ci * fi.magnitude(q); });
+                       [fraction, &fi](auto q, auto b) { return b + fraction * fi.magnitude(q); });
     }
 
     // Square the averages
@@ -152,8 +144,12 @@ std::vector<double> XRayWeights::boundCoherentSquareOfAverage(const std::vector<
 // Calculate and return Q-dependent squared average scattering (<b**2>) for supplied Q value
 double XRayWeights::boundCoherentAverageOfSquares(double Q) const
 {
-    return std::inner_product(concentrations_.begin(), concentrations_.end(), formFactorData_.begin(), 0.0, std::plus<>(),
-                              [Q](auto con, auto form) { return con * form.get().magnitude(Q) * form.get().magnitude(Q); });
+    return std::accumulate(typeFractions_.begin(), typeFractions_.end(), 0.0,
+                           [&, Q](auto acc, const auto &typePop)
+                           {
+                               auto mag = formFactorData_.at(typePop.first).get().magnitude(Q);
+                               return acc + typePop.second * mag * mag;
+                           });
 }
 
 // Calculate and return Q-dependent squared average scattering (<b**2>) for supplied Q values
@@ -162,13 +158,12 @@ std::vector<double> XRayWeights::boundCoherentAverageOfSquares(const std::vector
     // Initialise results array
     std::vector<double> bbar(Q.size(), 0.0);
 
-    for (auto typeI = 0; typeI < typeFractions_.size(); ++typeI)
+    for (auto &[atomType, fraction] : typeFractions_)
     {
-        const double ci = concentrations_[typeI];
-        auto &fi = formFactorData_[typeI].get();
+        auto &fi = formFactorData_.at(atomType).get();
 
         std::transform(Q.begin(), Q.end(), bbar.begin(), bbar.begin(),
-                       [&](auto q, auto b) { return b + ci * fi.magnitude(q) * fi.magnitude(q); });
+                       [&](auto q, auto b) { return b + fraction * fi.magnitude(q) * fi.magnitude(q); });
     }
 
     return bbar;

--- a/src/classes/xRayWeights.h
+++ b/src/classes/xRayWeights.h
@@ -42,10 +42,6 @@ class XRayWeights
     XRayFormFactors::XRayFormFactorData formFactors() const;
     // Return atom type fractions
     const KeyedVector<const AtomType *, double> &typeFractions() const;
-    // Return concentration product for type i
-    double concentration(int typeIndexI) const;
-    // Return concentration product for types i and j
-    double concentrationProduct(int typeIndexI, int typeIndexJ) const;
     // Return pre-factor for types i and j
     double preFactor(int typeIndexI, int typeIndexJ) const;
     // Return form factor product for types i and j at specified Q value

--- a/src/classes/xRayWeights.h
+++ b/src/classes/xRayWeights.h
@@ -4,9 +4,10 @@
 #pragma once
 
 #include "data/formFactors.h"
-#include "templates/array2D.h"
+#include "templates/doubleKeyedMap.h"
 #include "templates/keyedVector.h"
 #include <functional>
+#include <map>
 #include <vector>
 
 // Forward Declarations
@@ -21,37 +22,31 @@ class XRayWeights
     ~XRayWeights() = default;
 
     private:
-    // X-Ray form factors to use
-    XRayFormFactors::XRayFormFactorData formFactors_{XRayFormFactors::NoFormFactorData};
     // Type fractions
     KeyedVector<const AtomType *, double> typeFractions_;
     // Form factor data for atom types
-    std::vector<std::reference_wrapper<const FormFactorData>> formFactorData_;
-    // Concentration products (ci)
-    std::vector<double> concentrations_;
+    std::map<const AtomType *, std::reference_wrapper<const FormFactorData>> formFactorData_;
     // Concentration product matrix (ci * cj)
-    Array2D<double> concentrationProducts_;
+    DoubleKeyedMap<double> concentrationProducts_;
     // Pre-factors matrix (ci * cj * [2-dij])
-    Array2D<double> preFactors_;
+    DoubleKeyedMap<double> preFactors_;
 
     public:
     // Set-up from supplied species populations and form factors
     bool setUp(const std::vector<std::pair<const Species *, double>> &speciesPopulations,
                XRayFormFactors::XRayFormFactorData formFactors);
-    // Return X-Ray form factors being used
-    XRayFormFactors::XRayFormFactorData formFactors() const;
     // Return atom type fractions
     const KeyedVector<const AtomType *, double> &typeFractions() const;
     // Return pre-factor for types i and j
-    double preFactor(int typeIndexI, int typeIndexJ) const;
+    const DoubleKeyedMap<double> &preFactors() const;
     // Return form factor product for types i and j at specified Q value
-    double formFactorProduct(int typeIndexI, int typeIndexJ, double Q) const;
+    double formFactorProduct(const AtomType *i, const AtomType *j, double Q) const;
     // Return form factor for type i over supplied Q values
-    std::vector<double> formFactor(int typeIndexI, const std::vector<double> &Q) const;
+    std::vector<double> formFactor(const AtomType *i, const std::vector<double> &Q) const;
     // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) at specified Q value
-    double weight(int typeIndexI, int typeIndexJ, double Q) const;
+    double weight(const AtomType *i, const AtomType *j, double Q) const;
     // Return full weighting for types i and j (ci * cj * f(i,Q) * F(j,Q) * [2-dij]) over supplied Q values
-    std::vector<double> weight(int typeIndexI, int typeIndexJ, const std::vector<double> &Q) const;
+    std::vector<double> weight(const AtomType *i, const AtomType *j, const std::vector<double> &Q) const;
     // Calculate and return Q-dependent average squared scattering (<b>**2) for supplied Q value
     double boundCoherentSquareOfAverage(double Q) const;
     // Calculate and return Q-dependent average squared scattering (<b>**2) for supplied Q values

--- a/src/modules/xRaySQ/functions.cpp
+++ b/src/modules/xRaySQ/functions.cpp
@@ -16,7 +16,7 @@ bool XRaySQModule::calculateWeightedGR(const PartialSet &unweightedgr, PartialSe
                             {
                                 auto key = DoubleKeyedMapKey{popI.first->name(), popJ.first->name()};
 
-                                auto weight = weights.weight(indexI, indexJ, 0.0);
+                                auto weight = weights.weight(popI.first, popJ.first, 0.0);
 
                                 // Bound (intramolecular) partial (multiplied by the bound term weight)
                                 weightedgr.boundPartials().get(key).copyArrays(unweightedgr.boundPartials().get(key));
@@ -60,7 +60,8 @@ bool XRaySQModule::calculateWeightedSQ(const PartialSet &unweightedsq, PartialSe
                                 auto key = DoubleKeyedMapKey{popI.first->name(), popJ.first->name()};
 
                                 // Weight bound and unbound S(Q) and sum into full partial
-                                auto qWeights = weights.weight(indexI, indexJ, unweightedsq.boundPartials().get(key).xAxis());
+                                auto qWeights =
+                                    weights.weight(popI.first, popJ.first, unweightedsq.boundPartials().get(key).xAxis());
 
                                 // Bound (intramolecular) and unbound partials
                                 weightedsq.boundPartials().get(key).copyArrays(unweightedsq.boundPartials().get(key));

--- a/src/modules/xRaySQ/process.cpp
+++ b/src/modules/xRaySQ/process.cpp
@@ -232,7 +232,7 @@ Module::ExecutionResult XRaySQModule::process(Dissolve &dissolve)
                                               if (indexI == indexJ)
                                               {
                                                   Data1D atomicData = unweightedSQ.partials().get(key);
-                                                  atomicData.values() = weights.formFactor(indexI, atomicData.xAxis());
+                                                  atomicData.values() = weights.formFactor(popI.first, atomicData.xAxis());
                                                   Data1DExportFileFormat exportFormat(
                                                       std::format("{}-{}.form", name(), popI.first->name()));
                                                   if (!exportFormat.exportData(atomicData))
@@ -240,7 +240,7 @@ Module::ExecutionResult XRaySQModule::process(Dissolve &dissolve)
                                               }
 
                                               Data1D ffData = unweightedSQ.partials().get(key);
-                                              ffData.values() = weights.weight(indexI, indexJ, ffData.xAxis());
+                                              ffData.values() = weights.weight(popI.first, popJ.first, ffData.xAxis());
                                               Data1DExportFileFormat exportFormat(
                                                   std::format("{}-{}-{}.form", name(), popI.first->name(), popJ.first->name()));
                                               if (!exportFormat.exportData(ffData))


### PR DESCRIPTION
## Follows #2222

This PR moves `XRayWeights` to use `DoubleKeyedMap`, but retains some `AtomType`-specific accessors because of the nature of the class.  Since we never (de)serialise `XRayWeights`, we can do this safely.