### PR TITLE
build: Fix continuous2 CI

### DIFF
--- a/.github/workflows/continuous2.yml
+++ b/.github/workflows/continuous2.yml
@@ -19,7 +19,6 @@ jobs:
   Checkout:
     uses: "./.github/workflows/_checkout.yml"
     with:
-      bump: true
       publishType: 'continuous'
 
   QC:


### PR DESCRIPTION
Just noticed that our continuous Dissolve2 builds were broken - apparently my previous self had also noticed this on the 8th of October, made the fix, and neglected to push the branch.