### PR TITLE
refactor: Refer to triangular rather than half-matrices

### DIFF
--- a/src/classes/histogramSet.cpp
+++ b/src/classes/histogramSet.cpp
@@ -17,9 +17,9 @@ void HistogramSet::initialise(const std::vector<const AtomType *> &types, double
 {
     atomTypes_ = types;
 
-    fullHistograms_.clear(half_);
-    boundHistograms_.clear(half_);
-    unboundHistograms_.clear(half_);
+    fullHistograms_.clear(triangular_);
+    boundHistograms_.clear(triangular_);
+    unboundHistograms_.clear(triangular_);
 
     dissolve::for_each_pair(
         ParallelPolicies::seq, atomTypes_,
@@ -31,7 +31,7 @@ void HistogramSet::initialise(const std::vector<const AtomType *> &types, double
             boundHistograms_.get(key).initialise(0.0, rdfRange, binWidth);
             unboundHistograms_.get(key).initialise(0.0, rdfRange, binWidth);
         },
-        half_);
+        triangular_);
 }
 
 // Clear all histogram data

--- a/src/classes/histogramSet.h
+++ b/src/classes/histogramSet.h
@@ -29,8 +29,8 @@ class HistogramSet
     DoubleKeyedMap<Histogram1D> boundHistograms_;
     // Histograms used for deriving unbound atom-atom partials in r
     DoubleKeyedMap<Histogram1D> unboundHistograms_;
-    // Check for full or half matrix
-    bool half_{true};
+    // Whether the histogram is a triangular matrix
+    bool triangular_{true};
 
     public:
     // Set up histograms

--- a/src/classes/partialSet.cpp
+++ b/src/classes/partialSet.cpp
@@ -14,18 +14,18 @@
 #include <filesystem>
 
 // Initialise
-void PartialSet::initialise(const KeyedVector<const Species *, int> &speciesPopulations, bool half)
+void PartialSet::initialise(const KeyedVector<const Species *, int> &speciesPopulations, bool triangular)
 {
     // Take integer species populations and convert to real
     realSpeciesPopulations_.clear();
     for (const auto &[species, population] : speciesPopulations)
         realSpeciesPopulations_[species] = double(population);
 
-    half_ = half;
+    triangular_ = triangular;
 
-    partials_.clear(half_);
-    boundPartials_.clear(half_);
-    unboundPartials_.clear(half_);
+    partials_.clear(triangular_);
+    boundPartials_.clear(triangular_);
+    unboundPartials_.clear(triangular_);
 
     // Create data for partials and set tags
     dissolve::for_each_pair(
@@ -37,7 +37,7 @@ void PartialSet::initialise(const KeyedVector<const Species *, int> &speciesPopu
             boundPartials_.get(key).setTag(std::format("{}-{}//Bound", popI.first->name(), popJ.first->name()));
             unboundPartials_.get(key).setTag(std::format("{}-{}//Unbound", popI.first->name(), popJ.first->name()));
         },
-        half_);
+        triangular_);
 
     // Set up arrays for totals
     total_.setTag("Total");
@@ -49,18 +49,18 @@ void PartialSet::initialise(const KeyedVector<const Species *, int> &speciesPopu
 }
 
 // Initialise from supplied real species populations
-void PartialSet::initialise(const KeyedVector<const Species *, double> &realSpeciesPopulations, bool half)
+void PartialSet::initialise(const KeyedVector<const Species *, double> &realSpeciesPopulations, bool triangular)
 {
     // Take integer species populations and convert to real
     realSpeciesPopulations_.clear();
     for (const auto &[species, population] : realSpeciesPopulations)
         realSpeciesPopulations_[species] = double(population);
 
-    half_ = half;
+    triangular_ = triangular;
 
-    partials_.clear(half_);
-    boundPartials_.clear(half_);
-    unboundPartials_.clear(half_);
+    partials_.clear(triangular_);
+    boundPartials_.clear(triangular_);
+    unboundPartials_.clear(triangular_);
 
     // Create data for partials and set tags
     dissolve::for_each_pair(
@@ -72,7 +72,7 @@ void PartialSet::initialise(const KeyedVector<const Species *, double> &realSpec
             boundPartials_.get(key).setTag(std::format("{}-{}//Bound", popI.first->name(), popJ.first->name()));
             unboundPartials_.get(key).setTag(std::format("{}-{}//Unbound", popI.first->name(), popJ.first->name()));
         },
-        half_);
+        triangular_);
 
     // Set up arrays for totals
     total_.setTag("Total");
@@ -87,7 +87,7 @@ void PartialSet::initialise(const KeyedVector<const Species *, double> &realSpec
 void PartialSet::initialise(const PartialSet &partialSet)
 {
     realSpeciesPopulations_ = partialSet.realSpeciesPopulations_;
-    half_ = partialSet.half_;
+    triangular_ = partialSet.triangular_;
 
     // Template data from source PartialSet and set tags
     dissolve::for_each_pair(
@@ -103,7 +103,7 @@ void PartialSet::initialise(const PartialSet &partialSet)
             unboundPartials_.get(key).setTag(std::format("{}-{}//Unbound", popI.first->name(), popJ.first->name()));
             unboundPartials_.get(key).initialise(partialSet.unboundPartials_.get(key));
         },
-        half_);
+        triangular_);
 
     // Set up arrays for totals
     total_.setTag("Total");
@@ -201,7 +201,7 @@ void PartialSet::formTotals(bool applyConcentrationWeights)
                            unboundPartials_.get(key).values().begin(), unboundTotal_.values().begin(),
                            [=](auto total, auto partial) { return total + partial * factor; });
         },
-        half_);
+        triangular_);
 
     total_ += boundTotal_;
     total_ += unboundTotal_;
@@ -238,7 +238,7 @@ void PartialSet::formTRTotals(const NeutronWeights &weights)
                            unboundPartials_.get(key).values().begin(), unboundTotal_.values().begin(),
                            [=](auto total, auto partial) { return total + partial * factor; });
         },
-        half_);
+        triangular_);
 
     total_ += boundTotal_;
     total_ += unboundTotal_;
@@ -304,7 +304,7 @@ bool PartialSet::save(std::string_view prefix, std::string_view tag, std::string
 
             return EarlyReturn<bool>::Continue;
         },
-        half_);
+        triangular_);
 
     Messenger::printVerbose("Writing total file '{}'...\n", total_.tag());
     if (!Data1DExportFileFormat(std::format("{}-{}-total.{}", prefix, tag, suffix)).exportData(total_))
@@ -465,7 +465,7 @@ bool PartialSet::deserialise(LineParser &parser, const CoreData &coreData)
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
     fingerprint_ = parser.argsv(0);
-    half_ = parser.hasArg(1) ? parser.argb(1) : true;
+    triangular_ = parser.hasArg(1) ? parser.argb(1) : true;
 
     // Read species populations
     realSpeciesPopulations_.clear();
@@ -482,9 +482,9 @@ bool PartialSet::deserialise(LineParser &parser, const CoreData &coreData)
     }
 
     // Clear partials
-    partials_.clear(half_);
-    boundPartials_.clear(half_);
-    unboundPartials_.clear(half_);
+    partials_.clear(triangular_);
+    boundPartials_.clear(triangular_);
+    unboundPartials_.clear(triangular_);
 
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;
@@ -528,7 +528,7 @@ std::string writeDataPoint(int i, Data1D data)
 // Write data through specified LineParser
 bool PartialSet::serialise(LineParser &parser) const
 {
-    if (!parser.writeLineF("'{}'  {}\n", fingerprint_, half_))
+    if (!parser.writeLineF("'{}'  {}\n", fingerprint_, triangular_))
         return false;
 
     // Write out species populations first

--- a/src/classes/partialSet.h
+++ b/src/classes/partialSet.h
@@ -30,16 +30,16 @@ class PartialSet
     DoubleKeyedMap<Data1D> boundPartials_;
     // Total functions
     Data1D boundTotal_, unboundTotal_, total_;
-    // Check for full or half matrix
-    bool half_{true};
+    // Whether the partial set is a triangular matrix
+    bool triangular_{true};
     // Effective density
     double rho_;
 
     public:
     // Initialise from supplied species populations
-    void initialise(const KeyedVector<const Species *, int> &speciesPopulations, bool half = true);
+    void initialise(const KeyedVector<const Species *, int> &speciesPopulations, bool triangular = true);
     // Initialise from supplied real species populations
-    void initialise(const KeyedVector<const Species *, double> &realSpeciesPopulations, bool half = true);
+    void initialise(const KeyedVector<const Species *, double> &realSpeciesPopulations, bool triangular = true);
     // Initialise based on supplied PartialSet, templating all data
     void initialise(const PartialSet &partialSet);
     // Reset partial arrays

--- a/src/math/gj.cpp
+++ b/src/math/gj.cpp
@@ -9,7 +9,7 @@ namespace GaussJordan
 // Perform Gauss-Jordan inversion of the supplied Array2D<double>
 bool invert(Array2D<double> &A)
 {
-    // Matrix must be square, and not stored as a half-matrix
+    // Matrix must be square, and not stored as a triangular-matrix
     if (A.nRows() != A.nColumns())
     {
         Messenger::error("Can't invert this Array2D since it is not square (it is {}x{}).\n", A.nRows(), A.nColumns());
@@ -17,7 +17,7 @@ bool invert(Array2D<double> &A)
     }
     if (A.halved())
     {
-        Messenger::error("Can't invert this matrix since it is stored as a half-matrix.\n");
+        Messenger::error("Can't invert this matrix since it is stored as a triangular matrix.\n");
         return false;
     }
 

--- a/src/templates/algorithms.h
+++ b/src/templates/algorithms.h
@@ -41,18 +41,18 @@ template <typename T>
 concept PairIndexLambda = requires(T lam, int x, int y) { lam(x, y); };
 
 // Perform an operation on every pair of elements in a container,
-// or the half-matrix only ([i,j] == [j,i])
+// or the triangular matrix only ([i,j] == [j,i])
 // Please note that this can *not* be transformed to use the
 // FullPairIterator, since it would prevent using `Break` to move to
 // the next loop iteration
 template <std::ranges::range Range, class Lam>
-auto for_each_pair_early(Range range, Lam lambda, bool half = true) -> std::optional<bool>
+auto for_each_pair_early(Range range, Lam lambda, bool triangular = true) -> std::optional<bool>
 {
     int i = 0;
     for (auto elem1 = range.begin(); elem1 != range.end(); ++elem1, ++i)
     {
-        int j = half ? i : 0;
-        for (auto elem2 = half ? elem1 : range.begin(); elem2 != range.end(); ++elem2, ++j)
+        int j = triangular ? i : 0;
+        for (auto elem2 = triangular ? elem1 : range.begin(); elem2 != range.end(); ++elem2, ++j)
         {
             EarlyReturn<bool> result;
             if constexpr (PairIndexLambda<Lam>)
@@ -74,9 +74,9 @@ auto for_each_pair_early(Range range, Lam lambda, bool half = true) -> std::opti
 }
 
 // Overload to avoid using iota everywhere
-template <class Lam> auto for_each_pair_early(int count, Lam lambda, bool half = true) -> std::optional<bool>
+template <class Lam> auto for_each_pair_early(int count, Lam lambda, bool triangular = true) -> std::optional<bool>
 {
-    return for_each_pair_early(std::views::iota(0, count), lambda, half);
+    return for_each_pair_early(std::views::iota(0, count), lambda, triangular);
 }
 
 template <typename... Args> class ZipIterator
@@ -225,9 +225,9 @@ void for_each(ParallelPolicy, Range range, UnaryOp unaryOp)
     dissolve::for_each(range, unaryOp);
 }
 
-// Perform an operation on every pair of elements in a contained, or the half-matrix only ([i,j] == [j,i])
+// Perform an operation on every pair of elements in a container, or the triangular elements only ([i,j] == [j,i])
 template <typename ParallelPolicy, std::ranges::range Range, class Lam>
-void for_each_pair(ParallelPolicy policy, Range range, Lam lambda, bool half = true)
+void for_each_pair(ParallelPolicy policy, Range range, Lam lambda, bool triangular = true)
 {
     auto actions = [&lambda, &range](const auto pair)
     {
@@ -237,7 +237,7 @@ void for_each_pair(ParallelPolicy policy, Range range, Lam lambda, bool half = t
         else
             lambda(i, range.begin()[i], j, range.begin()[j]);
     };
-    if (half)
+    if (triangular)
     {
         PairIterator start(range.end() - range.begin()),
             stop(range.end() - range.begin(), ((range.end() - range.begin()) * (range.end() - range.begin() + 1)) / 2);
@@ -252,9 +252,10 @@ void for_each_pair(ParallelPolicy policy, Range range, Lam lambda, bool half = t
 }
 
 // Overload to avoid using iota everywhere
-template <typename ParallelPolicy, class Lam> void for_each_pair(ParallelPolicy policy, int count, Lam lambda, bool half = true)
+template <typename ParallelPolicy, class Lam>
+void for_each_pair(ParallelPolicy policy, int count, Lam lambda, bool triangular = true)
 {
-    for_each_pair(policy, std::views::iota(0, count), lambda, half);
+    for_each_pair(policy, std::views::iota(0, count), lambda, triangular);
 }
 
 template <typename ParallelPolicy, class Iter, class Lam>

--- a/src/templates/array2D.h
+++ b/src/templates/array2D.h
@@ -13,7 +13,7 @@
 template <class A> class Array2D
 {
     public:
-    Array2D(int nrows = 0, int ncolumns = 0, bool half = false) : half_(half)
+    Array2D(int nrows = 0, int ncolumns = 0, bool triangular = false) : triangular_(triangular)
     {
         if ((nrows > 0) && (ncolumns > 0))
             resize(nrows, ncolumns);
@@ -33,7 +33,7 @@ template <class A> class Array2D
     {
         // Clear any existing data and reinitialise the array
         clear();
-        initialise(source.nRows_, source.nColumns_, source.half_);
+        initialise(source.nRows_, source.nColumns_, source.triangular_);
         std::copy(source.array_.begin(), source.array_.end(), array_.begin());
     }
 
@@ -46,7 +46,7 @@ template <class A> class Array2D
     // Array dimensions
     int nRows_{0}, nColumns_{0};
     // Half-matrix mode
-    bool half_;
+    bool triangular_;
     // Row offsets
     std::vector<int> rowOffsets_;
 
@@ -57,15 +57,15 @@ template <class A> class Array2D
         // Clear old data
         clear();
 
-        // If we're only interested in half the matrix then it must be square
-        if (half_)
+        // If we're only interested in the triangular matrix it must be square
+        if (triangular_)
             assert(nrows == ncolumns);
 
         // Create new array
         nRows_ = nrows;
         nColumns_ = ncolumns;
         rowOffsets_.resize(nRows_);
-        if (half_)
+        if (triangular_)
         {
             // Half-array, with element (i,j) == (j,i)
             int linearSize = 0;
@@ -86,11 +86,11 @@ template <class A> class Array2D
 
     public:
     // Initialise array
-    void initialise(int nrows, int ncolumns, bool half = false)
+    void initialise(int nrows, int ncolumns, bool triangular = false)
     {
         clear();
 
-        half_ = half;
+        triangular_ = triangular;
         if ((nrows > 0) && (ncolumns > 0))
             resize(nrows, ncolumns);
     }
@@ -114,14 +114,14 @@ template <class A> class Array2D
             nCols = nColumns_;
 
         // Reinitialise the present matrix to the new size
-        if (half_ && (nRows_ == nCols.value()))
+        if (triangular_ && (nRows_ == nCols.value()))
         {
             Messenger::warn("Adding a row to this Array2D<A> will force it to be rectangular, so it will no longer "
                             "be halved.\n");
             initialise(nRows_ + 1, nCols.value(), false);
         }
         else
-            initialise(nRows_ + 1, nCols.value(), half_);
+            initialise(nRows_ + 1, nCols.value(), triangular_);
 
         // Copy old data back in
         for (auto n = 0; n < oldArray.nRows_; ++n)
@@ -156,7 +156,7 @@ template <class A> class Array2D
         assert(row >= 0 && row < nRows_);
         assert(column >= 0 && column < nColumns_);
 
-        if (half_)
+        if (triangular_)
         {
             if (row > column)
                 return array_[rowOffsets_[column] + row - column];
@@ -173,7 +173,7 @@ template <class A> class Array2D
         assert(row >= 0 && row < nRows_);
         assert(column >= 0 && column < nColumns_);
 
-        if (half_)
+        if (triangular_)
         {
             if (row > column)
                 return array_[rowOffsets_[column] + row - column];
@@ -189,7 +189,7 @@ template <class A> class Array2D
         assert(row >= 0 && row < nRows_);
         assert(column >= 0 && column < nColumns_);
 
-        if (half_)
+        if (triangular_)
         {
             if (row > column)
                 return &array_[rowOffsets_[column] + row - column];
@@ -200,7 +200,7 @@ template <class A> class Array2D
             return &array_[rowOffsets_[row] + column];
     }
     // Return whether the array is halved
-    bool halved() const { return half_; }
+    bool halved() const { return triangular_; }
     // Return number of rows
     int nRows() const { return nRows_; }
     // Return number of columns
@@ -257,11 +257,11 @@ template <class A> class Array2D
     Array2D<A> operator+(const Array2D<A> &other) const
     {
         assert(nColumns_ == other.nColumns_ && nRows_ == other.nRows_);
-        auto half = this->half_ && other.half_;
-        Array2D<A> ret(nRows_, nColumns_, half);
+        auto triangular = this->triangular_ && other.triangular_;
+        Array2D<A> ret(nRows_, nColumns_, triangular);
         for (int i = 0; i < this->nRows_; i++)
         {
-            int colStart = i ? half : 0;
+            int colStart = i ? triangular : 0;
             for (int j = colStart; j < this->nColumns_; ++j)
                 ret[{i, j}] = other[{i, j}] + (*this)[{i, j}];
         };


### PR DESCRIPTION
Just correcting language and variable naming for triangular matrices.