### PR TITLE
refactor: SpeciesParticle base class

### DIFF
--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(
   speciesAngle.cpp
   speciesAtom.cpp
   speciesBond.cpp
+  speciesParticle.cpp
   species.cpp
   species_atomic.cpp
   species_ff.cpp
@@ -121,6 +122,7 @@ add_library(
   speciesAngle.h
   speciesAtom.h
   speciesBond.h
+  speciesParticle.h
   speciesImproper.h
   speciesIntra.h
   speciesRing.h

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -3,13 +3,13 @@
 
 #include "classes/speciesAngle.h"
 #include "classes/coreData.h"
-#include "classes/speciesAtom.h"
+#include "classes/speciesParticle.h"
 #include "math/mathFunc.h"
 #include <map>
 
 SpeciesAngle::SpeciesAngle() : SpeciesIntra(AngleFunctions::Form::None) {}
 
-SpeciesAngle::SpeciesAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k) : SpeciesIntra(AngleFunctions::Form::None)
+SpeciesAngle::SpeciesAngle(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k) : SpeciesIntra(AngleFunctions::Form::None)
 {
     assign(i, j, k);
 }
@@ -70,8 +70,8 @@ SpeciesAngle &SpeciesAngle::operator=(SpeciesAngle &&source) noexcept
  * Atom Information
  */
 
-// Rewrite SpeciesAtom pointer
-void SpeciesAngle::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
+// Rewrite SpeciesParticle pointer
+void SpeciesAngle::switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr)
 {
     assert(i_ == oldPtr || j_ == oldPtr || k_ == oldPtr);
 
@@ -84,7 +84,7 @@ void SpeciesAngle::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
 }
 
 // Assign the three atoms in the angle
-void SpeciesAngle::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k)
+void SpeciesAngle::assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k)
 {
     i_ = i;
     j_ = j;
@@ -96,40 +96,40 @@ void SpeciesAngle::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k)
     k_->addAngle(*this);
 }
 
-// Return first SpeciesAtom
-SpeciesAtom *SpeciesAngle::i() const { return i_; }
+// Return first SpeciesParticle
+SpeciesParticle *SpeciesAngle::i() const { return i_; }
 
-// Return second (central) SpeciesAtom
-SpeciesAtom *SpeciesAngle::j() const { return j_; }
+// Return second (central) SpeciesParticle
+SpeciesParticle *SpeciesAngle::j() const { return j_; }
 
-// Return third SpeciesAtom
-SpeciesAtom *SpeciesAngle::k() const { return k_; }
+// Return third SpeciesParticle
+SpeciesParticle *SpeciesAngle::k() const { return k_; }
 
 // Return vector of involved atoms
-std::vector<const SpeciesAtom *> SpeciesAngle::atoms() const { return {i_, j_, k_}; }
+std::vector<const SpeciesParticle *> SpeciesAngle::atoms() const { return {i_, j_, k_}; }
 
-// Return index (in parent Species) of first SpeciesAtom
+// Return index (in parent Species) of first SpeciesParticle
 int SpeciesAngle::indexI() const
 {
     assert(i_);
     return i_->index();
 }
 
-// Return index (in parent Species) of second (central) SpeciesAtom
+// Return index (in parent Species) of second (central) SpeciesParticle
 int SpeciesAngle::indexJ() const
 {
     assert(j_);
     return j_->index();
 }
 
-// Return index (in parent Species) of third SpeciesAtom
+// Return index (in parent Species) of third SpeciesParticle
 int SpeciesAngle::indexK() const
 {
     assert(k_);
     return k_->index();
 }
 
-// Return index (in parent Species) of nth SpeciesAtom in interaction
+// Return index (in parent Species) of nth SpeciesParticle in interaction
 int SpeciesAngle::index(int n) const
 {
     if (n == 0)
@@ -139,12 +139,12 @@ int SpeciesAngle::index(int n) const
     else if (n == 2)
         return indexK();
 
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesAngle::index(int). Returning 0...\n", n);
+    Messenger::error("SpeciesParticle index {} is out of range in SpeciesAngle::index(int). Returning 0...\n", n);
     return 0;
 }
 
 // Return whether Atoms in Angle match those specified
-bool SpeciesAngle::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k) const
+bool SpeciesAngle::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k) const
 {
     return (j_ == j) && ((i_ == i && k_ == k) || (i_ == k && k_ == i));
 }

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -9,7 +9,8 @@
 
 SpeciesAngle::SpeciesAngle() : SpeciesIntra(AngleFunctions::Form::None) {}
 
-SpeciesAngle::SpeciesAngle(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k) : SpeciesIntra(AngleFunctions::Form::None)
+SpeciesAngle::SpeciesAngle(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k)
+    : SpeciesIntra(AngleFunctions::Form::None)
 {
     assign(i, j, k);
 }

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class SpeciesParticle;
 class Species;
 class CoreData;
 
@@ -20,7 +20,7 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
 {
     public:
     SpeciesAngle();
-    SpeciesAngle(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k);
+    SpeciesAngle(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k);
     ~SpeciesAngle() override = default;
     SpeciesAngle(SpeciesAngle &source);
     SpeciesAngle(SpeciesAngle &&source) noexcept;
@@ -28,15 +28,15 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     SpeciesAngle &operator=(SpeciesAngle &&source) noexcept;
 
     /*
-     * SpeciesAtom Information
+     * SpeciesParticle Information
      */
     private:
-    // First SpeciesAtom in interaction
-    SpeciesAtom *i_{nullptr};
-    // Second (central) SpeciesAtom in interaction
-    SpeciesAtom *j_{nullptr};
-    // Third SpeciesAtom in interaction
-    SpeciesAtom *k_{nullptr};
+    // First SpeciesParticle in interaction
+    SpeciesParticle *i_{nullptr};
+    // Second (central) SpeciesParticle in interaction
+    SpeciesParticle *j_{nullptr};
+    // Third SpeciesParticle in interaction
+    SpeciesParticle *k_{nullptr};
 
     private:
     // Detach from current atoms
@@ -44,27 +44,27 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
 
     public:
     // Assign the three atoms in the angle
-    void assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k);
-    // Rewrite SpeciesAtom pointer
-    void switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr);
-    // Return first SpeciesAtom
-    SpeciesAtom *i() const;
-    // Return second (central) SpeciesAtom
-    SpeciesAtom *j() const;
-    // Return third SpeciesAtom
-    SpeciesAtom *k() const;
+    void assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k);
+    // Rewrite SpeciesParticle pointer
+    void switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr);
+    // Return first SpeciesParticle
+    SpeciesParticle *i() const;
+    // Return second (central) SpeciesParticle
+    SpeciesParticle *j() const;
+    // Return third SpeciesParticle
+    SpeciesParticle *k() const;
     // Return vector of involved atoms
-    std::vector<const SpeciesAtom *> atoms() const override;
-    // Return index (in parent Species) of first SpeciesAtom
+    std::vector<const SpeciesParticle *> atoms() const override;
+    // Return index (in parent Species) of first SpeciesParticle
     int indexI() const;
-    // Return index (in parent Species) of second (central) SpeciesAtom
+    // Return index (in parent Species) of second (central) SpeciesParticle
     int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
+    // Return index (in parent Species) of third SpeciesParticle
     int indexK() const;
-    // Return index (in parent Species) of nth SpeciesAtom
+    // Return index (in parent Species) of nth SpeciesParticle
     int index(int n) const;
-    // Return whether SpeciesAtom match those specified
-    bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k) const;
+    // Return whether SpeciesParticle match those specified
+    bool matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k) const;
     // Return whether all atoms in the interaction are currently selected
     bool isSelected() const;
 

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -21,40 +21,19 @@ SpeciesAtom &SpeciesAtom::operator=(SpeciesAtom &&source) noexcept
 // Move all data from source to this
 void SpeciesAtom::move(SpeciesAtom &source)
 {
+    // Move atom specific data 
     Z_ = source.Z_;
-    setCoordinates(source.r());
     charge_ = source.charge_;
     atomType_ = source.atomType_;
-    selected_ = source.selected_;
-    index_ = source.index_;
     presence_ = source.presence_;
-
-    bonds_ = std::move(source.bonds_);
-    angles_ = std::move(source.angles_);
-    torsions_ = std::move(source.torsions_);
-    impropers_ = std::move(source.impropers_);
-
-    // Rewrite pointers in intramolecular terms
-    for (auto &bond : bonds_)
-        bond.get().switchAtom(&source, this);
-    for (auto &angle : angles_)
-        angle.get().switchAtom(&source, this);
-    for (auto &torsion : torsions_)
-        torsion.get().switchAtom(&source, this);
-    for (auto &improper : impropers_)
-        improper.get().switchAtom(&source, this);
 
     // Tidy old data
     source.Z_ = Elements::Unknown;
-    source.setCoordinates({});
     source.charge_ = 0.0;
     source.atomType_ = nullptr;
-    source.selected_ = false;
-    source.index_ = -1;
-    source.bonds_.clear();
-    source.angles_.clear();
-    source.torsions_.clear();
-    source.impropers_.clear();
+
+    // Call parent class move 
+    SpeciesParticle::move(source);
 }
 
 /*

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -110,12 +110,12 @@ void SpeciesAtom::setScaledInteractions()
      */
 
     // Bonds
-    for (const auto &b : bonds_)
+    for (const auto &b : bonds())
         addInteractionFunction(dynamic_cast<SpeciesAtom *>(b.get().partner(this)), SpeciesAtom::ScaledInteraction::Excluded,
                                0.0, 0.0);
 
     // Angles
-    for (const auto &aRef : angles_)
+    for (const auto &aRef : angles())
     {
         auto &a = aRef.get();
 
@@ -128,7 +128,7 @@ void SpeciesAtom::setScaledInteractions()
     }
 
     // Torsions
-    for (const auto &tRef : torsions_)
+    for (const auto &tRef : torsions())
     {
         auto &t = tRef.get();
 
@@ -342,7 +342,7 @@ SerialisedValue SpeciesAtom::serialise() const
 }
 void SpeciesAtom::deserialise(const SerialisedValue &node, CoreData &coreData)
 {
-    index_ = toml::find<int>(node, "index") - 1;
+    setIndex(toml::find<int>(node, "index") - 1);
 
     set(toml::find<Elements::Element>(node, "z"), toml::find<Vector3>(node, "r"), toml::find_or<double>(node, "charge", 0));
 

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -22,7 +22,7 @@ SpeciesAtom &SpeciesAtom::operator=(SpeciesAtom &&source) noexcept
 void SpeciesAtom::move(SpeciesAtom &source)
 {
     Z_ = source.Z_;
-    r_ = source.r_;
+    setCoordinates(source.r());
     charge_ = source.charge_;
     atomType_ = source.atomType_;
     selected_ = source.selected_;
@@ -46,7 +46,7 @@ void SpeciesAtom::move(SpeciesAtom &source)
 
     // Tidy old data
     source.Z_ = Elements::Unknown;
-    source.r_ = {};
+    source.setCoordinates({});
     source.charge_ = 0.0;
     source.atomType_ = nullptr;
     source.selected_ = false;
@@ -66,7 +66,7 @@ void SpeciesAtom::set(Elements::Element Z, double rx, double ry, double rz, doub
 void SpeciesAtom::set(Elements::Element Z, const Vector3 &r, double q)
 {
     Z_ = Z;
-    r_ = r;
+    setCoordinates(r);
     charge_ = q;
 
     presence_ = Z_ == Elements::Phantom ? Presence::Phantom : Presence::Physical;
@@ -83,9 +83,6 @@ bool SpeciesAtom::isPresence(SpeciesAtom::Presence presence) const
 {
     return presence == SpeciesAtom::Presence::Any || presence_ == presence;
 }
-
-// Return coordinates
-const Vector3 &SpeciesAtom::r() const { return r_; }
 
 // Set charge of SpeciesAtom
 void SpeciesAtom::setCharge(double charge) { charge_ = charge; }
@@ -109,21 +106,6 @@ void SpeciesAtom::setAtomType(const std::shared_ptr<AtomType> &at)
 
 // Return SpeciesAtomType of SpeciesAtom
 std::shared_ptr<AtomType> SpeciesAtom::atomType() const { return atomType_; }
-
-// Set index (0->[N-1])
-void SpeciesAtom::setIndex(int id) { index_ = id; }
-
-// Return index (0->[N-1])
-int SpeciesAtom::index() const { return index_; }
-
-// Return 'user' index (1->N)
-int SpeciesAtom::userIndex() const { return index_ + 1; }
-
-// Set whether the atom is currently selected
-void SpeciesAtom::setSelected(bool selected) { selected_ = selected; }
-
-// Return whether the atom is currently selected
-bool SpeciesAtom::isSelected() const { return selected_; }
 
 // Return presence of atom
 SpeciesAtom::Presence SpeciesAtom::presence() const { return presence_; }
@@ -293,27 +275,6 @@ SpeciesAtom::ScaledInteractionDefinition SpeciesAtom::scaling(const SpeciesAtom 
         return it->second;
     return {SpeciesAtom::ScaledInteraction::NotScaled, 1.0, 1.0};
 }
-
-/*
- * Coordinate Manipulation
- */
-
-// Set coordinate
-void SpeciesAtom::setCoordinate(int index, double value) { r_.set(index, value); }
-
-// Set coordinates
-void SpeciesAtom::setCoordinates(double x, double y, double z)
-{
-    r_.x = x;
-    r_.y = y;
-    r_.z = z;
-}
-
-// Set coordinates (from Vec3)
-void SpeciesAtom::setCoordinates(const Vector3 &newr) { r_ = newr; }
-
-// Translate coordinates of atom
-void SpeciesAtom::translateCoordinates(const Vector3 &delta) { r_ += delta; }
 
 /*
  * Atom Environment Helpers
@@ -486,7 +447,7 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
 // Express as a serialisable value
 SerialisedValue SpeciesAtom::serialise() const
 {
-    return {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"charge", charge_}, {"type", atomType_->name().data()}};
+    return {{"index", userIndex()}, {"z", Z_}, {"r", r()}, {"charge", charge_}, {"type", atomType_->name().data()}};
 }
 void SpeciesAtom::deserialise(const SerialisedValue &node, CoreData &coreData)
 {

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -194,7 +194,7 @@ bool SpeciesAtom::isGeometry(SpeciesAtom::AtomGeometry geom) const { return geom
 SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
 {
     double angle, largest;
-    SpeciesAtom *h, *j;
+    SpeciesParticle *h, *j;
     const auto &bonds = i->bonds();
 
     // Work based on the number of bound atoms
@@ -211,8 +211,8 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
             return AtomGeometry::Octahedral;
             // For the remaining types, take averages of bond angles about the atom
         case (2):
-            h = dynamic_cast<SpeciesAtom*>(bonds[0].get().partner(i));
-            j = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
+            h = bonds[0].get().partner(i);
+            j = bonds[1].get().partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > 150.0)
                 return AtomGeometry::Linear;
@@ -220,15 +220,15 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
                 return AtomGeometry::Tetrahedral;
             break;
         case (3):
-            h = dynamic_cast<SpeciesAtom*>(bonds[0].get().partner(i));
-            j = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
+            h = bonds[0].get().partner(i);
+            j = bonds[1].get().partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             largest = angle;
-            j = dynamic_cast<SpeciesAtom*>(bonds[2].get().partner(i));
+            j = bonds[2].get().partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
-            h = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
+            h = bonds[1].get().partner(i);
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
@@ -245,10 +245,10 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
             angle = 0.0;
             for (auto n = 0; n < i->nBonds(); ++n)
             {
-                h = dynamic_cast<SpeciesAtom*>(bonds[n].get().partner(i));
+                h = bonds[n].get().partner(i);
                 for (auto m = n + 1; m < i->nBonds(); ++m)
                 {
-                    j = dynamic_cast<SpeciesAtom*>(bonds[m].get().partner(i));
+                    j = bonds[m].get().partner(i);
                     angle += NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
                 }
             }

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -110,97 +110,6 @@ std::shared_ptr<AtomType> SpeciesAtom::atomType() const { return atomType_; }
 // Return presence of atom
 SpeciesAtom::Presence SpeciesAtom::presence() const { return presence_; }
 
-/*
- * Bond Information
- */
-
-// Add Bond reference
-void SpeciesAtom::addBond(SpeciesBond &bond)
-{
-    if (find_if(bonds_.begin(), bonds_.end(), [&bond](const SpeciesBond &b) { return &b == &bond; }) == bonds_.end())
-        bonds_.emplace_back(bond);
-}
-
-// Remove Bond reference
-void SpeciesAtom::removeBond(SpeciesBond &b)
-{
-    bonds_.erase(find_if(bonds_.begin(), bonds_.end(), [&b](const SpeciesBond &bond) { return &b == &bond; }));
-}
-
-// Return number of Bond references
-int SpeciesAtom::nBonds() const { return bonds_.size(); }
-
-// Return specified bond
-SpeciesBond &SpeciesAtom::bond(int index) { return bonds_.at(index); }
-
-// Return bonds list
-const std::vector<std::reference_wrapper<SpeciesBond>> &SpeciesAtom::bonds() const { return bonds_; }
-
-// Return whether Bond to specified Atom exists
-OptionalReferenceWrapper<SpeciesBond> SpeciesAtom::getBond(const SpeciesAtom *partner)
-{
-    auto result = find_if(bonds_.begin(), bonds_.end(), [&](const SpeciesBond &bond) { return bond.partner(this) == partner; });
-    if (result == bonds_.end())
-        return std::nullopt;
-    return *result;
-}
-
-// Add specified SpeciesAngle to Atom
-void SpeciesAtom::addAngle(SpeciesAngle &angle) { angles_.emplace_back(angle); }
-
-// Remove angle reference
-void SpeciesAtom::removeAngle(SpeciesAngle &angle)
-{
-    angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle &a) { return &a == &angle; }));
-}
-
-// Return the number of Angles in which the Atom is involved
-int SpeciesAtom::nAngles() const { return angles_.size(); }
-
-// Return specified angle
-SpeciesAngle &SpeciesAtom::angle(int index) { return angles_.at(index); }
-
-// Return array of Angles in which the Atom is involved
-const std::vector<std::reference_wrapper<SpeciesAngle>> &SpeciesAtom::angles() const { return angles_; }
-
-// Add specified SpeciesTorsion to Atom
-void SpeciesAtom::addTorsion(SpeciesTorsion &torsion) { torsions_.emplace_back(torsion); }
-
-// Remove torsion reference
-void SpeciesAtom::removeTorsion(SpeciesTorsion &torsion)
-{
-    torsions_.erase(
-        find_if(torsions_.begin(), torsions_.end(), [&torsion](const SpeciesTorsion &t) { return &t == &torsion; }));
-}
-
-// Return the number of Torsions in which the Atom is involved
-int SpeciesAtom::nTorsions() const { return torsions_.size(); }
-
-// Return specified torsion
-SpeciesTorsion &SpeciesAtom::torsion(int index) { return torsions_.at(index); }
-
-// Return array of Torsions in which the Atom is involved
-const std::vector<std::reference_wrapper<SpeciesTorsion>> &SpeciesAtom::torsions() const { return torsions_; }
-
-// Add specified SpeciesImproper to Atom
-void SpeciesAtom::addImproper(SpeciesImproper &improper) { impropers_.emplace_back(improper); }
-
-// Remove improper reference
-void SpeciesAtom::removeImproper(SpeciesImproper &improper)
-{
-    impropers_.erase(
-        find_if(impropers_.begin(), impropers_.end(), [&improper](const SpeciesImproper &i) { return &i == &improper; }));
-}
-
-// Return the number of Impropers in which the Atom is involved
-int SpeciesAtom::nImpropers() const { return impropers_.size(); }
-
-// Return specified improper
-SpeciesImproper &SpeciesAtom::improper(int index) { return impropers_.at(index); }
-
-// Return array of Impropers in which the Atom is involved
-const std::vector<std::reference_wrapper<SpeciesImproper>> &SpeciesAtom::impropers() const { return impropers_; }
-
 // Set all scaled intramolecular interactions
 void SpeciesAtom::setScaledInteractions()
 {
@@ -223,7 +132,7 @@ void SpeciesAtom::setScaledInteractions()
 
     // Bonds
     for (const auto &b : bonds_)
-        addInteractionFunction(b.get().partner(this), SpeciesAtom::ScaledInteraction::Excluded, 0.0, 0.0);
+        addInteractionFunction(dynamic_cast<SpeciesAtom*>(b.get().partner(this)), SpeciesAtom::ScaledInteraction::Excluded, 0.0, 0.0);
 
     // Angles
     for (const auto &aRef : angles_)
@@ -231,11 +140,11 @@ void SpeciesAtom::setScaledInteractions()
         auto &a = aRef.get();
 
         if (a.i() != this)
-            addInteractionFunction(a.i(), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.i()), ScaledInteraction::Excluded, 0.0, 0.0);
         if (a.j() != this)
-            addInteractionFunction(a.j(), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.j()), ScaledInteraction::Excluded, 0.0, 0.0);
         if (a.k() != this)
-            addInteractionFunction(a.k(), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.k()), ScaledInteraction::Excluded, 0.0, 0.0);
     }
 
     // Torsions
@@ -245,24 +154,24 @@ void SpeciesAtom::setScaledInteractions()
 
         if (t.i() == this)
         {
-            addInteractionFunction(t.j(), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(t.k(), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(t.l(), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.l()), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
         }
         else if (t.l() == this)
         {
-            addInteractionFunction(t.i(), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
-            addInteractionFunction(t.j(), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(t.k(), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.i()), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
         }
         else
         {
-            addInteractionFunction(t.i(), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(t.l(), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.i()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.l()), ScaledInteraction::Excluded, 0.0, 0.0);
             if (t.j() != this)
-                addInteractionFunction(t.j(), ScaledInteraction::Excluded, 0.0, 0.0);
+                addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
             if (t.k() != this)
-                addInteractionFunction(t.k(), ScaledInteraction::Excluded, 0.0, 0.0);
+                addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
         }
     }
 }
@@ -323,8 +232,8 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
             return AtomGeometry::Octahedral;
             // For the remaining types, take averages of bond angles about the atom
         case (2):
-            h = bonds[0].get().partner(i);
-            j = bonds[1].get().partner(i);
+            h = dynamic_cast<SpeciesAtom*>(bonds[0].get().partner(i));
+            j = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > 150.0)
                 return AtomGeometry::Linear;
@@ -332,15 +241,15 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
                 return AtomGeometry::Tetrahedral;
             break;
         case (3):
-            h = bonds[0].get().partner(i);
-            j = bonds[1].get().partner(i);
+            h = dynamic_cast<SpeciesAtom*>(bonds[0].get().partner(i));
+            j = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             largest = angle;
-            j = bonds[2].get().partner(i);
+            j = dynamic_cast<SpeciesAtom*>(bonds[2].get().partner(i));
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
-            h = bonds[1].get().partner(i);
+            h = dynamic_cast<SpeciesAtom*>(bonds[1].get().partner(i));
             angle = NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
             if (angle > largest)
                 largest = angle;
@@ -357,10 +266,10 @@ SpeciesAtom::AtomGeometry SpeciesAtom::geometry(const SpeciesAtom *i)
             angle = 0.0;
             for (auto n = 0; n < i->nBonds(); ++n)
             {
-                h = bonds[n].get().partner(i);
+                h = dynamic_cast<SpeciesAtom*>(bonds[n].get().partner(i));
                 for (auto m = n + 1; m < i->nBonds(); ++m)
                 {
-                    j = bonds[m].get().partner(i);
+                    j = dynamic_cast<SpeciesAtom*>(bonds[m].get().partner(i));
                     angle += NonPeriodicBox::literalAngleInDegrees(h->r(), i->r(), j->r());
                 }
             }
@@ -395,7 +304,7 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
     const auto &bonds = i->bonds();
     for (const SpeciesBond &bond : bonds)
     {
-        auto Z = bond.partner(i)->Z();
+        auto Z = dynamic_cast<SpeciesAtom*>(bond.partner(i))->Z();
         switch (Z)
         {
             // Group 1A - Alkali earth metals (includes Hydrogen)

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -21,7 +21,7 @@ SpeciesAtom &SpeciesAtom::operator=(SpeciesAtom &&source) noexcept
 // Move all data from source to this
 void SpeciesAtom::move(SpeciesAtom &source)
 {
-    // Move atom specific data 
+    // Move atom specific data
     Z_ = source.Z_;
     charge_ = source.charge_;
     atomType_ = source.atomType_;
@@ -32,7 +32,7 @@ void SpeciesAtom::move(SpeciesAtom &source)
     source.charge_ = 0.0;
     source.atomType_ = nullptr;
 
-    // Call parent class move 
+    // Call parent class move
     SpeciesParticle::move(source);
 }
 
@@ -111,7 +111,8 @@ void SpeciesAtom::setScaledInteractions()
 
     // Bonds
     for (const auto &b : bonds_)
-        addInteractionFunction(dynamic_cast<SpeciesAtom*>(b.get().partner(this)), SpeciesAtom::ScaledInteraction::Excluded, 0.0, 0.0);
+        addInteractionFunction(dynamic_cast<SpeciesAtom *>(b.get().partner(this)), SpeciesAtom::ScaledInteraction::Excluded,
+                               0.0, 0.0);
 
     // Angles
     for (const auto &aRef : angles_)
@@ -119,11 +120,11 @@ void SpeciesAtom::setScaledInteractions()
         auto &a = aRef.get();
 
         if (a.i() != this)
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.i()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(a.i()), ScaledInteraction::Excluded, 0.0, 0.0);
         if (a.j() != this)
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(a.j()), ScaledInteraction::Excluded, 0.0, 0.0);
         if (a.k() != this)
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(a.k()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(a.k()), ScaledInteraction::Excluded, 0.0, 0.0);
     }
 
     // Torsions
@@ -133,24 +134,26 @@ void SpeciesAtom::setScaledInteractions()
 
         if (t.i() == this)
         {
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.l()), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.l()), ScaledInteraction::Scaled, t.electrostatic14Scaling(),
+                                   t.vanDerWaals14Scaling());
         }
         else if (t.l() == this)
         {
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.i()), ScaledInteraction::Scaled, t.electrostatic14Scaling(), t.vanDerWaals14Scaling());
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.i()), ScaledInteraction::Scaled, t.electrostatic14Scaling(),
+                                   t.vanDerWaals14Scaling());
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
         }
         else
         {
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.i()), ScaledInteraction::Excluded, 0.0, 0.0);
-            addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.l()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.i()), ScaledInteraction::Excluded, 0.0, 0.0);
+            addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.l()), ScaledInteraction::Excluded, 0.0, 0.0);
             if (t.j() != this)
-                addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
+                addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.j()), ScaledInteraction::Excluded, 0.0, 0.0);
             if (t.k() != this)
-                addInteractionFunction(dynamic_cast<SpeciesAtom*>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
+                addInteractionFunction(dynamic_cast<SpeciesAtom *>(t.k()), ScaledInteraction::Excluded, 0.0, 0.0);
         }
     }
 }
@@ -283,7 +286,7 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
     const auto &bonds = i->bonds();
     for (const SpeciesBond &bond : bonds)
     {
-        auto Z = dynamic_cast<SpeciesAtom*>(bond.partner(i))->Z();
+        auto Z = dynamic_cast<SpeciesAtom *>(bond.partner(i))->Z();
         switch (Z)
         {
             // Group 1A - Alkali earth metals (includes Hydrogen)

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -16,9 +16,8 @@
 // Forward Declarations
 class AtomType;
 
-
 // SpeciesAtom Definition
-class SpeciesAtom : public SpeciesParticle 
+class SpeciesAtom : public SpeciesParticle
 {
     public:
     SpeciesAtom() = default;

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -5,6 +5,7 @@
 
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
+#include "classes/speciesParticle.h"
 #include "data/elements.h"
 #include "math/vector3.h"
 #include "templates/optionalRef.h"
@@ -14,14 +15,13 @@
 
 // Forward Declarations
 class AtomType;
-class CoreData;
 class SpeciesAngle;
 class SpeciesBond;
 class SpeciesImproper;
 class SpeciesTorsion;
 
 // SpeciesAtom Definition
-class SpeciesAtom : public Serialisable<CoreData &>
+class SpeciesAtom : public SpeciesParticle 
 {
     public:
     SpeciesAtom() = default;
@@ -50,16 +50,10 @@ class SpeciesAtom : public Serialisable<CoreData &>
     private:
     // Atomic element
     Elements::Element Z_{Elements::Unknown};
-    // Coordinates
-    Vector3 r_{0.0, 0.0, 0.0};
     // Charge (if contained in file)
     double charge_{0.0};
     // Assigned AtomType
     std::shared_ptr<AtomType> atomType_{nullptr};
-    // Index in Species
-    int index_{-1};
-    // Whether the atom is currently selected
-    bool selected_{false};
     // Presence of atom
     Presence presence_{Presence::Physical};
 
@@ -73,8 +67,6 @@ class SpeciesAtom : public Serialisable<CoreData &>
     Elements::Element Z() const;
     // Return whether the atom is of the presence specified
     bool isPresence(SpeciesAtom::Presence presence) const;
-    // Return coordinates (read-only)
-    const Vector3 &r() const;
     // Set charge of Atom
     void setCharge(double charge);
     // Return charge of Atom
@@ -83,16 +75,6 @@ class SpeciesAtom : public Serialisable<CoreData &>
     void setAtomType(const std::shared_ptr<AtomType> &at);
     // Return AtomType of Atom
     std::shared_ptr<AtomType> atomType() const;
-    // Set index (0->[N-1])
-    void setIndex(int id);
-    // Return index (0->[N-1])
-    int index() const;
-    // Return 'user' index (1->N)
-    int userIndex() const;
-    // Set whether the atom is currently selected
-    void setSelected(bool selected);
-    // Return whether the atom is currently selected
-    bool isSelected() const;
     // Return presence of atom
     Presence presence() const;
 
@@ -168,19 +150,6 @@ class SpeciesAtom : public Serialisable<CoreData &>
     void setScaledInteractions();
     // Return scaling type and factors (electrostatic, van der Waals) to employ with specified Atom
     ScaledInteractionDefinition scaling(const SpeciesAtom *j) const;
-
-    /*
-     * Coordinate Manipulation
-     */
-    public:
-    // Set coordinate
-    void setCoordinate(int index, double value);
-    // Set coordinates
-    void setCoordinates(double x, double y, double z);
-    // Set coordinates (from Vec3)
-    void setCoordinates(const Vector3 &newr);
-    // Translate coordinates
-    void translateCoordinates(const Vector3 &delta);
 
     /*
      * Atom Environment Helpers

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -15,10 +15,7 @@
 
 // Forward Declarations
 class AtomType;
-class SpeciesAngle;
-class SpeciesBond;
-class SpeciesImproper;
-class SpeciesTorsion;
+
 
 // SpeciesAtom Definition
 class SpeciesAtom : public SpeciesParticle 
@@ -92,60 +89,10 @@ class SpeciesAtom : public SpeciesParticle
     using ScaledInteractionDefinition = std::tuple<ScaledInteraction, double, double>;
 
     private:
-    // Vector of bonds which this atom participates in
-    std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
-    // Vector of angles which this atom participates in
-    std::vector<std::reference_wrapper<SpeciesAngle>> angles_;
-    // Vector of torsions which this atom participates in
-    std::vector<std::reference_wrapper<SpeciesTorsion>> torsions_;
-    // Vector of torsions which this atom participates in
-    std::vector<std::reference_wrapper<SpeciesImproper>> impropers_;
     // Vector of Atoms with scaled or excluded interactions
     std::vector<std::pair<const SpeciesAtom *, ScaledInteractionDefinition>> scaledInteractions_;
 
     public:
-    // Add bond reference
-    void addBond(SpeciesBond &b);
-    // Remove bond reference
-    void removeBond(SpeciesBond &b);
-    // Return number of bonds
-    int nBonds() const;
-    // Return specified bond
-    SpeciesBond &bond(int index);
-    // Return bonds list
-    const std::vector<std::reference_wrapper<SpeciesBond>> &bonds() const;
-    // Return whether bond to specified atom exists
-    OptionalReferenceWrapper<SpeciesBond> getBond(const SpeciesAtom *j);
-    // Add specified Angle to Atom
-    void addAngle(SpeciesAngle &angle);
-    // Remove angle reference
-    void removeAngle(SpeciesAngle &a);
-    // Return the number of SpeciesAngles in which the Atom is involved
-    int nAngles() const;
-    // Return specified angle
-    SpeciesAngle &angle(int index);
-    // Return array of Angles in which the Atom is involved
-    const std::vector<std::reference_wrapper<SpeciesAngle>> &angles() const;
-    // Add specified SpeciesTorsion to Atom
-    void addTorsion(SpeciesTorsion &torsion);
-    // Remove torsion reference
-    void removeTorsion(SpeciesTorsion &t);
-    // Return the number of SpeciesTorsions in which the Atom is involved
-    int nTorsions() const;
-    // Return specified torsion
-    SpeciesTorsion &torsion(int index);
-    // Return array of Torsions in which the Atom is involved
-    const std::vector<std::reference_wrapper<SpeciesTorsion>> &torsions() const;
-    // Add specified SpeciesImproper to Atom
-    void addImproper(SpeciesImproper &improper);
-    // Remove improper reference
-    void removeImproper(SpeciesImproper &t);
-    // Return the number of SpeciesImpropers in which the Atom is involved
-    int nImpropers() const;
-    // Return specified improper
-    SpeciesImproper &improper(int index);
-    // Return array of Impropers in which the Atom is involved
-    const std::vector<std::reference_wrapper<SpeciesImproper>> &impropers() const;
     // Set all scaled intramolecular interactions
     void setScaledInteractions();
     // Return scaling type and factors (electrostatic, van der Waals) to employ with specified Atom

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -4,7 +4,7 @@
 #include "classes/speciesBond.h"
 #include "base/sysFunc.h"
 #include "classes/coreData.h"
-//#include "classes/speciesAtom.h"
+// #include "classes/speciesAtom.h"
 #include "classes/speciesParticle.h"
 #include "data/atomicMasses.h"
 #include <map>
@@ -224,8 +224,8 @@ double SpeciesBond::energy(double distance) const
          *           sqrt( (mi + mj) / (mi * mj) )
          */
         auto delta = distance - params[1];
-        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(i_)->Z());
-        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(j_)->Z());
+        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom *>(i_)->Z());
+        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom *>(j_)->Z());
         return params[0] * delta * delta / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
     else if (bondForm == BondFunctions::Form::Morse)
@@ -283,8 +283,8 @@ double SpeciesBond::force(double distance) const
          * 0 : general force constant C / 2.0
          * 1 : equilibrium distance
          */
-        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(i_)->Z());
-        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(j_)->Z());
+        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom *>(i_)->Z());
+        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom *>(j_)->Z());
         return -2.0 * params[0] * (distance - params[1]) / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
     else if (bondForm == BondFunctions::Form::Morse)

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -4,13 +4,14 @@
 #include "classes/speciesBond.h"
 #include "base/sysFunc.h"
 #include "classes/coreData.h"
-#include "classes/speciesAtom.h"
+//#include "classes/speciesAtom.h"
+#include "classes/speciesParticle.h"
 #include "data/atomicMasses.h"
 #include <map>
 
 SpeciesBond::SpeciesBond() : SpeciesIntra(BondFunctions::Form::None) {}
 
-SpeciesBond::SpeciesBond(SpeciesAtom *i, SpeciesAtom *j) : SpeciesIntra(BondFunctions::Form::None) { assign(i, j); }
+SpeciesBond::SpeciesBond(SpeciesParticle *i, SpeciesParticle *j) : SpeciesIntra(BondFunctions::Form::None) { assign(i, j); }
 
 SpeciesBond::SpeciesBond(SpeciesBond &source) : SpeciesIntra(source) { this->operator=(source); }
 
@@ -66,11 +67,11 @@ SpeciesBond &SpeciesBond::operator=(SpeciesBond &&source) noexcept
 }
 
 /*
- * SpeciesAtom Information
+ * SpeciesParticle Information
  */
 
-// Rewrite SpeciesAtom pointer
-void SpeciesBond::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
+// Rewrite SpeciesParticle pointer
+void SpeciesBond::switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr)
 {
     assert(i_ == oldPtr || j_ == oldPtr);
 
@@ -81,7 +82,7 @@ void SpeciesBond::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
 }
 
 // Assign the two atoms in the bond
-void SpeciesBond::assign(SpeciesAtom *i, SpeciesAtom *j)
+void SpeciesBond::assign(SpeciesParticle *i, SpeciesParticle *j)
 {
     i_ = i;
     j_ = j;
@@ -92,33 +93,33 @@ void SpeciesBond::assign(SpeciesAtom *i, SpeciesAtom *j)
     j_->addBond(*this);
 }
 
-// Return first SpeciesAtom involved in interaction
-SpeciesAtom *SpeciesBond::i() const { return i_; }
+// Return first SpeciesParticle involved in interaction
+SpeciesParticle *SpeciesBond::i() const { return i_; }
 
-// Return second SpeciesAtom involved in SpeciesBond
-SpeciesAtom *SpeciesBond::j() const { return j_; }
+// Return second SpeciesParticle involved in SpeciesBond
+SpeciesParticle *SpeciesBond::j() const { return j_; }
 
 // Return vector of involved atoms
-std::vector<const SpeciesAtom *> SpeciesBond::atoms() const { return {i_, j_}; }
+std::vector<const SpeciesParticle *> SpeciesBond::atoms() const { return {i_, j_}; }
 
-// Return the 'other' SpeciesAtom in the SpeciesBond
-SpeciesAtom *SpeciesBond::partner(const SpeciesAtom *i) const { return (i == i_ ? j_ : i_); }
+// Return the 'other' SpeciesParticle in the SpeciesBond
+SpeciesParticle *SpeciesBond::partner(const SpeciesParticle *i) const { return (i == i_ ? j_ : i_); }
 
-// Return index (in parent Species) of first SpeciesAtom
+// Return index (in parent Species) of first SpeciesParticle
 int SpeciesBond::indexI() const
 {
     assert(i_);
     return i_->index();
 }
 
-// Return index (in parent Species) of second SpeciesAtom
+// Return index (in parent Species) of second SpeciesParticle
 int SpeciesBond::indexJ() const
 {
     assert(j_);
     return j_->index();
 }
 
-// Return index (in parent Species) of nth SpeciesAtom in interaction
+// Return index (in parent Species) of nth SpeciesParticle in interaction
 int SpeciesBond::index(int n) const
 {
     if (n == 0)
@@ -126,12 +127,12 @@ int SpeciesBond::index(int n) const
     else if (n == 1)
         return indexJ();
 
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesBond::index(int). Returning 0...\n", n);
+    Messenger::error("SpeciesParticle index {} is out of range in SpeciesBond::index(int). Returning 0...\n", n);
     return 0;
 }
 
-// Return whether SpeciesAtoms in Angle match those specified
-bool SpeciesBond::matches(const SpeciesAtom *i, const SpeciesAtom *j) const
+// Return whether SpeciesParticles in Angle match those specified
+bool SpeciesBond::matches(const SpeciesParticle *i, const SpeciesParticle *j) const
 {
     return (i_ == i && j_ == j) || (i_ == j && j_ == i);
 }
@@ -223,8 +224,8 @@ double SpeciesBond::energy(double distance) const
          *           sqrt( (mi + mj) / (mi * mj) )
          */
         auto delta = distance - params[1];
-        auto massI = AtomicMass::mass(i_->Z());
-        auto massJ = AtomicMass::mass(j_->Z());
+        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(i_)->Z());
+        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(j_)->Z());
         return params[0] * delta * delta / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
     else if (bondForm == BondFunctions::Form::Morse)
@@ -282,8 +283,8 @@ double SpeciesBond::force(double distance) const
          * 0 : general force constant C / 2.0
          * 1 : equilibrium distance
          */
-        auto massI = AtomicMass::mass(i_->Z());
-        auto massJ = AtomicMass::mass(j_->Z());
+        auto massI = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(i_)->Z());
+        auto massJ = AtomicMass::mass(dynamic_cast<SpeciesAtom*>(j_)->Z());
         return -2.0 * params[0] * (distance - params[1]) / (params[1] / sqrt((massI + massJ) / (massI * massJ)));
     }
     else if (bondForm == BondFunctions::Form::Morse)

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class SpeciesParticle;
 class Species;
 class CoreData;
 
@@ -20,7 +20,7 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
 {
     public:
     SpeciesBond();
-    SpeciesBond(SpeciesAtom *i, SpeciesAtom *j);
+    SpeciesBond(SpeciesParticle *i, SpeciesParticle *j);
     ~SpeciesBond() override = default;
     SpeciesBond(SpeciesBond &source);
     SpeciesBond(SpeciesBond &&source) noexcept;
@@ -28,37 +28,37 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     SpeciesBond &operator=(SpeciesBond &&source) noexcept;
 
     /*
-     * SpeciesAtom Information
+     * SpeciesParticle Information
      */
     private:
-    // First SpeciesAtom in interaction
-    SpeciesAtom *i_{nullptr};
-    // Second SpeciesAtom in interaction
-    SpeciesAtom *j_{nullptr};
+    // First SpeciesParticle in interaction
+    SpeciesParticle *i_{nullptr};
+    // Second SpeciesParticle in interaction
+    SpeciesParticle *j_{nullptr};
 
     public:
     // Assign the two atoms in the bond
-    void assign(SpeciesAtom *i, SpeciesAtom *j);
+    void assign(SpeciesParticle *i, SpeciesParticle *j);
     // Set scaled intramolecular interactions on the involved atoms
     void addScaledInteractions();
-    // Rewrite SpeciesAtom pointer
-    void switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr);
-    // Return first SpeciesAtom
-    SpeciesAtom *i() const;
-    // Return second SpeciesAtom
-    SpeciesAtom *j() const;
+    // Rewrite SpeciesParticle pointer
+    void switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr);
+    // Return first SpeciesParticle
+    SpeciesParticle *i() const;
+    // Return second SpeciesParticle
+    SpeciesParticle *j() const;
     // Return vector of involved atoms
-    std::vector<const SpeciesAtom *> atoms() const override;
-    // Return the 'other' SpeciesAtom
-    SpeciesAtom *partner(const SpeciesAtom *i) const;
-    // Return index (in parent Species) of first SpeciesAtom
+    std::vector<const SpeciesParticle *> atoms() const override;
+    // Return the 'other' SpeciesParticle
+    SpeciesParticle *partner(const SpeciesParticle *i) const;
+    // Return index (in parent Species) of first SpeciesParticle
     int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
+    // Return index (in parent Species) of second SpeciesParticle
     int indexJ() const;
-    // Return index (in parent Species) of nth SpeciesAtom
+    // Return index (in parent Species) of nth SpeciesParticle
     int index(int n) const;
-    // Return whether SpeciesAtoms match those specified
-    bool matches(const SpeciesAtom *i, const SpeciesAtom *j) const;
+    // Return whether SpeciesParticles match those specified
+    bool matches(const SpeciesParticle *i, const SpeciesParticle *j) const;
     // Return whether all atoms in the interaction are currently selected
     bool isSelected() const;
     // Detach from current atoms

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -181,7 +181,8 @@ int SpeciesImproper::index(int n) const
 }
 
 // Return whether Atoms in Improper match those specified
-bool SpeciesImproper::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const
+bool SpeciesImproper::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k,
+                              const SpeciesParticle *l) const
 {
     if (i_ != i)
         return false;

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -3,12 +3,12 @@
 
 #include "classes/speciesImproper.h"
 #include "classes/coreData.h"
-#include "classes/speciesAtom.h"
+#include "classes/speciesParticle.h"
 #include "classes/speciesTorsion.h"
 
 SpeciesImproper::SpeciesImproper() : SpeciesIntra(TorsionFunctions::Form::None) {}
 
-SpeciesImproper::SpeciesImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l)
+SpeciesImproper::SpeciesImproper(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l)
     : SpeciesIntra(TorsionFunctions::Form::None)
 {
     assign(i, j, k, l);
@@ -68,8 +68,8 @@ SpeciesImproper &SpeciesImproper::operator=(SpeciesImproper &&source) noexcept
  * Atom Information
  */
 
-// Rewrite SpeciesAtom pointer
-void SpeciesImproper::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
+// Rewrite SpeciesParticle pointer
+void SpeciesImproper::switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr)
 {
     assert(i_ == oldPtr || j_ == oldPtr || k_ == oldPtr || l_ == oldPtr);
 
@@ -84,7 +84,7 @@ void SpeciesImproper::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
 }
 
 // Set Atoms involved in Improper
-void SpeciesImproper::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l)
+void SpeciesImproper::assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l)
 {
     i_ = i;
     j_ = j;
@@ -115,56 +115,56 @@ void SpeciesImproper::detach()
     l_ = nullptr;
 }
 
-// Return first SpeciesAtom
-SpeciesAtom *SpeciesImproper::i() const { return i_; }
+// Return first SpeciesParticle
+SpeciesParticle *SpeciesImproper::i() const { return i_; }
 
-// Return second SpeciesAtom
-SpeciesAtom *SpeciesImproper::j() const { return j_; }
+// Return second SpeciesParticle
+SpeciesParticle *SpeciesImproper::j() const { return j_; }
 
-// Return third SpeciesAtom
-SpeciesAtom *SpeciesImproper::k() const { return k_; }
+// Return third SpeciesParticle
+SpeciesParticle *SpeciesImproper::k() const { return k_; }
 
-// Return fourth SpeciesAtom
-SpeciesAtom *SpeciesImproper::l() const { return l_; }
+// Return fourth SpeciesParticle
+SpeciesParticle *SpeciesImproper::l() const { return l_; }
 
 // Return vector of involved atoms
-std::vector<const SpeciesAtom *> SpeciesImproper::atoms() const { return {i_, j_, k_, l_}; }
+std::vector<const SpeciesParticle *> SpeciesImproper::atoms() const { return {i_, j_, k_, l_}; }
 
-// Return whether the improper uses the specified SpeciesAtom
-bool SpeciesImproper::uses(SpeciesAtom *spAtom) const
+// Return whether the improper uses the specified SpeciesParticle
+bool SpeciesImproper::uses(SpeciesParticle *spAtom) const
 {
     return ((i_ == spAtom) || (j_ == spAtom) || (k_ == spAtom) || (l_ == spAtom));
 }
 
-// Return index (in parent Species) of first SpeciesAtom
+// Return index (in parent Species) of first SpeciesParticle
 int SpeciesImproper::indexI() const
 {
     assert(i_);
     return i_->index();
 }
 
-// Return index (in parent Species) of second (central) SpeciesAtom
+// Return index (in parent Species) of second (central) SpeciesParticle
 int SpeciesImproper::indexJ() const
 {
     assert(j_);
     return j_->index();
 }
 
-// Return index (in parent Species) of third SpeciesAtom
+// Return index (in parent Species) of third SpeciesParticle
 int SpeciesImproper::indexK() const
 {
     assert(k_);
     return k_->index();
 }
 
-// Return index (in parent Species) of fourth SpeciesAtom
+// Return index (in parent Species) of fourth SpeciesParticle
 int SpeciesImproper::indexL() const
 {
     assert(l_);
     return l_->index();
 }
 
-// Return index (in parent Species) of nth SpeciesAtom in interaction
+// Return index (in parent Species) of nth SpeciesParticle in interaction
 int SpeciesImproper::index(int n) const
 {
     if (n == 0)
@@ -176,12 +176,12 @@ int SpeciesImproper::index(int n) const
     else if (n == 3)
         return indexL();
 
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesImproper::index(int). Returning 0...\n", n);
+    Messenger::error("SpeciesParticle index {} is out of range in SpeciesImproper::index(int). Returning 0...\n", n);
     return 0;
 }
 
 // Return whether Atoms in Improper match those specified
-bool SpeciesImproper::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const
+bool SpeciesImproper::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const
 {
     if (i_ != i)
         return false;

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class SpeciesParticle;
 class Species;
 
 // SpeciesImproper Definition
@@ -20,7 +20,7 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
 {
     public:
     SpeciesImproper();
-    SpeciesImproper(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l);
+    SpeciesImproper(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l);
     ~SpeciesImproper() override;
     SpeciesImproper(SpeciesImproper &source);
     SpeciesImproper(SpeciesImproper &&source) noexcept;
@@ -31,14 +31,14 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
      * Atom Information
      */
     private:
-    // First SpeciesAtom in interaction
-    SpeciesAtom *i_{nullptr};
-    // Second SpeciesAtom in interaction
-    SpeciesAtom *j_{nullptr};
-    // Third SpeciesAtom in interaction
-    SpeciesAtom *k_{nullptr};
-    // Fourth SpeciesAtom in interaction
-    SpeciesAtom *l_{nullptr};
+    // First SpeciesParticle in interaction
+    SpeciesParticle *i_{nullptr};
+    // Second SpeciesParticle in interaction
+    SpeciesParticle *j_{nullptr};
+    // Third SpeciesParticle in interaction
+    SpeciesParticle *k_{nullptr};
+    // Fourth SpeciesParticle in interaction
+    SpeciesParticle *l_{nullptr};
 
     private:
     // Detach from current atoms
@@ -46,33 +46,33 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
 
     public:
     // Set Atoms involved in Improper
-    void assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l);
-    // Rewrite SpeciesAtom pointer
-    void switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr);
-    // Return first SpeciesAtom
-    SpeciesAtom *i() const;
-    // Return second SpeciesAtom
-    SpeciesAtom *j() const;
-    // Return third SpeciesAtom
-    SpeciesAtom *k() const;
-    // Return fourth SpeciesAtom
-    SpeciesAtom *l() const;
+    void assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l);
+    // Rewrite SpeciesParticle pointer
+    void switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr);
+    // Return first SpeciesParticle
+    SpeciesParticle *i() const;
+    // Return second SpeciesParticle
+    SpeciesParticle *j() const;
+    // Return third SpeciesParticle
+    SpeciesParticle *k() const;
+    // Return fourth SpeciesParticle
+    SpeciesParticle *l() const;
     // Return vector of involved atoms
-    std::vector<const SpeciesAtom *> atoms() const override;
-    // Return whether the improper uses the specified SpeciesAtom
-    bool uses(SpeciesAtom *spAtom) const;
-    // Return index (in parent Species) of first SpeciesAtom
+    std::vector<const SpeciesParticle *> atoms() const override;
+    // Return whether the improper uses the specified SpeciesParticle
+    bool uses(SpeciesParticle *spAtom) const;
+    // Return index (in parent Species) of first SpeciesParticle
     int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
+    // Return index (in parent Species) of second SpeciesParticle
     int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
+    // Return index (in parent Species) of third SpeciesParticle
     int indexK() const;
-    // Return index (in parent Species) of fourth SpeciesAtom
+    // Return index (in parent Species) of fourth SpeciesParticle
     int indexL() const;
-    // Return index (in parent Species) of nth SpeciesAtom in interaction
+    // Return index (in parent Species) of nth SpeciesParticle in interaction
     int index(int n) const;
-    // Return whether SpeciesAtoms match those specified
-    bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
+    // Return whether SpeciesParticles match those specified
+    bool matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const;
     // Return whether all atoms in the interaction are currently selected
     bool isSelected() const;
 

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -12,7 +12,7 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class SpeciesParticle;
 class Species;
 
 // Base class for intramolecular interactions within Species
@@ -36,11 +36,11 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     SpeciesIntra &operator=(SpeciesIntra &&source) = delete;
 
     /*
-     * SpeciesAtom Information
+     * SpeciesParticle Information
      */
     public:
     // Return vector of involved atoms
-    virtual std::vector<const SpeciesAtom *> atoms() const = 0;
+    virtual std::vector<const SpeciesParticle *> atoms() const = 0;
 
     /*
      * Interaction Parameters

--- a/src/classes/speciesParticle.cpp
+++ b/src/classes/speciesParticle.cpp
@@ -19,7 +19,32 @@ SpeciesParticle &SpeciesParticle::operator=(SpeciesParticle &&source) noexcept
 void SpeciesParticle::move(SpeciesParticle &source)
 {
     setCoordinates(source.r());
+    selected_ = source.selected_;
+    index_ = source.index_;
+
+    bonds_ = std::move(source.bonds_);
+    angles_ = std::move(source.angles_);
+    torsions_ = std::move(source.torsions_);
+    impropers_ = std::move(source.impropers_);
+
+    // Rewrite pointers in intramolecular terms
+    for (auto &bond : bonds_)
+        bond.get().switchAtom(&source, this);
+    for (auto &angle : angles_)
+        angle.get().switchAtom(&source, this);
+    for (auto &torsion : torsions_)
+        torsion.get().switchAtom(&source, this);
+    for (auto &improper : impropers_)
+        improper.get().switchAtom(&source, this);
+
+    // Tidy old data 
     source.setCoordinates({});
+    source.selected_ = false;
+    source.index_ = -1;
+    source.bonds_.clear();
+    source.angles_.clear();
+    source.torsions_.clear();
+    source.impropers_.clear();
 }
 
 // Set index (0->[N-1])

--- a/src/classes/speciesParticle.cpp
+++ b/src/classes/speciesParticle.cpp
@@ -3,6 +3,10 @@
 
 #include "classes/coreData.h"
 #include "classes/speciesParticle.h"
+#include "classes/speciesAngle.h"
+#include "classes/speciesBond.h"
+#include "classes/speciesTorsion.h"
+#include "classes/speciesImproper.h"
 
 SpeciesParticle::SpeciesParticle(SpeciesParticle &&source) noexcept { move(source); }
 
@@ -56,3 +60,106 @@ void SpeciesParticle::setCoordinates(const Vector3 &newr) { r_ = newr; }
 
 // Translate coordinates of atom
 void SpeciesParticle::translateCoordinates(const Vector3 &delta) { r_ += delta; }
+
+/*
+ * Bond Information
+ */
+
+// Add Bond reference
+void SpeciesParticle::addBond(SpeciesBond &bond)
+{
+    if (find_if(bonds_.begin(), bonds_.end(), [&bond](const SpeciesBond &b) { return &b == &bond; }) == bonds_.end())
+        bonds_.emplace_back(bond);
+}
+
+// Remove Bond reference
+void SpeciesParticle::removeBond(SpeciesBond &b)
+{
+    bonds_.erase(find_if(bonds_.begin(), bonds_.end(), [&b](const SpeciesBond &bond) { return &b == &bond; }));
+}
+
+// Return number of Bond references
+int SpeciesParticle::nBonds() const { return bonds_.size(); }
+
+// Return specified bond
+SpeciesBond &SpeciesParticle::bond(int index) { return bonds_.at(index); }
+
+// Return bonds list
+const std::vector<std::reference_wrapper<SpeciesBond>> &SpeciesParticle::bonds() const { return bonds_; }
+
+// Return whether Bond to specified Atom exists
+OptionalReferenceWrapper<SpeciesBond> SpeciesParticle::getBond(const SpeciesParticle *partner)
+{
+    auto result = find_if(bonds_.begin(), bonds_.end(), [&](const SpeciesBond &bond) { return bond.partner(this) == partner; });
+    if (result == bonds_.end())
+        return std::nullopt;
+    return *result;
+}
+
+/* 
+ * Angle Information  
+ */
+
+// Add specified SpeciesAngle to Atom
+void SpeciesParticle::addAngle(SpeciesAngle &angle) { angles_.emplace_back(angle); }
+
+// Remove angle reference
+void SpeciesParticle::removeAngle(SpeciesAngle &angle)
+{
+    angles_.erase(find_if(angles_.begin(), angles_.end(), [&angle](const SpeciesAngle &a) { return &a == &angle; }));
+}
+
+// Return the number of Angles in which the Atom is involved
+int SpeciesParticle::nAngles() const { return angles_.size(); }
+
+// Return specified angle
+SpeciesAngle &SpeciesParticle::angle(int index) { return angles_.at(index); }
+
+// Return array of Angles in which the Atom is involved
+const std::vector<std::reference_wrapper<SpeciesAngle>> &SpeciesParticle::angles() const { return angles_; }
+
+/*
+ * Torsion Information  
+ */
+
+// Add specified SpeciesTorsion to Atom
+void SpeciesParticle::addTorsion(SpeciesTorsion &torsion) { torsions_.emplace_back(torsion); }
+
+// Remove torsion reference
+void SpeciesParticle::removeTorsion(SpeciesTorsion &torsion)
+{
+    torsions_.erase(
+        find_if(torsions_.begin(), torsions_.end(), [&torsion](const SpeciesTorsion &t) { return &t == &torsion; }));
+}
+
+// Return the number of Torsions in which the Atom is involved
+int SpeciesParticle::nTorsions() const { return torsions_.size(); }
+
+// Return specified torsion
+SpeciesTorsion &SpeciesParticle::torsion(int index) { return torsions_.at(index); }
+
+// Return array of Torsions in which the Atom is involved
+const std::vector<std::reference_wrapper<SpeciesTorsion>> &SpeciesParticle::torsions() const { return torsions_; }
+
+/* 
+ * Improper Information
+ */
+
+// Add specified SpeciesImproper to Atom
+void SpeciesParticle::addImproper(SpeciesImproper &improper) { impropers_.emplace_back(improper); }
+
+// Remove improper reference
+void SpeciesParticle::removeImproper(SpeciesImproper &improper)
+{
+    impropers_.erase(
+        find_if(impropers_.begin(), impropers_.end(), [&improper](const SpeciesImproper &i) { return &i == &improper; }));
+}
+
+// Return the number of Impropers in which the Atom is involved
+int SpeciesParticle::nImpropers() const { return impropers_.size(); }
+
+// Return specified improper
+SpeciesImproper &SpeciesParticle::improper(int index) { return impropers_.at(index); }
+
+// Return array of Impropers in which the Atom is involved
+const std::vector<std::reference_wrapper<SpeciesImproper>> &SpeciesParticle::impropers() const { return impropers_; }

--- a/src/classes/speciesParticle.cpp
+++ b/src/classes/speciesParticle.cpp
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "classes/coreData.h"
+#include "classes/speciesParticle.h"
+
+SpeciesParticle::SpeciesParticle(SpeciesParticle &&source) noexcept { move(source); }
+
+SpeciesParticle &SpeciesParticle::operator=(SpeciesParticle &&source) noexcept
+{
+    move(source);
+    return *this;
+}
+
+void SpeciesParticle::move(SpeciesParticle &source)
+{
+    setCoordinates(source.r());
+    source.setCoordinates({});
+}
+
+// Set index (0->[N-1])
+void SpeciesParticle::setIndex(int id) { index_ = id; }
+
+// Return index (0->[N-1])
+int SpeciesParticle::index() const { return index_; }
+
+// Return 'user' index (1->N)
+int SpeciesParticle::userIndex() const { return index_ + 1; }
+
+// Set whether the atom is currently selected
+void SpeciesParticle::setSelected(bool selected) { selected_ = selected; }
+
+// Return whether the atom is currently selected
+bool SpeciesParticle::isSelected() const { return selected_; }
+
+// Return coordinates
+const Vector3 &SpeciesParticle::r() const { return r_; }
+
+/*
+ * Coordinate Manipulation
+ */
+
+// Set coordinate
+void SpeciesParticle::setCoordinate(int index, double value) { r_.set(index, value); }
+
+// Set coordinates
+void SpeciesParticle::setCoordinates(double x, double y, double z)
+{
+    r_.x = x;
+    r_.y = y;
+    r_.z = z;
+}
+
+// Set coordinates (from Vec3)
+void SpeciesParticle::setCoordinates(const Vector3 &newr) { r_ = newr; }
+
+// Translate coordinates of atom
+void SpeciesParticle::translateCoordinates(const Vector3 &delta) { r_ += delta; }

--- a/src/classes/speciesParticle.cpp
+++ b/src/classes/speciesParticle.cpp
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#include "classes/coreData.h"
 #include "classes/speciesParticle.h"
+#include "classes/coreData.h"
 #include "classes/speciesAngle.h"
 #include "classes/speciesBond.h"
-#include "classes/speciesTorsion.h"
 #include "classes/speciesImproper.h"
+#include "classes/speciesTorsion.h"
 
 SpeciesParticle::SpeciesParticle(SpeciesParticle &&source) noexcept { move(source); }
 
@@ -37,7 +37,7 @@ void SpeciesParticle::move(SpeciesParticle &source)
     for (auto &improper : impropers_)
         improper.get().switchAtom(&source, this);
 
-    // Tidy old data 
+    // Tidy old data
     source.setCoordinates({});
     source.selected_ = false;
     source.index_ = -1;
@@ -121,8 +121,8 @@ OptionalReferenceWrapper<SpeciesBond> SpeciesParticle::getBond(const SpeciesPart
     return *result;
 }
 
-/* 
- * Angle Information  
+/*
+ * Angle Information
  */
 
 // Add specified SpeciesAngle to Atom
@@ -144,7 +144,7 @@ SpeciesAngle &SpeciesParticle::angle(int index) { return angles_.at(index); }
 const std::vector<std::reference_wrapper<SpeciesAngle>> &SpeciesParticle::angles() const { return angles_; }
 
 /*
- * Torsion Information  
+ * Torsion Information
  */
 
 // Add specified SpeciesTorsion to Atom
@@ -166,7 +166,7 @@ SpeciesTorsion &SpeciesParticle::torsion(int index) { return torsions_.at(index)
 // Return array of Torsions in which the Atom is involved
 const std::vector<std::reference_wrapper<SpeciesTorsion>> &SpeciesParticle::torsions() const { return torsions_; }
 
-/* 
+/*
  * Improper Information
  */
 

--- a/src/classes/speciesParticle.h
+++ b/src/classes/speciesParticle.h
@@ -99,13 +99,22 @@ class SpeciesParticle : public Serialisable<CoreData &>
     // Return array of Impropers in which the Atom is involved
     const std::vector<std::reference_wrapper<SpeciesImproper>> &impropers() const;
 
-    protected:
+    private:
+    /*
+     * Basic Properties
+     */
+
     // Index in Species
     int index_{-1};
     // Whether the SpeciesParticle is currently selected
     bool selected_{false};
+    // Coordinates
+    Vector3 r_{0.0, 0.0, 0.0};
 
-    // TODO: Make these private
+    /*
+     * Species interaction references
+     */
+
     // Vector of bonds which this atom participates in
     std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
     // Vector of angles which this atom participates in
@@ -114,8 +123,4 @@ class SpeciesParticle : public Serialisable<CoreData &>
     std::vector<std::reference_wrapper<SpeciesTorsion>> torsions_;
     // Vector of torsions which this atom participates in
     std::vector<std::reference_wrapper<SpeciesImproper>> impropers_;
-
-    private:
-    // Coordinates
-    Vector3 r_{0.0, 0.0, 0.0};
 };

--- a/src/classes/speciesParticle.h
+++ b/src/classes/speciesParticle.h
@@ -5,9 +5,14 @@
 
 #include "base/serialiser.h"
 #include "math/vector3.h"
+#include "templates/optionalRef.h"
 
 // Forward Declarations 
 class CoreData; 
+class SpeciesAngle;
+class SpeciesBond;
+class SpeciesImproper;
+class SpeciesTorsion;
 
 class SpeciesParticle : public Serialisable<CoreData&>
 {
@@ -46,13 +51,71 @@ class SpeciesParticle : public Serialisable<CoreData&>
     // Translate coordinates
     void translateCoordinates(const Vector3 &delta);
 
+    /*
+     * SpeciesIntra 
+     */
+    // Add bond reference
+    void addBond(SpeciesBond &b);
+    // Remove bond reference
+    void removeBond(SpeciesBond &b);
+    // Return number of bonds
+    int nBonds() const;
+    // Return specified bond
+    SpeciesBond &bond(int index);
+    // Return bonds list
+    const std::vector<std::reference_wrapper<SpeciesBond>> &bonds() const;
+    // Return whether bond to specified atom exists
+    OptionalReferenceWrapper<SpeciesBond> getBond(const SpeciesParticle *j);
+    // Add specified Angle to Atom
+    void addAngle(SpeciesAngle &angle);
+    // Remove angle reference
+    void removeAngle(SpeciesAngle &a);
+    // Return the number of SpeciesAngles in which the Atom is involved
+    int nAngles() const;
+    // Return specified angle
+    SpeciesAngle &angle(int index);
+    // Return array of Angles in which the Atom is involved
+    const std::vector<std::reference_wrapper<SpeciesAngle>> &angles() const;
+    // Add specified SpeciesTorsion to Atom
+    void addTorsion(SpeciesTorsion &torsion);
+    // Remove torsion reference
+    void removeTorsion(SpeciesTorsion &t);
+    // Return the number of SpeciesTorsions in which the Atom is involved
+    int nTorsions() const;
+    // Return specified torsion
+    SpeciesTorsion &torsion(int index);
+    // Return array of Torsions in which the Atom is involved
+    const std::vector<std::reference_wrapper<SpeciesTorsion>> &torsions() const;
+    // Add specified SpeciesImproper to Atom
+    void addImproper(SpeciesImproper &improper);
+    // Remove improper reference
+    void removeImproper(SpeciesImproper &t);
+    // Return the number of SpeciesImpropers in which the Atom is involved
+    int nImpropers() const;
+    // Return specified improper
+    SpeciesImproper &improper(int index);
+    // Return array of Impropers in which the Atom is involved
+    const std::vector<std::reference_wrapper<SpeciesImproper>> &impropers() const;
+
     protected:
     // Index in Species 
     int index_{-1};
     // Whether the SpeciesParticle is currently selected 
-    bool selected_{false};      
+    bool selected_{false};    
+
+    // TODO: Make these private 
+    // Vector of bonds which this atom participates in
+    std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
+    // Vector of angles which this atom participates in
+    std::vector<std::reference_wrapper<SpeciesAngle>> angles_;
+    // Vector of torsions which this atom participates in
+    std::vector<std::reference_wrapper<SpeciesTorsion>> torsions_;
+    // Vector of torsions which this atom participates in
+    std::vector<std::reference_wrapper<SpeciesImproper>> impropers_;
 
     private:
     // Coordinates 
     Vector3 r_ { 0.0, 0.0, 0.0 };
+
+    
 };

--- a/src/classes/speciesParticle.h
+++ b/src/classes/speciesParticle.h
@@ -24,8 +24,10 @@ class SpeciesParticle : public Serialisable<CoreData&>
     SpeciesParticle &operator=(const SpeciesParticle &) = delete;
     SpeciesParticle &operator=(SpeciesParticle &&source) noexcept;
 
+    protected:
     void move(SpeciesParticle &);
 
+    public:
     // Set index (0->[N-1])
     void setIndex(int id);
     // Return index (0->[N-1])

--- a/src/classes/speciesParticle.h
+++ b/src/classes/speciesParticle.h
@@ -1,25 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2025 Team Dissolve and contributors
 
-#pragma once 
+#pragma once
 
 #include "base/serialiser.h"
 #include "math/vector3.h"
 #include "templates/optionalRef.h"
 
-// Forward Declarations 
-class CoreData; 
+// Forward Declarations
+class CoreData;
 class SpeciesAngle;
 class SpeciesBond;
 class SpeciesImproper;
 class SpeciesTorsion;
 
-class SpeciesParticle : public Serialisable<CoreData&>
+class SpeciesParticle : public Serialisable<CoreData &>
 {
     public:
     SpeciesParticle() = default;
     ~SpeciesParticle() = default;
-    SpeciesParticle(SpeciesParticle&) = delete;
+    SpeciesParticle(SpeciesParticle &) = delete;
     SpeciesParticle(SpeciesParticle &&source) noexcept;
     SpeciesParticle &operator=(const SpeciesParticle &) = delete;
     SpeciesParticle &operator=(SpeciesParticle &&source) noexcept;
@@ -54,7 +54,7 @@ class SpeciesParticle : public Serialisable<CoreData&>
     void translateCoordinates(const Vector3 &delta);
 
     /*
-     * SpeciesIntra 
+     * SpeciesIntra
      */
     // Add bond reference
     void addBond(SpeciesBond &b);
@@ -100,12 +100,12 @@ class SpeciesParticle : public Serialisable<CoreData&>
     const std::vector<std::reference_wrapper<SpeciesImproper>> &impropers() const;
 
     protected:
-    // Index in Species 
+    // Index in Species
     int index_{-1};
-    // Whether the SpeciesParticle is currently selected 
-    bool selected_{false};    
+    // Whether the SpeciesParticle is currently selected
+    bool selected_{false};
 
-    // TODO: Make these private 
+    // TODO: Make these private
     // Vector of bonds which this atom participates in
     std::vector<std::reference_wrapper<SpeciesBond>> bonds_;
     // Vector of angles which this atom participates in
@@ -116,8 +116,6 @@ class SpeciesParticle : public Serialisable<CoreData&>
     std::vector<std::reference_wrapper<SpeciesImproper>> impropers_;
 
     private:
-    // Coordinates 
-    Vector3 r_ { 0.0, 0.0, 0.0 };
-
-    
+    // Coordinates
+    Vector3 r_{0.0, 0.0, 0.0};
 };

--- a/src/classes/speciesParticle.h
+++ b/src/classes/speciesParticle.h
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once 
+
+#include "base/serialiser.h"
+#include "math/vector3.h"
+
+// Forward Declarations 
+class CoreData; 
+
+class SpeciesParticle : public Serialisable<CoreData&>
+{
+    public:
+    SpeciesParticle() = default;
+    ~SpeciesParticle() = default;
+    SpeciesParticle(SpeciesParticle&) = delete;
+    SpeciesParticle(SpeciesParticle &&source) noexcept;
+    SpeciesParticle &operator=(const SpeciesParticle &) = delete;
+    SpeciesParticle &operator=(SpeciesParticle &&source) noexcept;
+
+    void move(SpeciesParticle &);
+
+    // Set index (0->[N-1])
+    void setIndex(int id);
+    // Return index (0->[N-1])
+    int index() const;
+    // Return 'user' index (1->N)
+    int userIndex() const;
+    // Set whether the atom is currently selected
+    void setSelected(bool selected);
+    // Return whether the atom is currently selected
+    bool isSelected() const;
+
+    /*
+     * Coordinate Manipulation
+     */
+    // Return coordinates (read-only)
+    const Vector3 &r() const;
+    // Set coordinate
+    void setCoordinate(int index, double value);
+    // Set coordinates
+    void setCoordinates(double x, double y, double z);
+    // Set coordinates (from Vec3)
+    void setCoordinates(const Vector3 &newr);
+    // Translate coordinates
+    void translateCoordinates(const Vector3 &delta);
+
+    protected:
+    // Index in Species 
+    int index_{-1};
+    // Whether the SpeciesParticle is currently selected 
+    bool selected_{false};      
+
+    private:
+    // Coordinates 
+    Vector3 r_ { 0.0, 0.0, 0.0 };
+};

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -3,13 +3,13 @@
 
 #include "classes/speciesTorsion.h"
 #include "classes/coreData.h"
-#include "classes/speciesAtom.h"
+#include "classes/speciesParticle.h"
 #include "math/mathFunc.h"
 #include <map>
 
 SpeciesTorsion::SpeciesTorsion() : SpeciesIntra(TorsionFunctions::Form::None) {}
 
-SpeciesTorsion::SpeciesTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l)
+SpeciesTorsion::SpeciesTorsion(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l)
     : SpeciesIntra(TorsionFunctions::Form::None)
 {
     assign(i, j, k, l);
@@ -70,8 +70,8 @@ SpeciesTorsion &SpeciesTorsion::operator=(SpeciesTorsion &&source) noexcept
  * Atom Information
  */
 
-// Rewrite SpeciesAtom pointer
-void SpeciesTorsion::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
+// Rewrite SpeciesParticle pointer
+void SpeciesTorsion::switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr)
 {
     assert(i_ == oldPtr || j_ == oldPtr || k_ == oldPtr || l_ == oldPtr);
 
@@ -86,7 +86,7 @@ void SpeciesTorsion::switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr)
 }
 
 // Set Atoms involved in Torsion
-void SpeciesTorsion::assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l)
+void SpeciesTorsion::assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l)
 {
     i_ = i;
     j_ = j;
@@ -116,50 +116,50 @@ void SpeciesTorsion::detach()
     l_ = nullptr;
 }
 
-// Return first SpeciesAtom
-SpeciesAtom *SpeciesTorsion::i() const { return i_; }
+// Return first SpeciesParticle
+SpeciesParticle *SpeciesTorsion::i() const { return i_; }
 
-// Return second SpeciesAtom
-SpeciesAtom *SpeciesTorsion::j() const { return j_; }
+// Return second SpeciesParticle
+SpeciesParticle *SpeciesTorsion::j() const { return j_; }
 
-// Return third SpeciesAtom
-SpeciesAtom *SpeciesTorsion::k() const { return k_; }
+// Return third SpeciesParticle
+SpeciesParticle *SpeciesTorsion::k() const { return k_; }
 
-// Return fourth SpeciesAtom
-SpeciesAtom *SpeciesTorsion::l() const { return l_; }
+// Return fourth SpeciesParticle
+SpeciesParticle *SpeciesTorsion::l() const { return l_; }
 
 // Return vector of involved atoms
-std::vector<const SpeciesAtom *> SpeciesTorsion::atoms() const { return {i_, j_, k_, l_}; }
+std::vector<const SpeciesParticle *> SpeciesTorsion::atoms() const { return {i_, j_, k_, l_}; }
 
-// Return index (in parent Species) of first SpeciesAtom
+// Return index (in parent Species) of first SpeciesParticle
 int SpeciesTorsion::indexI() const
 {
     assert(i_);
     return i_->index();
 }
 
-// Return index (in parent Species) of second (central) SpeciesAtom
+// Return index (in parent Species) of second (central) SpeciesParticle
 int SpeciesTorsion::indexJ() const
 {
     assert(j_);
     return j_->index();
 }
 
-// Return index (in parent Species) of third SpeciesAtom
+// Return index (in parent Species) of third SpeciesParticle
 int SpeciesTorsion::indexK() const
 {
     assert(k_);
     return k_->index();
 }
 
-// Return index (in parent Species) of fourth SpeciesAtom
+// Return index (in parent Species) of fourth SpeciesParticle
 int SpeciesTorsion::indexL() const
 {
     assert(l_);
     return l_->index();
 }
 
-// Return index (in parent Species) of nth SpeciesAtom in interaction
+// Return index (in parent Species) of nth SpeciesParticle in interaction
 int SpeciesTorsion::index(int n) const
 {
     if (n == 0)
@@ -171,12 +171,12 @@ int SpeciesTorsion::index(int n) const
     else if (n == 3)
         return indexL();
 
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesTorsion::index(int). Returning 0...\n", n);
+    Messenger::error("SpeciesParticle index {} is out of range in SpeciesTorsion::index(int). Returning 0...\n", n);
     return 0;
 }
 
 // Return whether Atoms in Torsion match those specified
-bool SpeciesTorsion::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const
+bool SpeciesTorsion::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const
 {
     return (i_ == i && j_ == j && k_ == k && l_ == l) || (i_ == l && j_ == k && k_ == j && l_ == i);
 }

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -176,7 +176,8 @@ int SpeciesTorsion::index(int n) const
 }
 
 // Return whether Atoms in Torsion match those specified
-bool SpeciesTorsion::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const
+bool SpeciesTorsion::matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k,
+                             const SpeciesParticle *l) const
 {
     return (i_ == i && j_ == j && k_ == k && l_ == l) || (i_ == l && j_ == k && k_ == j && l_ == i);
 }

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -11,7 +11,7 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class SpeciesParticle;
 class Species;
 class CoreData;
 
@@ -20,7 +20,7 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
 {
     public:
     SpeciesTorsion();
-    SpeciesTorsion(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l);
+    SpeciesTorsion(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l);
     ~SpeciesTorsion() override;
     SpeciesTorsion(SpeciesTorsion &source);
     SpeciesTorsion(SpeciesTorsion &&source) noexcept;
@@ -31,14 +31,14 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
      * Atom Information
      */
     private:
-    // First SpeciesAtom in interaction
-    SpeciesAtom *i_{nullptr};
-    // Second SpeciesAtom in interaction
-    SpeciesAtom *j_{nullptr};
-    // Third SpeciesAtom in interaction
-    SpeciesAtom *k_{nullptr};
-    // Fourth SpeciesAtom in interaction
-    SpeciesAtom *l_{nullptr};
+    // First SpeciesParticle in interaction
+    SpeciesParticle *i_{nullptr};
+    // Second SpeciesParticle in interaction
+    SpeciesParticle *j_{nullptr};
+    // Third SpeciesParticle in interaction
+    SpeciesParticle *k_{nullptr};
+    // Fourth SpeciesParticle in interaction
+    SpeciesParticle *l_{nullptr};
 
     private:
     // Detach from current atoms
@@ -46,31 +46,31 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
 
     public:
     // Set Atoms involved in Torsion
-    void assign(SpeciesAtom *i, SpeciesAtom *j, SpeciesAtom *k, SpeciesAtom *l);
-    // Rewrite SpeciesAtom pointer
-    void switchAtom(const SpeciesAtom *oldPtr, SpeciesAtom *newPtr);
-    // Return first SpeciesAtom
-    SpeciesAtom *i() const;
-    // Return second SpeciesAtom
-    SpeciesAtom *j() const;
-    // Return third SpeciesAtom
-    SpeciesAtom *k() const;
-    // Return fourth SpeciesAtom
-    SpeciesAtom *l() const;
+    void assign(SpeciesParticle *i, SpeciesParticle *j, SpeciesParticle *k, SpeciesParticle *l);
+    // Rewrite SpeciesParticle pointer
+    void switchAtom(const SpeciesParticle *oldPtr, SpeciesParticle *newPtr);
+    // Return first SpeciesParticle
+    SpeciesParticle *i() const;
+    // Return second SpeciesParticle
+    SpeciesParticle *j() const;
+    // Return third SpeciesParticle
+    SpeciesParticle *k() const;
+    // Return fourth SpeciesParticle
+    SpeciesParticle *l() const;
     // Return vector of involved atoms
-    std::vector<const SpeciesAtom *> atoms() const override;
-    // Return index (in parent Species) of first SpeciesAtom
+    std::vector<const SpeciesParticle *> atoms() const override;
+    // Return index (in parent Species) of first SpeciesParticle
     int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
+    // Return index (in parent Species) of second SpeciesParticle
     int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
+    // Return index (in parent Species) of third SpeciesParticle
     int indexK() const;
-    // Return index (in parent Species) of fourth SpeciesAtom
+    // Return index (in parent Species) of fourth SpeciesParticle
     int indexL() const;
-    // Return index (in parent Species) of nth SpeciesAtom in interaction
+    // Return index (in parent Species) of nth SpeciesParticle in interaction
     int index(int n) const;
-    // Return whether SpeciesAtoms match those specified
-    bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
+    // Return whether SpeciesParticles match those specified
+    bool matches(const SpeciesParticle *i, const SpeciesParticle *j, const SpeciesParticle *k, const SpeciesParticle *l) const;
     // Return whether all atoms in the interaction are currently selected
     bool isSelected() const;
 

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -159,7 +159,7 @@ void Species::recalculateIntermolecularTerms(double tolerance)
 {
     // Need to detach().
     while (bonds_.size())
-        removeBond(bonds_[0].i(), bonds_[0].j());
+        removeBond(dynamic_cast<SpeciesAtom*>(bonds_[0].i()), dynamic_cast<SpeciesAtom*>(bonds_[0].j()));
 
     addMissingBonds(tolerance);
     updateIntramolecularTerms();

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -174,8 +174,8 @@ void Species::updateIntramolecularTerms()
     for (auto &jk : bonds_)
     {
         // Get atoms 'j' and 'k'
-        j = jk.i();
-        k = jk.j();
+        j = dynamic_cast<SpeciesAtom*>(jk.i());
+        k = dynamic_cast<SpeciesAtom*>(jk.j());
 
         // Swap j and k over if j is terminal and has only a single bond (i.e. jk)
         if (j->nBonds() == 1)
@@ -189,7 +189,7 @@ void Species::updateIntramolecularTerms()
                 continue;
 
             // Get atom 'i'
-            i = ij.partner(j);
+            i = dynamic_cast<SpeciesAtom*>(ij.partner(j));
 
             // Attempt to add angle term 'ijk' if 'i' > 'k'
             if (!hasAngle(i, j, k))
@@ -203,7 +203,7 @@ void Species::updateIntramolecularTerms()
                     continue;
 
                 // Get atom 'l'
-                l = kl.partner(k);
+                l = dynamic_cast<SpeciesAtom*>(kl.partner(k));
 
                 // Attempt to add angle term 'jkl'
                 if (!hasAngle(j, k, l))
@@ -224,7 +224,8 @@ void Species::updateIntramolecularTerms()
                                  {
                                      return ((!atomsContains(angle.i())) || (!atomsContains(angle.j())) ||
                                              (!atomsContains(angle.k()))) ||
-                                            ((!hasBond(angle.i(), angle.j())) || (!hasBond(angle.j(), angle.k())));
+                                            ((!hasBond(dynamic_cast<SpeciesAtom*>(angle.i()), dynamic_cast<SpeciesAtom*>(angle.j()))) || 
+                                                (!hasBond(dynamic_cast<SpeciesAtom*>(angle.j()), dynamic_cast<SpeciesAtom*>(angle.k()))));
                                  }),
                   angles_.end());
 
@@ -234,8 +235,9 @@ void Species::updateIntramolecularTerms()
                                    {
                                        return ((!atomsContains(torsion.i())) || (!atomsContains(torsion.j())) ||
                                                (!atomsContains(torsion.k())) || (!atomsContains(torsion.l()))) ||
-                                              ((!hasBond(torsion.i(), torsion.j())) || (!hasBond(torsion.j(), torsion.k())) ||
-                                               (!hasBond(torsion.k(), torsion.l())));
+                                              ((!hasBond(dynamic_cast<SpeciesAtom*>(torsion.i()), dynamic_cast<SpeciesAtom*>(torsion.j()))) || 
+                                                  (!hasBond(dynamic_cast<SpeciesAtom*>(torsion.j()), dynamic_cast<SpeciesAtom*>(torsion.k()))) ||
+                                               (!hasBond(dynamic_cast<SpeciesAtom*>(torsion.k()), dynamic_cast<SpeciesAtom*>(torsion.l()))));
                                    }),
                     torsions_.end());
 
@@ -245,9 +247,9 @@ void Species::updateIntramolecularTerms()
                                     {
                                         return ((!atomsContains(improper.i())) || (!atomsContains(improper.j())) ||
                                                 (!atomsContains(improper.k())) || (!atomsContains(improper.l()))) ||
-                                               ((!hasBond(improper.i(), improper.j())) ||
-                                                (!hasBond(improper.j(), improper.k())) ||
-                                                (!hasBond(improper.k(), improper.l())));
+                                               ((!hasBond(dynamic_cast<SpeciesAtom*>(improper.i()), dynamic_cast<SpeciesAtom*>(improper.j()))) ||
+                                                (!hasBond(dynamic_cast<SpeciesAtom*>(improper.j()), dynamic_cast<SpeciesAtom*>(improper.k()))) ||
+                                                (!hasBond(dynamic_cast<SpeciesAtom*>(improper.k()), dynamic_cast<SpeciesAtom*>(improper.l()))));
                                     }),
                      impropers_.end());
 
@@ -667,7 +669,7 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        std::vector<std::string_view> names = {bond.i()->atomType()->name(), bond.j()->atomType()->name()};
+        std::vector<std::string_view> names = {dynamic_cast<SpeciesAtom*>(bond.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(bond.j())->atomType()->name()};
         std::sort(names.begin(), names.end());
         generateMasterTerm<MasterBond>(
             bond, joinStrings(names, "-"), [&coreData](std::string_view name) { return coreData.getMasterBond(name); },
@@ -682,18 +684,18 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        if (angle.i()->atomType()->name() < angle.k()->atomType()->name())
+        if (dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name() < dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name())
             generateMasterTerm<MasterAngle>(
                 angle,
-                std::format("{}-{}-{}", angle.i()->atomType()->name(), angle.j()->atomType()->name(),
-                            angle.k()->atomType()->name()),
+                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
                 [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
         else
             generateMasterTerm<MasterAngle>(
                 angle,
-                std::format("{}-{}-{}", angle.k()->atomType()->name(), angle.j()->atomType()->name(),
-                            angle.i()->atomType()->name()),
+                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name(), dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
                 [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
     }
@@ -706,18 +708,18 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        if (torsion.i()->atomType()->name() < torsion.l()->atomType()->name())
+        if (dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name() < dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name())
             generateMasterTerm<MasterTorsion>(
                 torsion,
-                std::format("{}-{}-{}-{}", torsion.i()->atomType()->name(), torsion.j()->atomType()->name(),
-                            torsion.k()->atomType()->name(), torsion.l()->atomType()->name()),
+                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterTorsion(name); },
                 [&coreData](auto name) -> MasterTorsion & { return coreData.addMasterTorsion(name); });
         else
             generateMasterTerm<MasterTorsion>(
                 torsion,
-                std::format("{}-{}-{}-{}", torsion.l()->atomType()->name(), torsion.k()->atomType()->name(),
-                            torsion.j()->atomType()->name(), torsion.i()->atomType()->name()),
+                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterTorsion(name); },
                 [&coreData](auto name) -> MasterTorsion & { return coreData.addMasterTorsion(name); });
     }
@@ -730,11 +732,11 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        std::vector<std::string_view> jkl = {improper.j()->atomType()->name(), improper.k()->atomType()->name(),
-                                             improper.l()->atomType()->name()};
+        std::vector<std::string_view> jkl = {dynamic_cast<SpeciesAtom*>(improper.j())->atomType()->name(), dynamic_cast<SpeciesAtom*>(improper.k())->atomType()->name(),
+                                             dynamic_cast<SpeciesAtom*>(improper.l())->atomType()->name()};
         std::sort(jkl.begin(), jkl.end());
         generateMasterTerm<MasterImproper>(
-            improper, std::format("{}-{}", improper.i()->atomType()->name(), joinStrings(jkl, "-")),
+            improper, std::format("{}-{}", dynamic_cast<SpeciesAtom*>(improper.i())->atomType()->name(), joinStrings(jkl, "-")),
             [&coreData](std::string_view name) { return coreData.getMasterImproper(name); },
             [&coreData](auto name) -> MasterImproper & { return coreData.addMasterImproper(name); });
     }

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -159,7 +159,7 @@ void Species::recalculateIntermolecularTerms(double tolerance)
 {
     // Need to detach().
     while (bonds_.size())
-        removeBond(dynamic_cast<SpeciesAtom*>(bonds_[0].i()), dynamic_cast<SpeciesAtom*>(bonds_[0].j()));
+        removeBond(dynamic_cast<SpeciesAtom *>(bonds_[0].i()), dynamic_cast<SpeciesAtom *>(bonds_[0].j()));
 
     addMissingBonds(tolerance);
     updateIntramolecularTerms();
@@ -174,8 +174,8 @@ void Species::updateIntramolecularTerms()
     for (auto &jk : bonds_)
     {
         // Get atoms 'j' and 'k'
-        j = dynamic_cast<SpeciesAtom*>(jk.i());
-        k = dynamic_cast<SpeciesAtom*>(jk.j());
+        j = dynamic_cast<SpeciesAtom *>(jk.i());
+        k = dynamic_cast<SpeciesAtom *>(jk.j());
 
         // Swap j and k over if j is terminal and has only a single bond (i.e. jk)
         if (j->nBonds() == 1)
@@ -189,7 +189,7 @@ void Species::updateIntramolecularTerms()
                 continue;
 
             // Get atom 'i'
-            i = dynamic_cast<SpeciesAtom*>(ij.partner(j));
+            i = dynamic_cast<SpeciesAtom *>(ij.partner(j));
 
             // Attempt to add angle term 'ijk' if 'i' > 'k'
             if (!hasAngle(i, j, k))
@@ -203,7 +203,7 @@ void Species::updateIntramolecularTerms()
                     continue;
 
                 // Get atom 'l'
-                l = dynamic_cast<SpeciesAtom*>(kl.partner(k));
+                l = dynamic_cast<SpeciesAtom *>(kl.partner(k));
 
                 // Attempt to add angle term 'jkl'
                 if (!hasAngle(j, k, l))
@@ -219,39 +219,43 @@ void Species::updateIntramolecularTerms()
     { return std::find_if(atoms_.begin(), atoms_.end(), [&x](const auto &p) { return &p == x; }) != atoms_.end(); };
 
     // Check existing angle terms for any that are invalid
-    angles_.erase(std::remove_if(angles_.begin(), angles_.end(),
-                                 [this, &atomsContains](const auto &angle)
-                                 {
-                                     return ((!atomsContains(angle.i())) || (!atomsContains(angle.j())) ||
-                                             (!atomsContains(angle.k()))) ||
-                                            ((!hasBond(dynamic_cast<SpeciesAtom*>(angle.i()), dynamic_cast<SpeciesAtom*>(angle.j()))) || 
-                                                (!hasBond(dynamic_cast<SpeciesAtom*>(angle.j()), dynamic_cast<SpeciesAtom*>(angle.k()))));
-                                 }),
-                  angles_.end());
+    angles_.erase(
+        std::remove_if(angles_.begin(), angles_.end(),
+                       [this, &atomsContains](const auto &angle)
+                       {
+                           return ((!atomsContains(angle.i())) || (!atomsContains(angle.j())) || (!atomsContains(angle.k()))) ||
+                                  ((!hasBond(dynamic_cast<SpeciesAtom *>(angle.i()), dynamic_cast<SpeciesAtom *>(angle.j()))) ||
+                                   (!hasBond(dynamic_cast<SpeciesAtom *>(angle.j()), dynamic_cast<SpeciesAtom *>(angle.k()))));
+                       }),
+        angles_.end());
 
     // Remove torsions with invalid atoms or bonds
-    torsions_.erase(std::remove_if(torsions_.begin(), torsions_.end(),
-                                   [this, &atomsContains](const auto &torsion)
-                                   {
-                                       return ((!atomsContains(torsion.i())) || (!atomsContains(torsion.j())) ||
-                                               (!atomsContains(torsion.k())) || (!atomsContains(torsion.l()))) ||
-                                              ((!hasBond(dynamic_cast<SpeciesAtom*>(torsion.i()), dynamic_cast<SpeciesAtom*>(torsion.j()))) || 
-                                                  (!hasBond(dynamic_cast<SpeciesAtom*>(torsion.j()), dynamic_cast<SpeciesAtom*>(torsion.k()))) ||
-                                               (!hasBond(dynamic_cast<SpeciesAtom*>(torsion.k()), dynamic_cast<SpeciesAtom*>(torsion.l()))));
-                                   }),
-                    torsions_.end());
+    torsions_.erase(
+        std::remove_if(
+            torsions_.begin(), torsions_.end(),
+            [this, &atomsContains](const auto &torsion)
+            {
+                return ((!atomsContains(torsion.i())) || (!atomsContains(torsion.j())) || (!atomsContains(torsion.k())) ||
+                        (!atomsContains(torsion.l()))) ||
+                       ((!hasBond(dynamic_cast<SpeciesAtom *>(torsion.i()), dynamic_cast<SpeciesAtom *>(torsion.j()))) ||
+                        (!hasBond(dynamic_cast<SpeciesAtom *>(torsion.j()), dynamic_cast<SpeciesAtom *>(torsion.k()))) ||
+                        (!hasBond(dynamic_cast<SpeciesAtom *>(torsion.k()), dynamic_cast<SpeciesAtom *>(torsion.l()))));
+            }),
+        torsions_.end());
 
     // Remove impropers with invalid atoms or bonds
-    impropers_.erase(std::remove_if(impropers_.begin(), impropers_.end(),
-                                    [this, &atomsContains](const auto &improper)
-                                    {
-                                        return ((!atomsContains(improper.i())) || (!atomsContains(improper.j())) ||
-                                                (!atomsContains(improper.k())) || (!atomsContains(improper.l()))) ||
-                                               ((!hasBond(dynamic_cast<SpeciesAtom*>(improper.i()), dynamic_cast<SpeciesAtom*>(improper.j()))) ||
-                                                (!hasBond(dynamic_cast<SpeciesAtom*>(improper.j()), dynamic_cast<SpeciesAtom*>(improper.k()))) ||
-                                                (!hasBond(dynamic_cast<SpeciesAtom*>(improper.k()), dynamic_cast<SpeciesAtom*>(improper.l()))));
-                                    }),
-                     impropers_.end());
+    impropers_.erase(
+        std::remove_if(
+            impropers_.begin(), impropers_.end(),
+            [this, &atomsContains](const auto &improper)
+            {
+                return ((!atomsContains(improper.i())) || (!atomsContains(improper.j())) || (!atomsContains(improper.k())) ||
+                        (!atomsContains(improper.l()))) ||
+                       ((!hasBond(dynamic_cast<SpeciesAtom *>(improper.i()), dynamic_cast<SpeciesAtom *>(improper.j()))) ||
+                        (!hasBond(dynamic_cast<SpeciesAtom *>(improper.j()), dynamic_cast<SpeciesAtom *>(improper.k()))) ||
+                        (!hasBond(dynamic_cast<SpeciesAtom *>(improper.k()), dynamic_cast<SpeciesAtom *>(improper.l()))));
+            }),
+        impropers_.end());
 
     ++version_;
 }
@@ -669,7 +673,8 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        std::vector<std::string_view> names = {dynamic_cast<SpeciesAtom*>(bond.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(bond.j())->atomType()->name()};
+        std::vector<std::string_view> names = {dynamic_cast<SpeciesAtom *>(bond.i())->atomType()->name(),
+                                               dynamic_cast<SpeciesAtom *>(bond.j())->atomType()->name()};
         std::sort(names.begin(), names.end());
         generateMasterTerm<MasterBond>(
             bond, joinStrings(names, "-"), [&coreData](std::string_view name) { return coreData.getMasterBond(name); },
@@ -684,18 +689,21 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        if (dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name() < dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name())
+        if (dynamic_cast<SpeciesAtom *>(angle.i())->atomType()->name() <
+            dynamic_cast<SpeciesAtom *>(angle.k())->atomType()->name())
             generateMasterTerm<MasterAngle>(
                 angle,
-                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name(),
-                            dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name()),
+                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom *>(angle.i())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(angle.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(angle.k())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
                 [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
         else
             generateMasterTerm<MasterAngle>(
                 angle,
-                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name(), dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name(),
-                            dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name()),
+                std::format("{}-{}-{}", dynamic_cast<SpeciesAtom *>(angle.k())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(angle.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(angle.i())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterAngle(name); },
                 [&coreData](auto name) -> MasterAngle & { return coreData.addMasterAngle(name); });
     }
@@ -708,18 +716,23 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        if (dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name() < dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name())
+        if (dynamic_cast<SpeciesAtom *>(torsion.i())->atomType()->name() <
+            dynamic_cast<SpeciesAtom *>(torsion.l())->atomType()->name())
             generateMasterTerm<MasterTorsion>(
                 torsion,
-                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name(),
-                            dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name()),
+                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom *>(torsion.i())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.k())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.l())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterTorsion(name); },
                 [&coreData](auto name) -> MasterTorsion & { return coreData.addMasterTorsion(name); });
         else
             generateMasterTerm<MasterTorsion>(
                 torsion,
-                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name(),
-                            dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name(), dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name()),
+                std::format("{}-{}-{}-{}", dynamic_cast<SpeciesAtom *>(torsion.l())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.k())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.j())->atomType()->name(),
+                            dynamic_cast<SpeciesAtom *>(torsion.i())->atomType()->name()),
                 [&coreData](std::string_view name) { return coreData.getMasterTorsion(name); },
                 [&coreData](auto name) -> MasterTorsion & { return coreData.addMasterTorsion(name); });
     }
@@ -732,11 +745,13 @@ void Species::reduceToMasterTerms(CoreData &coreData, bool selectionOnly)
             continue;
 
         // Construct a name for the master term based on the atom types
-        std::vector<std::string_view> jkl = {dynamic_cast<SpeciesAtom*>(improper.j())->atomType()->name(), dynamic_cast<SpeciesAtom*>(improper.k())->atomType()->name(),
-                                             dynamic_cast<SpeciesAtom*>(improper.l())->atomType()->name()};
+        std::vector<std::string_view> jkl = {dynamic_cast<SpeciesAtom *>(improper.j())->atomType()->name(),
+                                             dynamic_cast<SpeciesAtom *>(improper.k())->atomType()->name(),
+                                             dynamic_cast<SpeciesAtom *>(improper.l())->atomType()->name()};
         std::sort(jkl.begin(), jkl.end());
         generateMasterTerm<MasterImproper>(
-            improper, std::format("{}-{}", dynamic_cast<SpeciesAtom*>(improper.i())->atomType()->name(), joinStrings(jkl, "-")),
+            improper,
+            std::format("{}-{}", dynamic_cast<SpeciesAtom *>(improper.i())->atomType()->name(), joinStrings(jkl, "-")),
             [&coreData](std::string_view name) { return coreData.getMasterImproper(name); },
             [&coreData](auto name) -> MasterImproper & { return coreData.addMasterImproper(name); });
     }

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -352,8 +352,8 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, C
 bool Forcefield::assignBondTermParameters(const Species *parent, SpeciesBond &bond, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    auto *i = dynamic_cast<SpeciesAtom*>(bond.i());
-    auto *j = dynamic_cast<SpeciesAtom*>(bond.j());
+    auto *i = dynamic_cast<SpeciesAtom *>(bond.i());
+    auto *j = dynamic_cast<SpeciesAtom *>(bond.j());
 
     auto atomTypes = getAtomTypes({i, j}, determineTypes);
     if (atomTypes.size() != 2)
@@ -374,9 +374,9 @@ bool Forcefield::assignBondTermParameters(const Species *parent, SpeciesBond &bo
 bool Forcefield::assignAngleTermParameters(const Species *parent, SpeciesAngle &angle, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    auto *i = dynamic_cast<SpeciesAtom*>(angle.i());
-    auto *j = dynamic_cast<SpeciesAtom*>(angle.j());
-    auto *k = dynamic_cast<SpeciesAtom*>(angle.k());
+    auto *i = dynamic_cast<SpeciesAtom *>(angle.i());
+    auto *j = dynamic_cast<SpeciesAtom *>(angle.j());
+    auto *k = dynamic_cast<SpeciesAtom *>(angle.k());
 
     auto atomTypes = getAtomTypes({i, j, k}, determineTypes);
     if (atomTypes.size() != 3)
@@ -398,10 +398,10 @@ bool Forcefield::assignAngleTermParameters(const Species *parent, SpeciesAngle &
 bool Forcefield::assignTorsionTermParameters(const Species *parent, SpeciesTorsion &torsion, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    SpeciesAtom *i = dynamic_cast<SpeciesAtom*>(torsion.i());
-    SpeciesAtom *j = dynamic_cast<SpeciesAtom*>(torsion.j());
-    SpeciesAtom *k = dynamic_cast<SpeciesAtom*>(torsion.k());
-    SpeciesAtom *l = dynamic_cast<SpeciesAtom*>(torsion.l());
+    SpeciesAtom *i = dynamic_cast<SpeciesAtom *>(torsion.i());
+    SpeciesAtom *j = dynamic_cast<SpeciesAtom *>(torsion.j());
+    SpeciesAtom *k = dynamic_cast<SpeciesAtom *>(torsion.k());
+    SpeciesAtom *l = dynamic_cast<SpeciesAtom *>(torsion.l());
 
     auto atomTypes = getAtomTypes({i, j, k, l}, determineTypes);
     if (atomTypes.size() != 4)
@@ -517,12 +517,9 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                             continue;
 
                         // Try to assign / generate an improper term (which may legitimately not exist)
-                        if (!assignImproperTermParameters(improperTerm, 
-                            dynamic_cast<SpeciesAtom *>(&i), 
-                            dynamic_cast<SpeciesAtom*>(j), 
-                            dynamic_cast<SpeciesAtom*>(k), 
-                            dynamic_cast<SpeciesAtom*>(l), 
-                            determineTypes))
+                        if (!assignImproperTermParameters(improperTerm, dynamic_cast<SpeciesAtom *>(&i),
+                                                          dynamic_cast<SpeciesAtom *>(j), dynamic_cast<SpeciesAtom *>(k),
+                                                          dynamic_cast<SpeciesAtom *>(l), determineTypes))
                             return false;
 
                         if (improperTerm.form() == TorsionFunctions::Form::None)

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -352,8 +352,8 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, C
 bool Forcefield::assignBondTermParameters(const Species *parent, SpeciesBond &bond, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    auto *i = bond.i();
-    auto *j = bond.j();
+    auto *i = dynamic_cast<SpeciesAtom*>(bond.i());
+    auto *j = dynamic_cast<SpeciesAtom*>(bond.j());
 
     auto atomTypes = getAtomTypes({i, j}, determineTypes);
     if (atomTypes.size() != 2)
@@ -374,9 +374,9 @@ bool Forcefield::assignBondTermParameters(const Species *parent, SpeciesBond &bo
 bool Forcefield::assignAngleTermParameters(const Species *parent, SpeciesAngle &angle, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    auto *i = angle.i();
-    auto *j = angle.j();
-    auto *k = angle.k();
+    auto *i = dynamic_cast<SpeciesAtom*>(angle.i());
+    auto *j = dynamic_cast<SpeciesAtom*>(angle.j());
+    auto *k = dynamic_cast<SpeciesAtom*>(angle.k());
 
     auto atomTypes = getAtomTypes({i, j, k}, determineTypes);
     if (atomTypes.size() != 3)
@@ -398,10 +398,10 @@ bool Forcefield::assignAngleTermParameters(const Species *parent, SpeciesAngle &
 bool Forcefield::assignTorsionTermParameters(const Species *parent, SpeciesTorsion &torsion, bool determineTypes) const
 {
     // Default implementation - search term lists in the forcefield
-    SpeciesAtom *i = torsion.i();
-    SpeciesAtom *j = torsion.j();
-    SpeciesAtom *k = torsion.k();
-    SpeciesAtom *l = torsion.l();
+    SpeciesAtom *i = dynamic_cast<SpeciesAtom*>(torsion.i());
+    SpeciesAtom *j = dynamic_cast<SpeciesAtom*>(torsion.j());
+    SpeciesAtom *k = dynamic_cast<SpeciesAtom*>(torsion.k());
+    SpeciesAtom *l = dynamic_cast<SpeciesAtom*>(torsion.l());
 
     auto atomTypes = getAtomTypes({i, j, k, l}, determineTypes);
     if (atomTypes.size() != 4)
@@ -517,7 +517,12 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                             continue;
 
                         // Try to assign / generate an improper term (which may legitimately not exist)
-                        if (!assignImproperTermParameters(improperTerm, &i, j, k, l, determineTypes))
+                        if (!assignImproperTermParameters(improperTerm, 
+                            dynamic_cast<SpeciesAtom *>(&i), 
+                            dynamic_cast<SpeciesAtom*>(j), 
+                            dynamic_cast<SpeciesAtom*>(k), 
+                            dynamic_cast<SpeciesAtom*>(l), 
+                            determineTypes))
                             return false;
 
                         if (improperTerm.form() == TorsionFunctions::Form::None)
@@ -525,9 +530,11 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
 
                         // If an improper term already exists in the species, overwrite its parameters. Otherwise, create a new
                         // one.
-                        auto optImproper = sp->getImproper(&i, j, k, l);
+                        auto optImproper = sp->getImproper(dynamic_cast<SpeciesAtom *>(&i), dynamic_cast<SpeciesAtom *>(j),
+                                                           dynamic_cast<SpeciesAtom *>(k), dynamic_cast<SpeciesAtom *>(l));
                         if (!optImproper)
-                            optImproper = sp->addImproper(&i, j, k, l);
+                            optImproper = sp->addImproper(dynamic_cast<SpeciesAtom *>(&i), dynamic_cast<SpeciesAtom *>(j),
+                                                          dynamic_cast<SpeciesAtom *>(k), dynamic_cast<SpeciesAtom *>(l));
                         SpeciesImproper &improper = *optImproper;
 
                         improper.setInteractionFormAndParameters(improperTerm.form(), improperTerm.parameters());

--- a/src/data/ff/uff/uff.cpp
+++ b/src/data/ff/uff/uff.cpp
@@ -334,8 +334,10 @@ double Forcefield_UFF::electronegativityCorrection(const ForcefieldAtomType &i, 
 // Assign / generate bond term parameters
 bool Forcefield_UFF::assignBondTermParameters(const Species *parent, SpeciesBond &bond, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(bond.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(bond.i())->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(bond.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(bond.j())->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(bond.i()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(bond.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(bond.j()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(bond.j())->atomType()->name());
     if (!typeI || !typeJ)
         return Messenger::error("Failed to create parameters for bond {}-{} (atom types could not be determined).\n",
                                 bond.i()->userIndex(), bond.j()->userIndex());
@@ -365,9 +367,12 @@ bool Forcefield_UFF::assignBondTermParameters(const Species *parent, SpeciesBond
 // Assign / generate angle term parameters
 bool Forcefield_UFF::assignAngleTermParameters(const Species *parent, SpeciesAngle &angle, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name());
-    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.k())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(angle.i()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(angle.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(angle.j()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(angle.j())->atomType()->name());
+    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(angle.k()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(angle.k())->atomType()->name());
 
     if (!typeI || !typeJ || !typeK)
         Messenger::error("Failed to create parameters for angle {}-{}-{} (atom types could not be determined).\n",
@@ -432,10 +437,14 @@ bool Forcefield_UFF::assignAngleTermParameters(const Species *parent, SpeciesAng
 // Assign / generate torsion term parameters
 bool Forcefield_UFF::assignTorsionTermParameters(const Species *parent, SpeciesTorsion &torsion, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name());
-    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.k())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name());
-    auto typeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.l())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(torsion.i()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(torsion.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(torsion.j()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(torsion.j())->atomType()->name());
+    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(torsion.k()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(torsion.k())->atomType()->name());
+    auto typeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(torsion.l()))
+                                : atomTypeByName(dynamic_cast<SpeciesAtom *>(torsion.l())->atomType()->name());
 
     if (!typeI || !typeJ || !typeK || !typeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",
@@ -528,10 +537,14 @@ bool Forcefield_UFF::assignTorsionTermParameters(const Species *parent, SpeciesT
 bool Forcefield_UFF::assignImproperTermParameters(ForcefieldImproperTerm &improper, SpeciesAtom *i, SpeciesAtom *j,
                                                   SpeciesAtom *k, SpeciesAtom *l, bool determineTypes) const
 {
-    auto optTypeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(i)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(i)->atomType()->name());
-    auto optTypeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(j)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(j)->atomType()->name());
-    auto optTypeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(k)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(k)->atomType()->name());
-    auto optTypeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(l)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(l)->atomType()->name());
+    auto optTypeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(i))
+                                   : atomTypeByName(dynamic_cast<SpeciesAtom *>(i)->atomType()->name());
+    auto optTypeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(j))
+                                   : atomTypeByName(dynamic_cast<SpeciesAtom *>(j)->atomType()->name());
+    auto optTypeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(k))
+                                   : atomTypeByName(dynamic_cast<SpeciesAtom *>(k)->atomType()->name());
+    auto optTypeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom *>(l))
+                                   : atomTypeByName(dynamic_cast<SpeciesAtom *>(l)->atomType()->name());
 
     if (!optTypeI || !optTypeJ || !optTypeK || !optTypeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",

--- a/src/data/ff/uff/uff.cpp
+++ b/src/data/ff/uff/uff.cpp
@@ -334,8 +334,8 @@ double Forcefield_UFF::electronegativityCorrection(const ForcefieldAtomType &i, 
 // Assign / generate bond term parameters
 bool Forcefield_UFF::assignBondTermParameters(const Species *parent, SpeciesBond &bond, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*bond.i()) : atomTypeByName(bond.i()->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*bond.j()) : atomTypeByName(bond.j()->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(bond.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(bond.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(bond.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(bond.j())->atomType()->name());
     if (!typeI || !typeJ)
         return Messenger::error("Failed to create parameters for bond {}-{} (atom types could not be determined).\n",
                                 bond.i()->userIndex(), bond.j()->userIndex());
@@ -365,9 +365,9 @@ bool Forcefield_UFF::assignBondTermParameters(const Species *parent, SpeciesBond
 // Assign / generate angle term parameters
 bool Forcefield_UFF::assignAngleTermParameters(const Species *parent, SpeciesAngle &angle, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*angle.i()) : atomTypeByName(angle.i()->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*angle.j()) : atomTypeByName(angle.j()->atomType()->name());
-    auto typeK = determineTypes ? determineAtomType(*angle.k()) : atomTypeByName(angle.k()->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.j())->atomType()->name());
+    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(angle.k())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(angle.k())->atomType()->name());
 
     if (!typeI || !typeJ || !typeK)
         Messenger::error("Failed to create parameters for angle {}-{}-{} (atom types could not be determined).\n",
@@ -432,10 +432,10 @@ bool Forcefield_UFF::assignAngleTermParameters(const Species *parent, SpeciesAng
 // Assign / generate torsion term parameters
 bool Forcefield_UFF::assignTorsionTermParameters(const Species *parent, SpeciesTorsion &torsion, bool determineTypes) const
 {
-    auto typeI = determineTypes ? determineAtomType(*torsion.i()) : atomTypeByName(torsion.i()->atomType()->name());
-    auto typeJ = determineTypes ? determineAtomType(*torsion.j()) : atomTypeByName(torsion.j()->atomType()->name());
-    auto typeK = determineTypes ? determineAtomType(*torsion.k()) : atomTypeByName(torsion.k()->atomType()->name());
-    auto typeL = determineTypes ? determineAtomType(*torsion.l()) : atomTypeByName(torsion.l()->atomType()->name());
+    auto typeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.i())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.i())->atomType()->name());
+    auto typeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.j())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.j())->atomType()->name());
+    auto typeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.k())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.k())->atomType()->name());
+    auto typeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(torsion.l())) : atomTypeByName(dynamic_cast<SpeciesAtom*>(torsion.l())->atomType()->name());
 
     if (!typeI || !typeJ || !typeK || !typeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",
@@ -528,10 +528,10 @@ bool Forcefield_UFF::assignTorsionTermParameters(const Species *parent, SpeciesT
 bool Forcefield_UFF::assignImproperTermParameters(ForcefieldImproperTerm &improper, SpeciesAtom *i, SpeciesAtom *j,
                                                   SpeciesAtom *k, SpeciesAtom *l, bool determineTypes) const
 {
-    auto optTypeI = determineTypes ? determineAtomType(*i) : atomTypeByName(i->atomType()->name());
-    auto optTypeJ = determineTypes ? determineAtomType(*j) : atomTypeByName(j->atomType()->name());
-    auto optTypeK = determineTypes ? determineAtomType(*k) : atomTypeByName(k->atomType()->name());
-    auto optTypeL = determineTypes ? determineAtomType(*l) : atomTypeByName(l->atomType()->name());
+    auto optTypeI = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(i)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(i)->atomType()->name());
+    auto optTypeJ = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(j)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(j)->atomType()->name());
+    auto optTypeK = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(k)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(k)->atomType()->name());
+    auto optTypeL = determineTypes ? determineAtomType(*dynamic_cast<SpeciesAtom*>(l)) : atomTypeByName(dynamic_cast<SpeciesAtom*>(l)->atomType()->name());
 
     if (!optTypeI || !optTypeJ || !optTypeK || !optTypeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",

--- a/src/data/ff/zhao2010/zhao2010.cpp
+++ b/src/data/ff/zhao2010/zhao2010.cpp
@@ -108,7 +108,7 @@ bool Forcefield_Zhao2010::assignAngleTermParameters(const Species *parent, Speci
     // as harmonic angles and we have a mix of ~180 and ~90 angles.
 
     // Is this an O-Cu-O angle?
-    if (angle.i()->Z() == Elements::O && angle.j()->Z() == Elements::Cu && angle.k()->Z() == Elements::O)
+    if (dynamic_cast<SpeciesAtom*>(angle.i())->Z() == Elements::O && dynamic_cast<SpeciesAtom*>(angle.j())->Z() == Elements::Cu && dynamic_cast<SpeciesAtom*>(angle.k())->Z() == Elements::O)
     {
         // Determine the geometry
         auto theta = parent->box()->angleInDegrees(angle.i()->r(), angle.j()->r(), angle.k()->r());

--- a/src/data/ff/zhao2010/zhao2010.cpp
+++ b/src/data/ff/zhao2010/zhao2010.cpp
@@ -108,7 +108,9 @@ bool Forcefield_Zhao2010::assignAngleTermParameters(const Species *parent, Speci
     // as harmonic angles and we have a mix of ~180 and ~90 angles.
 
     // Is this an O-Cu-O angle?
-    if (dynamic_cast<SpeciesAtom*>(angle.i())->Z() == Elements::O && dynamic_cast<SpeciesAtom*>(angle.j())->Z() == Elements::Cu && dynamic_cast<SpeciesAtom*>(angle.k())->Z() == Elements::O)
+    if (dynamic_cast<SpeciesAtom *>(angle.i())->Z() == Elements::O &&
+        dynamic_cast<SpeciesAtom *>(angle.j())->Z() == Elements::Cu &&
+        dynamic_cast<SpeciesAtom *>(angle.k())->Z() == Elements::O)
     {
         // Determine the geometry
         auto theta = parent->box()->angleInDegrees(angle.i()->r(), angle.j()->r(), angle.k()->r());

--- a/src/gui/copySpeciesTermsDialog.cpp
+++ b/src/gui/copySpeciesTermsDialog.cpp
@@ -70,22 +70,25 @@ void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<Intra *, cons
 
         // Check for a suitable term in the target species
         auto js = targetTerm.atoms();
-        auto it = std::find_if(sourceTerms.begin(), sourceTerms.end(),
-                               [js](const auto &sourceTerm)
-                               {
-                                   // Assess atom types between the two terms, from both vector directions
-                                   auto n = 0;
-                                   auto sameForwards = true, sameBackwards = true;
-                                   for (const auto *i : sourceTerm.atoms())
-                                   {
-                                       if (sameForwards && dynamic_cast<const SpeciesAtom*>(i)->atomType() != dynamic_cast<const SpeciesAtom*>(js[n])->atomType())
-                                           sameForwards = false;
-                                       if (sameBackwards && dynamic_cast<const SpeciesAtom*>(i)->atomType() != dynamic_cast<const SpeciesAtom*>(js[js.size() - n - 1])->atomType())
-                                           sameBackwards = false;
-                                       ++n;
-                                   }
-                                   return sameForwards || sameBackwards;
-                               });
+        auto it =
+            std::find_if(sourceTerms.begin(), sourceTerms.end(),
+                         [js](const auto &sourceTerm)
+                         {
+                             // Assess atom types between the two terms, from both vector directions
+                             auto n = 0;
+                             auto sameForwards = true, sameBackwards = true;
+                             for (const auto *i : sourceTerm.atoms())
+                             {
+                                 if (sameForwards && dynamic_cast<const SpeciesAtom *>(i)->atomType() !=
+                                                         dynamic_cast<const SpeciesAtom *>(js[n])->atomType())
+                                     sameForwards = false;
+                                 if (sameBackwards && dynamic_cast<const SpeciesAtom *>(i)->atomType() !=
+                                                          dynamic_cast<const SpeciesAtom *>(js[js.size() - n - 1])->atomType())
+                                     sameBackwards = false;
+                                 ++n;
+                             }
+                             return sameForwards || sameBackwards;
+                         });
         if (it != sourceTerms.end())
             termVector.emplace_back(&targetTerm, &(*it));
     }

--- a/src/gui/copySpeciesTermsDialog.cpp
+++ b/src/gui/copySpeciesTermsDialog.cpp
@@ -78,9 +78,9 @@ void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<Intra *, cons
                                    auto sameForwards = true, sameBackwards = true;
                                    for (const auto *i : sourceTerm.atoms())
                                    {
-                                       if (sameForwards && i->atomType() != js[n]->atomType())
+                                       if (sameForwards && dynamic_cast<SpeciesAtom*>(i)->atomType() != dynamic_cast<SpeciesAtom*>(js[n])->atomType())
                                            sameForwards = false;
-                                       if (sameBackwards && i->atomType() != js[js.size() - n - 1]->atomType())
+                                       if (sameBackwards && dynamic_cast<SpeciesAtom*>(i)->atomType() != dynamic_cast<SpeciesAtom*>(js[js.size() - n - 1])->atomType())
                                            sameBackwards = false;
                                        ++n;
                                    }

--- a/src/gui/copySpeciesTermsDialog.cpp
+++ b/src/gui/copySpeciesTermsDialog.cpp
@@ -78,9 +78,9 @@ void CopySpeciesTermsDialog::findTermsToCopy(std::vector<std::pair<Intra *, cons
                                    auto sameForwards = true, sameBackwards = true;
                                    for (const auto *i : sourceTerm.atoms())
                                    {
-                                       if (sameForwards && dynamic_cast<SpeciesAtom*>(i)->atomType() != dynamic_cast<SpeciesAtom*>(js[n])->atomType())
+                                       if (sameForwards && dynamic_cast<const SpeciesAtom*>(i)->atomType() != dynamic_cast<const SpeciesAtom*>(js[n])->atomType())
                                            sameForwards = false;
-                                       if (sameBackwards && dynamic_cast<SpeciesAtom*>(i)->atomType() != dynamic_cast<SpeciesAtom*>(js[js.size() - n - 1])->atomType())
+                                       if (sameBackwards && dynamic_cast<const SpeciesAtom*>(i)->atomType() != dynamic_cast<const SpeciesAtom*>(js[js.size() - n - 1])->atomType())
                                            sameBackwards = false;
                                        ++n;
                                    }

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -88,7 +88,7 @@ std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateGrapheneSpeciesDialog:
         {
             auto *j = b.get().partner(&i);
             if ((i.r() - j->r()).magnitude() > localCutoff)
-                pbcJ.push_back(j);
+                pbcJ.push_back(dynamic_cast<SpeciesAtom*>(j));
         }
 
         if (pbcJ.size() == 2)
@@ -121,9 +121,9 @@ void CreateGrapheneSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, V
     {
         auto j = b.get().partner(i);
         if ((i->r() - j->r()).magnitude() > localCutoff)
-            pbcJ.push_back(j);
+            pbcJ.push_back(dynamic_cast<SpeciesAtom*>(j));
         else if (std::find(branch.begin(), branch.end(), j) == branch.end())
-            localJ.push_back(j);
+            localJ.push_back(dynamic_cast<SpeciesAtom*>(j));
     }
 
     // If all atoms are local this is a completely internally-bound atom, and we are done here.

--- a/src/gui/createGrapheneSpeciesDialog.cpp
+++ b/src/gui/createGrapheneSpeciesDialog.cpp
@@ -88,7 +88,7 @@ std::map<SpeciesAtom *, std::vector<SpeciesAtom *>> CreateGrapheneSpeciesDialog:
         {
             auto *j = b.get().partner(&i);
             if ((i.r() - j->r()).magnitude() > localCutoff)
-                pbcJ.push_back(dynamic_cast<SpeciesAtom*>(j));
+                pbcJ.push_back(dynamic_cast<SpeciesAtom *>(j));
         }
 
         if (pbcJ.size() == 2)
@@ -121,9 +121,9 @@ void CreateGrapheneSpeciesDialog::extendBranch(SpeciesAtom *i, const Box *box, V
     {
         auto j = b.get().partner(i);
         if ((i->r() - j->r()).magnitude() > localCutoff)
-            pbcJ.push_back(dynamic_cast<SpeciesAtom*>(j));
+            pbcJ.push_back(dynamic_cast<SpeciesAtom *>(j));
         else if (std::find(branch.begin(), branch.end(), j) == branch.end())
-            localJ.push_back(dynamic_cast<SpeciesAtom*>(j));
+            localJ.push_back(dynamic_cast<SpeciesAtom *>(j));
     }
 
     // If all atoms are local this is a completely internally-bound atom, and we are done here.

--- a/src/gui/render/renderableConfiguration.cpp
+++ b/src/gui/render/renderableConfiguration.cpp
@@ -135,10 +135,12 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
                         0.5;
 
                     // Draw bond halves
-                    lineConfigurationPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
-                                                      ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()).data());
-                    lineConfigurationPrimitive_->line(rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
-                                                      ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()).data());
+                    lineConfigurationPrimitive_->line(
+                        ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
+                        ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.i())->Z()).data());
+                    lineConfigurationPrimitive_->line(
+                        rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
+                        ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.j())->Z()).data());
                 }
             }
         }

--- a/src/gui/render/renderableConfiguration.cpp
+++ b/src/gui/render/renderableConfiguration.cpp
@@ -136,9 +136,9 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
 
                     // Draw bond halves
                     lineConfigurationPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
-                                                      ElementColours::colour(bond.i()->Z()).data());
+                                                      ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()).data());
                     lineConfigurationPrimitive_->line(rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
-                                                      ElementColours::colour(bond.j()->Z()).data());
+                                                      ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()).data());
                 }
             }
         }

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -168,9 +168,9 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
 
             // Draw bond halves
             lineSpeciesPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
-                                        ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()).data());
+                                        ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.i())->Z()).data());
             lineSpeciesPrimitive_->line(rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
-                                        ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()).data());
+                                        ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.j())->Z()).data());
         }
     }
     else if (displayStyle_ == SpheresStyle)
@@ -201,11 +201,13 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
             if (periodic)
                 speciesAssembly_.createCylinderBond(
                     bondPrimitive_, bond.i()->r(), bond.j()->r(), source_->box()->minimumVector(bond.i()->r(), bond.j()->r()),
-                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()), ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()), true, spheresBondRadius_);
+                    ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.j())->Z()),
+                    ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.i())->Z()), true, spheresBondRadius_);
             else
                 speciesAssembly_.createCylinderBond(bondPrimitive_, bond.i()->r(), bond.j()->r(), bond.j()->r() - bond.i()->r(),
-                                                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()),
-                                                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()), false, spheresBondRadius_);
+                                                    ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.i())->Z()),
+                                                    ElementColours::colour(dynamic_cast<SpeciesAtom *>(bond.j())->Z()), false,
+                                                    spheresBondRadius_);
         }
     }
 

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -168,9 +168,9 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
 
             // Draw bond halves
             lineSpeciesPrimitive_->line(ri.x, ri.y, ri.z, ri.x + dij.x, ri.y + dij.y, ri.z + dij.z,
-                                        ElementColours::colour(bond.i()->Z()).data());
+                                        ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()).data());
             lineSpeciesPrimitive_->line(rj.x, rj.y, rj.z, rj.x - dij.x, rj.y - dij.y, rj.z - dij.z,
-                                        ElementColours::colour(bond.j()->Z()).data());
+                                        ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()).data());
         }
     }
     else if (displayStyle_ == SpheresStyle)
@@ -201,11 +201,11 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
             if (periodic)
                 speciesAssembly_.createCylinderBond(
                     bondPrimitive_, bond.i()->r(), bond.j()->r(), source_->box()->minimumVector(bond.i()->r(), bond.j()->r()),
-                    ElementColours::colour(bond.j()->Z()), ElementColours::colour(bond.i()->Z()), true, spheresBondRadius_);
+                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()), ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()), true, spheresBondRadius_);
             else
                 speciesAssembly_.createCylinderBond(bondPrimitive_, bond.i()->r(), bond.j()->r(), bond.j()->r() - bond.i()->r(),
-                                                    ElementColours::colour(bond.i()->Z()),
-                                                    ElementColours::colour(bond.j()->Z()), false, spheresBondRadius_);
+                                                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.i())->Z()),
+                                                    ElementColours::colour(dynamic_cast<SpeciesAtom*>(bond.j())->Z()), false, spheresBondRadius_);
         }
     }
 

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -1244,14 +1244,14 @@ CIFHandler::matchAtom(const SpeciesAtom *referenceAtom, const SpeciesAtom *insta
     for (const auto &referenceBond : referenceAtom->bonds())
     {
         // Get the reference bond partner
-        auto *referenceBondPartner = referenceBond.get().partner(referenceAtom);
+        auto *referenceBondPartner = dynamic_cast<SpeciesAtom*>(referenceBond.get().partner(referenceAtom));
 
         // Try to find a match over bonds on the instance atom
         std::map<const SpeciesAtom *, const SpeciesAtom *> bondResult;
         for (const auto &instanceBond : instanceAtom->bonds())
         {
             // Get the instance bond partner
-            auto *instanceBondPartner = instanceBond.get().partner(instanceAtom);
+            auto *instanceBondPartner = dynamic_cast<SpeciesAtom*>(instanceBond.get().partner(instanceAtom));
 
             // Recurse
             bondResult = matchAtom(referenceBondPartner, instanceBondPartner, refNETA, newMap);

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -1244,14 +1244,14 @@ CIFHandler::matchAtom(const SpeciesAtom *referenceAtom, const SpeciesAtom *insta
     for (const auto &referenceBond : referenceAtom->bonds())
     {
         // Get the reference bond partner
-        auto *referenceBondPartner = dynamic_cast<SpeciesAtom*>(referenceBond.get().partner(referenceAtom));
+        auto *referenceBondPartner = dynamic_cast<SpeciesAtom *>(referenceBond.get().partner(referenceAtom));
 
         // Try to find a match over bonds on the instance atom
         std::map<const SpeciesAtom *, const SpeciesAtom *> bondResult;
         for (const auto &instanceBond : instanceAtom->bonds())
         {
             // Get the instance bond partner
-            auto *instanceBondPartner = dynamic_cast<SpeciesAtom*>(instanceBond.get().partner(instanceAtom));
+            auto *instanceBondPartner = dynamic_cast<SpeciesAtom *>(instanceBond.get().partner(instanceAtom));
 
             // Recurse
             bondResult = matchAtom(referenceBondPartner, instanceBondPartner, refNETA, newMap);

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -72,7 +72,7 @@ bool ClusteringModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSigna
                                 Messenger::error("Inaccessible bond partner found, skipping...");
                                 continue;
                             }
-                            if (atom->Z() == Elements::H)
+                            if (dynamic_cast<const SpeciesAtom*>(atom)->Z() == Elements::H)
                                 directionIndexes_[s].emplace(atom->index());
                         }
                 }

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -72,7 +72,7 @@ bool ClusteringModule::setUp(Dissolve &dissolve, Flags<KeywordBase::KeywordSigna
                                 Messenger::error("Inaccessible bond partner found, skipping...");
                                 continue;
                             }
-                            if (dynamic_cast<const SpeciesAtom*>(atom)->Z() == Elements::H)
+                            if (dynamic_cast<const SpeciesAtom *>(atom)->Z() == Elements::H)
                                 directionIndexes_[s].emplace(atom->index());
                         }
                 }

--- a/src/modules/forces/functions.cpp
+++ b/src/modules/forces/functions.cpp
@@ -68,11 +68,11 @@ void ForcesModule::totalForces(const Species *sp, const PotentialMap &potentialM
         assert(sp->nAtoms() == r->get().size());
 
     // Set position retrieval function
-    std::function<Vector3(int, const SpeciesAtom *)> rFunction;
+    std::function<Vector3(int, const SpeciesParticle *)> rFunction;
     if (r)
-        rFunction = [&r, sp](int id, const SpeciesAtom *i) { return r->get()[id]; };
+        rFunction = [&r, sp](int id, const SpeciesParticle *i) { return r->get()[id]; };
     else
-        rFunction = [sp](int id, const SpeciesAtom *i) { return i->r(); };
+        rFunction = [sp](int id, const SpeciesParticle *i) { return i->r(); };
 
     // Zero force arrays
     std::fill(fUnbound.begin(), fUnbound.end(), Vector3());

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -122,7 +122,7 @@ int NETAConnectionNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath)
     std::map<const SpeciesAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
     for (const SpeciesBond &bond : i->bonds())
     {
-        const auto *partner = bond.partner(i);
+        const auto *partner = dynamic_cast<SpeciesAtom*>(bond.partner(i));
 
         // Search for this atom in the current match path
         if (!matchPath.contains(partner) || (allowRootMatch_ && matchPath.isRoot(partner)))

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -122,7 +122,7 @@ int NETAConnectionNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath)
     std::map<const SpeciesAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
     for (const SpeciesBond &bond : i->bonds())
     {
-        const auto *partner = dynamic_cast<SpeciesAtom*>(bond.partner(i));
+        const auto *partner = dynamic_cast<SpeciesAtom *>(bond.partner(i));
 
         // Search for this atom in the current match path
         if (!matchPath.contains(partner) || (allowRootMatch_ && matchPath.isRoot(partner)))

--- a/src/neta/hydrogenCount.cpp
+++ b/src/neta/hydrogenCount.cpp
@@ -32,8 +32,8 @@ int NETAHydrogenCountNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPa
         return NETANode::NoMatch;
 
     // Count number of hydrogens attached to this atom
-    auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
-                            [i](const SpeciesBond &bond) { return dynamic_cast<SpeciesAtom*>(bond.partner(i))->Z() == Elements::H; });
+    auto nH = std::count_if(i->bonds().begin(), i->bonds().end(), [i](const SpeciesBond &bond)
+                            { return dynamic_cast<SpeciesAtom *>(bond.partner(i))->Z() == Elements::H; });
 
     return compareValues(nH, operator_, *value_) ? 1 : NETANode::NoMatch;
 }

--- a/src/neta/hydrogenCount.cpp
+++ b/src/neta/hydrogenCount.cpp
@@ -33,7 +33,7 @@ int NETAHydrogenCountNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPa
 
     // Count number of hydrogens attached to this atom
     auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
-                            [i](const SpeciesBond &bond) { return bond.partner(i)->Z() == Elements::H; });
+                            [i](const SpeciesBond &bond) { return dynamic_cast<SpeciesAtom*>(bond.partner(i))->Z() == Elements::H; });
 
     return compareValues(nH, operator_, *value_) ? 1 : NETANode::NoMatch;
 }

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -113,7 +113,7 @@ std::string netaString(const SpeciesAtom *i, int currentDepth, const std::option
     auto nH = 0;
     for (auto &b : i->bonds())
     {
-        auto j = b.get().partner(i);
+        auto j = dynamic_cast<SpeciesAtom*>(b.get().partner(i));
 
         // Check for H
         if (!flags.isSet(NETADefinition::NETACreationFlags::ExplicitHydrogens) && j->Z() == Elements::H)

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -113,7 +113,7 @@ std::string netaString(const SpeciesAtom *i, int currentDepth, const std::option
     auto nH = 0;
     for (auto &b : i->bonds())
     {
-        auto j = dynamic_cast<SpeciesAtom*>(b.get().partner(i));
+        auto j = dynamic_cast<SpeciesAtom *>(b.get().partner(i));
 
         // Check for H
         if (!flags.isSet(NETADefinition::NETACreationFlags::ExplicitHydrogens) && j->Z() == Elements::H)

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -77,7 +77,7 @@ void NETARingNode::findRings(const SpeciesAtom *currentAtom, std::vector<Species
          * If it is the currentAtom then we have found a cyclic route back to the originating atom.
          * If not, check whether the atom is already elsewhere in the path - if so, continue with the next bond.
          */
-        j = dynamic_cast<SpeciesAtom*>(bond.partner(currentAtom));
+        j = dynamic_cast<SpeciesAtom *>(bond.partner(currentAtom));
         if ((path.size() >= minSize) && (j == path.at(0)))
         {
             // Special case - if NotEqualTo was specified as the comparison operator, check that against the maximum

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -77,7 +77,7 @@ void NETARingNode::findRings(const SpeciesAtom *currentAtom, std::vector<Species
          * If it is the currentAtom then we have found a cyclic route back to the originating atom.
          * If not, check whether the atom is already elsewhere in the path - if so, continue with the next bond.
          */
-        j = bond.partner(currentAtom);
+        j = dynamic_cast<SpeciesAtom*>(bond.partner(currentAtom));
         if ((path.size() >= minSize) && (j == path.at(0)))
         {
             // Special case - if NotEqualTo was specified as the comparison operator, check that against the maximum


### PR DESCRIPTION
Add a base class for an abstract particle from which SpeciesAtom will inherit. This will provide the base for adding in a SpeciesBead class for coarse grained workflows utilising several common properties which facilitate position/force evaluation. All SpeciesIntra classes have also been made to work with the new SpeciesParticle base class requiring dynamic casting in places where retrieving a SpeciesAtom object from a bond is necessary. 