### PR TITLE
build:Update singularity building pipeline

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -6,24 +6,35 @@
     nixGL-src.flake = false;
   };
   outputs =
-    { self, nixpkgs, outdated, home-manager, flake-utils, bundlers, nixGL-src }:
+    {
+      self,
+      nixpkgs,
+      outdated,
+      home-manager,
+      flake-utils,
+      bundlers,
+      nixGL-src,
+    }:
     let
 
       toml = pkgs: ((import ./nix/toml11.nix) { inherit pkgs; });
-      onedpl = pkgs:
+      onedpl =
+        pkgs:
         ((import ./nix/onedpl.nix) {
-          inherit (pkgs) lib stdenv fetchFromGitHub fetchpatch cmake;
+          inherit (pkgs)
+            lib
+            stdenv
+            fetchFromGitHub
+            fetchpatch
+            cmake
+            ;
           tbb = pkgs.tbb_2021_11;
         });
-      exe-name = mpi: gui:
-        if mpi then
-          "dissolve-mpi"
-        else
-          (if gui then "dissolve-gui" else "dissolve");
+      exe-name = mpi: gui: if mpi then "dissolve-mpi" else (if gui then "dissolve-gui" else "dissolve");
       cmake-bool = x: if x then "ON" else "OFF";
       version = "1.8.0";
-      base_libs = pkgs:
-        with pkgs; [
+      base_libs =
+        pkgs: with pkgs; [
           antlr4
           antlr4.runtime.cpp
           antlr4.runtime.cpp.dev
@@ -39,8 +50,8 @@
           pugixml
           (toml pkgs)
         ];
-      gui_libs = system: pkgs: qt:
-        with pkgs; [
+      gui_libs =
+        system: pkgs: qt: with pkgs; [
           glib
           freetype
           ftgl
@@ -60,15 +71,22 @@
         ];
       check_libs = pkgs: with pkgs; [ gtest ];
 
-    in flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+    in
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
 
       let
         pkgs = import nixpkgs { inherit system; };
-        old = import outdated { inherit system; };
         nixGL = import nixGL-src { inherit pkgs; };
-        qt = old.qt6;
-        dissolve = { mpi ? false, gui ? false, threading ? true, checks ? true
-          , benchmarks ? false }:
+        qt = (import outdated { inherit system; }).qt6;
+        dissolve =
+          {
+            mpi ? false,
+            gui ? false,
+            threading ? true,
+            checks ? true,
+            benchmarks ? false,
+          }:
           assert (!(gui && mpi));
           pkgs.stdenv.mkDerivation ({
             inherit version;
@@ -77,7 +95,9 @@
               path = ./.;
               name = "dissolve-src";
             };
-            buildInputs = base_libs pkgs ++ pkgs.lib.optional mpi pkgs.openmpi
+            buildInputs =
+              base_libs pkgs
+              ++ pkgs.lib.optional mpi pkgs.openmpi
               ++ pkgs.lib.optionals gui (gui_libs system pkgs qt)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optionals threading [
@@ -112,22 +132,28 @@
               # license = licenses.unlicense;
               maintainers = [ maintainers.rprospero ];
             };
-          }) // (if checks then { QT_QPA_PLATFORM = "offscreen"; } else { });
-        mkSingularity = { mpi ? false, gui ? false, threading ? true }:
-          outdated.legacyPackages.${system}.singularity-tools.buildImage {
+          })
+          // (if checks then { QT_QPA_PLATFORM = "offscreen"; } else { });
+        mkSingularity =
+          {
+            mpi ? false,
+            gui ? false,
+            threading ? true,
+          }:
+          pkgs.singularity-tools.buildImage {
             name = "${exe-name mpi gui}-${version}";
             diskSize = 1024 * 50;
             contents = [ (dissolve { inherit mpi gui threading; }) ];
-            runScript = if gui then
-              "${nixGL.nixGLIntel}/bin/nixGLIntel ${
-                dissolve { inherit mpi gui threading; }
-              }/bin/${exe-name mpi gui} $@"
-            else
-              "${dissolve { inherit mpi gui threading; }}/bin/${
-                exe-name mpi gui
-              } $@";
+            runScript =
+              if gui then
+                "${nixGL.nixGLIntel}/bin/nixGLIntel ${
+                  dissolve { inherit mpi gui threading; }
+                }/bin/${exe-name mpi gui} $@"
+              else
+                "${dissolve { inherit mpi gui threading; }}/bin/${exe-name mpi gui} $@";
           };
-      in {
+      in
+      {
         checks.dissolve = dissolve { checks = true; };
         checks.dissolve-gui = dissolve {
           gui = true;
@@ -148,8 +174,11 @@
 
         devShells.default = pkgs.mkShell {
           name = "dissolve-shell";
-          buildInputs = base_libs pkgs ++ gui_libs system pkgs qt
-            ++ check_libs pkgs ++ (with pkgs; [
+          buildInputs =
+            base_libs pkgs
+            ++ gui_libs system pkgs qt
+            ++ check_libs pkgs
+            ++ (with pkgs; [
               clang-tools
 
               (onedpl pkgs)
@@ -173,22 +202,12 @@
             ]);
           shellHook = ''
             export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS
-            export LIBGL_DRIVERS_PATH=${
-              pkgs.lib.makeSearchPathOutput "lib" "lib/dri"
-              [ pkgs.mesa.drivers ]
-            }
-            export LIBVA_DRIVERS_PATH=${
-              pkgs.lib.makeSearchPathOutput "out" "lib/dri"
-              [ pkgs.mesa.drivers ]
-            }
+            export LIBGL_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "lib" "lib/dri" [ pkgs.mesa.drivers ]}
+            export LIBVA_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "out" "lib/dri" [ pkgs.mesa.drivers ]}
             export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa.drivers}/share/glvnd/egl_vendor.d/50_mesa.json
-            export LD_LIBRARY_PATH=${
-              pkgs.lib.makeLibraryPath [ pkgs.mesa.drivers ]
-            }:${
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.mesa.drivers ]}:${
               pkgs.lib.makeSearchPathOutput "lib" "lib/vdpau" [ pkgs.libvdpau ]
-            }:${
-              pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]
-            }"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            }:${pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]}"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             # export QT_PLUGIN_PATH="${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
             export QT_PLUGIN_PATH="${qt.qtquick3d}/lib/qt-6/plugins:${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
           '';
@@ -198,31 +217,30 @@
           CMAKE_CXX_FLAGS_DEBUG = "-g -O0";
           CXXL = "${pkgs.stdenv.cc.cc.lib}";
           Qt6Quick3D_DIR = "${qt.qtquick3d}/lib/";
-          QML_IMPORT_PATH =
-            "${qt.qtquick3d}/lib/qt-6/qml:${qt.qtdeclarative}/lib/qt-6/qml/";
-          QML2_IMPORT_PATH =
-            "$\${qt.qtquick3d}/lib/qt-6/qml:{qt.qtdeclarative}/lib/qt-6/qml/";
+          QML_IMPORT_PATH = "${qt.qtquick3d}/lib/qt-6/qml:${qt.qtdeclarative}/lib/qt-6/qml/";
+          QML2_IMPORT_PATH = "$\${qt.qtquick3d}/lib/qt-6/qml:{qt.qtdeclarative}/lib/qt-6/qml/";
         };
 
         apps = {
           benchmarks = {
             type = "app";
-            program = toString (pkgs.writeScript "benchmark.sh" ''
-              #!/bin/sh
-              set -e
-              export TMP=$(mktemp -d)
-              for bm in ${self.packages.${system}.benchmarks}/bin/benchmark_*
-              do
-                export BENCHNAME=$(basename ${"$"}{bm})_result.json
-                >&2 echo Running ${"$"}{BENCHNAME}
-                ${"$"}{bm} --benchmark_format=json > $TMP/${"$"}{BENCHNAME}
-              done
-              ${pkgs.jq}/bin/jq -s '[.[] | to_entries] | flatten | reduce .[] as $dot ({}; .[$dot.key] += $dot.value)' $TMP/benchmark_*.json > $TMP/all_benchmark_results.json
-              cat $TMP/all_benchmark_results.json
-            '');
+            program = toString (
+              pkgs.writeScript "benchmark.sh" ''
+                #!/bin/sh
+                set -e
+                export TMP=$(mktemp -d)
+                for bm in ${self.packages.${system}.benchmarks}/bin/benchmark_*
+                do
+                  export BENCHNAME=$(basename ${"$"}{bm})_result.json
+                  >&2 echo Running ${"$"}{BENCHNAME}
+                  ${"$"}{bm} --benchmark_format=json > $TMP/${"$"}{BENCHNAME}
+                done
+                ${pkgs.jq}/bin/jq -s '[.[] | to_entries] | flatten | reduce .[] as $dot ({}; .[$dot.key] += $dot.value)' $TMP/benchmark_*.json > $TMP/all_benchmark_results.json
+                cat $TMP/all_benchmark_results.json
+              ''
+            );
           };
-          dissolve-app =
-            flake-utils.lib.mkApp { drv = self.packages.${system}.dissolve; };
+          dissolve-app = flake-utils.lib.mkApp { drv = self.packages.${system}.dissolve; };
           dissolve-mpi-app = flake-utils.lib.mkApp {
             drv = self.packages.${system}.dissolve-mpi;
           };
@@ -231,25 +249,22 @@
           };
           uploader = {
             type = "app";
-            program = toString (pkgs.writeScript "upload.sh" ''
-              #!/bin/sh
-              set -e
-              if [ "$#" -ne 4 ] ; then
-                echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
-                exit 1
-              fi
-              ${
-                outdated.legacyPackages.${system}.singularity
-              }/bin/singularity remote login --username $1 --password $2 docker://harbor.stfc.ac.uk
-              ${
-                outdated.legacyPackages.${system}.singularity
-              }/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
-            '');
+            program = toString (
+              pkgs.writeScript "upload.sh" ''
+                #!/bin/sh
+                set -e
+                if [ "$#" -ne 4 ] ; then
+                  echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
+                  exit 1
+                fi
+                ${pkgs.singularity}/bin/singularity remote login --username $1 --password $2 docker://harbor.stfc.ac.uk
+                ${pkgs.singularity}/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
+              ''
+            );
           };
         };
 
-        defaultApp =
-          flake-utils.lib.mkApp { drv = self.defaultPackage.${system}; };
+        defaultApp = flake-utils.lib.mkApp { drv = self.defaultPackage.${system}; };
 
         packages = {
           benchmarks = dissolve {
@@ -293,8 +308,7 @@
           docker-mpi = pkgs.dockerTools.buildImage {
             name = "dissolve-mpi";
             tag = "latest";
-            config.ENTRYPOINT =
-              [ "${self.packages.${system}.dissolve-mpi}/bin/dissolve-mpi" ];
+            config.ENTRYPOINT = [ "${self.packages.${system}.dissolve-mpi}/bin/dissolve-mpi" ];
           };
         };
 
@@ -305,6 +319,9 @@
           };
         };
 
-        homeManagerModule = { user-env = import ./nix/user-env.nix; };
-      });
+        homeManagerModule = {
+          user-env = import ./nix/user-env.nix;
+        };
+      }
+    );
 }


### PR DESCRIPTION
The main purpose of this PR is to fix the singularity build and get Dissolve running on IDAaaS again.  This change is mainly housed in the definition of `mkSingularity` around line 137.  We now pull in the latest singularity patches straight from nixpkgs, instead of using an older version.  My testing shows that this fixes the issue with the broken singularity images.

The remaining changes are just updating the flake to the correct nix formatting.

As part of testing this, I discovered that the latest nix versions can properly handle submodules, which can let us eliminate the "unholy hack" and should enable some other iterations on the build, but I wanted to get this in first to get IDAaaS fixed.