### PR TITLE
refactor: Const PairPotential

### DIFF
--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -255,13 +255,13 @@ double PairPotential::range() const { return range_; }
 double PairPotential::delta() const { return delta_; }
 
 // Return potential at specified r
-double PairPotential::energy(double r)
+double PairPotential::energy(double r) const
 {
     assert(r >= 0);
 
     return totalPotentialInterpolation_.y(r, r * rDelta_);
 }
-double PairPotential::energy(double r, double elecScale, double srScale)
+double PairPotential::energy(double r, double elecScale, double srScale) const
 {
     assert(r >= 0);
 
@@ -302,13 +302,13 @@ double PairPotential::analyticCoulombEnergy(double qiqj, double r, PairPotential
 }
 
 // Return derivative at specified r
-double PairPotential::force(double r)
+double PairPotential::force(double r) const
 {
     assert(r >= 0);
 
     return -totalDerivativeInterpolation_.y(r, r * rDelta_);
 }
-double PairPotential::force(double r, double elecScale, double srScale)
+double PairPotential::force(double r, double elecScale, double srScale) const
 {
     assert(r >= 0);
 

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -142,8 +142,8 @@ class PairPotential : Serialisable<>
     // Return spacing between points
     double delta() const;
     // Return potential at specified r
-    double energy(double r);
-    double energy(double r, double elecScale, double srScale);
+    double energy(double r) const;
+    double energy(double r, double elecScale, double srScale) const;
     // Return analytic potential at specified r, including Coulomb term from local charge product
     double analyticEnergy(double r, double elecScale, double srScale) const;
     // Return analytic potential at specified r, including Coulomb term from supplied charge product
@@ -154,8 +154,8 @@ class PairPotential : Serialisable<>
     analyticCoulombEnergy(double qiqj, double r,
                           PairPotential::CoulombTruncationScheme truncation = PairPotential::coulombTruncationScheme()) const;
     // Return derivative of potential at specified r
-    double force(double r);
-    double force(double r, double elecScale, double srScale);
+    double force(double r) const;
+    double force(double r, double elecScale, double srScale) const;
     // Return analytic force at specified r, including Coulomb term from local charge product
     double analyticForce(double r, double elecScale, double srScale) const;
     // Return analytic force at specified r, including Coulomb term from supplied charge product

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -9,8 +9,8 @@
 #include "classes/pairPotential.h"
 #include "classes/species.h"
 
-PotentialMap::PotentialMap(const std::vector<const AtomType *> &atomTypes,
-                           const DoubleKeyedMap<std::shared_ptr<PairPotential>> &pairPotentials, double pairPotentialRange)
+PotentialMap::PotentialMap(const std::vector<const AtomType *> &atomTypes, const DoubleKeyedMap<PairPotential> &pairPotentials,
+                           double pairPotentialRange)
 {
     // Create PairPotential matrix
     nTypes_ = atomTypes.size();
@@ -20,21 +20,18 @@ PotentialMap::PotentialMap(const std::vector<const AtomType *> &atomTypes,
         ParallelPolicies::seq, atomTypes,
         [&](int i, const auto &atI, int j, const auto &atJ)
         {
-            auto pp = pairPotentials.get({atI->name(), atJ->name()}).get();
-
             // Store PairPotential pointer
             if (i == j)
             {
                 Messenger::print("Linking self-interaction PairPotential for '{}' (index {},{} in matrix).\n", atI->name(), i,
                                  j);
-                potentialMatrix_[{i, j}] = pp;
+                potentialMatrix_[{i, j}] = &pairPotentials.get({atI->name(), atJ->name()});
             }
             else
             {
                 Messenger::print("Linking PairPotential between '{}' and '{}' (indices {},{} and {},{} in matrix).\n",
                                  atI->name(), atJ->name(), i, j, j, i);
-                potentialMatrix_[{i, j}] = pp;
-                potentialMatrix_[{j, i}] = pp;
+                potentialMatrix_[{i, j}] = &pairPotentials.get({atI->name(), atJ->name()});
             }
         });
 

--- a/src/classes/potentialMap.h
+++ b/src/classes/potentialMap.h
@@ -17,8 +17,8 @@ class PotentialMap
 {
     public:
     PotentialMap() = default;
-    PotentialMap(const std::vector<const AtomType *> &atomTypes,
-                 const DoubleKeyedMap<std::shared_ptr<PairPotential>> &pairPotentials, double pairPotentialRange);
+    PotentialMap(const std::vector<const AtomType *> &atomTypes, const DoubleKeyedMap<PairPotential> &pairPotentials,
+                 double pairPotentialRange);
     ~PotentialMap() = default;
     // Clear all data
     void clear();
@@ -30,7 +30,7 @@ class PotentialMap
     // Number of unique types forming the matrix
     int nTypes_;
     // PairPotential matrix
-    Array2D<PairPotential *> potentialMatrix_;
+    Array2D<const PairPotential *> potentialMatrix_;
     // PairPotential range
     double range_;
 

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -26,7 +26,7 @@ Dissolve &DissolveGraph::dissolve() const { return dissolve_; }
 DissolveGraph *DissolveGraph::dissolveGraph() { return this; }
 
 // Return pair potential store
-const DoubleKeyedMap<std::shared_ptr<PairPotential>> &DissolveGraph::pairPotentialStore() { return pairPotentialStore_; }
+const DoubleKeyedMap<PairPotential> &DissolveGraph::pairPotentialStore() { return pairPotentialStore_; }
 
 /*
  * Functions
@@ -70,10 +70,10 @@ void DissolveGraph::updatePairPotentials(const AtomType &i, const AtomType &j)
     auto interactionPotential = ShortRangeFunctions::combine(i.interactionPotential(), j.interactionPotential());
 
     if (interactionPotential.has_value())
-        pairPotentialStore_.set(nameI, nameJ, std::make_shared<PairPotential>(nameI, nameJ, *interactionPotential));
+        pairPotentialStore_.set(nameI, nameJ, {nameI, nameJ, *interactionPotential});
     else
-        pairPotentialStore_.set(nameI, nameJ, std::make_shared<PairPotential>(nameI, nameJ));
+        pairPotentialStore_.set(nameI, nameJ, {nameI, nameJ});
 
-    auto pot = pairPotentialStore_.get({nameI, nameJ});
-    pot->tabulate(pairPotentialRange_, pairPotentialDelta_, i.charge() * j.charge());
+    auto &pot = pairPotentialStore_.get({nameI, nameJ});
+    pot.tabulate(pairPotentialRange_, pairPotentialDelta_, i.charge() * j.charge());
 }

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -38,7 +38,7 @@ class DissolveGraph : public Graph
     // Dissolve reference
     Dissolve &dissolve_;
     // Pair potential store
-    DoubleKeyedMap<std::shared_ptr<PairPotential>> pairPotentialStore_{true};
+    DoubleKeyedMap<PairPotential> pairPotentialStore_{true};
     // Pair potential range
     double pairPotentialRange_{12};
     // Pair potential delta
@@ -50,7 +50,7 @@ class DissolveGraph : public Graph
     // Return the DissolveGraph reference
     DissolveGraph *dissolveGraph() override;
     // Return pair potential store
-    const DoubleKeyedMap<std::shared_ptr<PairPotential>> &pairPotentialStore();
+    const DoubleKeyedMap<PairPotential> &pairPotentialStore();
 
     /*
      * Functions


### PR DESCRIPTION
## Precedes #2242

Following #2248 this PR makes the `PairPotential` class completely `const` in its usage, and moves its storage in the new `DissolveNode` map to the bona fide object rather than a `std::shared_ptr`.