### PR TITLE
fix: SplitString function and PhantomAtom workflow test

### DIFF
--- a/src/base/sysFunc.cpp
+++ b/src/base/sysFunc.cpp
@@ -321,24 +321,27 @@ std::string DissolveSys::replace(const std::string_view source, const std::strin
 std::vector<std::string_view> DissolveSys::splitString(std::string_view str, std::string_view delim)
 {
     std::vector<std::string_view> parts;
-    auto index = 0;
+    size_t index = 0;
     while (true)
     {
         // Search for the next occurrence of the delimiter
         auto found = str.find(delim, index);
         if (found == std::string::npos)
         {
+            // No more delimiters, so add on any remaining characters as the final part
             if (index < str.size())
                 parts.emplace_back(str.substr(index));
             break;
         }
 
-        // Consume consecutive delimiters
-        if ((found - index) >= delim.size())
+        // Store the current string fragment from index->found if we didn't find a delimiter at the starting index
+        if (found != index)
             parts.emplace_back(str.substr(index, found - index));
 
+        // Move to character after current delimiter
         index = found + delim.size();
     }
+
     return parts;
 }
 

--- a/tests/algorithms/sysFunc.cpp
+++ b/tests/algorithms/sysFunc.cpp
@@ -12,13 +12,24 @@ struct NameObject
     NameObject(std::string newName) : name(std::move(newName)) {};
     std::string name;
 };
-TEST(SysFunc, StringManipulation)
+
+TEST(SysFunc, NiceName)
+{
+    // Nice name
+    EXPECT_TRUE(DissolveSys::niceName(" /\\#*$") == "______");
+    EXPECT_TRUE(DissolveSys::niceName("Under score") == "Under_score");
+}
+
+TEST(SysFunc, StringMatchingSimple)
 {
     // String matching
     EXPECT_TRUE(DissolveSys::sameString("Hello", "Hello", true));
     EXPECT_TRUE(DissolveSys::sameString("Hello", "hello"));
     EXPECT_FALSE(DissolveSys::sameString("Hello", "hello", true));
+}
 
+TEST(SysFunc, StringMatchingWildcard)
+{
     // Wildcard string matching
     EXPECT_TRUE(DissolveSys::sameWildString("*", "Literally Anything"));
     EXPECT_FALSE(DissolveSys::sameWildString("*A", "Not Quite Anything"));
@@ -32,7 +43,10 @@ TEST(SysFunc, StringManipulation)
     EXPECT_TRUE(DissolveSys::sameWildString("abc*efg", "ABCDEFG"));
     EXPECT_FALSE(DissolveSys::sameWildString("abc*efg", "ABCDEFGH"));
     EXPECT_TRUE(DissolveSys::sameWildString("abc*efg?", "ABCDEFGH"));
+}
 
+TEST(SysFunc, StringBeforeAfter)
+{
     // Before / after chars and strings
     EXPECT_TRUE(DissolveSys::beforeChar("Something=This", '=') == "Something");
     EXPECT_TRUE(DissolveSys::afterChar("Something=This", '=') == "This");
@@ -47,17 +61,19 @@ TEST(SysFunc, StringManipulation)
     EXPECT_TRUE(DissolveSys::afterLastChar("Just a string", '=').empty());
     EXPECT_TRUE(DissolveSys::afterString("Just a string", "I'm not here").empty());
     EXPECT_TRUE(DissolveSys::afterString("Just a string", "string").empty());
+}
 
+TEST(SysFunc, StringStartsEnds)
+{
     // Starts / ends with
     EXPECT_TRUE(DissolveSys::startsWith("I am a little man", "I am"));
     EXPECT_FALSE(DissolveSys::startsWith("I am a little man", "i am"));
     EXPECT_TRUE(DissolveSys::endsWith("I have a plan", "plan"));
     EXPECT_FALSE(DissolveSys::endsWith("I have a plan", "man"));
+}
 
-    // Nice name
-    EXPECT_TRUE(DissolveSys::niceName(" /\\#*$") == "______");
-    EXPECT_TRUE(DissolveSys::niceName("Under score") == "Under_score");
-
+TEST(SysFunc, StringToNumber)
+{
     // Conversion to numbers
     EXPECT_TRUE(DissolveSys::isNumber("1.0"));
     EXPECT_TRUE(DissolveSys::isNumber("1.0E-5"));
@@ -87,11 +103,17 @@ TEST(SysFunc, StringManipulation)
     EXPECT_FALSE(isFP);
     EXPECT_FALSE(DissolveSys::isNumber("e-1", isFP));
     EXPECT_FALSE(isFP);
+}
 
+TEST(SysFunc, StringReplacement)
+{
     // String replacement
     EXPECT_TRUE(DissolveSys::replace("Swap the aaa's", "a", "bee") == "Swbeep the beebeebee's");
     EXPECT_TRUE(DissolveSys::replace("Swap the AaA's", "A", "bee") == "Swap the beeabee's");
+}
 
+TEST(SysFunc, StringSplitSimple)
+{
     // String splitting / joining
     std::vector<std::string_view> v;
     const std::vector<std::string_view> expected = {"arma", "dillo", "is", "in", "pieces"};
@@ -118,11 +140,17 @@ TEST(SysFunc, StringManipulation)
     v = DissolveSys::splitString("   arma   dillo is in    pieces         ", " ");
     EXPECT_EQ(v.size(), 5);
     EXPECT_TRUE(expected == v);
+}
 
+TEST(SysFunc, StringStripping)
+{
     // String strip
     EXPECT_EQ(DissolveSys::strip("No more spaces "), "Nomorespaces");
     EXPECT_EQ(DissolveSys::strip("No more spaces ", 'o'), "N mre spaces ");
+}
 
+TEST(SysFunc, UniqueNames)
+{
     // Unique Naming
     std::vector<NameObject> names;
     EXPECT_TRUE(DissolveSys::uniqueName("IAmUnique", names, [](const auto &obj) { return obj.name; }) == "IAmUnique");

--- a/tests/algorithms/sysFunc.cpp
+++ b/tests/algorithms/sysFunc.cpp
@@ -142,6 +142,36 @@ TEST(SysFunc, StringSplitSimple)
     EXPECT_TRUE(expected == v);
 }
 
+TEST(SysFunc, StringSplitMultiple)
+{
+    const std::vector<std::string_view> abcd = {"A", "B", "C", "D"};
+
+    // -- Two character delimiter
+    auto split = DissolveSys::splitString("A//B//C//D", "//");
+    EXPECT_EQ(split.size(), 4);
+    EXPECT_TRUE(split == abcd);
+
+    // -- Trailing two character delimiter
+    split = DissolveSys::splitString("A//B//C//D//", "//");
+    EXPECT_EQ(split.size(), 4);
+    EXPECT_TRUE(split == abcd);
+
+    // -- Leading two character delimiter
+    split = DissolveSys::splitString("//A//B//C//D", "//");
+    EXPECT_EQ(split.size(), 4);
+    EXPECT_TRUE(split == abcd);
+
+    // -- Leading and trailing two character delimiter
+    split = DissolveSys::splitString("//A//B//C//D//", "//");
+    EXPECT_EQ(split.size(), 4);
+    EXPECT_TRUE(split == abcd);
+
+    // -- Larger delimiter
+    split = DissolveSys::splitString("AanklesBanklesCanklesDankles", "ankles");
+    EXPECT_EQ(split.size(), 4);
+    EXPECT_TRUE(split == abcd);
+}
+
 TEST(SysFunc, StringStripping)
 {
     // String strip

--- a/tests/workflows/phantomAtoms.cpp
+++ b/tests/workflows/phantomAtoms.cpp
@@ -41,6 +41,7 @@ TEST_F(PhantomAtomsTest, Basic)
     procedure.createRootNode<AddGeneratorNode>("ArtAr", artAr, nMolecules);
 
     // Set up the prior configuration
+    dissolve.updatePairPotentials();
     cfg->generate({dissolve});
 
     // Basic species checks


### PR DESCRIPTION
This PR fixes an issue with `DissolveSys::splitString()` and also the phantom atoms workflow test.  Also reorganises the sysFunc.cpp into smaller chunks for sanity.