### PR TITLE
feat:Inner graphs

### DIFF
--- a/.github/workflows/build/osx/action.yml
+++ b/.github/workflows/build/osx/action.yml
@@ -29,6 +29,11 @@ runs:
   # Setup / Install Dependencies
   #
 
+  - name: Choose XCode version
+    shell: bash
+    run: |
+      sudo xcode-select -s /Applications/Xcode_16.2.app
+
   - name: Manage Homebrew Dependencies
     shell: bash
     run: |

--- a/flake.lock
+++ b/flake.lock
@@ -182,11 +182,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1754292888,
-        "narHash": "sha256-1ziydHSiDuSnaiPzCQh1mRFBsM2d2yRX9I+5OPGEmIE=",
+        "lastModified": 1755704039,
+        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce01daebf8489ba97bd1609d185ea276efdeb121",
+        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
         "type": "github"
       },
       "original": {

--- a/src/gui-qml/qml/DissolveMain.qml
+++ b/src/gui-qml/qml/DissolveMain.qml
@@ -223,6 +223,9 @@ ApplicationWindow {
                     Label {
                         text: "Edges: " + graphModel.edgeCount
                     }
+                    Label {
+                        text: "Location: " + graphModel.location
+                    }
                 }
             }
             GraphView {

--- a/src/gui-qml/qml/DissolveMain.qml
+++ b/src/gui-qml/qml/DissolveMain.qml
@@ -223,6 +223,13 @@ ApplicationWindow {
                     Label {
                         text: "Edges: " + graphModel.edgeCount
                     }
+                    ToolButton {
+                        enabled: !graphModel.atRoot
+                        icon.color: graphModel.atRoot ? "grey" : "transparent"
+                        icon.source: "qrc:/IconsModule/arrowUp.svg"
+
+                        onClicked: graphModel.upLevel()
+                    }
                     Label {
                         text: "Location: " + graphModel.location
                     }

--- a/src/gui-qml/qml/DissolveMain.qml
+++ b/src/gui-qml/qml/DissolveMain.qml
@@ -250,6 +250,9 @@ ApplicationWindow {
                     GraphDelegate {
                         rootModel: graphModel
 
+                        onDescended: function (idx) {
+                            graphModel.descend(idx);
+                        }
                         onEdgeCreated: function (srcNode, srcOutput, tgtNode, tgtInput) {
                             graphModel.addEdge(srcNode, srcOutput, tgtNode, tgtInput);
                         }

--- a/src/gui/models/nodeGraph/graphModel.cpp
+++ b/src/gui/models/nodeGraph/graphModel.cpp
@@ -43,14 +43,18 @@ QAbstractListModel *GraphModel::nodes() { return &nodes_; }
 
 int GraphModel::count() { return nodes_.rowCount(); }
 
-QString GraphModel::location() const {
-  if (!graph_)
-    return "";
-  return QString::fromStdString(graph_->location());
+QString GraphModel::location() const
+{
+    if (!graph_)
+        return "";
+    return QString::fromStdString(graph_->location());
 };
 
-bool GraphModel::atRoot() const {
-  return !graph_;
+bool GraphModel::atRoot() const
+{
+    if (!graph_)
+        return true;
+    return !graph_->parentGraph();
 }
 
 // Provide relative coordinates for an input on a node
@@ -71,12 +75,22 @@ void GraphModel::addOutput(int nodeIndex, QString paramName, double x, double y)
     node.outputPos.insert({paramName.toStdString(), {x, y}});
 }
 
-
 // Switch to parent graph
-void GraphModel::upLevel() {
-  if (!graph_);
-    return;
+void GraphModel::upLevel()
+{
+    if (!graph_)
+        return;
     setGraph(graph_->parentGraph());
+}
+
+// Move into an inner graph
+void GraphModel::descend(int index)
+{
+    auto &node = wrapped_[index];
+    if (node.hasInner())
+    {
+        setGraph(static_cast<Graph *>(&node.rawValue()));
+    }
 }
 
 void GraphModel::emplace_back(int x, int y, QVariant type, QVariant name)

--- a/src/gui/models/nodeGraph/graphModel.cpp
+++ b/src/gui/models/nodeGraph/graphModel.cpp
@@ -49,6 +49,10 @@ QString GraphModel::location() const {
   return QString::fromStdString(graph_->location());
 };
 
+bool GraphModel::atRoot() const {
+  return !graph_;
+}
+
 // Provide relative coordinates for an input on a node
 void GraphModel::addInput(int nodeIndex, QString paramName, double x, double y)
 {
@@ -65,6 +69,14 @@ void GraphModel::addOutput(int nodeIndex, QString paramName, double x, double y)
     x += 16;
     y += 64;
     node.outputPos.insert({paramName.toStdString(), {x, y}});
+}
+
+
+// Switch to parent graph
+void GraphModel::upLevel() {
+  if (!graph_);
+    return;
+    setGraph(graph_->parentGraph());
 }
 
 void GraphModel::emplace_back(int x, int y, QVariant type, QVariant name)

--- a/src/gui/models/nodeGraph/graphModel.cpp
+++ b/src/gui/models/nodeGraph/graphModel.cpp
@@ -43,6 +43,12 @@ QAbstractListModel *GraphModel::nodes() { return &nodes_; }
 
 int GraphModel::count() { return nodes_.rowCount(); }
 
+QString GraphModel::location() const {
+  if (!graph_)
+    return "";
+  return QString::fromStdString(graph_->location());
+};
+
 // Provide relative coordinates for an input on a node
 void GraphModel::addInput(int nodeIndex, QString paramName, double x, double y)
 {

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -31,14 +31,14 @@ class GraphModel : public QObject
     GraphModel();
 
     public:
-    // Access the acutal nodes in the model
+    // Access the actual nodes in the model
     Graph *graph();
 
     void setGraph(Graph *graph);
 
     // The model for the edges in the graph
     GraphEdgeModel *edges();
-    // The modelfor the nodes in the graph
+    // The model for the nodes in the graph
     QAbstractListModel *nodes();
     // The total number of nodes in the graph
     int count();
@@ -50,7 +50,7 @@ class GraphModel : public QObject
     GraphNodeModel nodes_;
     // The abstract data model for the edges between nodes
     GraphEdgeModel edges_;
-    // The graph being modeled
+    // The graph being modelled
     Graph *graph_;
     // Graph nodes wrapped in the wrappers
     std::vector<NodeWrapper> wrapped_;

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -23,8 +23,8 @@ class GraphModel : public QObject
     Q_PROPERTY(QAbstractListModel *nodes READ nodes NOTIFY graphChanged);
     Q_PROPERTY(int nodeCount READ count NOTIFY graphChanged);
     Q_PROPERTY(int edgeCount READ nEdges NOTIFY graphChanged);
-    Q_PROPERTY(QString location READ location);
-    Q_PROPERTY(bool atRoot READ atRoot);
+    Q_PROPERTY(QString location READ location NOTIFY graphChanged);
+    Q_PROPERTY(bool atRoot READ atRoot NOTIFY graphChanged);
 
     friend GraphNodeModel;
     friend GraphEdgeModel;
@@ -94,4 +94,6 @@ class GraphModel : public QObject
 
     // Switch to parent graph
     void upLevel();
+    // Move into an inner graph
+    void descend(int index);
 };

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -23,6 +23,7 @@ class GraphModel : public QObject
     Q_PROPERTY(QAbstractListModel *nodes READ nodes NOTIFY graphChanged);
     Q_PROPERTY(int nodeCount READ count NOTIFY graphChanged);
     Q_PROPERTY(int edgeCount READ nEdges NOTIFY graphChanged);
+    Q_PROPERTY(QString location READ location NOTIFY graphChanged);
 
     friend GraphNodeModel;
     friend GraphEdgeModel;
@@ -44,6 +45,8 @@ class GraphModel : public QObject
     int count();
     // The total number of edges in the graph
     int nEdges();
+    // The path to the current graph
+    QString location() const;
 
     protected:
     // The abstract data model for the nodes

--- a/src/gui/models/nodeGraph/graphModel.h
+++ b/src/gui/models/nodeGraph/graphModel.h
@@ -23,7 +23,8 @@ class GraphModel : public QObject
     Q_PROPERTY(QAbstractListModel *nodes READ nodes NOTIFY graphChanged);
     Q_PROPERTY(int nodeCount READ count NOTIFY graphChanged);
     Q_PROPERTY(int edgeCount READ nEdges NOTIFY graphChanged);
-    Q_PROPERTY(QString location READ location NOTIFY graphChanged);
+    Q_PROPERTY(QString location READ location);
+    Q_PROPERTY(bool atRoot READ atRoot);
 
     friend GraphNodeModel;
     friend GraphEdgeModel;
@@ -47,6 +48,8 @@ class GraphModel : public QObject
     int nEdges();
     // The path to the current graph
     QString location() const;
+    // Whether the current graph has a parent
+    bool atRoot() const;
 
     protected:
     // The abstract data model for the nodes
@@ -88,4 +91,7 @@ class GraphModel : public QObject
 
     // Add a new node at a specific position
     void emplace_back(int x, int y, QVariant type, QVariant name);
+
+    // Switch to parent graph
+    void upLevel();
 };

--- a/src/gui/models/nodeGraph/graphNodeModel.cpp
+++ b/src/gui/models/nodeGraph/graphNodeModel.cpp
@@ -18,6 +18,7 @@ enum Role
     INPUTS,
     OUTPUTS,
     OPTIONS,
+    INNER_GRAPH,
 };
 
 GraphNodeModel &GraphNodeModel::operator=(const GraphNodeModel &other)
@@ -54,6 +55,7 @@ QHash<int, QByteArray> GraphNodeModel::roleNames() const
     roles[Qt::UserRole + (int)INPUTS] = "inputs";
     roles[Qt::UserRole + (int)OUTPUTS] = "outputs";
     roles[Qt::UserRole + (int)OPTIONS] = "options";
+    roles[Qt::UserRole + (int)INNER_GRAPH] = "inner_graph";
     return roles;
 }
 
@@ -79,6 +81,8 @@ QVariant GraphNodeModel::data(const QModelIndex &index, int role) const
             return QVariant::fromValue(item.outputs.get());
         case OPTIONS:
             return QVariant::fromValue(item.options.get());
+        case INNER_GRAPH:
+            return item.hasInner();
     }
     return {};
 }

--- a/src/gui/models/nodeGraph/nodeWrapper.h
+++ b/src/gui/models/nodeGraph/nodeWrapper.h
@@ -31,6 +31,9 @@ class NodeWrapper
     Node &rawValue() { return *value_; }
     const Node &rawValue() const { return *value_; }
 
+    // Does this node contain other nodes?
+    bool hasInner() { return dynamic_cast<Graph *>(value_) != nullptr; }
+
     private:
     // The actual value of the node
     Node *value_;

--- a/src/gui/qml/nodeGraph/GraphDelegate.qml
+++ b/src/gui/qml/nodeGraph/GraphDelegate.qml
@@ -12,6 +12,7 @@ NodeBox {
     property variant rootModel
     property double startX: x + width
     signal edgeCreated(srcNode: string, srcOutput: string, tgtNode: string, tgtInput: string)
+    signal descended(idx: int)
 
     image: icon
     nodeType: name
@@ -166,6 +167,15 @@ NodeBox {
             color: palette.active.mid
             height: options.rowCount() > 0 ? 2 : 0
             width: parent.width
+        }
+        Button {
+            Layout.fillWidth: true
+            text: "Inner Graph"
+            visible: inner_graph
+
+            onClicked: {
+                descended(index);
+            }
         }
         GridLayout {
             columns: 3

--- a/src/gui/qml/nodeGraph/GraphDelegate.qml
+++ b/src/gui/qml/nodeGraph/GraphDelegate.qml
@@ -11,8 +11,9 @@ NodeBox {
     property double midY: y + height / 2
     property variant rootModel
     property double startX: x + width
-    signal edgeCreated(srcNode: string, srcOutput: string, tgtNode: string, tgtInput: string)
-    signal descended(idx: int)
+
+    signal descended(int idx)
+    signal edgeCreated(string srcNode, string srcOutput, string tgtNode, string tgtInput)
 
     image: icon
     nodeType: name
@@ -28,50 +29,63 @@ NodeBox {
 
     ColumnLayout {
         anchors.fill: parent
+
         GridLayout {
             columns: 5
 
             Repeater {
                 id: inputRepeater
+
                 model: inputs
+
+                Component.onCompleted: {
+                    for (var i = 0; i < inputRepeater.count; i++) {
+                        let item = inputRepeater.itemAt(i);
+                        rootModel.addInput(index, item.title, item.x, item.y);
+                    }
+                }
+
                 Shape {
-                    property string title
-                    property string nodeName
-                    nodeName: root.nodeType
-                    title: name
-                    width: 20
-                    height: 20
+                    property string nodeName: root.nodeType
+                    property string title: name
+
+                    Layout.alignment: Qt.AlignLeft
                     Layout.column: 0
                     Layout.row: index
-                    Layout.alignment: Qt.AlignLeft
+                    height: 20
+                    width: 20
+
                     ShapePath {
                         fillColor: "black"
-                        startX: 20; startY: 0
-                        PathLine { x: 20; y: 20 }
-                        PathLine { x: 0; y: 10 }
-                        PathLine { x: 20; y: 0 }
+                        startX: 20
+                        startY: 0
+
+                        PathLine {
+                            x: 20
+                            y: 20
+                        }
+                        PathLine {
+                            x: 0
+                            y: 10
+                        }
+                        PathLine {
+                            x: 20
+                            y: 0
+                        }
                     }
                     DropArea {
                         anchors.fill: parent
-                        onDropped: function(event) {
-                            edgeCreated(event.source.parent.nodeName, event.source.parent.title, parent.nodeName, parent.title)
+
+                        onDropped: function (event) {
+                            edgeCreated(event.source.parent.nodeName, event.source.parent.title, parent.nodeName, parent.title);
                         }
                     }
                     MouseArea {
+                        Drag.active: drag.active
+                        Drag.dragType: Drag.Automatic
+                        Drag.proposedAction: Qt.LinkAction
                         anchors.fill: parent
                         drag.target: this
-                        Drag.active: drag.active
-                        Drag.proposedAction: Qt.LinkAction
-                        Drag.dragType: Drag.Automatic
-                    }
-                }
-                Component.onCompleted: {
-
-                    for(var i = 0;i < inputRepeater.count; i++)
-                    {
-                        let item = inputRepeater.itemAt(i);
-                        rootModel.addInput(index, item.title, item.x, item.y);
-
                     }
                 }
             }
@@ -79,81 +93,89 @@ NodeBox {
                 model: inputs
 
                 Text {
-                    height: 10
+                    Layout.alignment: Qt.AlignLeft
                     Layout.column: 1
                     Layout.row: index
-                    Layout.alignment: Qt.AlignLeft
                     ToolTip.text: description
                     ToolTip.visible: hovered
                     font.pointSize: 10
+                    height: 10
                     text: name
                     wrapMode: Text.Wrap
                 }
             }
-
             Repeater {
                 model: outputs
+
                 Item {
                     Layout.column: 2
-                    Layout.row: index
                     Layout.fillWidth: true
+                    Layout.row: index
                 }
             }
-
-
             Repeater {
                 id: outputRepeater
+
                 model: outputs
+
+                Component.onCompleted: {
+                    for (var i = 0; i < outputRepeater.count; i++) {
+                        let item = outputRepeater.itemAt(i);
+                        rootModel.addOutput(index, item.title, item.x + item.width / 2, item.y);
+                    }
+                }
+
                 Shape {
-                    property string title
-                    property string nodeName
-                    nodeName: root.nodeType
-                    title: name
-                    width: 20
-                    height: 20
+                    property string nodeName: root.nodeType
+                    property string title: name
+
+                    Layout.alignment: Qt.AlignRight
                     Layout.column: 4
                     Layout.row: index
-                    Layout.alignment: Qt.AlignRight
+                    height: 20
+                    width: 20
+
                     ShapePath {
                         fillColor: "black"
-                        startX: 0; startY: 0
-                        PathLine { x: 0; y: 20 }
-                        PathLine { x: 20; y: 10 }
-                        PathLine { x: 0; y: 0 }
+                        startX: 0
+                        startY: 0
+
+                        PathLine {
+                            x: 0
+                            y: 20
+                        }
+                        PathLine {
+                            x: 20
+                            y: 10
+                        }
+                        PathLine {
+                            x: 0
+                            y: 0
+                        }
                     }
                     DropArea {
                         anchors.fill: parent
-                        onDropped: function(event) {
-                            edgeCreated(parent.nodeName, parent.title, event.source.parent.nodeName, event.source.parent.title)
+
+                        onDropped: function (event) {
+                            edgeCreated(parent.nodeName, parent.title, event.source.parent.nodeName, event.source.parent.title);
                         }
                     }
                     MouseArea {
+                        Drag.active: drag.active
+                        Drag.dragType: Drag.Automatic
+                        Drag.proposedAction: Qt.LinkAction
                         anchors.fill: parent
                         drag.target: this
-                        Drag.active: drag.active
-                        Drag.proposedAction: Qt.LinkAction
-                        Drag.dragType: Drag.Automatic
-                    }
-                }
-
-                Component.onCompleted: {
-
-                    for(var i = 0;i < outputRepeater.count; i++)
-                    {
-                        let item = outputRepeater.itemAt(i);
-                        rootModel.addOutput(index, item.title, item.x + item.width/2, item.y);
-
                     }
                 }
             }
-
             Repeater {
                 model: outputs
 
                 Text {
+                    Layout.alignment: Qt.AlignRight
                     Layout.column: 3
                     Layout.row: index
-                    Layout.alignment: Qt.AlignRight
                     ToolTip.text: description
                     ToolTip.visible: hovered
                     anchors.margins: 4
@@ -183,24 +205,23 @@ NodeBox {
 
             Repeater {
                 model: options
+
                 Text {
-                    text: name
+                    Layout.alignment: Qt.AlignLeft
                     Layout.column: 0
                     Layout.row: index
-                    Layout.alignment: Qt.AlignLeft
+                    text: name
                 }
             }
-
             Repeater {
                 model: options
+
                 Item {
                     Layout.column: 1
-                    Layout.row: index
                     Layout.fillWidth: true
+                    Layout.row: index
                 }
             }
-
-
             Repeater {
                 model: options
 

--- a/src/gui/qml/nodeGraph/GraphView.qml
+++ b/src/gui/qml/nodeGraph/GraphView.qml
@@ -109,6 +109,11 @@ Pane {
 
                     onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Configuration", "New Node")
                 }
+                MenuItem {
+                    text: "Graph"
+
+                    onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Graph", "New Graph")
+                }
             }
         }
     }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -237,6 +237,14 @@ Graph::Nodes &Graph::nodes() { return nodes_; }
 // Return edges on the graph
 Graph::Edges &Graph::edges() { return edges_; }
 
+// Return a path to this graph from the root
+std::string Graph::location() const
+{
+    if (!parentGraph_)
+        return std::string("/") + std::string(name());
+    return parentGraph_->location() + "/" + std::string(name());
+}
+
 /*
  * I/O
  */

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -100,6 +100,8 @@ class Graph : public Node
     Nodes &nodes();
     // Return container of edges between nodes
     Edges &edges();
+    // Return a path to this graph from the root
+    std::string location() const;
 
     /*
      * I/O


### PR DESCRIPTION
When a node contains an inner graph, the user can press a button in the node to descend into the inner graph.  There is a location bar at the top of the window that states what node the user is currently in with an `up` button to return back to the parent graph.

I'm submitting this with the following known issue:  when you leave a graph, all of the nodes lose their positions.  This is because the positions are only stored in the graph model, which only looks at the current node.  It will be a larger change to start saving this information, but I thought that I should make this available before I go on leave next week.

This PR also includes a change to the Mac build on github actions.  GitHub has upgraded to XCode 17, but XCode 16 is the **last** version supported by Conan 1.  I've pinned XCode to version 16, but we need to migrate to Conan 2