### PR TITLE
fix:Update Clustering to develop2

### DIFF
--- a/.github/workflows/_checkout.yml
+++ b/.github/workflows/_checkout.yml
@@ -6,10 +6,10 @@ on:
     inputs:
       msvcVersion:
         type: string
-        default: 14.41.17.11
+        default: 14.44
       osxRunner:
         type: string
-        default: macos-15
+        default: macos-latest
       osxTargetDeploymentVersion:
         type: string
         default: 13.3

--- a/.github/workflows/build/windows/action.yml
+++ b/.github/workflows/build/windows/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: true
   msvcVersion:
     type: string
-    default: '14.44'
+    default: '19.44'
     required: true
 
 runs:

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -345,8 +345,7 @@ void CreateGrapheneSpeciesDialog::updateWidgets()
     // Sheet properties
     ui_.ALabel->setText(QString("%1 \u212B").arg(A_, 0, 'f', 3));
     ui_.CLabel->setText(QString("%1 (%2) \u212B").arg(c_, 0, 'f', 3).arg(c_ * ui_.CFactorSpin->value(), 0, 'f', 3));
-    auto DEGRAD = 180 / M_PI; // FIXME
-    ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha_ * DEGRAD, 0, 'f', 3));
+    ui_.AlphaLabel->setText(QString("%1\u00B0").arg(DissolveMath::toDegrees(alpha_), 0, 'f', 3));
     ui_.HLabel->setText(QString("%1 (%2)").arg(H_).arg(H_ * ui_.CFactorSpin->value()));
     ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius_, 0, 'f', 3));
 

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -55,8 +55,8 @@ void CreateGrapheneSpeciesDialog::calculateParameters()
     a0_ = r * root3;
 
     // Set principal vectors for reference
-    va1_ = Vec3<double>(a0_, 0.0, 0.0);
-    va2_ = Vec3<double>(a0_ * sin(oneSixthPi), a0_ * cos(oneSixthPi), 0.0);
+    va1_ = Vector3(a0_, 0.0, 0.0);
+    va2_ = Vector3(a0_ * sin(oneSixthPi), a0_ * cos(oneSixthPi), 0.0);
 
     // Calculate repeat dimensions of the (n,m) sheet
     // -- A is magnitude of vecA (equation 1) and represents our X dimension
@@ -111,7 +111,7 @@ CreateGrapheneSpeciesDialog::getSortedByY(const std::map<SpeciesAtom *, std::vec
 }
 
 // Recursive branch function
-void CreateGrapheneSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac,
+void CreateGrapheneSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, Vector3 &vFrac,
                                                std::vector<SpeciesAtom *> &branch, double localCutoff) const
 {
     // Get PBC and non-PBC (local) bond partners for this atom and see what type of atom we have...
@@ -150,17 +150,17 @@ void CreateGrapheneSpeciesDialog::regenerate()
     const auto cFactor = ui_.CFactorSpin->value();
 
     // Determine a suitable periodic box for the species - we will always create one so that we get proper folding.
-    auto offset = Vec3<double>(), cellLengths = Vec3<double>();
+    auto offset = Vector3(), cellLengths = Vector3();
     if (roll)
     {
         // Create some extra space and set an offset so the tube is central in XZ
         cellLengths = {radius_ * 3, c_ * cFactor, radius_ * 3};
-        offset = Vec3<double>(radius_ * 1.5, 0.0, radius_ * 1.5);
+        offset = Vector3(radius_ * 1.5, 0.0, radius_ * 1.5);
     }
     else
     {
         cellLengths = {A_, c_ * cFactor, sheetZ_};
-        offset = Vec3<double>(0.0, 0.0, sheetZ_ * 0.5);
+        offset = Vector3(0.0, 0.0, sheetZ_ * 0.5);
     }
     species_.createBox(cellLengths, {90, 90, 90});
 
@@ -184,20 +184,20 @@ void CreateGrapheneSpeciesDialog::regenerate()
         for (auto i = 0; i < H_ * cFactor; ++i)
         {
             // Generate translation vector for this copy (equation 9)
-            auto delta = Vec3<double>(-i * a0_ * sin(oneSixthPi - alpha_), i * a0_ * cos(oneSixthPi - alpha_), 0.0);
-            auto r1 = delta + Vec3<double>(x1j, y1j, 0.0);
-            auto r2 = delta + Vec3<double>(x2j, y2j, 0.0);
+            auto delta = Vector3(-i * a0_ * sin(oneSixthPi - alpha_), i * a0_ * cos(oneSixthPi - alpha_), 0.0);
+            auto r1 = delta + Vector3(x1j, y1j, 0.0);
+            auto r2 = delta + Vector3(x2j, y2j, 0.0);
 
             // Get new helix pair coordinates
-            Vec3<double> p1, p2;
+            Vector3 p1, p2;
             if (roll)
             {
                 // Wrap the X coordinate (== real position on circumference) onto a tube of radius 'radius', applying the
                 // offset we set earlier when creating the periodic box so as to put it in the centre of XZ.
                 p1 = species_.box()->fold(
-                    offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y, radius_ * cos(2.0 * M_PI * r1.x / A_)));
+                    offset + Vector3(radius_ * sin(2.0 * M_PI * r1.x / A_), r1.y, radius_ * cos(2.0 * M_PI * r1.x / A_)));
                 p2 = species_.box()->fold(
-                    offset + Vec3<double>(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y, radius_ * cos(2.0 * M_PI * r2.x / A_)));
+                    offset + Vector3(radius_ * sin(2.0 * M_PI * r2.x / A_), r2.y, radius_ * cos(2.0 * M_PI * r2.x / A_)));
             }
             else
             {
@@ -246,7 +246,7 @@ void CreateGrapheneSpeciesDialog::regenerate()
                 auto &pbcJ = atoms.at(i);
 
                 // Determine the fractional average vector to the pbc atoms
-                Vec3<double> vFrac;
+                Vector3 vFrac;
                 for (auto j : pbcJ)
                     vFrac += species_.box()->getFractional(j->r()) - species_.box()->getFractional(i->r());
 
@@ -279,11 +279,11 @@ void CreateGrapheneSpeciesDialog::regenerate()
                 // interested in. Along the way we maintain a fractional translation vector based on all PBC bonds we encounter
                 // which will inform the direction we might want to move the branch. Or we could just remove it.
 
-                Vec3<double> vFrac;
+                Vector3 vFrac;
                 std::vector<SpeciesAtom *> branch;
                 extendBranch(i, species_.box(), vFrac, branch, localCutoff);
                 auto maxEl = vFrac.absMaxElement();
-                Vec3<double> tVec;
+                Vector3 tVec;
                 tVec.set(maxEl, round(vFrac.get(maxEl) / fabs(vFrac.get(maxEl))));
                 tVec.multiply(cellLengths);
                 ;
@@ -345,6 +345,7 @@ void CreateGrapheneSpeciesDialog::updateWidgets()
     // Sheet properties
     ui_.ALabel->setText(QString("%1 \u212B").arg(A_, 0, 'f', 3));
     ui_.CLabel->setText(QString("%1 (%2) \u212B").arg(c_, 0, 'f', 3).arg(c_ * ui_.CFactorSpin->value(), 0, 'f', 3));
+    auto DEGRAD = 180 / M_PI; // FIXME
     ui_.AlphaLabel->setText(QString("%1\u00B0").arg(alpha_ * DEGRAD, 0, 'f', 3));
     ui_.HLabel->setText(QString("%1 (%2)").arg(H_).arg(H_ * ui_.CFactorSpin->value()));
     ui_.RadiusLabel->setText(QString("%1 \u212B").arg(radius_, 0, 'f', 3));

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -4,6 +4,7 @@
 #include "gui/createGrapheneSpeciesDialog.h"
 #include "classes/empiricalFormula.h"
 #include "gui/helpers/comboPopulator.h"
+#include "math/mathFunc.h"
 #include <numeric>
 
 // Useful constants

--- a/src/gui/createGrapheneSpeciesDialog.h
+++ b/src/gui/createGrapheneSpeciesDialog.h
@@ -48,7 +48,7 @@ class CreateGrapheneSpeciesDialog : public QDialog
     // Representative unit length
     double a0_{0.0};
     // Principal vectors
-    Vec3<double> va1_, va2_;
+    Vector3 va1_, va2_;
     // Angle between principal vector va1 and the sheet vector
     double alpha_{0.0};
     // Radius of resulting tube
@@ -68,7 +68,7 @@ class CreateGrapheneSpeciesDialog : public QDialog
     // Get vector of atom keys from atom/neighbour map, sorted by position along y
     std::vector<SpeciesAtom *> getSortedByY(const std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> &atoms) const;
     // Recursive branch function
-    void extendBranch(SpeciesAtom *i, const Box *box, Vec3<double> &vFrac, std::vector<SpeciesAtom *> &branch,
+    void extendBranch(SpeciesAtom *i, const Box *box, Vector3 &vFrac, std::vector<SpeciesAtom *> &branch,
                       double localCutoff) const;
     // Regenerate species
     void regenerate();

--- a/src/modules/clustering/clustering.h
+++ b/src/modules/clustering/clustering.h
@@ -5,12 +5,11 @@
 
 #include "analyser/siteFilter.h"
 #include "analyser/siteSelector.h"
-#include "base/processPool.h"
 #include "classes/configuration.h"
 #include "classes/coreData.h"
 #include "generator/context.h"
 #include "main/dissolve.h"
-#include "module/context.h"
+#include "math/vector3.h"
 #include "module/module.h"
 #include <unordered_set>
 
@@ -70,7 +69,7 @@ class ClusteringModule : public Module
     int gyrationMinSize_{5};
     // Map of cluster ID to CoM vector from reference site (first member in cluster map) - Required in Rg calc. Might be useful
     // down the road
-    std::map<int, Vec3<double>> clusterCoM_;
+    std::map<int, Vector3> clusterCoM_;
     // Fractal dimension from linear regression of LogLog Radius of gyration - cluster mass
     double fractalDimension_{-1};
     // Cluster display configuration
@@ -86,13 +85,13 @@ class ClusteringModule : public Module
      */
     private:
     // Run main processing
-    Module::ExecutionResult process(ModuleContext &moduleContext) override;
+    Module::ExecutionResult process(Dissolve &dissolve) override;
     // Recursion for cluster generation
     void buildCluster(const Site *startSite, std::unordered_set<const Site *> &visited);
 
     public:
     // Set up module for processings
-    bool setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordSignal> actionSignals) override;
+    bool setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSignal> actionSignals) override;
     // Generation of the cluster visualisation configuration
     void generateClustersConfig(Dissolve &dissolve, int displaySize, int displayID);
     // Calculate the coordination numbers for pairs in the current cluster config

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -10,7 +10,7 @@
 #include "math/regression.h"
 #include "modules/clustering/clustering.h"
 
-bool ClusteringModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::KeywordSignal> actionSignals)
+bool ClusteringModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSignal> actionSignals)
 {
     // Check user definitions
     if (!(a_ && b_ && (cutoff_ > 0)))
@@ -85,9 +85,9 @@ bool ClusteringModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Ke
     return true;
 }
 
-Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
+Module::ExecutionResult ClusteringModule::process(Dissolve &dissolve)
 {
-    auto &moduleData = moduleContext.dissolve().processingModuleData();
+    auto &moduleData = dissolve.processingModuleData();
 
     // Produce NeighbourMap - combining map A and B from two filters. base/filter vecs required for site selector
     neighbourMap_.clear();
@@ -195,7 +195,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
                 {
                     // Get the relevant vectors
                     auto oHVec = box->minimumVector(site->origin(), site->molecule()->atom(h)->r());
-                    auto angle = box->angleInDegrees(oOVec / oOVec.magnitude(), oHVec / oHVec.magnitude());
+                    auto angle = 0; // FIXME: box->angleInDegrees(oOVec / oOVec.magnitude(), oHVec / oHVec.magnitude());
 
                     // Make sure we have the smallest angle possible
                     if (360.0 - angle < angle)
@@ -263,9 +263,9 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     histSizeData.zeroBins();
 
     // Figure out how many molecules of interest are in the configuration
-    auto interestingMols = a_->parent() == b_->parent() ? targetConfiguration_->speciesPopulation(a_->parent())
-                                                        : targetConfiguration_->speciesPopulation(a_->parent()) +
-                                                              targetConfiguration_->speciesPopulation(b_->parent());
+    auto interestingMols = a_->parent() == b_->parent() ? targetConfiguration_->speciesPopulations().value(a_->parent())
+                                                        : targetConfiguration_->speciesPopulations().value(a_->parent()) +
+                                                              targetConfiguration_->speciesPopulations().value(b_->parent());
 
     // Find the number of molecules not in clusters
     auto totalMolsClustered = 0;
@@ -321,7 +321,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
             continue;
 
         // CoM mass weighted calc from reference site (first member of cluster in clusterMap)
-        Vec3<double> massWeightedTotalVec{0, 0, 0};
+        Vector3 massWeightedTotalVec{0, 0, 0};
         const auto refMol{clusterVec[0]};
         std::vector<int> refIdxs(refMol->nAtoms());
         std::iota(refIdxs.begin(), refIdxs.end(), 0);
@@ -366,7 +366,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     {
         LineParser parser;
         parser.appendOutput(std::format("{}.{}.sizedist.txt", targetConfiguration_->niceName(), name()));
-        parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
+        parser.writeLineF("\n# Iteration: {}\n", dissolve.iteration());
         parser.writeLineF("# Cluster size : number of clusters\n");
         for (const auto &[clusterSize, mems] : sizeDistribution_)
             parser.writeLineF("{} {}\n", clusterSize, mems.size());
@@ -375,7 +375,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     {
         LineParser parser;
         parser.appendOutput(std::format("{}.{}.massdist.txt", targetConfiguration_->niceName(), name()));
-        parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
+        parser.writeLineF("\n# Iteration: {}\n", dissolve.iteration());
         parser.writeLineF("# Cluster mass : number of clusters\n");
         for (const auto &[clusterMass, mems] : massDistribution_)
             parser.writeLineF("{:.3f} {}\n", clusterMass, mems.size());
@@ -384,7 +384,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     {
         LineParser parser;
         parser.appendOutput(std::format("{}.{}.massRg.txt", targetConfiguration_->niceName(), name()));
-        parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
+        parser.writeLineF("\n# Iteration: {}\n", dissolve.iteration());
         parser.writeLineF("# Fractal dimension:\n{}\n", fractalDimension_);
         parser.writeLineF("# Cluster mass : radius of gyration\n");
         for (const auto &[clusterID, radius] : radiusOfGyration_)
@@ -401,7 +401,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
                                                 base->name() == partner->name() ? base->parent()->name() : base->name(),
                                                 base->name() == partner->name() ? partner->parent()->name() : partner->name()));
 
-                parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
+                parser.writeLineF("\n# Iteration: {}\n", dissolve.iteration());
                 parser.writeLineF("{:.3f}\n", cn);
             }
     }
@@ -432,7 +432,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
 
     // Can only get molecule transfer working with a generator...
     clusterConfig_.generator().createRootNode<CopyGeneratorNode>("clusters", targetConfiguration_);
-    clusterConfig_.generate({dissolve.worldPool(), dissolve});
+    clusterConfig_.generate(dissolve);
     clusterConfig_.removeMolecules(clusterConfig_.molecules());
 
     // Display all clusters
@@ -480,7 +480,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
         }
     }
 
-    clusterConfig_.incrementContentsVersion();
+    // FIXME: clusterConfig_.incrementContentsVersion();
     clusterConfig_.updateObjectRelationships();
 }
 

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -7,6 +7,7 @@
 #include "data/elements.h"
 #include "generator/box.h"
 #include "generator/copy.h"
+#include "math/mathFunc.h"
 #include "math/regression.h"
 #include "modules/clustering/clustering.h"
 

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -195,7 +195,7 @@ Module::ExecutionResult ClusteringModule::process(Dissolve &dissolve)
                 {
                     // Get the relevant vectors
                     auto oHVec = box->minimumVector(site->origin(), site->molecule()->atom(h)->r());
-                    auto angle = 0; // FIXME: box->angleInDegrees(oOVec / oOVec.magnitude(), oHVec / oHVec.magnitude());
+                    auto angle = DissolveMath::toDegrees(acos((oOVec / oOVec.magnitude()).dp(oHVec / oHVec.magnitude())));
 
                     // Make sure we have the smallest angle possible
                     if (360.0 - angle < angle)

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -480,7 +480,6 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
         }
     }
 
-    // FIXME: clusterConfig_.incrementContentsVersion();
     clusterConfig_.updateObjectRelationships();
 }
 


### PR DESCRIPTION
The clustering module and graphene dialog had some issues after the rebase.  Most of the changes were fairly obvious (e.g. rename `Vec3<double>` to `Vectorr`), but a couple were not.  I've marked these in the PR with a `FIXME`.  The issues are

1. in src/gui/createGrapheneSpeciesDialog.cpp, there is a reference to an undefined DEGRAD constant.  I've assigned it what I expected to be the correct value, but it is worth checking.
2. in src/modules/clustering/process.cpp, A call is made to `angleInDegree` with only two points.
3. in src/modules/clustering/process.cpp, the configuration version number is explicitly updated in a way we no longer support.

@trisyoungs If you could comment on these issues, we can get this merged in quickly and unbreak develop2 for everyone.