### PR TITLE
fix: Replace gtest_discover_tests for Visual Studio 2022 builds

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ function(dissolve_add_test)
     )
   endif(DISSOLVE_UNIT_TEST_GUI)
 
-    # Register the test
+  # Register the test
   if(MSVC_DEV)
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
     set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,8 +55,7 @@ function(dissolve_add_test)
     # Register the test
   if(MSVC_DEV)
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
-    set_tests_properties(${TEST_NAME}
-        PROPERTIES WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
+    set_tests_properties(${TEST_NAME} PROPERTIES WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
   else(MSVC_DEV)
     gtest_discover_tests(${TEST_NAME} WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
   endif(MSVC_DEV)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,8 +52,14 @@ function(dissolve_add_test)
     )
   endif(DISSOLVE_UNIT_TEST_GUI)
 
-  # Register the test
-  gtest_discover_tests(${TEST_NAME} WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
+    # Register the test
+  if(MSVC_DEV)
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    set_tests_properties(${TEST_NAME}
+        PROPERTIES WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
+  else(MSVC_DEV)
+    gtest_discover_tests(${TEST_NAME} WORKING_DIRECTORY ${DISSOLVE_UNIT_TEST_USE_TEST_DIRECTORY})
+  endif(MSVC_DEV)
 
 endfunction()
 


### PR DESCRIPTION
DIssolve GTest unit tests have been failing to build in our Visual Studio 2022 (MSVC) setup. The failure appears to be related to a timeout at the link step* when GTest is attempting to run a test executable. I have found that swapping out the call to `gtest_discover_tests` with the lower-level CTest `add_test` gets around this hang, allow the tests to proceed to link and allows for running and debugging.

*See the example below:
```
  CMake Error at C:/Program Files/Microsoft Visual Studio/2022/Community/Common7/IDE/CommonExtensions/Microsoft/CMake/CMake/share/cmake-3.31/Modules/GoogleTestAddTests.cmake:132 (message):
    Error running test executable.
  
      Path: 'C:/Users/vcb31993/source/repos/disorderedmaterials/dissolve/build/bin/nodes_graph_argon.exe'
      Working directory: 'C:/Users/vcb31993/source/repos/disorderedmaterials/dissolve/tests/data'
      Result: Process terminated due to timeout
      Output:
```