### PR TITLE
chore:Fix submodule hack on CI

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -50,45 +50,12 @@ runs:
     run: |
       set -ex
 
-      ### Begin unholy hack
-      ###
-      ### For reasons unknown, when nix is run under GitHub actions,
-      ### it ignores the submodules flag, meaning that flakes with
-      ### submodules cannot be built
-      ###
-      ### As a blasphemous workaround, I've added a step to bring the
-      ### submodule into the main repo.  Hopefully, submodules are
-      ### made the default flake behaviour in the upcoming release,
-      ### this will no longer be necessary.  If not, we might have to
-      ### make the submodule an extra input to the flake, but that
-      ### will take some extra time.
-      ###
-      ### If you are reading this comment in 2026, try removing this
-      ### entire hack and see if the problem fixed itself.  You may
-      ### also need to update the action that installs nix in the
-      ### first place.  If that doesn't solve the problem, then we
-      ### should go ahead and just make the submodule a flake input.
-
       git submodule update --init --recursive
-      git config --global user.email "no_one@example.com"
-      git config --global user.name "GitHub Actions"
-      git rm .gitmodules
-
-      cp -r QuickPlot QuickPlot.bak
-      rm -rf QuickPlot.bak/.git
-      git rm -r QuickPlot
-      git commit -m "Kill submodule"
-
-      mv QuickPlot.bak QuickPlot
-      git add QuickPlot
-      git commit -m "Resurrect submodule"
-
-      ### End unholy hack
 
       # Build Singularity target
       target=${{ inputs.target }}
       singularityTarget=${target/dissolve/singularity}
-      nix build -L ".?submodules=1#$singularityTarget"
+      nix build -L ".#$singularityTarget"
 
       # Assemble artifacts
       mkdir packages-sif

--- a/.github/workflows/get-nix/action.yml
+++ b/.github/workflows/get-nix/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
 
   - name: Install Nix
-    uses: cachix/install-nix-action@v25
+    uses: cachix/install-nix-action@v31
     with:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: |

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    self.submodules = true;
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     outdated.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixGL-src.url = "github:guibou/nixGL";


### PR DESCRIPTION
At the base level, this PR just updates the nix version that we use on the CI.  However, that nix version includes support for flakes in submodules, so that is added to the flake.  In turn, since flakes are support in submodules, we can remove the submodule hack on the CI.