### PR TITLE
build: Add action to free up space on Linux, run on QC step.

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -23,14 +23,8 @@ runs:
   using: "composite"
   steps:
 
-  - name: Free Space
-    shell: bash
-    run: |
-      set -ex
-      df -mh .
-      sudo rm -rf /usr/share/dotnet
-      sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-      df -mh .
+  - name: Free Up Space
+    uses: "./.github/workflows/linux-free-up-space"
 
   - name: Install nix
     uses: "./.github/workflows/get-nix"

--- a/.github/workflows/linux-free-up-space/action.yml
+++ b/.github/workflows/linux-free-up-space/action.yml
@@ -1,0 +1,22 @@
+name: Linux Free Up Space
+description: Free up space on Linux runners
+
+runs:
+  using: "composite"
+  steps:
+
+  - name: Remove Unused Files
+    shell: bash
+    run: |
+      # See https://github.com/actions/runner-images/issues/10386
+      echo "Disk space before cleanup:"
+      df -h
+      sudo rm -rf /usr/local/.ghcup
+      sudo rm -rf /opt/hostedtoolcache/CodeQL
+      sudo rm -rf /usr/local/lib/android/sdk/ndk
+      sudo rm -rf /usr/share/dotnet
+      sudo rm -rf /opt/ghc
+      sudo rm -rf /usr/local/share/boost
+      sudo apt-get clean
+      echo "Disk space after cleanup:"
+      df -h

--- a/.github/workflows/qc/action.yml
+++ b/.github/workflows/qc/action.yml
@@ -10,6 +10,9 @@ runs:
   using: "composite"
   steps:
 
+  - name: Free Up Space
+    uses: "./.github/workflows/linux-free-up-space"
+
   - name: Install nix
     uses: "./.github/workflows/get-nix"
     with:


### PR DESCRIPTION
Our QC was failing because the Linux runners were running out of space when downloading and installing the nix cache.  We freed up space in the build stage, but not in the QC.