### PR TITLE
feat: Introduce SerialisableParameter.

### DIFF
--- a/src/nodes/add.cpp
+++ b/src/nodes/add.cpp
@@ -5,8 +5,8 @@
 
 AddNode::AddNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<Number>("A", "First operand to the addition", a_);
-    addInput<Number>("B", "Second operand to the addition", b_);
+    addSerialisableInput<Number>("A", "First operand to the addition", a_);
+    addSerialisableInput<Number>("B", "Second operand to the addition", b_);
     addOutput<Number>("Result", "The sum of the operands", result_);
 }
 

--- a/src/nodes/dotProduct.cpp
+++ b/src/nodes/dotProduct.cpp
@@ -2,8 +2,8 @@
 
 DotProductNode::DotProductNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<Vector3>("U", "Vector dot product factor", u_);
-    addInput<Vector3>("V", "Vector dot product factor", v_);
+    addSerialisableInput<Vector3>("U", "Vector dot product factor", u_);
+    addSerialisableInput<Vector3>("V", "Vector dot product factor", v_);
     addOutput<Number>("Result", "The inner product of the vectors", dotProduct_);
 }
 

--- a/src/nodes/multiply.cpp
+++ b/src/nodes/multiply.cpp
@@ -2,8 +2,8 @@
 
 MultiplyNode::MultiplyNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<Number>("A", "First factor to the multiplication", a_);
-    addInput<Number>("B", "Second factor to the multiplication", b_);
+    addSerialisableInput<Number>("A", "First factor to the multiplication", a_);
+    addSerialisableInput<Number>("B", "Second factor to the multiplication", b_);
     addOutput<Number>("Result", "The product of the two factors", result_);
 }
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -161,8 +161,10 @@ class Node : public Serialisable<>
         if (findInput(optionName))
             Messenger::exception("Option '{}' already exists, and can't be added again.", optionName);
 
-        auto param = options_.emplace(std::make_pair(optionName, ParameterFactory::create(this, optionName, description, data)))
-                         .first->second;
+        auto param =
+            options_
+                .emplace(std::make_pair(optionName, ParameterFactory::createSerialisable(this, optionName, description, data)))
+                .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
     }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -180,6 +180,19 @@ class Node : public Serialisable<>
         param->setFlags(ParameterBase::ParameterFlags::Input);
         return param;
     }
+    // Add serialisable input parameter
+    template <class T>
+    std::shared_ptr<ParameterBase> addSerialisableInput(std::string_view inputName, std::string_view description, T &data)
+    {
+        if (findInput(inputName))
+            Messenger::exception("Input parameter '{}' already exists, and can't be added again.", inputName);
+
+        auto param =
+            inputs_.emplace(std::make_pair(inputName, ParameterFactory::createSerialisable(this, inputName, description, data)))
+                .first->second;
+        param->setFlags(ParameterBase::ParameterFlags::Input);
+        return param;
+    }
     // Add output parameter
     template <class T>
     std::shared_ptr<ParameterBase> addOutput(std::string_view outputName, std::string_view description, T &data)

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -21,6 +21,7 @@
 class Node;
 class ParameterBase;
 template <typename T> class Parameter;
+template <typename T> class SerialisableParameter;
 
 // Parameter Proxy
 template <class T> class ParameterProxy
@@ -179,6 +180,12 @@ std::shared_ptr<ParameterBase> createPointer(Node *parent, std::string_view name
                                              std::optional<DataClass> &fromOptional)
 {
     return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromOptional);
+}
+template <typename DataClass>
+std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view name, std::string_view description,
+                                                  DataClass &value)
+{
+    return std::make_shared<SerialisableParameter<DataClass>>(parent, name, description, value);
 }
 }; // namespace ParameterFactory
 
@@ -387,6 +394,12 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 
         return {inputParameter, outputParameter};
     }
+};
+
+// Primary type for a Parameter to a specific DataClass
+template <typename DataClass>
+class SerialisableParameter : public Parameter<DataClass>, public std::enable_shared_from_this<Parameter<DataClass>>
+{
 
     // Helper templates for handling serialisation
 
@@ -409,20 +422,20 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 
         // Serialise non-pointer values
         if constexpr (HasEnumOptions<DataClass>)
-            result["data"] = getEnumOptions(data_).serialise(data_);
+            result["data"] = getEnumOptions(Parameter<DataClass>::data_).serialise(Parameter<DataClass>::data_);
         else if constexpr (std::is_convertible<DataClass, Number>::value)
-            result["data"] = data_;
+            result["data"] = Parameter<DataClass>::data_;
         else if constexpr (std::is_convertible<DataClass, std::string>::value)
-            result["data"] = data_;
+            result["data"] = Parameter<DataClass>::data_;
         else if constexpr (std::is_convertible<DataClass, std::optional<Number>>::value)
         {
-            if (data_)
-                result["data"] = *data_;
+            if (Parameter<DataClass>::data_)
+                result["data"] = *Parameter<DataClass>::data_;
         }
         else if constexpr (serialisablePointer<DataClass>)
-            result["data"] = data_->serialise();
+            result["data"] = Parameter<DataClass>::data_->serialise();
         else
-            result["data"] = data_;
+            result["data"] = Parameter<DataClass>::data_;
 
         return result;
     };
@@ -431,39 +444,39 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     {
         if constexpr (std::is_pointer<DataClass>::value)
         {
-            data_ = nullptr;
+            Parameter<DataClass>::data_ = nullptr;
         }
         else if constexpr (is_ptr_vector<DataClass>::value)
-            data_.clear();
+            Parameter<DataClass>::data_.clear();
         else if constexpr (HasEnumOptions<DataClass>)
         {
             DataClass proxy; // Fake T value to get the correct overload
-            data_ = getEnumOptions(proxy).deserialise(node);
+            Parameter<DataClass>::data_ = getEnumOptions(proxy).deserialise(node);
         }
         else if constexpr (std::is_convertible<DataClass, std::optional<double>>::value)
         {
             if (node.contains("data"))
-                data_ = toml::find<double>(node, "data");
+                Parameter<DataClass>::data_ = toml::find<double>(node, "data");
             else
-                data_ = {};
+                Parameter<DataClass>::data_ = {};
         }
         else if constexpr (std::is_convertible<DataClass, std::optional<Number>>::value)
         {
             if (node.contains("data"))
-                data_ = toml::find<Number>(node, "data");
+                Parameter<DataClass>::data_ = toml::find<Number>(node, "data");
             else
-                data_ = {};
+                Parameter<DataClass>::data_ = {};
         }
         else if constexpr (std::is_convertible<DataClass, std::optional<Data1D>>::value)
         {
             if (node.contains("data"))
-                data_ = toml::find<Data1D>(node, "data");
+                Parameter<DataClass>::data_ = toml::find<Data1D>(node, "data");
             else
-                data_ = {};
+                Parameter<DataClass>::data_ = {};
         }
         else
         {
-            data_ = toml::find<DataClass>(node, "data");
+            Parameter<DataClass>::data_ = toml::find<DataClass>(node, "data");
         }
     }
 };

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -397,10 +397,13 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 };
 
 // Primary type for a Parameter to a specific DataClass
-template <typename DataClass>
-class SerialisableParameter : public Parameter<DataClass>, public std::enable_shared_from_this<Parameter<DataClass>>
+template <typename DataClass> class SerialisableParameter : public Parameter<DataClass>
 {
-
+    public:
+    SerialisableParameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
+        : Parameter<DataClass>(parent, name, description, value)
+    {
+    }
     // Helper templates for handling serialisation
 
     template <typename V> struct is_ptr_vector : std::false_type

--- a/src/nodes/subtract.cpp
+++ b/src/nodes/subtract.cpp
@@ -2,8 +2,8 @@
 
 SubtractNode::SubtractNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<Number>("A", "First operand to the subtraction", a_);
-    addInput<Number>("B", "Second operand to the subtraction, subtracted from A", b_);
+    addSerialisableInput<Number>("A", "First operand to the subtraction", a_);
+    addSerialisableInput<Number>("B", "Second operand to the subtraction, subtracted from A", b_);
     addOutput<Number>("Result", "The difference of the operands", result_);
 }
 

--- a/src/nodes/vec3Assembly.cpp
+++ b/src/nodes/vec3Assembly.cpp
@@ -2,9 +2,9 @@
 
 Vec3AssemblyNode::Vec3AssemblyNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<double>("X", "The x value of the assembled vector", x_);
-    addInput<double>("Y", "The y value of the assembled vector", y_);
-    addInput<double>("Z", "The z value of the assembled vector", z_);
+    addSerialisableInput<double>("X", "The x value of the assembled vector", x_);
+    addSerialisableInput<double>("Y", "The y value of the assembled vector", y_);
+    addSerialisableInput<double>("Z", "The z value of the assembled vector", z_);
     addOutput<Vector3>("V", "The assembled vector", outputVector_);
 }
 

--- a/src/nodes/vec3Decomposition.cpp
+++ b/src/nodes/vec3Decomposition.cpp
@@ -2,7 +2,7 @@
 
 Vec3DecompositionNode::Vec3DecompositionNode(Graph *parentGraph) : Node(parentGraph)
 {
-    addInput<Vector3>("V", "The 3-dimensional vector to be decomposed", inputVector_);
+    addSerialisableInput<Vector3>("V", "The 3-dimensional vector to be decomposed", inputVector_);
     addOutput<Number>("X", "The x component of the vector", x_);
     addOutput<Number>("Y", "The y component of the vector", y_);
     addOutput<Number>("Z", "The z component of the vector", z_);


### PR DESCRIPTION
To date we had made the assumption (willingly or not) that any `Parameter` must be serialisable to/from an input file, since `ParameterBase` inherits `Serialisable`. However, there are certain use cases of parameters, as well as certain data types, that never need to be / can't be serialised in the first place, leading to lots of boilerplate `constexpr` and compile-time type-checking.

This PR clears things up considerably by stating the following rules:
1) Any option in a `Node` (via `addOption`) is _always_ potentially serialised, but conversely always represents a simple type (`int`, `float`, `Number`, `EnumOptions` etc.) that are easily serialisable.
2) Node outputs (via `addOutput`) should _never_ need to be explicitly serialised as they represent either access to local complex data variables (the results of the node's processing, and which should be covered by specific `addSerialisable` calls sending data to the restart file) or are straight pointer variables which are set via `Edge` connections and should not be written out explicitly.
3) Node inputs (via `addInput`) are generally not serialisable as they typically represent data which is never locally available and delivered via an `Edge`, hence there is no need for serialisation. However, some node inputs _do_require serialisation - e.g. `Number`s provided to the `AddNode` and other math functions - _if_ they do not have a current `Edge` connection defining their value. Detecting whether this is actually the case is difficult at the point of serialising the data, so current values should be written to the input file regardless. Node inputs are therefore not serialisable _by default_.

To achieve this neatly a new `template` `SerialisableParameter<T>` which inherits from `Parameter<T>` is introduced, and simply defines the (virtual) `serialise()` and `deserialise()` functions. Calling `addOption` always creates a `SerialisableParameter<T>`,  `addOutput` always creates a non-serialisable `Parameter<T>`, and `addInput` creates a non-serialisable `Parameter<T>` by default, but which can be flagged to be generated as a `SerialisableParameter<T>` with the new `addSerialisableInput()`.