### PR TITLE
chore:Nix flake whitelist

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -72,33 +72,33 @@ runs:
       mkdir packages-binary
       cp -v binary packages-binary/${{ inputs.target }}-${{ inputs.currentVersion }}
 
-  - name: Run benchmarks
-    if: inputs.benchmark == 'true'
-    shell: bash
-    run: |
-      set -ex
-      export LD_LIBRARY_PATH=`pwd`/build/onetbb/lib
+  # - name: Run benchmarks
+  #   if: inputs.benchmark == 'true'
+  #   shell: bash
+  #   run: |
+  #     set -ex
+  #     export LD_LIBRARY_PATH=`pwd`/build/onetbb/lib
 
-      nix build -L .#benchmarks
-      rm result
-      nix run -L .#benchmarks > all_benchmark_results.json
+  #     nix build -L .#benchmarks
+  #     rm result
+  #     nix run -L .#benchmarks > all_benchmark_results.json
 
-      cat all_benchmark_results.json
+  #     cat all_benchmark_results.json
 
       # Must reset to HEAD here otherwise the benchmark publishing step will (rightly) fail
-      git reset HEAD --hard
+      # git reset HEAD --hard
 
-  - name: Store benchmark result
-    uses: benchmark-action/github-action-benchmark@v1
-    if: inputs.publishBenchmarks == 'true' && inputs.benchmark == 'true'
-    with:
-      tool: 'googlecpp'
-      output-file-path: all_benchmark_results.json
-      github-token: ${{ github.token }}
-      auto-push: true
-      comment-on-alert: true
-      alert-threshold: '200%'
-      alert-comment-cc-users: '@disorderedmaterials/dissolve-devs'
+  # - name: Store benchmark result
+  #   uses: benchmark-action/github-action-benchmark@v1
+  #   if: inputs.publishBenchmarks == 'true' && inputs.benchmark == 'true'
+  #   with:
+  #     tool: 'googlecpp'
+  #     output-file-path: all_benchmark_results.json
+  #     github-token: ${{ github.token }}
+  #     auto-push: true
+  #     comment-on-alert: true
+  #     alert-threshold: '200%'
+  #     alert-comment-cc-users: '@disorderedmaterials/dissolve-devs'
 
   - name: Tidy nix Store
     if: inputs.cacheOnly == 'true'

--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -50,45 +50,12 @@ runs:
     run: |
       set -ex
 
-      ### Begin unholy hack
-      ###
-      ### For reasons unknown, when nix is run under GitHub actions,
-      ### it ignores the submodules flag, meaning that flakes with
-      ### submodules cannot be built
-      ###
-      ### As a blasphemous workaround, I've added a step to bring the
-      ### submodule into the main repo.  Hopefully, submodules are
-      ### made the default flake behaviour in the upcoming release,
-      ### this will no longer be necessary.  If not, we might have to
-      ### make the submodule an extra input to the flake, but that
-      ### will take some extra time.
-      ###
-      ### If you are reading this comment in 2026, try removing this
-      ### entire hack and see if the problem fixed itself.  You may
-      ### also need to update the action that installs nix in the
-      ### first place.  If that doesn't solve the problem, then we
-      ### should go ahead and just make the submodule a flake input.
-
       git submodule update --init --recursive
-      git config --global user.email "no_one@example.com"
-      git config --global user.name "GitHub Actions"
-      git rm .gitmodules
-
-      cp -r QuickPlot QuickPlot.bak
-      rm -rf QuickPlot.bak/.git
-      git rm -r QuickPlot
-      git commit -m "Kill submodule"
-
-      mv QuickPlot.bak QuickPlot
-      git add QuickPlot
-      git commit -m "Resurrect submodule"
-
-      ### End unholy hack
 
       # Build Singularity target
       target=${{ inputs.target }}
       singularityTarget=${target/dissolve/singularity}
-      nix build -L ".?submodules=1#$singularityTarget"
+      nix build -L ".#$singularityTarget"
 
       # Assemble artifacts
       mkdir packages-sif

--- a/.github/workflows/continuous.yml
+++ b/.github/workflows/continuous.yml
@@ -31,8 +31,8 @@ jobs:
     needs: [Checkout]
     uses: "./.github/workflows/_build_and_package.yml"
     with:
-      benchmark: true
-      publishBenchmarks: true
+      benchmark: false
+      publishBenchmarks: false
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}

--- a/.github/workflows/get-nix/action.yml
+++ b/.github/workflows/get-nix/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
 
   - name: Install Nix
-    uses: cachix/install-nix-action@v25
+    uses: cachix/install-nix-action@v31
     with:
       nix_path: nixpkgs=channel:nixos-unstable
       extra_nix_config: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,7 +35,7 @@ jobs:
     needs: [Checkout]
     uses: "./.github/workflows/_build_and_package.yml"
     with:
-      benchmark: true
+      benchmark: false
       currentVersion: ${{ needs.Checkout.outputs.currentVersion }}
       msvcVersion: ${{ needs.Checkout.outputs.msvcVersion }}
       osxTargetDeploymentVersion: ${{ needs.Checkout.outputs.osxTargetDeploymentVersion }}

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   inputs = {
+    self.submodules = true;
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     outdated.url = "github:NixOS/nixpkgs/nixos-24.05";
     nixGL-src.url = "github:guibou/nixGL";

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,7 @@
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
   };
+
   outputs =
     {
       self,
@@ -80,6 +81,7 @@
         pkgs = import nixpkgs { inherit system; };
         nixGL = import nixGL-src { inherit pkgs; };
         qt = (import outdated { inherit system; }).qt6;
+        fs = pkgs.lib.fileset;
         dissolve =
           {
             mpi ? false,
@@ -92,9 +94,19 @@
           pkgs.stdenv.mkDerivation ({
             inherit version;
             pname = exe-name mpi gui;
-            src = builtins.path {
-              path = ./.;
-              name = "dissolve-src";
+            src = fs.toSource {
+              root = ./.;
+              fileset = (
+                fs.unions [
+                  ./src
+                  ./cmake
+                  ./examples
+                  ./tests
+                  ./benchmark
+                  ./CMakeLists.txt
+                  ./QuickPlot
+                ]
+              );
             };
             buildInputs =
               base_libs pkgs


### PR DESCRIPTION
This PR sets a specific whitelist of the files and folders needed to build Dissolve within the flake.  Anything *not* on this list is invisible to the flake.

Previously, we allowed the flake to see the whole repo.  However, this meant that *any* changes to the folder meant that nix would perform a full rebuild, often resulting in double compilation.  For example, we currently build the executable and then build the singularity image.  However, building the executable puts the resulting binary in the folder.  Nix sees that the folder has changed and, just to be safe, recompiles Dissolve when we go to build the singularity image.  With the whitelist, nix will know that the binary output of the build process isn't part of the compilation, so it will just use the previously cached output to build the singularity image.

The most interesting question to review is where there are any other files or folders that we truly require.