### PR TITLE
fix: Consistent object naming

### DIFF
--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -40,19 +40,10 @@ void Configuration::clear()
  */
 
 // Set name of the Configuration
-void Configuration::setName(std::string_view name)
-{
-    name_ = name;
-
-    // Generate a nice name (i.e. no spaces, slashes etc.)
-    niceName_ = DissolveSys::niceName(name_);
-}
+void Configuration::setName(std::string_view name) { name_ = DissolveSys::niceName(name); }
 
 // Return name of the Configuration
 std::string_view Configuration::name() const { return name_; }
-
-// Return nice name of the Configuration
-std::string_view Configuration::niceName() const { return niceName_; }
 
 // Return the current generator
 Generator &Configuration::generator() { return generator_; }
@@ -64,10 +55,10 @@ bool Configuration::generate(const GeneratorContext &generatorContext)
     empty();
 
     // Generate the contents
-    Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", niceName());
+    Messenger::print("\nExecuting generator procedure for Configuration '{}'...\n\n", name_);
     auto result = generator_.execute({generatorContext, this});
     if (!result)
-        return Messenger::error("Failed to generate Configuration '{}'.\n", niceName());
+        return Messenger::error("Failed to generate Configuration '{}'.\n", name_);
     Messenger::print("\n");
 
     // Set-up Cells for the Box

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -49,8 +49,6 @@ class Configuration : public Serialisable<const CoreData &>
     private:
     // Name of the Configuration
     std::string name_;
-    // Nice name (generated from name_) used for output files
-    std::string niceName_;
     // Generator for the Configuration
     Generator generator_;
     // Temperature of this configuration (K)
@@ -62,8 +60,6 @@ class Configuration : public Serialisable<const CoreData &>
     void setName(std::string_view name);
     // Return name of the Configuration
     std::string_view name() const;
-    // Return nice name of the Configuration
-    std::string_view niceName() const;
     // Return the generator for the Configuration
     Generator &generator();
     // Create the Configuration according to its generator

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -127,7 +127,7 @@ bool Configuration::deserialise(LineParser &parser, const CoreData &coreData, do
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
 
-        auto sp = coreData.findSpecies(parser.argsv(1));
+        auto sp = coreData.findSpecies(DissolveSys::niceName(parser.argsv(1)));
         if (!sp)
             return Messenger::error("Unrecognised Species '{}' found in Configuration '{}' in restart file.\n", parser.argsv(1),
                                     name());
@@ -223,8 +223,8 @@ bool Configuration::deserialise(LineParser &parser, const CoreData &coreData, do
             }
             else if (coreData.findAtomType(parser.args(n)))
                 pot->addTargetAtomType(coreData.findAtomType(parser.args(n)));
-            else if (coreData.findSpecies(parser.args(n)))
-                pot->addTargetSpecies(coreData.findSpecies(parser.args(n)));
+            else if (coreData.findSpecies(DissolveSys::niceName(parser.args(n))))
+                pot->addTargetSpecies(coreData.findSpecies(DissolveSys::niceName(parser.args(n))));
             else
                 Messenger::exception("Unrecognised target '{}' for potential.\n", parser.args(n));
         }

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -624,7 +624,7 @@ Configuration *CoreData::findConfiguration(std::string_view name) const
 Configuration *CoreData::findConfigurationByNiceName(std::string_view name) const
 {
     auto it = std::find_if(configurations().begin(), configurations().end(),
-                           [&name](const auto &cfg) { return DissolveSys::sameString(name, cfg->niceName()); });
+                           [&name](const auto &cfg) { return DissolveSys::sameString(name, cfg->name()); });
     if (it == configurations().end())
         return nullptr;
     return it->get();

--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -20,7 +20,7 @@ void Isotopologue::setParent(const Species *parent) { parent_ = parent; }
 const Species *Isotopologue::parent() const { return parent_; }
 
 // Set name of Isotopologue
-void Isotopologue::setName(std::string_view name) { name_ = name; }
+void Isotopologue::setName(std::string_view name) { name_ = DissolveSys::niceName(name); }
 
 // Return name of Isotopologue
 std::string_view Isotopologue::name() const { return name_; }

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -112,7 +112,7 @@ bool Isotopologues::deserialise(LineParser &parser, const CoreData &coreData)
     // Read Species name
     if (parser.getArgsDelim() != LineParser::Success)
         return false;
-    species_ = coreData.findSpecies(parser.argsv(0));
+    species_ = coreData.findSpecies(DissolveSys::niceName(parser.argsv(0)));
     if (species_ == nullptr)
     {
         Messenger::error("Failed to find Species '{}' while reading Isotopologues.\n", parser.argsv(0));
@@ -127,7 +127,7 @@ bool Isotopologues::deserialise(LineParser &parser, const CoreData &coreData)
             return false;
 
         // Search for the named Isotopologue in the Species
-        const Isotopologue *iso = species_->findIsotopologue(parser.argsv(0));
+        const Isotopologue *iso = species_->findIsotopologue(DissolveSys::niceName(parser.argsv(0)));
         if (!iso)
         {
             Messenger::error("Failed to find Isotopologue '{}' for Species '{}' while reading Isotopologues.\n",

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -54,7 +54,7 @@ void Species::copyBasic(const Species *source, bool copyAtomTypes)
  */
 
 // Set name of the Species
-void Species::setName(std::string_view name) { name_ = name; }
+void Species::setName(std::string_view name) { name_ = DissolveSys::niceName(name); }
 
 // Return the name of the Species
 std::string_view Species::name() const { return name_; }

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -459,7 +459,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                 break;
             case (Species::SpeciesKeyword::Site):
                 // First argument is the name of the site to create - make sure it doesn't exist already
-                site = findSite(parser.argsv(1));
+                site = findSite(DissolveSys::niceName(parser.argsv(1)));
                 if (site)
                 {
                     Messenger::error("The site '{}' already exists on Species '{}', and cannot be redefined.\n",

--- a/src/classes/species_site.cpp
+++ b/src/classes/species_site.cpp
@@ -36,7 +36,7 @@ std::vector<std::unique_ptr<SpeciesSite>> &Species::sites() { return sites_; }
 // Generate unique site name with base name provided
 std::string Species::uniqueSiteName(std::string_view base, const SpeciesSite *exclude) const
 {
-    std::string_view baseName = base.empty() ? "NewSite" : base;
+    auto baseName = DissolveSys::niceName(base.empty() ? "NewSite" : base);
     std::string uniqueName{baseName};
 
     // Find all existing names which are the same as 'existingName' up to the first '_', and get the highest appended number

--- a/src/gui/importSpeciesDialog.cpp
+++ b/src/gui/importSpeciesDialog.cpp
@@ -342,7 +342,7 @@ void ImportSpeciesDialog::on_SpeciesNameEdit_textChanged(const QString text)
     if (text.isEmpty())
         readyForImport = false;
     else
-        readyForImport = dissolve_.coreData().findSpecies(qPrintable(text)) == nullptr;
+        readyForImport = dissolve_.coreData().findSpecies(DissolveSys::niceName(qPrintable(text))) == nullptr;
 
     ui_.SpeciesNameIndicator->setOK(readyForImport);
 

--- a/src/keywords/isotopologueSet.cpp
+++ b/src/keywords/isotopologueSet.cpp
@@ -30,10 +30,10 @@ std::optional<int> IsotopologueSetKeyword::maxArguments() const { return 3; }
 bool IsotopologueSetKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
     // Find specified Species (first argument)
-    Species *sp = coreData.findSpecies(parser.argsv(startArg));
+    Species *sp = coreData.findSpecies(DissolveSys::niceName(parser.argsv(startArg)));
     if (!sp)
         return Messenger::error("Error defining Isotopologue reference - no Species named '{}' exists.\n",
-                                parser.argsv(startArg + 1));
+                                DissolveSys::niceName(parser.argsv(startArg)));
 
     // Finally, locate isotopologue definition for species (second argument)
     const Isotopologue *iso = sp->findIsotopologue(parser.argsv(startArg + 1));

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -24,9 +24,10 @@ const Species *&SpeciesKeyword::data() const { return data_; }
 bool SpeciesKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
     // Find target Species (first argument)
-    data_ = coreData.findSpecies(parser.argsv(startArg));
+    data_ = coreData.findSpecies(DissolveSys::niceName(parser.argsv(startArg)));
     if (!data_)
-        return Messenger::error("Error setting Species - no Species named '{}' exists.\n", parser.argsv(startArg));
+        return Messenger::error("Error setting Species - no Species named '{}' exists.\n",
+                                DissolveSys::niceName(parser.argsv(startArg)));
 
     return true;
 }
@@ -57,5 +58,5 @@ SerialisedValue SpeciesKeyword::serialise() const { return data_->name(); }
 // Read values from a serialisable value
 void SpeciesKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
 {
-    data_ = coreData.findSpecies(std::string_view(std::string(node.as_string())));
+    data_ = coreData.findSpecies(DissolveSys::niceName(std::string(node.as_string())));
 }

--- a/src/keywords/speciesSite.cpp
+++ b/src/keywords/speciesSite.cpp
@@ -36,7 +36,7 @@ std::optional<int> SpeciesSiteKeyword::maxArguments() const { return 2; }
 bool SpeciesSiteKeyword::deserialise(LineParser &parser, int startArg, const CoreData &coreData)
 {
     // Find target Species (first argument)
-    Species *sp = coreData.findSpecies(parser.argsv(startArg));
+    Species *sp = coreData.findSpecies(DissolveSys::niceName(parser.argsv(startArg)));
     if (!sp)
     {
         Messenger::error("Error setting SpeciesSite - no Species named '{}' exists.\n", parser.argsv(startArg));
@@ -44,7 +44,7 @@ bool SpeciesSiteKeyword::deserialise(LineParser &parser, int startArg, const Cor
     }
 
     // Find specified Site (second argument) in the Species
-    data_ = sp->findSite(parser.argsv(startArg + 1));
+    data_ = sp->findSite(DissolveSys::niceName(parser.argsv(startArg + 1)));
     if (!data_)
         return Messenger::error("Error setting SpeciesSite - no such site named '{}' exists in Species '{}'.\n",
                                 parser.argsv(startArg + 1), sp->name());

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -40,12 +40,13 @@ bool SpeciesSiteVectorKeyword::deserialise(LineParser &parser, int startArg, con
     for (int n = startArg; n < parser.nArgs() - 1; n += 2)
     {
         // Find target Species (first argument)
-        Species *sp = coreData.findSpecies(parser.argsv(n));
+        Species *sp = coreData.findSpecies(DissolveSys::niceName(parser.argsv(n)));
         if (!sp)
-            return Messenger::error("Error adding SpeciesSite - no Species named '{}' exists.\n", parser.argsv(n));
+            return Messenger::error("Error adding SpeciesSite - no Species named '{}' exists.\n",
+                                    DissolveSys::niceName(parser.argsv(n)));
 
         // Find specified Site (second argument) in the Species
-        auto speciesSite = sp->findSite(parser.argsv(n + 1));
+        auto speciesSite = sp->findSite(DissolveSys::niceName(parser.argsv(n + 1)));
         if (!speciesSite)
             return Messenger::error("Error setting SpeciesSite - no such site named '{}' exists in Species '{}'.\n",
                                     parser.argsv(n + 1), sp->name());

--- a/src/keywords/speciesVector.cpp
+++ b/src/keywords/speciesVector.cpp
@@ -30,9 +30,10 @@ bool SpeciesVectorKeyword::deserialise(LineParser &parser, int startArg, const C
     // Each argument is the name of a Species
     for (auto n = startArg; n < parser.nArgs(); ++n)
     {
-        const auto *sp = coreData.findSpecies(parser.argsv(n));
+        const auto *sp = coreData.findSpecies(DissolveSys::niceName(parser.argsv(n)));
         if (!sp)
-            return Messenger::error("Error reading keyword '{}' - no Species named '{}' exists.\n", name(), parser.argsv(n));
+            return Messenger::error("Error reading keyword '{}' - no Species named '{}' exists.\n", name(),
+                                    DissolveSys::niceName(parser.argsv(n)));
 
         data_.push_back(sp);
     }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -80,7 +80,7 @@ bool Dissolve::loadInput(LineParser &parser)
                 break;
             case (BlockKeywords::SpeciesBlockKeyword):
                 // Check to see if a Species with this name already exists...
-                if (coreData_.findSpecies(parser.argsv(1)))
+                if (coreData_.findSpecies(DissolveSys::niceName(parser.argsv(1))))
                     return Messenger::error("Redefinition of species '{}'.\n", parser.argsv(1));
 
                 sp = coreData_.addSpecies();

--- a/src/modules/benchmark/process.cpp
+++ b/src/modules/benchmark/process.cpp
@@ -36,7 +36,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "Generator"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "Generator"),
                           "Configuration generator", timing, save_);
     }
 
@@ -62,7 +62,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RDFCells"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "RDFCells"),
                           "RDF (Cells) to half-cell limit", timing, save_);
     }
 
@@ -88,7 +88,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RDFSimple"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "RDFSimple"),
                           "RDF (Simple) to half-cell limit", timing, save_);
     }
 
@@ -107,7 +107,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "IntraEnergy"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "IntraEnergy"),
                           "Intramolecular energy", timing, save_);
     }
 
@@ -126,7 +126,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "InterEnergy"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "InterEnergy"),
                           "Interatomic energy", timing, save_);
     }
 
@@ -164,7 +164,7 @@ Module::ExecutionResult BenchmarkModule::process(ModuleContext &moduleContext)
             Messenger::unMute();
             timing += timer.split();
         }
-        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->niceName(), "RegionalDist"),
+        printTimingResult(std::format("{}_{}_{}.txt", name(), targetConfiguration_->name(), "RegionalDist"),
                           "Distributor (regional)", timing, save_);
     }
 

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -28,7 +28,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, const ProcessPool
         return true;
 
     // Realise the arrays from the Configuration
-    auto &braggKVectors = moduleData.realise<std::vector<KVector>>("KVectors", cfg->niceName());
+    auto &braggKVectors = moduleData.realise<std::vector<KVector>>("KVectors", cfg->name());
     auto &braggReflections =
         moduleData.realise<std::vector<BraggReflection>>("Reflections", name(), GenericItem::InRestartFileFlag);
     auto &braggAtomVectorXCos = moduleData.realise<Array2D<double>>("AtomVectorXCos", name());

--- a/src/modules/clustering/gui/clusteringWidgetFuncs.cpp
+++ b/src/modules/clustering/gui/clusteringWidgetFuncs.cpp
@@ -58,8 +58,8 @@ void ClusteringModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlag
 
         sizeDist_->createRenderable<RenderableData1D>(
             std::format("{}//SizeData", module_->name()),
-            std::format("SizeData//{}", module_->keywords().getConfiguration("Configuration")->niceName()),
-            module_->keywords().getConfiguration("Configuration")->niceName());
+            std::format("SizeData//{}", module_->keywords().getConfiguration("Configuration")->name()),
+            module_->keywords().getConfiguration("Configuration")->name());
 
         sizeDist_->view().showAllData();
     }

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -365,7 +365,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     if (saveSizeDist_)
     {
         LineParser parser;
-        parser.appendOutput(std::format("{}.{}.sizedist.txt", targetConfiguration_->niceName(), name()));
+        parser.appendOutput(std::format("{}.{}.sizedist.txt", targetConfiguration_->name(), name()));
         parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
         parser.writeLineF("# Cluster size : number of clusters\n");
         for (const auto &[clusterSize, mems] : sizeDistribution_)
@@ -374,7 +374,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     if (saveMassDist_)
     {
         LineParser parser;
-        parser.appendOutput(std::format("{}.{}.massdist.txt", targetConfiguration_->niceName(), name()));
+        parser.appendOutput(std::format("{}.{}.massdist.txt", targetConfiguration_->name(), name()));
         parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
         parser.writeLineF("# Cluster mass : number of clusters\n");
         for (const auto &[clusterMass, mems] : massDistribution_)
@@ -383,7 +383,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
     if (saveRgMass_)
     {
         LineParser parser;
-        parser.appendOutput(std::format("{}.{}.massRg.txt", targetConfiguration_->niceName(), name()));
+        parser.appendOutput(std::format("{}.{}.massRg.txt", targetConfiguration_->name(), name()));
         parser.writeLineF("\n# Iteration: {}\n", moduleContext.dissolve().iteration());
         parser.writeLineF("# Fractal dimension:\n{}\n", fractalDimension_);
         parser.writeLineF("# Cluster mass : radius of gyration\n");
@@ -397,7 +397,7 @@ Module::ExecutionResult ClusteringModule::process(ModuleContext &moduleContext)
         for (const auto &[base, map] : clusterSpeciesCoordNo_)
             for (const auto &[partner, cn] : map)
             {
-                parser.appendOutput(std::format("{}.{}.{}{}.CN.txt", targetConfiguration_->niceName(), name(),
+                parser.appendOutput(std::format("{}.{}.{}{}.CN.txt", targetConfiguration_->name(), name(),
                                                 base->name() == partner->name() ? base->parent()->name() : base->name(),
                                                 base->name() == partner->name() ? partner->parent()->name() : partner->name()));
 

--- a/src/modules/energy/functions.cpp
+++ b/src/modules/energy/functions.cpp
@@ -309,7 +309,7 @@ double EnergyModule::totalEnergy(const ProcessPool &procPool, const Species *sp,
 EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processingData, const Configuration *cfg)
 {
     // First, check if the Configuration is targetted by an EnergyModule
-    if (!processingData.valueOr<bool>("IsEnergyModuleTarget", cfg->niceName(), false))
+    if (!processingData.valueOr<bool>("IsEnergyModuleTarget", cfg->name(), false))
     {
         Messenger::error("Configuration '{}' is not targeted by any EnergyModule, so stability cannot be assessed. "
                          "Check your setup!\n",
@@ -318,9 +318,9 @@ EnergyModule::EnergyStability EnergyModule::checkStability(GenericList &processi
     }
 
     // Retrieve the EnergyStable flag from the Configuration's module data
-    if (processingData.contains("EnergyStable", cfg->niceName()))
+    if (processingData.contains("EnergyStable", cfg->name()))
     {
-        auto stable = processingData.value<bool>("EnergyStable", cfg->niceName());
+        auto stable = processingData.value<bool>("EnergyStable", cfg->name());
         if (!stable)
         {
             Messenger::print("Energy for Configuration '{}' is not yet stable.\n", cfg->name());

--- a/src/modules/energy/gui/energyWidgetFuncs.cpp
+++ b/src/modules/energy/gui/energyWidgetFuncs.cpp
@@ -58,7 +58,7 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
         // Clear any existing renderables
         energyGraph_->clearRenderables();
 
-        auto prefix = std::format("{}//{}", module_->name(), cfg->niceName());
+        auto prefix = std::format("{}//{}", module_->name(), cfg->name());
         energyGraph_->createRenderable<RenderableData1D>(std::format("{}//Total", prefix), "Total", "Totals");
         energyGraph_->createRenderable<RenderableData1D>(std::format("{}//PairPotential", prefix), "PairPotential", "Totals")
             ->setColour(StockColours::RedStockColour);
@@ -87,13 +87,13 @@ void EnergyModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &
     QPalette labelPalette = ui_.StableLabel->palette();
     if (cfg)
     {
-        if (dissolve_.processingModuleData().contains("EnergyGradient", cfg->niceName()))
+        if (dissolve_.processingModuleData().contains("EnergyGradient", cfg->name()))
             ui_.GradientValueLabel->setText(
-                QString::number(dissolve_.processingModuleData().value<double>("EnergyGradient", cfg->niceName())));
+                QString::number(dissolve_.processingModuleData().value<double>("EnergyGradient", cfg->name())));
         else
             ui_.GradientValueLabel->setText("N/A");
 
-        if (dissolve_.processingModuleData().valueOr<bool>("EnergyStable", cfg->niceName(), false))
+        if (dissolve_.processingModuleData().valueOr<bool>("EnergyStable", cfg->name(), false))
         {
             labelPalette.setColor(QPalette::WindowText, Qt::darkGreen);
             ui_.StableLabel->setText("Yes");

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -17,7 +17,7 @@ bool EnergyModule::setUp(ModuleContext &moduleContext, Flags<KeywordBase::Keywor
     // For the Configuration target add a flag to its moduleData (which is *not* stored in the restart file) to specify that we
     // are targeting it
     if (targetConfiguration_)
-        moduleContext.dissolve().processingModuleData().realise<bool>("IsEnergyModuleTarget", targetConfiguration_->niceName(),
+        moduleContext.dissolve().processingModuleData().realise<bool>("IsEnergyModuleTarget", targetConfiguration_->name(),
                                                                       GenericItem::ProtectedFlag) = true;
 
     return true;
@@ -65,33 +65,33 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
 
     // Store current energies in the Configuration in case somebody else needs them
     auto &interData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//PairPotential", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//PairPotential", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     interData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.total());
     auto &intraData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Bound", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Bound", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     intraData.addPoint(moduleContext.dissolve().iteration(), boundEnergy);
     auto &bondData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Bond", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Bond", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     bondData.addPoint(moduleContext.dissolve().iteration(), bondEnergy);
     auto &angleData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Angle", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Angle", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     angleData.addPoint(moduleContext.dissolve().iteration(), angleEnergy);
     auto &torsionData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Torsion", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Torsion", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     torsionData.addPoint(moduleContext.dissolve().iteration(), torsionEnergy);
     auto &improperData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Improper", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Improper", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     improperData.addPoint(moduleContext.dissolve().iteration(), improperEnergy);
     auto &cohesiveData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Cohesive", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Cohesive", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     cohesiveData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.interMolecular());
     auto &intraPPData = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//IntraPP", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//IntraPP", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     intraPPData.addPoint(moduleContext.dissolve().iteration(), ppEnergy.intraMolecular());
 
     // Append to arrays of total energies
     auto &totalEnergyArray = moduleContext.dissolve().processingModuleData().realise<Data1D>(
-        std::format("{}//Total", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Total", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     totalEnergyArray.addPoint(moduleContext.dissolve().iteration(), ppEnergy.total() + boundEnergy);
 
     // Determine stability of energy
@@ -113,16 +113,16 @@ Module::ExecutionResult EnergyModule::process(ModuleContext &moduleContext)
     }
 
     // Set energy data under the configuration's prefix
-    moduleContext.dissolve().processingModuleData().realise<double>("EnergyGradient", targetConfiguration_->niceName(),
+    moduleContext.dissolve().processingModuleData().realise<double>("EnergyGradient", targetConfiguration_->name(),
                                                                     GenericItem::InRestartFileFlag) = grad;
-    moduleContext.dissolve().processingModuleData().realise<bool>("EnergyStable", targetConfiguration_->niceName(),
+    moduleContext.dissolve().processingModuleData().realise<bool>("EnergyStable", targetConfiguration_->name(),
                                                                   GenericItem::InRestartFileFlag) = stable;
 
     // If writing to a file, append it here
     if (save_)
     {
         LineParser parser;
-        std::string filename = std::format("{}.energy.txt", targetConfiguration_->niceName());
+        std::string filename = std::format("{}.energy.txt", targetConfiguration_->name());
 
         if (!DissolveSys::fileExists(filename))
         {

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -39,7 +39,7 @@ Module::ExecutionResult ForcesModule::process(ModuleContext &moduleContext)
 
     // Realise the force vector
     auto &f = moduleContext.dissolve().processingModuleData().realise<std::vector<Vec3<double>>>(
-        std::format("{}//Forces", targetConfiguration_->niceName()), name());
+        std::format("{}//Forces", targetConfiguration_->name()), name());
     f.resize(targetConfiguration_->nAtoms());
 
     // Calculate forces

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -328,8 +328,8 @@ bool GRModule::calculateGR(GenericList &processingData, const ProcessPool &procP
                            bool &alreadyUpToDate)
 {
     // Does a PartialSet already exist for this Configuration?
-    auto originalGRObject = processingData.realiseIf<PartialSet>(std::format("{}//OriginalGR", cfg->niceName()), name_,
-                                                                 GenericItem::InRestartFileFlag);
+    auto originalGRObject =
+        processingData.realiseIf<PartialSet>(std::format("{}//OriginalGR", cfg->name()), name_, GenericItem::InRestartFileFlag);
     auto &originalgr = originalGRObject.first;
     if (originalGRObject.second == GenericItem::ItemStatus::Created)
         originalgr.setUp(cfg->atomTypePopulations(), rdfRange, rdfBinWidth);
@@ -579,9 +579,9 @@ bool GRModule::sumUnweightedGR(GenericList &processingData, const ProcessPool &p
         double weight = ((cfgWeight / totalWeight) * *cfg->atomicDensity()) / rho0;
 
         // Grab partials for Configuration and add into our set
-        if (!processingData.contains(std::format("{}//UnweightedGR", cfg->niceName()), targetPrefix))
+        if (!processingData.contains(std::format("{}//UnweightedGR", cfg->name()), targetPrefix))
             return Messenger::error("Couldn't find UnweightedGR data for Configuration '{}'.\n", cfg->name());
-        auto cfgPartialGR = processingData.value<PartialSet>(std::format("{}//UnweightedGR", cfg->niceName()), targetPrefix);
+        auto cfgPartialGR = processingData.value<PartialSet>(std::format("{}//UnweightedGR", cfg->name()), targetPrefix);
         summedUnweightedGR.addPartials(cfgPartialGR, weight);
     }
     summedUnweightedGR.setFingerprint(fingerprint);

--- a/src/modules/gr/gui/grWidgetFuncs.cpp
+++ b/src/modules/gr/gui/grWidgetFuncs.cpp
@@ -110,14 +110,14 @@ void GRModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> &upda
         }
         else if (ui_.ConfigurationPartialsButton->isChecked())
         {
-            auto targetPrefix = std::format("{}//UnweightedGR", (*optConfig)->niceName());
+            auto targetPrefix = std::format("{}//UnweightedGR", (*optConfig)->name());
             targetPartials_ = dissolve_.processingModuleData().valueIf<PartialSet>(targetPrefix, module_->name());
             createPartialSetRenderables(targetPrefix);
         }
         else
             for (auto *cfg : cfgs)
                 rdfGraph_->createRenderable<RenderableData1D>(
-                    std::format("{}//{}//UnweightedGR//Total", module_->name(), cfg->niceName()), cfg->niceName(), "Total");
+                    std::format("{}//{}//UnweightedGR//Total", module_->name(), cfg->name()), cfg->name(), "Total");
     }
 
     // Validate renderables if they need it

--- a/src/modules/gr/process.cpp
+++ b/src/modules/gr/process.cpp
@@ -52,19 +52,19 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
         // Check RDF range
         double rdfRange = cfg->box()->inscribedSphereRadius();
         if (!requestedRange_)
-            Messenger::print("Maximal cutoff used for Configuration '{}' ({} Angstroms).\n", cfg->niceName(), rdfRange);
+            Messenger::print("Maximal cutoff used for Configuration '{}' ({} Angstroms).\n", cfg->name(), rdfRange);
         else
         {
             if (requestedRange_.value_or(0.0) > rdfRange)
             {
                 Messenger::error("Specified RDF range of {} Angstroms is out of range for Configuration "
                                  "'{}' (max = {} Angstroms).\n",
-                                 requestedRange_.value(), cfg->niceName(), rdfRange);
+                                 requestedRange_.value(), cfg->name(), rdfRange);
                 return ExecutionResult::Failed;
             }
 
             rdfRange = requestedRange_.value();
-            Messenger::print("Cutoff for Configuration '{}' is {} Angstroms.\n", cfg->niceName(), rdfRange);
+            Messenger::print("Cutoff for Configuration '{}' is {} Angstroms.\n", cfg->name(), rdfRange);
         }
 
         // 'Snap' rdfRange_ to nearest bin width...
@@ -76,7 +76,7 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
         calculateGR(moduleContext.dissolve().processingModuleData(), moduleContext.processPool(), cfg, partialsMethod_,
                     rdfRange, binWidth_, alreadyUpToDate);
         auto &originalgr = moduleContext.dissolve().processingModuleData().retrieve<PartialSet>(
-            std::format("{}//OriginalGR", cfg->niceName()), name_);
+            std::format("{}//OriginalGR", cfg->name()), name_);
 
         // Perform averagingLength_ of unweighted partials if requested, and if we're not already up-to-date
         if ((averagingLength_.value_or(1) > 1) && (!alreadyUpToDate))
@@ -85,7 +85,7 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
             std::string currentFingerprint{originalgr.fingerprint()};
 
             Averaging::average<PartialSet>(moduleContext.dissolve().processingModuleData(),
-                                           std::format("{}//OriginalGR", cfg->niceName()), name_, averagingLength_.value(),
+                                           std::format("{}//OriginalGR", cfg->name()), name_, averagingLength_.value(),
                                            averagingScheme_);
 
             // Re-set the object names and fingerprints of the partials
@@ -105,7 +105,7 @@ Module::ExecutionResult GRModule::process(ModuleContext &moduleContext)
 
         // Form unweighted g(r) from original g(r), applying any requested nSmooths_ / intramolecular broadening
         auto &unweightedgr = moduleContext.dissolve().processingModuleData().realise<PartialSet>(
-            std::format("{}//UnweightedGR", cfg->niceName()), name_, GenericItem::InRestartFileFlag);
+            std::format("{}//UnweightedGR", cfg->name()), name_, GenericItem::InRestartFileFlag);
         calculateUnweightedGR(moduleContext.processPool(), cfg, originalgr, unweightedgr, intraBroadening_,
                               nSmooths_.value_or(0));
 

--- a/src/modules/importTrajectory/process.cpp
+++ b/src/modules/importTrajectory/process.cpp
@@ -23,7 +23,7 @@ Module::ExecutionResult ImportTrajectoryModule::process(ModuleContext &moduleCon
     }
 
     // Does a seek position exist in the processing module info?
-    std::string streamPosName = std::format("TrajectoryPosition_{}", targetConfiguration_->niceName());
+    std::string streamPosName = std::format("TrajectoryPosition_{}", targetConfiguration_->name());
     if (moduleContext.dissolve().processingModuleData().contains(streamPosName, name()))
     {
         // Retrieve the streampos and go to it in the file

--- a/src/modules/intraDistance/gui/intraDistanceWidgetFuncs.cpp
+++ b/src/modules/intraDistance/gui/intraDistanceWidgetFuncs.cpp
@@ -39,7 +39,7 @@ void IntraDistanceModuleWidget::updateControls(const Flags<ModuleWidget::UpdateF
         if (cfg)
             rdfGraph_
                 ->createRenderable<RenderableData1D>(std::format("{}//NormalisedHistogram", module_->name()),
-                                                     std::format("RDF//{}", cfg->niceName()), cfg->niceName())
+                                                     std::format("RDF//{}", cfg->name()), cfg->name())
                 ->setColour(StockColours::BlueStockColour);
     }
 

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -58,7 +58,7 @@ Module::ExecutionResult MDModule::process(ModuleContext &moduleContext)
         }
         else if (stabilityResult == EnergyModule::EnergyUnstable)
         {
-            Messenger::print("Skipping MD for Configuration '{}'.\n", targetConfiguration_->niceName());
+            Messenger::print("Skipping MD for Configuration '{}'.\n", targetConfiguration_->name());
             return ExecutionResult::NotExecuted;
         }
     }
@@ -102,7 +102,7 @@ Module::ExecutionResult MDModule::process(ModuleContext &moduleContext)
 
     // Read in or assign random velocities
     auto [velocities, status] = moduleContext.dissolve().processingModuleData().realiseIf<std::vector<Vec3<double>>>(
-        std::format("{}//Velocities", targetConfiguration_->niceName()), name(), GenericItem::InRestartFileFlag);
+        std::format("{}//Velocities", targetConfiguration_->name()), name(), GenericItem::InRestartFileFlag);
     if ((status == GenericItem::ItemStatus::Created || randomVelocities_ ||
          velocities.size() != targetConfiguration_->nAtoms()) &&
         !intramolecularForcesOnly_)

--- a/src/modules/moleculeTorsion/gui/moleculeTorsionWidgetFuncs.cpp
+++ b/src/modules/moleculeTorsion/gui/moleculeTorsionWidgetFuncs.cpp
@@ -39,7 +39,7 @@ void MoleculeTorsionModuleWidget::updateControls(const Flags<ModuleWidget::Updat
         if (cfg)
             histogramGraph_
                 ->createRenderable<RenderableData1D>(std::format("{}//NormalisedHistogram", module_->name()),
-                                                     std::format("RDF//{}", cfg->niceName()), cfg->niceName())
+                                                     std::format("RDF//{}", cfg->name()), cfg->name())
                 ->setColour(StockColours::BlueStockColour);
     }
 

--- a/src/modules/siteRDF/gui/siteRDFWidgetFuncs.cpp
+++ b/src/modules/siteRDF/gui/siteRDFWidgetFuncs.cpp
@@ -67,7 +67,7 @@ void SiteRDFModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFlags> 
         auto *cfg = module_->keywords().getConfiguration("Configuration");
         if (cfg)
             rdfGraph_->createRenderable<RenderableData1D>(std::format("{}//RDF", module_->name()),
-                                                          std::format("RDF//{}", cfg->niceName()), cfg->niceName());
+                                                          std::format("RDF//{}", cfg->name()), cfg->name());
     }
     if (runningCNGraph_->renderables().empty())
         runningCNGraph_->createRenderable<RenderableData1D>(std::format("{}//RunningCN", module_->name()), "Running CN");

--- a/src/modules/voxelDensity/gui/voxelDensityWidgetFuncs.cpp
+++ b/src/modules/voxelDensity/gui/voxelDensityWidgetFuncs.cpp
@@ -59,7 +59,7 @@ void VoxelDensityModuleWidget::updateControls(const Flags<ModuleWidget::UpdateFl
         auto *cfg = module_->keywords().getConfiguration("Configuration");
         if (cfg)
             voxelDensityGraph_->createRenderable<RenderableData1D>(std::format("{}//Data1D", module_->name()),
-                                                                   std::format("Data1D//{}", cfg->niceName()), cfg->niceName());
+                                                                   std::format("Data1D//{}", cfg->name()), cfg->name());
     }
 
     voxelDensityGraph_->view().axes().setTitle(0, getData1DAxisLabel().value_or(""));


### PR DESCRIPTION
This PR forces the use of "nice names" (i.e. with spaces and other annoying characters removed) in `Configuration`s, `Species`, `SpeciesSite`s, and `Isotopologues`. This came about from a bug report where a species containing a space in its name (which was previously allowed) was written without quotes by `SpeciesVectorKeyword` / `SpeciesKeyword` and subsequently broke the input file on re-reading.

Here, using `setName()` on any of the above objects calls `DissolveSys::niceName()` automatically - this was already done for `Configuration`, but the original unchanged `name_` was also stored - this is now removed.  To prevent these changes from breaking existing input files, I/O routines have been modified to convert any read-in name to its nice equivalent before searching for the object. I have left the TOML-related I/O largely untouched since it is not the prinicipal I/O stream at present.