### PR TITLE
refactor: Move ScatteringMatrix to use keyed mappings where required

### DIFF
--- a/src/classes/cellArray.cpp
+++ b/src/classes/cellArray.cpp
@@ -159,7 +159,7 @@ Vector3i CellArray::wrappedGridRef(const Vector3i &gridRef) const
 // Construct cell neighbour pairs
 void CellArray::createCellNeighbourPairs()
 {
-    auto nPairs = cells_.size() * ((cells_.size() + 1) / 2);
+    auto nPairs = DissolveMath::triangularIncDiagonals(cells_.size());
     neighbourPairs_.clear();
     neighbourPairs_.reserve(nPairs);
     for (auto &cell : cells_)

--- a/src/classes/pairIterator.cpp
+++ b/src/classes/pairIterator.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "classes/pairIterator.h"
+#include "math/mathFunc.h"
 #include <cmath>
 
 PairIterator::PairIterator(int size, int index) : size_(size)
@@ -62,4 +63,4 @@ PairIterator &PairIterator::operator+=(difference_type forward)
 PairIterator::value_type PairIterator::operator[](difference_type i) const { return *(*this + i); }
 
 PairIterator PairIterator::begin() const { return PairIterator(size_, 0); }
-PairIterator PairIterator::end() const { return PairIterator(size_, size_ * (size_ + 1) / 2); }
+PairIterator PairIterator::end() const { return PairIterator(size_, DissolveMath::triangularIncDiagonals(size_)); }

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -37,14 +37,8 @@ Array2D<double> ScatteringMatrix::A() const
     return result;
 }
 
-// Return number of atom types involved
-int ScatteringMatrix::nAtomTypes() const { return atomTypes_.size(); }
-
 // Return atom types
 const std::vector<const AtomType *> &ScatteringMatrix::atomTypes() const { return atomTypes_; }
-
-// Return atom type at index specified
-const AtomType *ScatteringMatrix::atomType(int index) const { return atomTypes_[index]; }
 
 // Generate matrices
 void ScatteringMatrix::generateMatrices(const std::vector<double> &qValues)

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -11,12 +11,7 @@
 #include <algorithm>
 #include <utility>
 
-ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomTypes)
-{
-    atomTypes_ = atomTypes;
-    rows_.clear();
-    matricesValid_ = false;
-}
+ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomTypes) : atomTypes_(atomTypes) { rows_.clear(); }
 
 /*
  * Data
@@ -53,10 +48,13 @@ const std::vector<const AtomType *> &ScatteringMatrix::atomTypes() const { retur
 const AtomType *ScatteringMatrix::atomType(int index) const { return atomTypes_[index]; }
 
 // Generate matrices
-void ScatteringMatrix::generateMatrices()
+void ScatteringMatrix::generateMatrices(const std::vector<double> &qValues)
 {
-    if (matricesValid_)
+    // If the supplied and current qValue vectors are identical, nothing to do...
+    if (qValues_ == qValues)
         return;
+
+    qValues_ = qValues;
 
     // We always generate the matrices for Q = 0
     Messenger::printVerbose("Generating Q = 0.0 matrix and inverse.\n");
@@ -69,11 +67,9 @@ void ScatteringMatrix::generateMatrices()
     qMatrices_.clear();
     if (qDependentWeighting())
     {
-        // Use the first reference data as the Q-axis template (as is done elsewhere)
         assert(!rows_.empty());
-        auto &qs = rows_.begin()->second.data.xAxis();
-        qMatrices_.reserve(qs.size());
-        for (auto q : qs)
+        qMatrices_.reserve(qValues_.size());
+        for (auto q : qValues_)
         {
             Messenger::printVerbose("Generating Q = {} matrix and inverse.\n", q);
 
@@ -85,8 +81,6 @@ void ScatteringMatrix::generateMatrices()
                 Messenger::exception("Failed to invert the scattering matrix at Q = {}.\n", q);
         }
     }
-
-    matricesValid_ = true;
 }
 
 // Return the precalculated Q = 0.0 scattering matrix inverse
@@ -278,14 +272,17 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
      */
 
     DoubleKeyedMap<Data1D> estimatedPartials;
+    Data1D emptyData;
+    emptyData.initialise(qValues_.size());
+    emptyData.xAxis() = qValues_;
 
     // Template the estimated partials from the first data item
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
                             [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
                             {
+                                estimatedPartials[{typeI->name(), typeJ->name()}] = emptyData;
                                 estimatedPartials[{typeI->name(), typeJ->name()}].setTag(
                                     std::format("{}-{}", typeI->name(), typeJ->name()));
-                                estimatedPartials[{typeI->name(), typeJ->name()}].initialise(rows_.begin()->second.data);
                             });
 
     auto qDependentWeights = qDependentWeighting();

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -14,7 +14,7 @@
 ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomTypes)
 {
     atomTypes_ = atomTypes;
-    rows_.clear(true);
+    rows_.clear();
     matricesValid_ = false;
 }
 
@@ -26,6 +26,21 @@ ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomType
 bool ScatteringMatrix::qDependentWeighting() const
 {
     return std::find_if(rows_.begin(), rows_.end(), [](auto &row) { return row.second.xRayWeights; }) != rows_.end();
+}
+
+// Create and return the full coefficients matrix
+Array2D<double> ScatteringMatrix::A() const
+{
+    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
+    auto row = 0;
+    for (const auto &[rowKey, rowData] : rows_)
+    {
+        for (auto col = 0; col < rowData.coefficients.size(); ++col)
+            result[{row, col}] = rowData.coefficients[col];
+        ++row;
+    }
+
+    return result;
 }
 
 // Return number of atom types involved
@@ -65,21 +80,6 @@ int ScatteringMatrix::columnIndex(const AtomType *typeI, const AtomType *typeJ) 
     }
 
     return -1;
-}
-
-// Create and return the full coefficients matrix
-Array2D<double> ScatteringMatrix::A() const
-{
-    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
-    auto row = 0;
-    for (const auto &[rowKey, rowData] : rows_)
-    {
-        for (auto col = 0; col < rowData.coefficients.size(); ++col)
-            result[{row, col}] = rowData.coefficients[col];
-        ++row;
-    }
-
-    return result;
 }
 
 // Generate matrices
@@ -354,7 +354,7 @@ Array2D<double> ScatteringMatrix::matrixProduct(double q) const { return inverse
  */
 
 // Set data and coefficients for the supplied row (from NeutronWeights)
-void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const NeutronWeights &weights, double factor)
+void ScatteringMatrix::setRow(const std::string &key, const Data1D &data, const NeutronWeights &weights, double factor)
 {
     auto &row = rows_[key];
 
@@ -366,7 +366,7 @@ void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const N
 }
 
 // Set data and coefficients for the supplied row (from XRayWeights)
-void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const XRayWeights &weights, double factor)
+void ScatteringMatrix::setRow(const std::string &key, const Data1D &data, const XRayWeights &weights, double factor)
 {
     auto &row = rows_[key];
 
@@ -382,7 +382,7 @@ void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const X
 }
 
 // Set data and coefficients for the supplied row (single coefficient)
-void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const AtomType *i, const AtomType *j, double factor)
+void ScatteringMatrix::setRow(const std::string &key, const Data1D &data, const AtomType *i, const AtomType *j, double factor)
 {
     auto &row = rows_[key];
 

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -25,7 +25,22 @@ ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomType
 // Return whether Q-dependent weighting is required
 bool ScatteringMatrix::qDependentWeighting() const
 {
-    return std::find_if(xRayData_.begin(), xRayData_.end(), [](auto data) { return std::get<0>(data); }) != xRayData_.end();
+    return std::find_if(rows_.begin(), rows_.end(), [](auto &row) { return row.second.xRayWeights; }) != rows_.end();
+}
+
+// Create and return the full coefficients matrix
+Array2D<double> ScatteringMatrix::A() const
+{
+    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
+    auto row = 0;
+    for (const auto &[rowKey, rowData] : rows_)
+    {
+        for (auto col = 0; col < rowData.coefficients.size(); ++col)
+            result[{row, col}] = rowData.coefficients[col];
+        ++row;
+    }
+
+    return result;
 }
 
 // Return number of atom types involved
@@ -108,34 +123,37 @@ const Array2D<double> &ScatteringMatrix::qZeroMatrixInverse() const { return qZe
 // Calculate and return the scattering matrix at the specified Q value
 Array2D<double> ScatteringMatrix::matrix(double q) const
 {
-    // Take a copy of A to begin with
-    auto m = A_;
+    // Start with the plain scattering matrix coefficients
+    auto m = A();
 
-    // Go over rows of the matrix (corresponding to the reference data) and check if any need to be xray-weighted
-    for (auto row = 0; row < m.nRows(); ++row)
+    // Check rows to see if any are xray-weighted
+    auto row = 0;
+    for (const auto &[rowKey, rowData] : rows_)
     {
-        // If this is not xray data we can move on to the next
-        if (!std::get<0>(xRayData_[row]))
-            continue;
-
-        // Grab the weights and normalisation to apply to the matrix elements
-        auto optWeights = std::get<1>(xRayData_[row]);
-        auto &weights = (*optWeights);
-        auto normType = std::get<2>(xRayData_[row]);
-        auto normFactor = 1.0;
-        if (normType == StructureFactors::AverageOfSquaresNormalisation)
-            normFactor = weights.boundCoherentAverageOfSquares(q);
-        else if (normType == StructureFactors::SquareOfAverageNormalisation)
-            normFactor = weights.boundCoherentSquareOfAverage(q);
-
-        // Loop over columns (partials) and weight according to the elements of the atom types
-        auto col = 0;
-        for (auto [i, j] : typePairs_)
+        if (rowData.xRayWeights)
         {
-            m[{row, col}] *= weights.formFactorProduct(i, j, q) / normFactor;
+            // Grab the weights and normalisation to apply to the matrix elements
+            auto &xRayWeights = *rowData.xRayWeights;
+            auto normFactor = 1.0;
+            if (rowData.xRayNormalisation == StructureFactors::AverageOfSquaresNormalisation)
+                normFactor = xRayWeights.boundCoherentAverageOfSquares(q);
+            else if (rowData.xRayNormalisation == StructureFactors::SquareOfAverageNormalisation)
+                normFactor = xRayWeights.boundCoherentSquareOfAverage(q);
 
-            ++col;
+            // Loop over columns and get weights for columns according to the elements of the atom type pairs
+            std::vector<double> weights;
+            dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
+                        [&](int i, auto &atI, int j, auto &atJ)
+                                    {
+                                        weights.push_back(xRayWeights.formFactorProduct(atI, atJ, q) / normFactor);
+});
+
+            // Apply the weights
+            for (auto col = 0; col < weights.size(); ++col)
+                m[{row, col}] *= weights[col];
         }
+
+        ++row;
     }
 
     return m;
@@ -178,8 +196,9 @@ void ScatteringMatrix::print(double q) const
     }
     Messenger::print("{}", line);
 
-    // Loop over reference data
-    for (auto row = 0; row < data_.size(); ++row)
+    // Loop over rows
+    auto row = 0;
+    for (const auto &[rowKey, rowData] : rows_)
     {
         line.clear();
         for (auto n = 0; n < m.nColumns(); ++n)
@@ -193,7 +212,7 @@ void ScatteringMatrix::print(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.at(row).tag());
+        Messenger::print("{}  {}\n", line, rowKey);
 
         // Limit to sensible number of rows
         if (row >= std::max(nColsWritten, 10))
@@ -231,7 +250,8 @@ void ScatteringMatrix::printInverse(double q) const
     Messenger::print(line);
 
     // Loop over inverse matrix columns, rather than rows, to match the AtomType headers
-    for (auto col = 0; col < inverseA.nColumns(); ++col)
+    auto col = 0;
+    for (const auto &[rowKey, rowData] : rows_)
     {
         line.clear();
         for (auto row = 0; row < inverseA.nRows(); ++row)
@@ -245,7 +265,7 @@ void ScatteringMatrix::printInverse(double q) const
                 break;
             }
         }
-        Messenger::print("{}  {}\n", line, data_.at(col).tag());
+        Messenger::print("{}  {}\n", line, rowKey);
 
         // Limit to sensible number of rows
         if (col >= std::max(nColsWritten, 10))
@@ -259,14 +279,14 @@ void ScatteringMatrix::printInverse(double q) const
     }
 }
 
-// Generate partials from reference data using the inverse coefficients matrix
-bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
+// Generate estimated partials from reference data using the inverse coefficients matrix
+DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
 {
     // Check that we have the correct number of reference data to be able to invert the matrix
-    if (data_.size() < A_.nColumns())
+    if (rows_.size() <  (atomTypes_.size() * (atomTypes_.size() + 1)) / 2 )
         return Messenger::error("Can't finalise this scattering matrix, since there are not enough reference data ({}) "
                                 "compared to rows in the matrix ({}).\n",
-                                data_.size(), A_.nColumns());
+                                rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2);
 
     /*
      * Currently our scattering matrix / data look as follows:
@@ -282,6 +302,8 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
      *
      * Take the matrix inverse and multiply it by the known data to generate the estimated partials.
      */
+
+    DoubleKeyedMap<Data1D> estimatedPartials;
 
     // Template the estimatedSQ from the first data item
     for (auto &estSQ : estimatedSQ)
@@ -319,18 +341,21 @@ bool ScatteringMatrix::generatePartials(Array2D<Data1D> &estimatedSQ)
     }
     else
     {
-        // Generate new partials (nPartials = nColumns)
-        for (auto refDataIndex = 0; refDataIndex < data_.size(); ++refDataIndex)
+        // Loop over reference data
+        auto dataIndex = 0;
+        for (const auto &[rowKey, rowData] : rows_)
         {
             // Generate interpolation for this dataset (row).
-            Interpolator I(data_[refDataIndex]);
+            Interpolator I(rowData.data);
 
-            for (auto partialIndex = 0; partialIndex < A_.nColumns(); ++partialIndex)
-                Interpolator::addInterpolated(I, estimatedSQ[partialIndex], qZeroInverse_[{partialIndex, refDataIndex}]);
+            auto partialIndex = 0;
+            dissolve::for_each_pair(
+                ParallelPolicies::seq, atomTypes_, [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
+                { Interpolator::addInterpolated(I, estimatedPartials.get(typeI->name(), typeJ->name()), qZeroInverse_[{partialIndex++, dataIndex}]); });
         }
     }
 
-    return true;
+    return estimatedPartials;
 }
 
 // Return the product of inverseA_ and A_ (which should be the identity matrix) at the specified Q value
@@ -380,6 +405,3 @@ void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const A
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_, [&](int indexI, auto &atI, int indexJ, auto &atJ)
                             { row.coefficients.push_back((atI == i && atJ == j) || (atI == j && atJ == i) ? factor : 0.0); });
 }
-
-// Return number of currently-defined reference data sets (== matrix rows)
-int ScatteringMatrix::nReferenceData() const { return A_.nRows(); }

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -67,7 +67,6 @@ void ScatteringMatrix::generateMatrices(const std::vector<double> &qValues)
     qInverses_.clear();
     if (qDependentWeighting())
     {
-        assert(!rows_.empty());
         qMatrices_.reserve(qValues_.size());
         qInverses_.reserve(qValues_.size());
         for (auto q : qValues_)
@@ -273,7 +272,7 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
     emptyData.initialise(qValues_.size());
     emptyData.xAxis() = qValues_;
 
-    // Template the estimated partials from the first data item
+    // Template the estimated partials
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
                             [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
                             {
@@ -288,8 +287,9 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
     auto dataIndex = 0;
     for (const auto &[rowKey, rowData] : rows_)
     {
-        // Generate interpolation for this dataset (row).
-        Interpolator I(rowData.data);
+        // Generate interpolation for this dataset (row) - has to be Linear since (experimental) datasets are likely to have
+        // been extrapolated to zero, and trying to spline over it will create artifacts.
+        Interpolator I(rowData.data, Interpolator::InterpolationScheme::LinearInterpolation);
         auto dataQMin = rowData.data.xAxis().front();
         auto dataQMax = rowData.data.xAxis().back();
 
@@ -302,10 +302,9 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
                                     auto &partial = estimatedPartials.get(typeI->name(), typeJ->name());
 
                                     // Loop over Q points
-                                    const auto &qAxis = partial.xAxis();
-                                    for (auto qIndex = 0; qIndex < qAxis.size(); ++qIndex)
+                                    for (auto qIndex = 0; qIndex < qValues_.size(); ++qIndex)
                                     {
-                                        auto q = qAxis[qIndex];
+                                        auto q = qValues_[qIndex];
                                         if (q < dataQMin)
                                             continue;
                                         if (q > dataQMax)

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -115,6 +115,8 @@ void ScatteringMatrix::generateMatrices()
                 Messenger::exception("Failed to invert the scattering matrix at Q = {}.\n", q);
         }
     }
+
+    matricesValid_ = true;
 }
 
 // Return the precalculated Q = 0.0 scattering matrix inverse
@@ -142,11 +144,8 @@ Array2D<double> ScatteringMatrix::matrix(double q) const
 
             // Loop over columns and get weights for columns according to the elements of the atom type pairs
             std::vector<double> weights;
-            dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
-                        [&](int i, auto &atI, int j, auto &atJ)
-                                    {
-                                        weights.push_back(xRayWeights.formFactorProduct(atI, atJ, q) / normFactor);
-});
+            dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_, [&](int i, auto &atI, int j, auto &atJ)
+                                    { weights.push_back(xRayWeights.formFactorProduct(atI, atJ, q) / normFactor); });
 
             // Apply the weights
             for (auto col = 0; col < weights.size(); ++col)
@@ -283,7 +282,7 @@ void ScatteringMatrix::printInverse(double q) const
 DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
 {
     // Check that we have the correct number of reference data to be able to invert the matrix
-    if (rows_.size() <  (atomTypes_.size() * (atomTypes_.size() + 1)) / 2 )
+    if (rows_.size() < (atomTypes_.size() * (atomTypes_.size() + 1)) / 2)
         return Messenger::error("Can't finalise this scattering matrix, since there are not enough reference data ({}) "
                                 "compared to rows in the matrix ({}).\n",
                                 rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2);
@@ -305,54 +304,42 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
 
     DoubleKeyedMap<Data1D> estimatedPartials;
 
-    // Template the estimatedSQ from the first data item
-    for (auto &estSQ : estimatedSQ)
-        estSQ.initialise(data_[0]);
+    // Template the estimated partials from the first data item
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
+                            [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
+                            {
+                                estimatedPartials[{typeI->name(), typeJ->name()}].setTag(
+                                    std::format("{}-{}", typeI->name(), typeJ->name()));
+                                estimatedPartials[{typeI->name(), typeJ->name()}].initialise(rows_.begin()->second.data);
+                            });
 
-    if (qDependentWeighting())
+    auto qDependentWeights = qDependentWeighting();
+
+    // Loop over reference data
+    auto dataIndex = 0;
+    for (const auto &[rowKey, rowData] : rows_)
     {
-        // Generate interpolations for each dataset
-        std::vector<Interpolator> interpolations;
-        interpolations.reserve(data_.size());
-        for (const auto &ref : data_)
-            interpolations.emplace_back(Interpolator(ref));
+        // Generate interpolation for this dataset (row).
+        Interpolator I(rowData.data);
 
-        // Q-dependent terms in the scattering matrix, so need to invert once at each distinct Q value
-        const auto &x = estimatedSQ[0].xAxis();
-        for (auto n = 0; n < x.size(); ++n)
-        {
-            const auto q = x[n];
+        // Loop over columns (atom-atom partials)
+        auto partialIndex = 0;
+        dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
+                                [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
+                                {
+                                    // Get estimated partial
+                                    auto &partial = estimatedPartials.get(typeI->name(), typeJ->name());
 
-            // Grab the pre-calculated scattering matrix
-            auto &inverseA = std::get<2>(qMatrices_[n]);
-
-            // Sum in contributions from each dataset at this Q value, provided it is within the range of the dataset
-            for (auto partialIndex = 0; partialIndex < A_.nColumns(); ++partialIndex)
-            {
-                for (auto refDataIndex = 0; refDataIndex < data_.size(); ++refDataIndex)
-                {
-                    if ((q < data_[refDataIndex].xAxis().front()) || (q > data_[refDataIndex].xAxis().back()))
-                        continue;
-                    estimatedSQ[partialIndex].value(n) +=
-                        interpolations[refDataIndex].y(q) * inverseA[{partialIndex, refDataIndex}];
-                }
-            }
-        }
-    }
-    else
-    {
-        // Loop over reference data
-        auto dataIndex = 0;
-        for (const auto &[rowKey, rowData] : rows_)
-        {
-            // Generate interpolation for this dataset (row).
-            Interpolator I(rowData.data);
-
-            auto partialIndex = 0;
-            dissolve::for_each_pair(
-                ParallelPolicies::seq, atomTypes_, [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
-                { Interpolator::addInterpolated(I, estimatedPartials.get(typeI->name(), typeJ->name()), qZeroInverse_[{partialIndex++, dataIndex}]); });
-        }
+                                    // Loop over Q points
+                                    const auto &qAxis = partial.xAxis();
+                                    for (auto qIndex = 0; qIndex < qAxis.size(); ++qIndex)
+                                    {
+                                        partial.value(qIndex) +=
+                                            I.y(qAxis[qIndex]) *
+                                            (qDependentWeights ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
+                                                                 : qZeroInverse_[{partialIndex, dataIndex}]);
+                                    }
+                                });
     }
 
     return estimatedPartials;

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -322,6 +322,8 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
     {
         // Generate interpolation for this dataset (row).
         Interpolator I(rowData.data);
+        auto dataQMin = rowData.data.xAxis().front();
+        auto dataQMax = rowData.data.xAxis().back();
 
         // Loop over columns (atom-atom partials)
         auto partialIndex = 0;
@@ -335,12 +337,21 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
                                     const auto &qAxis = partial.xAxis();
                                     for (auto qIndex = 0; qIndex < qAxis.size(); ++qIndex)
                                     {
+                                        auto q = qAxis[qIndex];
+                                        if (q < dataQMin)
+                                            continue;
+                                        if (q > dataQMax)
+                                            break;
                                         partial.value(qIndex) +=
-                                            I.y(qAxis[qIndex]) *
+                                            I.y(q) *
                                             (qDependentWeights ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
                                                                : qZeroInverse_[{partialIndex, dataIndex}]);
                                     }
+
+                                    ++partialIndex;
                                 });
+
+        ++dataIndex;
     }
 
     return estimatedPartials;

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -37,9 +37,6 @@ Array2D<double> ScatteringMatrix::A() const
     return result;
 }
 
-// Return atom types
-const std::vector<const AtomType *> &ScatteringMatrix::atomTypes() const { return atomTypes_; }
-
 // Generate matrices
 void ScatteringMatrix::generateMatrices(const std::vector<double> &qValues)
 {

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -11,6 +11,13 @@
 #include <algorithm>
 #include <utility>
 
+ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomTypes)
+{
+    atomTypes_ = atomTypes;
+    rows_.clear(true);
+    matricesValid_ = false;
+}
+
 /*
  * Data
  */
@@ -63,6 +70,9 @@ int ScatteringMatrix::columnIndex(const AtomType *typeI, const AtomType *typeJ) 
 // Generate matrices
 void ScatteringMatrix::generateMatrices()
 {
+    if (matricesValid_)
+        return;
+
     // We always generate the matrices for Q = 0
     Messenger::printVerbose("Generating Q = 0.0 matrix and inverse.\n");
     qZeroMatrix_ = matrix(0.0);
@@ -75,8 +85,8 @@ void ScatteringMatrix::generateMatrices()
     if (qDependentWeighting())
     {
         // Use the first reference data as the Q-axis template (as is done elsewhere)
-        assert(!data_.empty());
-        auto &qs = data_[0].xAxis();
+        assert(!rows_.empty());
+        auto &qs = rows_.begin()->second.data.xAxis();
         qMatrices_.reserve(qs.size());
         for (auto q : qs)
         {
@@ -330,144 +340,45 @@ Array2D<double> ScatteringMatrix::matrixProduct(double q) const { return inverse
  * Construction
  */
 
-// Initialise from supplied list of AtomTypes
-void ScatteringMatrix::initialise(const std::vector<const AtomType *> &types, Array2D<Data1D> &estimatedSQ)
+// Set data and coefficients for the supplied row (from NeutronWeights)
+void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const NeutronWeights &weights, double factor)
 {
-    // Clear coefficients matrix and its inverse_, and empty our typePairs_ and data_ lists
-    A_.clear();
-    data_.clear();
-    atomTypes_.clear();
-    typePairs_.clear();
-    qZeroMatrix_.clear();
-    qZeroInverse_.clear();
-    qMatrices_.clear();
+    auto &row = rows_[key];
 
-    // Copy atom types and construct pairs
-    atomTypes_ = types;
-    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
-                            [this](int i, auto &at1, int j, auto &at2) { typePairs_.emplace_back(at1, at2); });
-
-    // Create partials array
-    estimatedSQ.initialise(atomTypes_.size(), atomTypes_.size(), true);
-    auto index = 0;
-    for (auto [i, j] : typePairs_)
-        estimatedSQ[index++].setTag(std::format("{}-{}", i->name(), j->name()));
+    row.data = data;
+    row.data *= factor;
+    row.coefficients.clear();
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_, [&](int indexI, auto &atI, int indexJ, auto &atJ)
+                            { row.coefficients.push_back(weights.weights().get({atI->name(), atJ->name()}) * factor); });
 }
 
-// Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
-bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor)
+// Set data and coefficients for the supplied row (from XRayWeights)
+void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const XRayWeights &weights, double factor)
 {
-    // Make sure that the scattering weights are valid
-    if (!dataWeights.isValid())
-        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.tag());
+    auto &row = rows_[key];
 
-    // Extend the scattering matrix by one row
-    A_.addRow(typePairs_.size());
-    const auto rowIndex = A_.nRows() - 1;
+    row.data = data;
+    row.data *= factor;
 
-    // Set coefficients in A_
-    auto success = for_each_pair_early(
-        dataWeights.isotopeMix().mix(),
-        [&](int indexI, auto &typeMixI, int indexJ, auto &typeMixJ) -> EarlyReturn<bool>
-        {
-            auto colIndex = columnIndex(typeMixI.first, typeMixJ.first);
-            if (colIndex == -1)
-                return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
-                                        "('{}' and/or '{}').\n",
-                                        typeMixI.first->name(), typeMixJ.first->name());
+    row.coefficients.clear();
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_, [&](int indexI, auto &atI, int indexJ, auto &atJ)
+                            { row.coefficients.push_back(weights.preFactors().get({atI->name(), atJ->name()}) * factor); });
 
-            // Now have the local column index of the AtomType pair in our matrix A_...
-            A_[{rowIndex, colIndex}] = dataWeights.weights().get({typeMixI.first->name(), typeMixJ.first->name()}) * factor;
-
-            return EarlyReturn<bool>::Continue;
-        });
-    if (!success.value_or(true))
-        return false;
-
-    // Add reference data and apply the associated factor
-    data_.emplace_back(weightedData) *= factor;
-
-    // Neutron data, so store dummy XRay form factor data indicator
-    xRayData_.emplace_back(false, std::nullopt, StructureFactors::NoNormalisation);
-
-    return true;
+    row.xRayWeights = weights;
+    row.xRayNormalisation = StructureFactors::AverageOfSquaresNormalisation;
 }
 
-// Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself
-bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWeights &dataWeights, double factor)
+// Set data and coefficients for the supplied row (single coefficient)
+void ScatteringMatrix::setRow(DoubleKeyedMapKey key, const Data1D &data, const AtomType *i, const AtomType *j, double factor)
 {
-    // Extend the scattering matrix by one row
-    A_.addRow(typePairs_.size());
-    const auto rowIndex = A_.nRows() - 1;
+    auto &row = rows_[key];
 
-    // Set coefficients in A_
-    auto success = for_each_pair_early(
-        dataWeights.typeFractions(),
-        [&](int indexI, auto &fracI, int indexJ, auto &fracJ) -> EarlyReturn<bool>
-        {
-            auto colIndex = columnIndex(fracI.first, fracJ.first);
-            if (colIndex == -1)
-                return Messenger::error("Weights associated to reference data contain one or more unknown AtomTypes "
-                                        "('{}' and/or '{}').\n",
-                                        fracI.first->name(), fracJ.first->name());
+    row.data = data;
+    row.data *= factor;
 
-            // Now have the local column index of the AtomType pair in our matrix A_.
-            // Since this is X-ray data, we will just store the product of the concentration
-            // weights and the factor
-            A_[{rowIndex, colIndex}] = dataWeights.preFactors().get({fracI.first->name(), fracJ.first->name()}) * factor;
-
-            return EarlyReturn<bool>::Continue;
-        });
-    if (!success.value_or(true))
-        return false;
-
-    // Add reference data and apply the associated factor
-    data_.emplace_back(weightedData) *= factor;
-
-    // Store XRay form factor data indicator
-    xRayData_.emplace_back(true, dataWeights, StructureFactors::AverageOfSquaresNormalisation);
-
-    return true;
-}
-
-// Update reference data)
-bool ScatteringMatrix::updateReferenceData(const Data1D &weightedData, double factor)
-{
-    auto it = std::find_if(data_.begin(), data_.end(), [weightedData](auto &data) { return weightedData.tag() == data.tag(); });
-    if (it == data_.end())
-        return false;
-
-    *it = weightedData;
-    *it *= factor;
-
-    return true;
-}
-
-// Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
-bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const AtomType *at1, const AtomType *at2,
-                                               double dataWeight, double factor)
-{
-    // Extend the scattering matrix by one row
-    A_.addRow(typePairs_.size());
-    const auto rowIndex = A_.nRows() - 1;
-
-    auto colIndex = columnIndex(at1, at2);
-    if (colIndex == -1)
-        return Messenger::error(
-            "Weights associated to reference data contain one or more unknown AtomTypes ('{}' and/or '{}').\n", at1->name(),
-            at2->name());
-
-    // Now have the local column index of the AtomType pair in our matrix A_...
-    A_.setRow(rowIndex, 0.0);
-    A_[{rowIndex, colIndex}] = dataWeight * factor;
-
-    // Add reference data and its associated factor
-    data_.emplace_back(weightedData) *= factor;
-
-    // Simulated partial data, so store dummy XRay form factor data indicator
-    xRayData_.emplace_back(false, std::nullopt, StructureFactors::NoNormalisation);
-
-    return true;
+    row.coefficients.clear();
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_, [&](int indexI, auto &atI, int indexJ, auto &atJ)
+                            { row.coefficients.push_back((atI == i && atJ == j) || (atI == j && atJ == i) ? factor : 0.0); });
 }
 
 // Return number of currently-defined reference data sets (== matrix rows)

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -337,7 +337,7 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
                                         partial.value(qIndex) +=
                                             I.y(qAxis[qIndex]) *
                                             (qDependentWeights ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
-                                                                 : qZeroInverse_[{partialIndex, dataIndex}]);
+                                                               : qZeroInverse_[{partialIndex, dataIndex}]);
                                     }
                                 });
     }

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -9,7 +9,6 @@
 #include "math/svd.h"
 #include "templates/algorithms.h"
 #include <algorithm>
-#include <utility>
 
 ScatteringMatrix::ScatteringMatrix(const std::vector<const AtomType *> &atomTypes) : atomTypes_(atomTypes) { rows_.clear(); }
 
@@ -65,19 +64,17 @@ void ScatteringMatrix::generateMatrices(const std::vector<double> &qValues)
 
     // Generate Q-dependent matrices if we need them
     qMatrices_.clear();
+    qInverses_.clear();
     if (qDependentWeighting())
     {
         assert(!rows_.empty());
         qMatrices_.reserve(qValues_.size());
+        qInverses_.reserve(qValues_.size());
         for (auto q : qValues_)
         {
             Messenger::printVerbose("Generating Q = {} matrix and inverse.\n", q);
 
-            auto &&[qValue, mat, inv] = qMatrices_.emplace_back();
-            qValue = q;
-            mat = matrix(q);
-            inv = mat;
-            if (!SVD::pseudoinverse(inv))
+            if (!SVD::pseudoinverse(qInverses_.emplace_back(qMatrices_.emplace_back(matrix(q)))))
                 Messenger::exception("Failed to invert the scattering matrix at Q = {}.\n", q);
         }
     }
@@ -314,9 +311,8 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
                                         if (q > dataQMax)
                                             break;
                                         partial.value(qIndex) +=
-                                            I.y(q) * (qDependentWeights
-                                                          ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
-                                                          : qZeroInverse_[{partialIndex, dataIndex}]);
+                                            I.y(q) * (qDependentWeights ? qInverses_[qIndex][{partialIndex, dataIndex}]
+                                                                        : qZeroInverse_[{partialIndex, dataIndex}]);
                                     }
 
                                     ++partialIndex;

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -6,6 +6,7 @@
 #include "classes/neutronWeights.h"
 #include "classes/xRayWeights.h"
 #include "math/interpolator.h"
+#include "math/mathFunc.h"
 #include "math/svd.h"
 #include "templates/algorithms.h"
 #include <algorithm>
@@ -25,7 +26,7 @@ bool ScatteringMatrix::qDependentWeighting() const
 // Create and return the full coefficients matrix
 Array2D<double> ScatteringMatrix::A() const
 {
-    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
+    Array2D<double> result(rows_.size(), DissolveMath::triangularIncDiagonals(atomTypes_.size()), false);
     auto row = 0;
     for (const auto &[rowKey, rowData] : rows_)
     {
@@ -238,10 +239,10 @@ void ScatteringMatrix::printInverse(double q) const
 DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
 {
     // Check that we have the correct number of reference data to be able to invert the matrix
-    if (rows_.size() < (atomTypes_.size() * (atomTypes_.size() + 1)) / 2)
+    if (rows_.size() < DissolveMath::triangularIncDiagonals(atomTypes_.size()))
         return Messenger::error("Can't finalise this scattering matrix, since there are not enough reference data ({}) "
                                 "compared to rows in the matrix ({}).\n",
-                                rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2);
+                                rows_.size(), DissolveMath::triangularIncDiagonals(atomTypes_.size()));
 
     /*
      * Currently our scattering matrix / data look as follows:

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -28,21 +28,6 @@ bool ScatteringMatrix::qDependentWeighting() const
     return std::find_if(rows_.begin(), rows_.end(), [](auto &row) { return row.second.xRayWeights; }) != rows_.end();
 }
 
-// Create and return the full coefficients matrix
-Array2D<double> ScatteringMatrix::A() const
-{
-    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
-    auto row = 0;
-    for (const auto &[rowKey, rowData] : rows_)
-    {
-        for (auto col = 0; col < rowData.coefficients.size(); ++col)
-            result[{row, col}] = rowData.coefficients[col];
-        ++row;
-    }
-
-    return result;
-}
-
 // Return number of atom types involved
 int ScatteringMatrix::nAtomTypes() const { return atomTypes_.size(); }
 
@@ -80,6 +65,21 @@ int ScatteringMatrix::columnIndex(const AtomType *typeI, const AtomType *typeJ) 
     }
 
     return -1;
+}
+
+// Create and return the full coefficients matrix
+Array2D<double> ScatteringMatrix::A() const
+{
+    Array2D<double> result(rows_.size(), (atomTypes_.size() * (atomTypes_.size() + 1)) / 2, false);
+    auto row = 0;
+    for (const auto &[rowKey, rowData] : rows_)
+    {
+        for (auto col = 0; col < rowData.coefficients.size(); ++col)
+            result[{row, col}] = rowData.coefficients[col];
+        ++row;
+    }
+
+    return result;
 }
 
 // Generate matrices

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -52,36 +52,6 @@ const std::vector<const AtomType *> &ScatteringMatrix::atomTypes() const { retur
 // Return atom type at index specified
 const AtomType *ScatteringMatrix::atomType(int index) const { return atomTypes_[index]; }
 
-// Return index of atom type in our local vector
-int ScatteringMatrix::indexOf(const AtomType *typeI) const
-{
-    auto it = std::find(atomTypes_.begin(), atomTypes_.end(), typeI);
-    assert(it != atomTypes_.end());
-    return it - atomTypes_.begin();
-}
-
-// Return index pair of atom types in our local vector
-std::pair<int, int> ScatteringMatrix::pairIndexOf(const AtomType *typeI, const AtomType *typeJ) const
-{
-    return {indexOf(typeI), indexOf(typeJ)};
-}
-
-// Return column index of specified AtomType pair
-int ScatteringMatrix::columnIndex(const AtomType *typeI, const AtomType *typeJ) const
-{
-    auto index = 0;
-    for (auto [i, j] : typePairs_)
-    {
-        if ((i == typeI) && (j == typeJ))
-            return index;
-        if ((i == typeJ) && (j == typeI))
-            return index;
-        ++index;
-    }
-
-    return -1;
-}
-
 // Generate matrices
 void ScatteringMatrix::generateMatrices()
 {
@@ -179,20 +149,22 @@ void ScatteringMatrix::print(double q) const
     // Write header
     std::string text, line;
     auto nColsWritten = 0;
-    for (auto [i, j] : typePairs_)
-    {
-        text = std::format("{}-{}", i->name(), j->name());
-        line += std::format("{:^10} ", text);
+    for_each_pair_early(atomTypes_,
+                        [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ) -> EarlyReturn<bool>
+                        {
+                            text = std::format("{}-{}", typeI->name(), typeJ->name());
+                            line += std::format("{:^10} ", text);
 
-        // Limit output to sensible length
-        if (line.length() >= 80)
-        {
-            line += " ...";
-            break;
-        }
+                            // Limit output to sensible length
+                            if (line.length() >= 80)
+                            {
+                                line += " ...";
+                                return false;
+                            }
 
-        ++nColsWritten;
-    }
+                            ++nColsWritten;
+                            return EarlyReturn<bool>::Continue;
+                        });
     Messenger::print("{}", line);
 
     // Loop over rows
@@ -234,19 +206,21 @@ void ScatteringMatrix::printInverse(double q) const
     // Write header
     std::string line;
     auto nColsWritten = 0;
-    for (auto [i, j] : typePairs_)
-    {
-        line += std::format("{:10} ", std::format("{}-{}", i->name(), j->name()));
+    for_each_pair_early(atomTypes_,
+                        [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ) -> EarlyReturn<bool>
+                        {
+                            line += std::format("{:10} ", std::format("{}-{}", typeI->name(), typeJ->name()));
 
-        // Limit output to sensible length
-        if (line.length() >= 80)
-        {
-            line += " ...";
-            break;
-        }
+                            // Limit output to sensible length
+                            if (line.length() >= 80)
+                            {
+                                line += " ...";
+                                return false;
+                            }
 
-        ++nColsWritten;
-    }
+                            ++nColsWritten;
+                            return EarlyReturn<bool>::Continue;
+                        });
     Messenger::print(line);
 
     // Loop over inverse matrix columns, rather than rows, to match the AtomType headers
@@ -343,9 +317,9 @@ DoubleKeyedMap<Data1D> ScatteringMatrix::generateEstimatedPartials() const
                                         if (q > dataQMax)
                                             break;
                                         partial.value(qIndex) +=
-                                            I.y(q) *
-                                            (qDependentWeights ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
-                                                               : qZeroInverse_[{partialIndex, dataIndex}]);
+                                            I.y(q) * (qDependentWeights
+                                                          ? std::get<2>(qMatrices_[qIndex])[{partialIndex, dataIndex}]
+                                                          : qZeroInverse_[{partialIndex, dataIndex}]);
                                     }
 
                                     ++partialIndex;

--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -212,6 +212,7 @@ void ScatteringMatrix::print(double q) const
             }
         }
         Messenger::print("{}  {}\n", line, rowKey);
+        ++row;
 
         // Limit to sensible number of rows
         if (row >= std::max(nColsWritten, 10))

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -59,12 +59,8 @@ class ScatteringMatrix
     Array2D<double> A() const;
 
     public:
-    // Return number of AtomTypes involved
-    int nAtomTypes() const;
     // Return atom types
     const std::vector<const AtomType *> &atomTypes() const;
-    // Return atom type at index specified
-    const AtomType *atomType(int index) const;
     // Generate matrices
     void generateMatrices(const std::vector<double> &qValues);
     // Return the precalculated Q = 0.0 scattering matrix inverse

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -43,8 +43,6 @@ class ScatteringMatrix
     private:
     // Source AtomTypes involved
     std::vector<const AtomType *> atomTypes_;
-    // Reference pairs of AtomTypes
-    std::vector<std::pair<const AtomType *, const AtomType *>> typePairs_;
     // Scattering matrix rows
     KeyedVector<std::string, ScatteringMatrixRow> rows_;
     // Scattering matrix and inverse at Q = 0
@@ -67,12 +65,6 @@ class ScatteringMatrix
     const std::vector<const AtomType *> &atomTypes() const;
     // Return atom type at index specified
     const AtomType *atomType(int index) const;
-    // Return index of atom type in our local vector
-    int indexOf(const AtomType *typeI) const;
-    // Return index pair of atom types in our local vector
-    std::pair<int, int> pairIndexOf(const AtomType *typeI, const AtomType *typeJ) const;
-    // Return column of specified AtomType pair
-    int columnIndex(const AtomType *typeI, const AtomType *typeJ) const;
     // Generate matrices
     void generateMatrices();
     // Return the precalculated Q = 0.0 scattering matrix inverse

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -49,8 +49,8 @@ class ScatteringMatrix
     Array2D<double> qZeroMatrix_, qZeroInverse_;
     // Scattering matrix / inverse pairs at specific Q values
     std::vector<std::tuple<double, Array2D<double>, Array2D<double>>> qMatrices_;
-    // Whether the matrices up-to-date
-    bool matricesValid_{false};
+    // Q values to use when generating matrices and data
+    std::vector<double> qValues_;
 
     private:
     // Return whether Q-dependent weighting is required
@@ -66,7 +66,7 @@ class ScatteringMatrix
     // Return atom type at index specified
     const AtomType *atomType(int index) const;
     // Generate matrices
-    void generateMatrices();
+    void generateMatrices(const std::vector<double> &qValues);
     // Return the precalculated Q = 0.0 scattering matrix inverse
     const Array2D<double> &qZeroMatrixInverse() const;
     // Calculate and return the scattering matrix at the specified Q value

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -56,6 +56,8 @@ class ScatteringMatrix
     private:
     // Return whether Q-dependent weighting is required
     bool qDependentWeighting() const;
+    // Create and return the full coefficients matrix
+    Array2D<double> A() const;
 
     public:
     // Return number of AtomTypes involved
@@ -82,8 +84,8 @@ class ScatteringMatrix
     void print(double q = 0.0) const;
     // Print the inverse matrix at the specified Q value
     void printInverse(double q = 0.0) const;
-    // Generate partials from reference data using inverse matrix
-    bool generatePartials(Array2D<Data1D> &estimatedSQ);
+    // Generate estimated partials from reference data using the inverse coefficients matrix
+    DoubleKeyedMap<Data1D> generateEstimatedPartials() const;
     // Return the product of inverseA_ and A_ (which should be the identity matrix) at the specified Q value
     Array2D<double> matrixProduct(double q = 0.0) const;
 

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -46,7 +46,7 @@ class ScatteringMatrix
     // Reference pairs of AtomTypes
     std::vector<std::pair<const AtomType *, const AtomType *>> typePairs_;
     // Scattering matrix rows
-    DoubleKeyedMap<ScatteringMatrixRow> rows_;
+    KeyedVector<std::string, ScatteringMatrixRow> rows_;
     // Scattering matrix and inverse at Q = 0
     Array2D<double> qZeroMatrix_, qZeroInverse_;
     // Scattering matrix / inverse pairs at specific Q values
@@ -57,6 +57,8 @@ class ScatteringMatrix
     private:
     // Return whether Q-dependent weighting is required
     bool qDependentWeighting() const;
+    // Create and return the full coefficients matrix
+    Array2D<double> A() const;
 
     public:
     // Return number of AtomTypes involved
@@ -71,8 +73,6 @@ class ScatteringMatrix
     std::pair<int, int> pairIndexOf(const AtomType *typeI, const AtomType *typeJ) const;
     // Return column of specified AtomType pair
     int columnIndex(const AtomType *typeI, const AtomType *typeJ) const;
-    // Create and return the full coefficients matrix
-    Array2D<double> A() const;
     // Generate matrices
     void generateMatrices();
     // Return the precalculated Q = 0.0 scattering matrix inverse
@@ -95,9 +95,9 @@ class ScatteringMatrix
      */
     public:
     // Set data and coefficients for the supplied row (from NeutronWeights)
-    void setRow(DoubleKeyedMapKey key, const Data1D &data, const NeutronWeights &weights, double factor);
+    void setRow(const std::string &key, const Data1D &data, const NeutronWeights &weights, double factor);
     // Set data and coefficients for the supplied row (from XRayWeights)
-    void setRow(DoubleKeyedMapKey key, const Data1D &data, const XRayWeights &weights, double factor);
+    void setRow(const std::string &key, const Data1D &data, const XRayWeights &weights, double factor);
     // Set data and coefficients for the supplied row (single coefficient)
-    void setRow(DoubleKeyedMapKey key, const Data1D &data, const AtomType *i, const AtomType *j, double factor);
+    void setRow(const std::string &key, const Data1D &data, const AtomType *i, const AtomType *j, double factor);
 };

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -57,8 +57,6 @@ class ScatteringMatrix
     private:
     // Return whether Q-dependent weighting is required
     bool qDependentWeighting() const;
-    // Create and return the full coefficients matrix
-    Array2D<double> A() const;
 
     public:
     // Return number of AtomTypes involved
@@ -73,6 +71,8 @@ class ScatteringMatrix
     std::pair<int, int> pairIndexOf(const AtomType *typeI, const AtomType *typeJ) const;
     // Return column of specified AtomType pair
     int columnIndex(const AtomType *typeI, const AtomType *typeJ) const;
+    // Create and return the full coefficients matrix
+    Array2D<double> A() const;
     // Generate matrices
     void generateMatrices();
     // Return the precalculated Q = 0.0 scattering matrix inverse

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -47,10 +47,10 @@ class ScatteringMatrix
     KeyedVector<std::string, ScatteringMatrixRow> rows_;
     // Scattering matrix and inverse at Q = 0
     Array2D<double> qZeroMatrix_, qZeroInverse_;
-    // Scattering matrix / inverse pairs at specific Q values
-    std::vector<std::tuple<double, Array2D<double>, Array2D<double>>> qMatrices_;
     // Q values to use when generating matrices and data
     std::vector<double> qValues_;
+    // Scattering matrix / inverse at specific Q values
+    std::vector<Array2D<double>> qMatrices_, qInverses_;
 
     private:
     // Return whether Q-dependent weighting is required

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -59,8 +59,6 @@ class ScatteringMatrix
     Array2D<double> A() const;
 
     public:
-    // Return atom types
-    const std::vector<const AtomType *> &atomTypes() const;
     // Generate matrices
     void generateMatrices(const std::vector<double> &qValues);
     // Return the precalculated Q = 0.0 scattering matrix inverse

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -16,9 +16,20 @@
 // Forward Declarations
 class AtomType;
 
+struct ScatteringMatrixRow
+{
+    Data1D data;
+    std::vector<double> coefficients;
+    std::optional<XRayWeights> xRayWeights;
+    StructureFactors::NormalisationType xRayNormalisation;
+};
+
 // Scattering Matrix Container
 class ScatteringMatrix
 {
+    public:
+    ScatteringMatrix(const std::vector<const AtomType *> &atomTypes);
+
     /*
      * Data
      *
@@ -33,16 +44,14 @@ class ScatteringMatrix
     std::vector<const AtomType *> atomTypes_;
     // Reference pairs of AtomTypes
     std::vector<std::pair<const AtomType *, const AtomType *>> typePairs_;
-    // Coefficients matrix (A) (ci * cj * bi * bj * (typei == typej ? 1 : 2)) (n * n)
-    Array2D<double> A_;
-    // Reference data (B) (n * 1)
-    std::vector<Data1D> data_;
-    // X-ray specification for reference data (if relevant)
-    std::vector<std::tuple<bool, std::optional<XRayWeights>, StructureFactors::NormalisationType>> xRayData_;
+    // Scattering matrix rows
+    DoubleKeyedMap<ScatteringMatrixRow> rows_;
     // Scattering matrix and inverse at Q = 0
     Array2D<double> qZeroMatrix_, qZeroInverse_;
     // Scattering matrix / inverse pairs at specific Q values
     std::vector<std::tuple<double, Array2D<double>, Array2D<double>>> qMatrices_;
+    // Whether the matrices up-to-date
+    bool matricesValid_{false};
 
     private:
     // Return whether Q-dependent weighting is required
@@ -82,17 +91,10 @@ class ScatteringMatrix
      * Construction
      */
     public:
-    // Initialise from supplied list of AtomTypes
-    void initialise(const std::vector<const AtomType *> &types, Array2D<Data1D> &estimatedSQ);
-    // Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
-    bool addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor = 1.0);
-    // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself
-    bool addReferenceData(const Data1D &weightedData, const XRayWeights &dataWeights, double factor = 1.0);
-    // Update reference data)
-    bool updateReferenceData(const Data1D &weightedData, double factor = 1.0);
-    // Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
-    bool addPartialReferenceData(Data1D &weightedData, const AtomType *at1, const AtomType *at2, double dataWeight,
-                                 double factor = 1.0);
-    // Return number of currently-defined reference data sets (== matrix rows)
-    int nReferenceData() const;
+    // Set data and coefficients for the supplied row (from NeutronWeights)
+    void setRow(DoubleKeyedMapKey key, const Data1D &data, const NeutronWeights &weights, double factor);
+    // Set data and coefficients for the supplied row (from XRayWeights)
+    void setRow(DoubleKeyedMapKey key, const Data1D &data, const XRayWeights &weights, double factor);
+    // Set data and coefficients for the supplied row (single coefficient)
+    void setRow(DoubleKeyedMapKey key, const Data1D &data, const AtomType *i, const AtomType *j, double factor);
 };

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -16,6 +16,7 @@
 // Forward Declarations
 class AtomType;
 
+// Scattering Matrix Row
 struct ScatteringMatrixRow
 {
     Data1D data;

--- a/src/items/producers.cpp
+++ b/src/items/producers.cpp
@@ -40,6 +40,8 @@ GenericItemProducer::GenericItemProducer()
     registerProducer<Data1D>("Data1D");
     registerProducer<Data2D>("Data2D");
     registerProducer<Data3D>("Data3D");
+    registerProducer<DoubleKeyedMap<double>>("DoubleKeyedMap<double>");
+    registerProducer<DoubleKeyedMap<Data1D>>("DoubleKeyedMap<Data1D>");
     registerProducer<Histogram1D>("Histogram1D");
     registerProducer<Histogram2D>("Histogram2D");
     registerProducer<Histogram3D>("Histogram3D");

--- a/src/items/searchers.cpp
+++ b/src/items/searchers.cpp
@@ -25,6 +25,15 @@ template <> GenericItemSearcher<const Data1D>::GenericItemSearcher()
             auto it = std::find_if(array.begin(), array.end(), [dataName](const auto &data) { return dataName == data.tag(); });
             return it == array.end() ? OptionalReferenceWrapper<const Data1D>() : OptionalReferenceWrapper<const Data1D>(*it);
         });
+    registerSearcher<DoubleKeyedMap<Data1D>>(
+        [](const std::any &a, std::string_view dataName)
+        {
+            auto &map = std::any_cast<const DoubleKeyedMap<Data1D> &>(a);
+            auto it =
+                std::find_if(map.begin(), map.end(), [dataName](const auto &pair) { return dataName == pair.second.tag(); });
+            return it == map.end() ? OptionalReferenceWrapper<const Data1D>()
+                                   : OptionalReferenceWrapper<const Data1D>(it->second);
+        });
     registerSearcher<PartialSet>(
         [](const std::any &a, std::string_view dataName)
         {

--- a/src/math/combinations.cpp
+++ b/src/math/combinations.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "math/combinations.h"
+#include "math/mathFunc.h"
 #include "math/polynomial.h"
 #include <cmath>
 
@@ -28,4 +29,4 @@ std::pair<int, int> Combinations::nthCombination(int n) const
     return {x, y};
 }
 
-int Combinations::getNumCombinations() const { return N_ * (N_ - 1) / 2; }
+int Combinations::getNumCombinations() const { return DissolveMath::triangularOffDiagonals(N_); }

--- a/src/math/mathFunc.cpp
+++ b/src/math/mathFunc.cpp
@@ -86,4 +86,13 @@ int cp3(int i) { return (i % 3); }
 double toRadians(double degrees) { return degrees / DegreesPerRadian; }
 double toDegrees(double radians) { return radians * DegreesPerRadian; }
 
+/*
+ * Triangular Matrices
+ */
+
+// Return the number of elements in a triangular matrix, disregarding the diagonal terms
+int triangularOffDiagonals(int matrixSize) { return matrixSize * (matrixSize - 1) / 2; }
+// Return the number of elements in a triangular matrix, including the diagonal terms
+int triangularIncDiagonals(int matrixSize) { return matrixSize * (matrixSize + 1) / 2; }
+
 } // namespace DissolveMath

--- a/src/math/mathFunc.h
+++ b/src/math/mathFunc.h
@@ -57,4 +57,13 @@ constexpr double Avogadro = 6.0221415E23;
 
 // Degrees per Radian
 constexpr double DegreesPerRadian = 180.0 / M_PI;
+
+/*
+ * Triangular Matrices
+ */
+
+// Return the number of elements in a triangular matrix, disregarding the diagonal terms
+int triangularOffDiagonals(int matrixSize);
+// Return the number of elements in a triangular matrix, including the diagonal terms
+int triangularIncDiagonals(int matrixSize);
 }; // namespace DissolveMath

--- a/src/modules/bragg/gui/braggWidgetFuncs.cpp
+++ b/src/modules/bragg/gui/braggWidgetFuncs.cpp
@@ -5,6 +5,7 @@
 #include "gui/dataViewer.h"
 #include "gui/render/renderableData1D.h"
 #include "main/dissolve.h"
+#include "math/mathFunc.h"
 #include "modules/bragg/bragg.h"
 #include "modules/bragg/gui/braggWidget.h"
 #include "templates/algorithms.h"
@@ -104,7 +105,7 @@ void BraggModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &u
             {
                 const auto typeVector = *reflectionAtomTypesData_;
                 std::vector<std::string> columnHeaders;
-                columnHeaders.reserve(typeVector.size() * (typeVector.size() + 1) / 2);
+                columnHeaders.reserve(DissolveMath::triangularIncDiagonals(typeVector.size()));
                 dissolve::for_each_pair(
                     ParallelPolicies::seq, typeVector, [&](int i, auto &popI, int j, auto &popJ)
                     { columnHeaders.emplace_back(std::format("{}-{}", popI.first->name(), popJ.first->name())); });

--- a/src/modules/epsr/epsr.cpp
+++ b/src/modules/epsr/epsr.cpp
@@ -89,7 +89,7 @@ EnumOptions<EPSRModule::ExpansionFunctionType> EPSRModule::expansionFunctionType
 }
 
 // Return current scattering matrix
-const ScatteringMatrix &EPSRModule::scatteringMatrix() const { return scatteringMatrix_; }
+const std::optional<ScatteringMatrix> &EPSRModule::scatteringMatrix() const { return scatteringMatrix_; }
 
 // Set whether to apply this module's generated potentials to the global pair potentials
 void EPSRModule::setApplyPotentials(bool b) { applyPotentials_ = b; }

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -115,8 +115,8 @@ class EPSRModule : public Module
     private:
     // Create / update delta S(Q) information
     void updateDeltaSQ(GenericList &processingData,
-                       OptionalReferenceWrapper<const Array2D<Data1D>> optCalculatedSQ = std::nullopt,
-                       OptionalReferenceWrapper<const Array2D<Data1D>> optEstimatedSQ = std::nullopt);
+                       OptionalReferenceWrapper<const DoubleKeyedMap<Data1D>> optCalculatedSQ = std::nullopt,
+                       OptionalReferenceWrapper<const DoubleKeyedMap<Data1D>> optEstimatedSQ = std::nullopt);
 
     public:
     // Create / retrieve arrays for storage of empirical potential coefficients

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -123,12 +123,12 @@ class EPSRModule : public Module
     Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
                                                         std::optional<int> ncoeffp = std::nullopt);
     // Generate empirical potentials from current coefficients
-    bool generateEmpiricalPotentials(Dissolve &dissolve, double rho, std::optional<int> ncoeffp, double rminpt, double rmaxpt,
-                                     double sigma1, double sigma2);
+    bool generateEmpiricalPotentials(Dissolve &dissolve, const std::vector<const AtomType *> &atomTypes, double rho,
+                                     std::optional<int> ncoeffp, double rminpt, double rmaxpt, double sigma1, double sigma2);
     // Generate and return single empirical potential function
-    Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n);
+    Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int nAtomTypes, int i, int j, int n);
     // Calculate absolute energy of empirical potentials
-    double absEnergyEP(GenericList &moduleData);
+    double absEnergyEP(GenericList &moduleData, const std::vector<const AtomType *> &atomTypes);
     // Truncate the supplied data
     void truncate(Data1D &data, double rMin, double rMax);
     // Return vector of empirical potentials

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -45,7 +45,7 @@ class EPSRModule : public Module
     // Confidence factor
     double feedback_{0.9};
     // Scattering matrix
-    ScatteringMatrix scatteringMatrix_;
+    std::optional<ScatteringMatrix> scatteringMatrix_;
     // EPSR 'inpa' file from which to read deltaFQ fit coefficients from
     std::string inpaFilename_;
     // Maximum Q value over which to generate potentials from total scattering data

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -101,7 +101,7 @@ class EPSRModule : public Module
 
     public:
     // Return current scattering matrix
-    const ScatteringMatrix &scatteringMatrix() const;
+    const std::optional<ScatteringMatrix> &scatteringMatrix() const;
     // Set whether to apply this module's generated potentials to the global pair potentials
     void setApplyPotentials(bool b);
 

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -65,14 +65,13 @@ Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &mod
 }
 
 // Generate empirical potentials from current coefficients
-bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, double averagedRho, std::optional<int> ncoeffp, double rminpt,
-                                             double rmaxpt, double sigma1, double sigma2)
+bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, const std::vector<const AtomType *> &atomTypes,
+                                             double averagedRho, std::optional<int> ncoeffp, double rminpt, double rmaxpt,
+                                             double sigma1, double sigma2)
 {
-    const auto &atomTypes = scatteringMatrix_->atomTypes();
-    const auto nAtomTypes = atomTypes.size();
-
     // Get coefficients array
-    Array2D<std::vector<double>> &coefficients = potentialCoefficients(dissolve.processingModuleData(), nAtomTypes, ncoeffp);
+    Array2D<std::vector<double>> &coefficients =
+        potentialCoefficients(dissolve.processingModuleData(), atomTypes.size(), ncoeffp);
 
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                             [&](int i, auto at1, int j, auto at2)
@@ -126,11 +125,8 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, double averaged
 }
 
 // Generate and return single empirical potential function
-Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n)
+Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int nAtomTypes, int i, int j, int n)
 {
-    const auto &atomTypes = scatteringMatrix_->atomTypes();
-    const auto nAtomTypes = atomTypes.size();
-
     // EPSR constants
     const auto mcoeff = 200;
 
@@ -169,7 +165,7 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i,
 }
 
 // Calculate absolute energy of empirical potentials
-double EPSRModule::absEnergyEP(GenericList &moduleData)
+double EPSRModule::absEnergyEP(GenericList &moduleData, const std::vector<const AtomType *> &atomTypes)
 {
     /*
      * Routine from EPSR25.
@@ -177,11 +173,8 @@ double EPSRModule::absEnergyEP(GenericList &moduleData)
      * Return the largest range we find.
      */
 
-    const auto &atomTypes = scatteringMatrix_->atomTypes();
-    const auto nAtomTypes = atomTypes.size();
-
     // Get coefficients array
-    auto &coefficients = potentialCoefficients(moduleData, nAtomTypes);
+    auto &coefficients = potentialCoefficients(moduleData, atomTypes.size());
     if (coefficients.empty())
         return 0.0;
 
@@ -203,7 +196,7 @@ double EPSRModule::absEnergyEP(GenericList &moduleData)
         Messenger::print("  abs_energy_ep>    {:4} {:4} {:12.6f}\n", atomTypes[i]->name(), atomTypes[j]->name(), range);
     };
 
-    PairIterator pairs(nAtomTypes);
+    PairIterator pairs(atomTypes.size());
     dissolve::for_each(ParallelPolicies::seq, pairs.begin(), pairs.end(), unaryOp);
 
     return absEnergyEP;

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -9,16 +9,17 @@
 #include "templates/algorithms.h"
 
 // Create / update delta S(Q) information
-void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWrapper<const Array2D<Data1D>> optCalculatedSQ,
-                               OptionalReferenceWrapper<const Array2D<Data1D>> optEstimatedSQ)
+void EPSRModule::updateDeltaSQ(GenericList &processingData,
+                               OptionalReferenceWrapper<const DoubleKeyedMap<Data1D>> optCalculatedSQ,
+                               OptionalReferenceWrapper<const DoubleKeyedMap<Data1D>> optEstimatedSQ)
 {
     // Find the relevant data if we were not provided them
     if (!optCalculatedSQ)
-        optCalculatedSQ = processingData.valueIf<Array2D<Data1D>>("UnweightedSQ", name_);
+        optCalculatedSQ = processingData.valueIf<DoubleKeyedMap<Data1D>>("UnweightedSQ", name_);
     if (!optCalculatedSQ)
         return;
     if (!optEstimatedSQ)
-        optEstimatedSQ = processingData.valueIf<Array2D<Data1D>>("EstimatedSQ", name_);
+        optEstimatedSQ = processingData.valueIf<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
     if (!optEstimatedSQ)
         return;
 
@@ -27,16 +28,16 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData, OptionalReferenceWra
     assert(calculatedSQ.nRows() == estimatedSQ.nRows() && calculatedSQ.nColumns() == estimatedSQ.nColumns());
 
     // Realise the DeltaSQ array
-    auto [deltaSQ, status] = processingData.realiseIf<Array2D<Data1D>>("DeltaSQ", name_, GenericItem::ItemFlag::NoFlags);
-    if (status == GenericItem::ItemStatus::Created)
-        deltaSQ.initialise(calculatedSQ.nRows(), calculatedSQ.nRows(), true);
+    auto deltaSQ = processingData.realise<DoubleKeyedMap<Data1D>>("DeltaSQ", name_, GenericItem::ItemFlag::NoFlags);
+    deltaSQ.clear(true);
 
-    // Copy the tags from the calculated data (so we avoid requiring the source AtomTypeList) and create the data
-    for (auto &&[delta, calc, est] : zip(deltaSQ, calculatedSQ, estimatedSQ))
+    for (auto &[key, calcSQ] : calculatedSQ)
     {
-        delta.setTag(calc.tag());
-        delta = est;
-        Interpolator::addInterpolated(calc, delta, -1.0);
+        deltaSQ[key] = estimatedSQ[key];
+        Interpolator::addInterpolated(calcSQ, deltaSQ[key], -1.0);
+
+        // Copy the tag
+        deltaSQ[key].setTag(calcSQ.tag());
     }
 }
 
@@ -67,7 +68,7 @@ Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &mod
 bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, double averagedRho, std::optional<int> ncoeffp, double rminpt,
                                              double rmaxpt, double sigma1, double sigma2)
 {
-    const auto &atomTypes = scatteringMatrix_.atomTypes();
+    const auto &atomTypes = scatteringMatrix_->atomTypes();
     const auto nAtomTypes = atomTypes.size();
 
     // Get coefficients array
@@ -127,7 +128,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, double averaged
 // Generate and return single empirical potential function
 Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n)
 {
-    const auto &atomTypes = scatteringMatrix_.atomTypes();
+    const auto &atomTypes = scatteringMatrix_->atomTypes();
     const auto nAtomTypes = atomTypes.size();
 
     // EPSR constants
@@ -176,7 +177,7 @@ double EPSRModule::absEnergyEP(GenericList &moduleData)
      * Return the largest range we find.
      */
 
-    const auto &atomTypes = scatteringMatrix_.atomTypes();
+    const auto &atomTypes = scatteringMatrix_->atomTypes();
     const auto nAtomTypes = atomTypes.size();
 
     // Get coefficients array

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -25,7 +25,7 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData,
 
     const auto &calculatedSQ = optCalculatedSQ->get();
     const auto &estimatedSQ = optEstimatedSQ->get();
-    assert(calculatedSQ.nRows() == estimatedSQ.nRows() && calculatedSQ.nColumns() == estimatedSQ.nColumns());
+    assert(calculatedSQ.size() == estimatedSQ.size());
 
     // Realise the DeltaSQ array
     auto deltaSQ = processingData.realise<DoubleKeyedMap<Data1D>>("DeltaSQ", name_, GenericItem::ItemFlag::NoFlags);

--- a/src/modules/epsr/gui/epsrWidgetFuncs.cpp
+++ b/src/modules/epsr/gui/epsrWidgetFuncs.cpp
@@ -67,7 +67,8 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
     {
         ui_.PlotWidget->clearRenderableData();
 
-        const auto &atomTypes = module_->scatteringMatrix().atomTypes();
+        const auto &atomTypes =
+            module_->scatteringMatrix() ? module_->scatteringMatrix()->atomTypes() : std::vector<const AtomType *>();
         const auto nAtomTypes = atomTypes.size();
         auto epsrModuleTargets = module_->keywords().getVectorModule("Target");
 

--- a/src/modules/epsr/gui/epsrWidgetFuncs.cpp
+++ b/src/modules/epsr/gui/epsrWidgetFuncs.cpp
@@ -67,9 +67,6 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
     {
         ui_.PlotWidget->clearRenderableData();
 
-        const auto &atomTypes =
-            module_->scatteringMatrix() ? module_->scatteringMatrix()->atomTypes() : std::vector<const AtomType *>();
-        const auto nAtomTypes = atomTypes.size();
         auto epsrModuleTargets = module_->keywords().getVectorModule("Target");
 
         // Set the relevant graph targets
@@ -108,25 +105,30 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         }
         else if (ui_.EstimatedSQButton->isChecked())
         {
-            // Add experimentally-determined partial S(Q)
-            dissolve::for_each_pair(
-                ParallelPolicies::seq, atomTypes,
-                [&](int typeI, const auto &at1, int typeJ, const auto &at2)
+            auto optEstimatedSQ =
+                dissolve_.processingModuleData().valueIf<DoubleKeyedMap<Data1D>>("EstimatedSQ", module_->name());
+            if (optEstimatedSQ)
+            {
+                auto &estimatedSQ = optEstimatedSQ->get();
+                for (auto &[key, value] : estimatedSQ)
                 {
-                    const std::string id = std::format("{}-{}", at1->name(), at2->name());
+                    // Get constituent key pair and reformat to get the tag
+                    auto keyPair = estimatedSQ.keyPair(key);
+                    const auto keyString = std::format("{}-{}", keyPair.first, keyPair.second);
 
                     // Unweighted estimated partial
-                    graph_->createRenderable<RenderableData1D>(std::format("{}//EstimatedSQ//{}", module_->name(), id),
-                                                               std::format("{} (Estimated)", id), "Estimated");
+                    graph_->createRenderable<RenderableData1D>(std::format("{}//EstimatedSQ//{}", module_->name(), keyString),
+                                                               std::format("{} (Estimated)", keyString), "Estimated");
 
                     // Calculated / summed partial
-                    graph_->createRenderable<RenderableData1D>(std::format("{}//UnweightedSQ//{}", module_->name(), id),
-                                                               std::format("{} (Calc)", id), "Calc");
+                    graph_->createRenderable<RenderableData1D>(std::format("{}//UnweightedSQ//{}", module_->name(), keyString),
+                                                               std::format("{} (Calc)", keyString), "Calc");
 
                     // Deltas
-                    graph_->createRenderable<RenderableData1D>(std::format("{}//DeltaSQ//{}", module_->name(), id),
-                                                               std::format("{} (Delta)", id), "Delta");
-                });
+                    graph_->createRenderable<RenderableData1D>(std::format("{}//DeltaSQ//{}", module_->name(), keyString),
+                                                               std::format("{} (Delta)", keyString), "Delta");
+                }
+            }
         }
         else if (ui_.EstimatedGRButton->isChecked())
         {
@@ -152,20 +154,27 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
             }
 
             // Add experimentally-determined partial g(r)
-            dissolve::for_each_pair(
-                ParallelPolicies::seq, atomTypes,
-                [&](int typeI, const auto &at1, int typeJ, const auto &at2)
+            auto optEstimatedGR =
+                dissolve_.processingModuleData().valueIf<DoubleKeyedMap<Data1D>>("EstimatedGR", module_->name());
+            if (optEstimatedGR)
+            {
+                auto &estimatedGR = optEstimatedGR->get();
+                for (auto &[key, value] : estimatedGR)
                 {
-                    const std::string id = std::format("{}-{}", at1->name(), at2->name());
+                    // Get constituent key pair and reformat to get the tag
+                    auto keyPair = estimatedGR.keyPair(key);
+                    const auto keyString = std::format("{}-{}", keyPair.first, keyPair.second);
 
                     // Experimentally-determined unweighted partial
-                    graph_->createRenderable<RenderableData1D>(std::format("{}//EstimatedGR//{}", module_->name(), id),
-                                                               std::format("{} (Estimated)", id), "Estimated");
+                    graph_->createRenderable<RenderableData1D>(std::format("{}//EstimatedGR//{}", module_->name(), keyString),
+                                                               std::format("{} (Estimated)", keyString), "Estimated");
 
                     // Calculated / summed partials, taken from the RDF module referenced by the first module target
-                    graph_->createRenderable<RenderableData1D>(std::format("{}//UnweightedGR//{}//Full", rdfModuleName, id),
-                                                               std::format("{} (Calc)", id), "Calc");
-                });
+                    graph_->createRenderable<RenderableData1D>(
+                        std::format("{}//UnweightedGR//{}//Full", rdfModuleName, keyString),
+                        std::format("{} (Calc)", keyString), "Calc");
+                }
+            }
         }
         else if (ui_.TotalGRButton->isChecked())
         {
@@ -183,17 +192,21 @@ void EPSRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &up
         }
         else if (ui_.PotentialsButton->isChecked())
         {
-            // Add on additional potentials
-            dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
-                                    [&](int typeI, const auto &at1, int typeJ, const auto &at2)
-                                    {
-                                        const std::string id = std::format("{}-{}", at1->name(), at2->name());
-
-                                        auto pp = dissolve_.pairPotential(at1, at2);
-                                        if (pp)
-                                            graph_->createRenderable<RenderableData1D>(
-                                                std::format("Dissolve//Potential_{}_Additional", id), id, "Phi");
-                                    });
+            // Add on additional potentials - use the EstimatedSQ data as the key reference
+            auto optEstimatedSQ =
+                dissolve_.processingModuleData().valueIf<DoubleKeyedMap<Data1D>>("EstimatedSQ", module_->name());
+            if (optEstimatedSQ)
+            {
+                auto &estimatedSQ = optEstimatedSQ->get();
+                for (auto &[key, value] : estimatedSQ)
+                {
+                    // Get constituent key pair and reformat to get the tag
+                    auto keyPair = estimatedSQ.keyPair(key);
+                    const auto keyString = std::format("{}-{}", keyPair.first, keyPair.second);
+                    graph_->createRenderable<RenderableData1D>(std::format("Dissolve//Potential_{}_Additional", keyString),
+                                                               keyString, "Phi");
+                }
+            }
         }
         else if (ui_.RFactorButton->isChecked())
         {

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -86,14 +86,16 @@ bool EPSRModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSignal> act
         auto rminpt = rMinPT_ ? rMinPT_.value() : rmaxpt - 2.0;
         if (expansionFunction_ == EPSRModule::GaussianExpansionFunction)
         {
-            if (!generateEmpiricalPotentials(dissolve, rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt, gSigma1_, gSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, targetConfiguration_->atomTypeVector(), rho.value_or(0.1), nCoeffP_,
+                                             rminpt, rmaxpt, gSigma1_, gSigma2_))
             {
                 return false;
             }
         }
         else
         {
-            if (!generateEmpiricalPotentials(dissolve, rho.value_or(0.1), nCoeffP_, rminpt, rmaxpt, pSigma1_, pSigma2_))
+            if (!generateEmpiricalPotentials(dissolve, targetConfiguration_->atomTypeVector(), rho.value_or(0.1), nCoeffP_,
+                                             rminpt, rmaxpt, pSigma1_, pSigma2_))
             {
                 return false;
             }
@@ -680,7 +682,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                 });
 
         // Determine absolute energy of empirical potentials
-        energabs = absEnergyEP(moduleData);
+        energabs = absEnergyEP(moduleData, atomTypes);
 
         /*
          * Determine the scaling we will apply to the coefficients (if any)
@@ -720,11 +722,11 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
         auto sigma1 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma1_ : gSigma1_;
         auto sigma2 = expansionFunction_ == EPSRModule::PoissonExpansionFunction ? pSigma2_ : gSigma2_;
 
-        if (!generateEmpiricalPotentials(dissolve, rho, ncoeffp, rminpt, rmaxpt, sigma1, sigma2))
+        if (!generateEmpiricalPotentials(dissolve, atomTypes, rho, ncoeffp, rminpt, rmaxpt, sigma1, sigma2))
             return ExecutionResult::Failed;
     }
     else
-        energabs = absEnergyEP(moduleData);
+        energabs = absEnergyEP(moduleData, atomTypes);
 
     // Save data?
     if (saveEmpiricalPotentials_)

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -221,17 +221,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                         [](const auto acc, const auto &targetWeight) { return acc + targetWeight.second; }) +
         (targets_.size() - targetWeights_.size());
 
-    // Realise storage for generated S(Q) and initialise a scattering matrix
-    auto &&[estimatedSQ, estimatedSQStatus] =
-        dissolve.processingModuleData().realiseIf<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
-    if (estimatedSQStatus == GenericItem::ItemStatus::Created)
-    {
-        // Create partials array
-        estimatedSQ.clear(true);
-        dissolve::for_each_pair(
-            ParallelPolicies::seq, atomTypes, [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
-            { estimatedSQ.get(typeI->name(), typeJ->name()).setTag(std::format("{}-{}", typeI->name(), typeJ->name())); });
-    }
+    // Initialise a scattering matrix if we haven't already
     if (!scatteringMatrix_)
         scatteringMatrix_.emplace(atomTypes);
 
@@ -492,7 +482,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
         dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                                 [&](int i, const auto &at1, int j, const auto &at2)
                                 {
-                                    auto pairIndex = scatteringMatrix_.pairIndexOf(at1, at2);
+                                    auto pairIndex = scatteringMatrix_->pairIndexOf(at1, at2);
 
                                     const auto &partialIJ = unweightedSQ.unboundPartials().get(at1->name(), at2->name());
                                     Interpolator::addInterpolated(partialIJ, calculatedUnweightedSQ[pairIndex],
@@ -540,13 +530,13 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
 
     // Add a contribution from each interatomic partial S(Q), weighted according to the feedback factor
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
-                            [&](int i, auto &at1, int j, auto &at2)
+                            [&](int i, auto &atI, int j, auto &atJ)
                             {
                                 // Copy and rename the data for clarity
                                 auto data = calculatedUnweightedSQ[{i, j}];
-                                data.setTag(std::format("Simulated {}-{}", at1->name(), at2->name()));
+                                data.setTag(std::format("Simulated {}-{}", atI->name(), atJ->name()));
 
-                                scatteringMatrix_->setRow({at1->name(), at2->name()}, data, at1, at2, 1.0 - feedback_);
+                                scatteringMatrix_->setRow({atI->name(), atJ->name()}, data, atI, atJ, 1.0 - feedback_);
                             });
 
     // Make sure inverse matrices are up-to-date
@@ -557,17 +547,19 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     if (Messenger::isVerbose())
     {
         Messenger::print("\nScattering Matrix Inverse (Q = 0.0):\n");
-        scatteringMatrix_.printInverse();
+        scatteringMatrix_->printInverse();
 
         Messenger::print("\nIdentity (Ainv * A):\n");
-        scatteringMatrix_.matrixProduct().print();
+        scatteringMatrix_->matrixProduct().print();
     }
 
     /*
      * Generate S(Q) from completed scattering matrix
      */
 
-    scatteringMatrix_.generatePartials(estimatedSQ);
+    auto &estimatedSQ=
+        dissolve.processingModuleData().realise<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
+    estimatedSQ = scatteringMatrix_->generateEstimatedPartials();
     updateDeltaSQ(moduleData, calculatedUnweightedSQ, estimatedSQ);
 
     // Save data?

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -557,8 +557,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
      * Generate S(Q) from completed scattering matrix
      */
 
-    auto &estimatedSQ=
-        dissolve.processingModuleData().realise<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
+    auto &estimatedSQ = dissolve.processingModuleData().realise<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
     estimatedSQ = scatteringMatrix_->generateEstimatedPartials();
     updateDeltaSQ(moduleData, calculatedUnweightedSQ, estimatedSQ);
 
@@ -574,22 +573,26 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     }
 
     /*
-     * Calculate g(r) from estimatedSQ
+     * Calculate estimated g(r) from estimated S(Q)
      */
-    auto &estimatedGR = moduleData.realise<Array2D<Data1D>>("EstimatedGR", name_, GenericItem::InRestartFileFlag);
-    estimatedGR.initialise(nAtomTypes, nAtomTypes, true);
+
+    DoubleKeyedMap<Data1D> estimatedGR;
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
-                            [&](int i, auto at1, int j, auto at2)
+                            [&](int indexI, auto atI, int indexJ, auto atJ)
                             {
-                                auto &expGR = estimatedGR[{i, j}];
-                                expGR.setTag(std::format("{}-{}", at1->name(), at2->name()));
+                                DoubleKeyedMapKey key(atI->name(), atJ->name());
+
+                                // Set tag
+                                estimatedGR.get(key).setTag(std::format("{}-{}", atI->name(), atJ->name()));
 
                                 // Copy experimental S(Q) and FT it
-                                expGR = estimatedSQ[{i, j}];
-                                Fourier::sineFT(expGR, 1.0 / (2 * M_PI * M_PI * rho), 0.0, 0.05, 30.0,
+                                estimatedGR[key] = estimatedSQ.get(key);
+                                Fourier::sineFT(estimatedGR[key], 1.0 / (2 * M_PI * M_PI * rho), 0.0, 0.05, 30.0,
                                                 WindowFunction(WindowFunction::Form::Lorch0));
-                                expGR += 1.0;
+                                estimatedGR[key] += 1.0;
                             });
+
+    moduleData.realise<DoubleKeyedMap<Data1D>>("EstimatedGR", name_) = estimatedGR;
 
     /*
      * Calculate contribution to potential coefficients.

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -438,7 +438,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             else if (normType == StructureFactors::SquareOfAverageNormalisation)
                 refMinusIntra *= weights.boundCoherentSquareOfAverage();
 
-            scatteringMatrix_->setRow({"Neutron", module->name()}, refMinusIntra, weights, dataSetWeight);
+            scatteringMatrix_->setRow(std::format("Neutron//{}", module->name()), refMinusIntra, weights, dataSetWeight);
         }
         else if (module->type() == ModuleTypes::XRaySQ)
         {
@@ -466,7 +466,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                refMinusIntra.values().begin(), std::divides<>());
             }
 
-            scatteringMatrix_->setRow({"XRay", module->name()}, refMinusIntra, weights, dataSetWeight);
+            scatteringMatrix_->setRow(std::format("XRay//{}", module->name()), refMinusIntra, weights, dataSetWeight);
         }
         else
         {
@@ -535,7 +535,8 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                 auto data = calculatedUnweightedSQ[{atI->name(), atJ->name()}];
                                 data.setTag(std::format("Simulated {}-{}", atI->name(), atJ->name()));
 
-                                scatteringMatrix_->setRow({atI->name(), atJ->name()}, data, atI, atJ, 1.0 - feedback_);
+                                scatteringMatrix_->setRow(std::format("{}-{}", atI->name(), atJ->name()), data, atI, atJ,
+                                                          1.0 - feedback_);
                             });
 
     // Make sure inverse matrices are up-to-date

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -607,34 +607,37 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             moduleData.value<std::vector<double>>(std::format("FitCoefficients_{}", module->name()), name_);
 
         // Loop over pair potentials and retrieve the inverse weight from the scattering matrix
-        dissolve::for_each_pair(
-            ParallelPolicies::seq, atomTypes,
-            [&](int i, auto at1, int j, auto at2)
-            {
-                auto weight = scatteringMatrix_->qZeroMatrixInverse()[{scatteringMatrix_->columnIndex(at1, at2), dataIndex}];
+        auto columnIndex = 0;
+        dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
+                                [&](int i, auto typeI, int j, auto typeJ)
+                                {
+                                    auto weight = scatteringMatrix_->qZeroMatrixInverse()[{columnIndex, dataIndex}];
 
-                /*
-                 * EPSR assembles the potential coefficients from the deltaFQ fit coefficients as a linear
-                 * combination with the following weighting factors (see circa line 3378 in
-                 * epsr_standalone_rev1.f):
-                 *
-                 * 1. The overall potential factor (potfac) which is typically set to 1.0 in EPSR (or 0.0 to
-                 * disable potential generation)
-                 * 2. A flag controlling whether specific potentials are refined (efacp)
-                 * 3. The value of the inverse scattering matrix for this dataset / potential (cwtpot),
-                 * multiplied by the feedback factor.
-                 */
+                                    /*
+                                     * EPSR assembles the potential coefficients from the deltaFQ fit coefficients as a linear
+                                     * combination with the following weighting factors (see circa line 3378 in
+                                     * epsr_standalone_rev1.f):
+                                     *
+                                     * 1. The overall potential factor (potfac) which is typically set to 1.0 in EPSR (or 0.0 to
+                                     * disable potential generation)
+                                     * 2. A flag controlling whether specific potentials are refined (efacp)
+                                     * 3. The value of the inverse scattering matrix for this dataset / potential (cwtpot),
+                                     * multiplied by the feedback factor.
+                                     */
 
-                // In the original EPSR the off-diagonal elements in the inverse matrix have also been
-                // halved so as not to double-count the i != j terms
-                if (i != j)
-                    weight *= 0.5;
+                                    // In the original EPSR the off-diagonal elements in the inverse matrix have also been
+                                    // halved so as not to double-count the i != j terms
+                                    if (i != j)
+                                        weight *= 0.5;
 
-                // Store fluctuation coefficients ready for addition to potential coefficients later on.
-                auto [begin, end] = fluctuationCoefficients[std::tuple{i, j}];
-                std::transform(fitCoefficients.begin(), fitCoefficients.end(), begin, begin,
-                               [weight, this](auto coeff, auto result) { return result + weight * feedback_ * coeff; });
-            });
+                                    // Store fluctuation coefficients ready for addition to potential coefficients later on.
+                                    auto [begin, end] = fluctuationCoefficients[std::tuple{i, j}];
+                                    std::transform(fitCoefficients.begin(), fitCoefficients.end(), begin, begin,
+                                                   [weight, this](auto coeff, auto result)
+                                                   { return result + weight * feedback_ * coeff; });
+
+                                    ++columnIndex;
+                                });
 
         // Increase dataIndex
         ++dataIndex;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -210,10 +210,11 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     fluctuationCoefficients = 0.0;
 
     // Create storage for our summed UnweightedSQ
-    auto &calculatedUnweightedSQ = moduleData.realise<Array2D<Data1D>>("UnweightedSQ", name_, GenericItem::InRestartFileFlag);
-    calculatedUnweightedSQ.initialise(nAtomTypes, nAtomTypes, true);
-    dissolve::for_each_pair(ParallelPolicies::par, atomTypes, [&](int i, auto at1, int j, auto at2)
-                            { calculatedUnweightedSQ[{i, j}].setTag(std::format("{}-{}", at1->name(), at2->name())); });
+    auto &calculatedUnweightedSQ = moduleData.realise<DoubleKeyedMap<Data1D>>("UnweightedSQ", name_);
+    calculatedUnweightedSQ.clear(true);
+    dissolve::for_each_pair(
+        ParallelPolicies::par, atomTypes, [&](int indexI, auto atI, int indexJ, auto atJ)
+        { calculatedUnweightedSQ[{atI->name(), atJ->name()}].setTag(std::format("{}-{}", atI->name(), atJ->name())); });
 
     // Get summed weights over all datasets
     const auto totalDataSetWeight =
@@ -482,10 +483,8 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
         dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                                 [&](int i, const auto &at1, int j, const auto &at2)
                                 {
-                                    auto pairIndex = scatteringMatrix_->pairIndexOf(at1, at2);
-
                                     const auto &partialIJ = unweightedSQ.unboundPartials().get(at1->name(), at2->name());
-                                    Interpolator::addInterpolated(partialIJ, calculatedUnweightedSQ[pairIndex],
+                                    Interpolator::addInterpolated(partialIJ, calculatedUnweightedSQ[{at1->name(), at2->name()}],
                                                                   1.0 / targets_.size());
                                 });
 
@@ -533,7 +532,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                             [&](int i, auto &atI, int j, auto &atJ)
                             {
                                 // Copy and rename the data for clarity
-                                auto data = calculatedUnweightedSQ[{i, j}];
+                                auto data = calculatedUnweightedSQ[{atI->name(), atJ->name()}];
                                 data.setTag(std::format("Simulated {}-{}", atI->name(), atJ->name()));
 
                                 scatteringMatrix_->setRow({atI->name(), atJ->name()}, data, atI, atJ, 1.0 - feedback_);

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -539,9 +539,8 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                                           1.0 - feedback_);
                             });
 
-    // Make sure inverse matrices are up-to-date
-    scatteringMatrix_->generateMatrices();
-
+    // Make sure inverse matrices are up-to-date, taking representative Q values from the calculated unweighted S(Q)
+    scatteringMatrix_->generateMatrices(calculatedUnweightedSQ.begin()->second.xAxis());
     scatteringMatrix_->print();
 
     if (Messenger::isVerbose())

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -295,12 +295,13 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                 y = 0.0;
 
         // Calculate r-factor over fit range and store
-        auto tempRefData = originalReferenceData;
-        Filters::trim(tempRefData, qMin_, qMax_);
-        const auto rFactorReport = Error::rFactor(tempRefData, weightedSQ.total());
+        auto trimmedReferenceData = originalReferenceData;
+        Filters::trim(trimmedReferenceData, qMin_, qMax_);
+        const auto rFactorReport = Error::rFactor(trimmedReferenceData, weightedSQ.total());
         rFacTot += rFactorReport.error;
         errors.addPoint(dissolve.iteration(), rFactorReport.error);
         Messenger::print("Current R-Factor for reference data '{}' is {:.5f}.\n", module->name(), rFactorReport.error);
+
         // Calculate r-factor over specified ranges_
         for (auto &&[range, rangeTot] : zip(ranges_, rangedRFacTots))
         {
@@ -310,7 +311,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                 "between {:.5f} and {:.5f}",
                                 range.minimum(), range.maximum(), module->name(), rFactorReport.firstX, rFactorReport.lastX);
             }
-            const auto rangedRFactorError = Error::rFactor(tempRefData, weightedSQ.total(), range).error;
+            const auto rangedRFactorError = Error::rFactor(trimmedReferenceData, weightedSQ.total(), range).error;
             rangeTot += rangedRFactorError;
             Messenger::print("Current R-Factor for reference data '{}' over range {:.5f} to {:.5f} is {:.5f}.\n",
                              module->name(), range.minimum(), range.maximum(), rangedRFactorError);
@@ -427,7 +428,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             const auto &weights = moduleData.value<NeutronWeights>("FullWeights", module->name());
 
             // Subtract intramolecular total from the reference data - this will enter into the ScatteringMatrix
-            auto refMinusIntra = originalReferenceData;
+            auto refMinusIntra = trimmedReferenceData;
             Interpolator::addInterpolated(weightedSQ.boundTotal(), refMinusIntra, -1.0);
 
             // Always add absolute data to the scattering matrix - if the calculated data has been normalised, remove this
@@ -438,7 +439,13 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             else if (normType == StructureFactors::SquareOfAverageNormalisation)
                 refMinusIntra *= weights.boundCoherentSquareOfAverage();
 
-            scatteringMatrix_->setRow(std::format("Neutron//{}", module->name()), refMinusIntra, weights, dataSetWeight);
+            // Set the zero limit on the data (equivalent to EPSR's szeros == 0.0)
+            Data1D zeroed;
+            zeroed.addPoint(0.0, refMinusIntra.values().front());
+            for (auto &&[x, y] : zip(refMinusIntra.xAxis(), refMinusIntra.values()))
+                zeroed.addPoint(x, y);
+
+            scatteringMatrix_->setRow(std::format("Neutron//{}", module->name()), zeroed, weights, dataSetWeight);
         }
         else if (module->type() == ModuleTypes::XRaySQ)
         {
@@ -447,7 +454,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             // For X-ray data we always add the reference data normalised to AverageOfSquares in order to give consistency
             // in terms of magnitude with any neutron data. If the calculated data have not been normalised, or were
             // normalised to something else, we correct it before adding.
-            auto refMinusIntra = originalReferenceData;
+            auto refMinusIntra = trimmedReferenceData;
             Interpolator::addInterpolated(weightedSQ.boundTotal(), refMinusIntra, -1.0);
 
             auto normType = module->keywords().getEnumeration<StructureFactors::NormalisationType>("NormaliseTo");
@@ -466,7 +473,13 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                refMinusIntra.values().begin(), std::divides<>());
             }
 
-            scatteringMatrix_->setRow(std::format("XRay//{}", module->name()), refMinusIntra, weights, dataSetWeight);
+            // Set the zero limit on the data (equivalent to EPSR's szeros == 0.0)
+            Data1D zeroed;
+            zeroed.addPoint(0.0, refMinusIntra.values().front());
+            for (auto &&[x, y] : zip(refMinusIntra.xAxis(), refMinusIntra.values()))
+                zeroed.addPoint(x, y);
+
+            scatteringMatrix_->setRow(std::format("XRay//{}", module->name()), zeroed, weights, dataSetWeight);
         }
         else
         {

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -72,14 +72,6 @@ bool EPSRModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSignal> act
         rho = targetConfiguration_->atomicDensity();
     }
 
-    // Realise storage for generated S(Q), and initialise a scattering matrix, but only if we have a valid configuration
-    if (targetConfiguration_)
-    {
-        auto &estimatedSQ =
-            dissolve.processingModuleData().realise<Array2D<Data1D>>("EstimatedSQ", name_, GenericItem::InRestartFileFlag);
-        scatteringMatrix_.initialise(targetConfiguration_->atomTypeVector(), estimatedSQ);
-    }
-
     // If a pcof file was provided, read in the parameters from it here
     if (!pCofFilename_.empty())
     {
@@ -120,6 +112,9 @@ bool EPSRModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSignal> act
 
     // Try to calculate the deltaSQ array
     updateDeltaSQ(dissolve.processingModuleData());
+
+    // Clear any existing scattering matrix
+    scatteringMatrix_ = std::nullopt;
 
     return true;
 }
@@ -208,7 +203,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
      */
 
     // Set up storage for the changes to coefficients used to generate the empirical potentials
-    const auto &atomTypes = scatteringMatrix_.atomTypes();
+    const auto atomTypes = targetConfiguration_->atomTypeVector();
     const auto nAtomTypes = atomTypes.size();
 
     Array3D<double> fluctuationCoefficients(nAtomTypes, nAtomTypes, ncoeffp);
@@ -220,20 +215,29 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     dissolve::for_each_pair(ParallelPolicies::par, atomTypes, [&](int i, auto at1, int j, auto at2)
                             { calculatedUnweightedSQ[{i, j}].setTag(std::format("{}-{}", at1->name(), at2->name())); });
 
-    // Is our scattering matrix fully set-up and just requiring updated data?
-    auto scatteringMatrixSetUp = scatteringMatrix_.nReferenceData() != 0;
-
     // Get summed weights over all datasets
     const auto totalDataSetWeight =
         std::accumulate(targetWeights_.begin(), targetWeights_.end(), 0.0,
                         [](const auto acc, const auto &targetWeight) { return acc + targetWeight.second; }) +
         (targets_.size() - targetWeights_.size());
 
+    // Realise storage for generated S(Q) and initialise a scattering matrix
+    auto &&[estimatedSQ, estimatedSQStatus] =
+        dissolve.processingModuleData().realiseIf<DoubleKeyedMap<Data1D>>("EstimatedSQ", name_);
+    if (estimatedSQStatus == GenericItem::ItemStatus::Created)
+    {
+        // Create partials array
+        estimatedSQ.clear(true);
+        dissolve::for_each_pair(
+            ParallelPolicies::seq, atomTypes, [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
+            { estimatedSQ.get(typeI->name(), typeJ->name()).setTag(std::format("{}-{}", typeI->name(), typeJ->name())); });
+    }
+    if (!scatteringMatrix_)
+        scatteringMatrix_.emplace(atomTypes);
+
     // Loop over target data
     auto rFacTot = 0.0;
     std::vector<double> rangedRFacTots(ranges_.size());
-
-    // Loop over target data
     for (auto *module : targets_)
     {
         /*
@@ -443,12 +447,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             else if (normType == StructureFactors::SquareOfAverageNormalisation)
                 refMinusIntra *= weights.boundCoherentSquareOfAverage();
 
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(refMinusIntra, dataSetWeight)
-                                      : !scatteringMatrix_.addReferenceData(refMinusIntra, weights, dataSetWeight))
-            {
-                Messenger::error("Failed to add target data '{}' to weights matrix.\n", module->name());
-                return ExecutionResult::Failed;
-            }
+            scatteringMatrix_->setRow({"Neutron", module->name()}, refMinusIntra, weights, dataSetWeight);
         }
         else if (module->type() == ModuleTypes::XRaySQ)
         {
@@ -476,12 +475,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
                                refMinusIntra.values().begin(), std::divides<>());
             }
 
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(refMinusIntra, dataSetWeight)
-                                      : !scatteringMatrix_.addReferenceData(refMinusIntra, weights, dataSetWeight))
-            {
-                Messenger::error("Failed to add target data '{}' to weights matrix.\n", module->name());
-                return ExecutionResult::Failed;
-            }
+            scatteringMatrix_->setRow({"XRay", module->name()}, refMinusIntra, weights, dataSetWeight);
         }
         else
         {
@@ -495,8 +489,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
          */
 
         // Add the unweighted from this target to our combined, unweighted S(Q) data
-        auto &types = scatteringMatrix_.atomTypes();
-        dissolve::for_each_pair(ParallelPolicies::seq, types,
+        dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                                 [&](int i, const auto &at1, int j, const auto &at2)
                                 {
                                     auto pairIndex = scatteringMatrix_.pairIndexOf(at1, at2);
@@ -546,32 +539,20 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
      */
 
     // Add a contribution from each interatomic partial S(Q), weighted according to the feedback factor
-    auto success = for_each_pair_early(
-        atomTypes,
-        [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool>
-        {
-            // Copy and rename the data for clarity
-            auto data = calculatedUnweightedSQ[{i, j}];
-            data.setTag(std::format("Simulated {}-{}", at1->name(), at2->name()));
+    dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
+                            [&](int i, auto &at1, int j, auto &at2)
+                            {
+                                // Copy and rename the data for clarity
+                                auto data = calculatedUnweightedSQ[{i, j}];
+                                data.setTag(std::format("Simulated {}-{}", at1->name(), at2->name()));
 
-            // Add this partial data to the scattering matrix - its factored weight will be (1.0 - feedback)
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(data, 1.0 - feedback_)
-                                      : !scatteringMatrix_.addPartialReferenceData(data, at1, at2, 1.0, (1.0 - feedback_)))
-            {
-                Messenger::error("EPSR: Failed to augment scattering matrix with partial {}-{}.\n", at1->name(), at2->name());
-                return false;
-            }
+                                scatteringMatrix_->setRow({at1->name(), at2->name()}, data, at1, at2, 1.0 - feedback_);
+                            });
 
-            return EarlyReturn<bool>::Continue;
-        });
-    if (!success.value_or(true))
-        return ExecutionResult::Failed;
+    // Make sure inverse matrices are up-to-date
+    scatteringMatrix_->generateMatrices();
 
-    // If the scattering matrix was not set-up, need to generate the necessary inverse matrix or matrices here
-    if (!scatteringMatrixSetUp)
-        scatteringMatrix_.generateMatrices();
-
-    scatteringMatrix_.print();
+    scatteringMatrix_->print();
 
     if (Messenger::isVerbose())
     {
@@ -586,17 +567,16 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
      * Generate S(Q) from completed scattering matrix
      */
 
-    auto &estimatedSQ = moduleData.realise<Array2D<Data1D>>("EstimatedSQ", name_, GenericItem::InRestartFileFlag);
     scatteringMatrix_.generatePartials(estimatedSQ);
     updateDeltaSQ(moduleData, calculatedUnweightedSQ, estimatedSQ);
 
     // Save data?
     if (saveEstimatedPartials_)
     {
-        for (auto &sq : estimatedSQ)
+        for (auto &[key, data] : estimatedSQ)
         {
-            Data1DExportFileFormat exportFormat(std::format("{}-EstSQ-{}.txt", name_, sq.tag()));
-            if (!exportFormat.exportData(sq))
+            Data1DExportFileFormat exportFormat(std::format("{}-EstSQ-{}.txt", name_, data.tag()));
+            if (!exportFormat.exportData(data))
                 return ExecutionResult::Failed;
         }
     }
@@ -636,7 +616,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
             ParallelPolicies::seq, atomTypes,
             [&](int i, auto at1, int j, auto at2)
             {
-                auto weight = scatteringMatrix_.qZeroMatrixInverse()[{scatteringMatrix_.columnIndex(at1, at2), dataIndex}];
+                auto weight = scatteringMatrix_->qZeroMatrixInverse()[{scatteringMatrix_->columnIndex(at1, at2), dataIndex}];
 
                 /*
                  * EPSR assembles the potential coefficients from the deltaFQ fit coefficients as a linear

--- a/src/modules/neutronSQ/functions.cpp
+++ b/src/modules/neutronSQ/functions.cpp
@@ -58,8 +58,6 @@ bool NeutronSQModule::calculateWeightedSQ(const PartialSet &unweightedsq, Partia
                             [&](int indexI, const auto &popI, int indexJ, const auto &popJ)
                             {
                                 auto key = DoubleKeyedMapKey{popI.first->name(), popJ.first->name()};
-                                std::cout << std::format(" calculateWeightedSQ -> {} {}\n", popI.first->name(),
-                                                         popJ.first->name());
 
                                 // Bound (intramolecular) partial (multiplied by the bound term weight)
                                 weightedsq.boundPartials().get(key).copyArrays(unweightedsq.boundPartials().get(key));

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -94,24 +94,8 @@ template <typename ValueClass> class DoubleKeyedMap
     {
         return get(pair.first, pair.second);
     }
-    ValueClass &get(const std::string_view key)
-    {
-        // Need to split key back into its constituent parts and find()
-        auto keys = DissolveSys::splitString(key, separator_);
-        if (keys.size() != 2)
-            throw(std::runtime_error(std::format("Invalid key '{}' given to DoubleKeyedMap::at()\n", key)));
-
-        return get(keys[0], keys[1]);
-    }
-    const ValueClass &get(const std::string_view key) const
-    {
-        // Need to split key back into its constituent parts and find()
-        auto keys = DissolveSys::splitString(key, separator_);
-        if (keys.size() != 2)
-            throw(std::runtime_error(std::format("Invalid key '{}' given to DoubleKeyedMap::at()\n", key)));
-
-        return get(keys[0], keys[1]);
-    }
+    ValueClass &get(const std::string_view key) { return get(keyPair(key)); }
+    const ValueClass &get(const std::string_view key) const { return get(keyPair(key)); }
     ValueClass &get(const std::pair<std::string_view, std::string_view> &pair) { return get(pair.first, pair.second); }
     const ValueClass &get(const std::pair<std::string_view, std::string_view> &pair) const
     {
@@ -147,6 +131,14 @@ template <typename ValueClass> class DoubleKeyedMap
     const std::map<std::string, ValueClass> &map() const { return data_; }
     // Return number of data in map
     int size() const { return data_.size(); }
+    // Return key parts from supplied string
+    std::pair<std::string, std::string> keyPair(std::string_view key) const
+    {
+        auto keys = DissolveSys::splitString(key, separator_);
+        if (keys.size() != 2)
+            throw(std::runtime_error(std::format("DoubleKeyedMap - can't split supplied key '{}' into a key pair.\n", key)));
+        return {std::string(keys[0]), std::string(keys[1])};
+    }
 
     /*
      * Look-Up Table

--- a/tests/data/dissolve/input/epsr-benzene-3n.txt
+++ b/tests/data/dissolve/input/epsr-benzene-3n.txt
@@ -183,6 +183,7 @@ Module  EPSR  'EPSR01'
   Target  'C6H6'
   Target  'C6D6'
   Target  '5050'
+  QMin 0.05
   Frequency  1
   EReq 3.0
   InpAFile  'epsr25/benzene200-neutron/benzene.EPSR.inpa'

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -221,7 +221,7 @@ TEST_F(EPSRModuleTest, ScatteringMatrix)
     equalWeights.setRow(5, {1.0 - feedback, 0.0, 0.0});
     equalWeights.setRow(6, {0.0, 1.0 - feedback, 0.0});
     equalWeights.setRow(7, {0.0, 0.0, 1.0 - feedback});
-    testMatrices(equalWeights, W.matrix(), 1.0e-6);
+    testMatrices(equalWeights, W->A(), 1.0e-6);
 }
 
 TEST_F(EPSRModuleTest, DataWeighting)
@@ -247,7 +247,7 @@ TEST_F(EPSRModuleTest, DataWeighting)
     unequalWeights.setRow(5, {1.0 - feedback, 0.0, 0.0});
     unequalWeights.setRow(6, {0.0, 1.0 - feedback, 0.0});
     unequalWeights.setRow(7, {0.0, 0.0, 1.0 - feedback});
-    testMatrices(unequalWeights, W.matrix(), 1.0e-6);
+    testMatrices(unequalWeights, W->A(), 1.0e-6);
 }
 
 } // namespace UnitTest

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -64,13 +64,13 @@ TEST_F(EPSRModuleTest, Water3NInpA)
     // Estimated Partials
     EXPECT_TRUE(systemTest.checkData1D(
         "EPSR01//EstimatedSQ//OW-OW",
-        {"epsr25/water1000-neutron-xray/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 2}, 0.24));
+        {"epsr25/water1000-neutron/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 2}, 2.0e-4));
     EXPECT_TRUE(systemTest.checkData1D(
         "EPSR01//EstimatedSQ//OW-HW",
-        {"epsr25/water1000-neutron-xray/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 4}, 8.0e-3));
+        {"epsr25/water1000-neutron/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 4}, 2.0e-4));
     EXPECT_TRUE(systemTest.checkData1D(
         "EPSR01//EstimatedSQ//HW-HW",
-        {"epsr25/water1000-neutron-xray/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 2.4e-2));
+        {"epsr25/water1000-neutron/water.EPSR.q01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 1.0e-4));
 
     // DeltaFQ Fits
     EXPECT_TRUE(systemTest.checkData1D(

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -221,7 +221,7 @@ TEST_F(EPSRModuleTest, ScatteringMatrix)
     equalWeights.setRow(5, {1.0 - feedback, 0.0, 0.0});
     equalWeights.setRow(6, {0.0, 1.0 - feedback, 0.0});
     equalWeights.setRow(7, {0.0, 0.0, 1.0 - feedback});
-    testMatrices(equalWeights, W->A(), 1.0e-6);
+    testMatrices(equalWeights, W->matrix(0.0), 1.0e-6);
 }
 
 TEST_F(EPSRModuleTest, DataWeighting)
@@ -247,7 +247,7 @@ TEST_F(EPSRModuleTest, DataWeighting)
     unequalWeights.setRow(5, {1.0 - feedback, 0.0, 0.0});
     unequalWeights.setRow(6, {0.0, 1.0 - feedback, 0.0});
     unequalWeights.setRow(7, {0.0, 0.0, 1.0 - feedback});
-    testMatrices(unequalWeights, W->A(), 1.0e-6);
+    testMatrices(unequalWeights, W->matrix(0.0), 1.0e-6);
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR moves `ScatteringMatrix` over to use keyed data storage where appropriate, in line with recent work on other classes. While this does not necessarily help the mathematical representation of the matrix, it does make data tracking a lot clearer. None of the functions are called in hot loops during running, so I think this is a good compromise.

One thing I'd like an opinion on from everybody is the new requirement to loop over a linear index in a pairwise loop - e.g. I use `for_each_pair` on a vector of `AtomType`s in order to generate the columns of a 2D matrix, but then later need to reference the column by its linear index:
```
        // Loop over columns (atom-atom partials)
        auto partialIndex = 0;
        dissolve::for_each_pair(ParallelPolicies::seq, atomTypes_,
                                [&](int indexI, const auto &typeI, int indexJ, const auto &typeJ)
                                {
                                    ... interesting code ...
                                    ++partialIndex;
                                });
```
Obviously this absolutely has to be `ParallelPolicies::seq`, but it still feels a little dangerous.