### PR TITLE
feat: LoopGraph

### DIFF
--- a/src/nodes/debug.cpp
+++ b/src/nodes/debug.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "nodes/debug.h"
+#include <format>
+
+namespace GraphDebug
+{
+// Current indent for printing
+int indent_{0};
+// Return current indent
+std::string indent() { return std::format("{:02d}{}", indent_, std::string(std::max(indent_, 0) * 2, ' ')); }
+// Increase current indent
+void increaseIndent() { ++indent_; }
+// Decrease current indent
+void decreaseIndent() { --indent_; }
+}; // namespace GraphDebug

--- a/src/nodes/debug.h
+++ b/src/nodes/debug.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+#include <string>
+
+namespace GraphDebug
+{
+// Return current indent
+std::string indent();
+// Increase current indent
+void increaseIndent();
+// Decrease current indent
+void decreaseIndent();
+}; // namespace GraphDebug

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -217,11 +217,8 @@ NodeConstants::ProcessResult Edge::pull()
         // All succeeded, so update version index
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();
 
-        std::cout << std::format(" ... pulled edge '{}. as it was out-of-date.\n", definition().asString());
         return NodeConstants::ProcessResult::Success;
     }
-    else
-        std::cout << std::format(" ... edge '{}' is up-to-date.\n", definition().asString());
 
     return NodeConstants::ProcessResult::Unchanged;
 }

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -209,6 +209,11 @@ NodeConstants::ProcessResult Edge::pull()
      */
     if (requiresPull())
     {
+        std::cout << std::format("{}Edge::pull() - edge '{}' needs updated data (versionIndex = {}, sourceNodeVersionIndex = "
+                                 "{}, sourceNodeUpToData = {}).\n",
+                                 GraphDebug::indent(), definition().asString(), sourceNodeVersionIndex_,
+                                 sourceNode_.versionIndex(), sourceNode_.isUpToDate());
+
         auto result = sourceNode_.run();
         if (result != NodeConstants::ProcessResult::Success && result != NodeConstants::ProcessResult::Unchanged)
         {
@@ -224,6 +229,13 @@ NodeConstants::ProcessResult Edge::pull()
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();
 
         return NodeConstants::ProcessResult::Success;
+    }
+    else
+    {
+        std::cout << std::format("{}Edge::pull() - edge '{}' is up-to-date (versionIndex = {}, sourceNodeVersionIndex = {}, "
+                                 "sourceNodeUpToData = {}).\n",
+                                 GraphDebug::indent(), definition().asString(), sourceNodeVersionIndex_,
+                                 sourceNode_.versionIndex(), sourceNode_.isUpToDate());
     }
 
     return NodeConstants::ProcessResult::Unchanged;

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -137,6 +137,9 @@ Node &Edge::targetNode() const { return targetNode_; }
 // Return target input parameter
 ParameterBase &Edge::targetInput() const { return targetInput_; }
 
+// Return version of the source node when this edge was last pulled by the target node.
+int Edge::sourceNodeVersionIndex() const { return sourceNodeVersionIndex_; }
+
 // Return definition for the edge
 EdgeDefinition Edge::definition() const
 {
@@ -209,11 +212,6 @@ NodeConstants::ProcessResult Edge::pull()
      */
     if (requiresPull())
     {
-        std::cout << std::format("{}Edge::pull() - edge '{}' needs updated data (versionIndex = {}, sourceNodeVersionIndex = "
-                                 "{}, sourceNodeUpToData = {}).\n",
-                                 GraphDebug::indent(), definition().asString(), sourceNodeVersionIndex_,
-                                 sourceNode_.versionIndex(), sourceNode_.isUpToDate());
-
         auto result = sourceNode_.run();
         if (result != NodeConstants::ProcessResult::Success && result != NodeConstants::ProcessResult::Unchanged)
         {
@@ -229,13 +227,6 @@ NodeConstants::ProcessResult Edge::pull()
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();
 
         return NodeConstants::ProcessResult::Success;
-    }
-    else
-    {
-        std::cout << std::format("{}Edge::pull() - edge '{}' is up-to-date (versionIndex = {}, sourceNodeVersionIndex = {}, "
-                                 "sourceNodeUpToData = {}).\n",
-                                 GraphDebug::indent(), definition().asString(), sourceNodeVersionIndex_,
-                                 sourceNode_.versionIndex(), sourceNode_.isUpToDate());
     }
 
     return NodeConstants::ProcessResult::Unchanged;

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -228,6 +228,12 @@ NodeConstants::ProcessResult Edge::pull()
 
         return NodeConstants::ProcessResult::Success;
     }
+    else
+    {
+        // Copy the parameter data over
+        if (!targetInput_.assign(&sourceOutput_))
+            return NodeConstants::ProcessResult::Failed;
+    }
 
     return NodeConstants::ProcessResult::Unchanged;
 }

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -217,8 +217,11 @@ NodeConstants::ProcessResult Edge::pull()
         // All succeeded, so update version index
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();
 
+        std::cout << std::format(" ... pulled edge '{}. as it was out-of-date.\n", definition().asString());
         return NodeConstants::ProcessResult::Success;
     }
+    else
+        std::cout << std::format(" ... edge '{}' is up-to-date.\n", definition().asString());
 
     return NodeConstants::ProcessResult::Unchanged;
 }

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -193,6 +193,12 @@ void EdgeDefinition::deserialise(const SerialisedValue &node)
     targetInput = toml::find<std::string>(node, "targetInput");
 }
 
+// Return whether the edge links to updated data and requires a pull
+bool Edge::requiresPull() const
+{
+    return (!sourceNode_.isUpToDate()) || (sourceNodeVersionIndex_ != sourceNode_.versionIndex());
+}
+
 // Pull the data from the source node to the target, returning a ProcessResult
 NodeConstants::ProcessResult Edge::pull()
 {
@@ -201,7 +207,7 @@ NodeConstants::ProcessResult Edge::pull()
      * itself we need to pull from or run the source node to get the updated output. We can then store the source node's
      * current versionIndex ready for next time.
      */
-    if (!sourceNode_.isUpToDate() || (sourceNodeVersionIndex_ != sourceNode_.versionIndex()))
+    if (requiresPull())
     {
         auto result = sourceNode_.run();
         if (result != NodeConstants::ProcessResult::Success && result != NodeConstants::ProcessResult::Unchanged)

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -67,6 +67,8 @@ class Edge : public Serialisable<>
     Node &targetNode() const;
     // Return target input parameter
     ParameterBase &targetInput() const;
+    // Return version of the source node when this edge was last pulled by the target node.
+    int sourceNodeVersionIndex() const;
     // Return definition for the edge
     EdgeDefinition definition() const;
     // Return whether the edge links to updated data and requires a pull

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -69,6 +69,8 @@ class Edge : public Serialisable<>
     ParameterBase &targetInput() const;
     // Return definition for the edge
     EdgeDefinition definition() const;
+    // Return whether the edge links to updated data and requires a pull
+    bool requiresPull() const;
     // Pull the data from the source node to the target, returning a ProcessResult
     NodeConstants::ProcessResult pull();
     // Ensure next call to pull() will retrieve the data from the source node

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -87,7 +87,7 @@ void Graph::setUpdateRequired()
 bool Graph::addProxyInput(std::shared_ptr<ParameterBase> &input, std::shared_ptr<ParameterBase> &output)
 {
     // We (the Graph) own the input and the proxyInputs_ owns the output
-    return ownParameter(input) && proxyInputs_->ownParameter(output, true);
+    return ownParameter(input) && proxyInputs_->addProxy(output);
 }
 
 // Add supplied proxy output, setting ownership of the parameters appropriately

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -35,34 +35,34 @@ NodeConstants::ProcessResult Graph::process()
      * one of two ways. Either 1) We cycle over Edge connections to inputs on our Outputs node and pull() those in, or 2) we
      * look for any nodes that don't have any edge connections to their Outputs and try to run() them one at a time. The
      * latter case is important if a Graph has no defined Outputs, and so no external dependence on running the child nodes.
+     * This logic boils down to the same check - if a given node has no outputs (as is always the case for the OutputsNode)
+     * then we run() it.
      */
-
-    // Pull outputs first
-    auto outputsResult = proxyOutputs_->run();
-    if (outputsResult == NodeConstants::ProcessResult::Failed)
-        return outputsResult;
-
-    // Check each node for output edges - any that have zero output edges need to be run()
-    auto terminalNodeResult = NodeConstants::ProcessResult::Unchanged;
+    auto result = NodeConstants::ProcessResult::Unchanged;
     for (auto &&[nodeName, node] : nodes_)
-        if (!node->outputEdges().empty())
+    {
+        if (node->outputEdges().empty())
         {
+            std::cout << std::format("{}Graph::process() - Node '{}' has no output edges and will be run...\n",
+                                     GraphDebug::indent(), node->name());
             switch (node->run())
             {
                 case (NodeConstants::ProcessResult::Failed):
                     return NodeConstants::ProcessResult::Failed;
+                case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                    /* This should never happen? */
+                    return NodeConstants::ProcessResult::Failed;
+                    break;
                 case (NodeConstants::ProcessResult::Success):
-                    terminalNodeResult = NodeConstants::ProcessResult::Success;
+                    result = NodeConstants::ProcessResult::Success;
                     break;
                 case (NodeConstants::ProcessResult::Unchanged):
                     break;
-                case (NodeConstants::ProcessResult::InputsNotSatisfied):
-                    /* This should never happen? */
-                    break;
             }
         }
+    }
 
-    return outputsResult == terminalNodeResult ? outputsResult : NodeConstants::ProcessResult::Success;
+    return result;
 }
 
 // Flag that the node data needs to be updated

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -43,8 +43,7 @@ NodeConstants::ProcessResult Graph::process()
     {
         if (node->outputEdges().empty())
         {
-            std::cout << std::format("{}Graph::process() - Node '{}' has no output edges and will be run...\n",
-                                     GraphDebug::indent(), node->name());
+            debug("{}Graph::process() - Node '{}' has no output edges and will be run...", GraphDebug::indent(), node->name());
             switch (node->run())
             {
                 case (NodeConstants::ProcessResult::Failed):

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -46,7 +46,7 @@ class Graph : public Node
     /*
      * Inputs, Outputs, and Options
      */
-    private:
+    protected:
     // Proxy input and output nodes
     InputsNode *proxyInputs_{nullptr};
     OutputsNode *proxyOutputs_{nullptr};
@@ -66,7 +66,7 @@ class Graph : public Node
     using ReverseNodes = std::map<const Node *, std::string>;
     using Edges = std::vector<std::unique_ptr<Edge>>;
 
-    private:
+    protected:
     // Map of node names to nodes
     Nodes nodes_;
     // Map of nodes to node names

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -3,7 +3,7 @@
 
 #include "nodes/inputs.h"
 
-InputsNode::InputsNode(Graph *parentGraph) : Node(parentGraph) {}
+InputsNode::InputsNode(Graph *parentGraph) : Node(parentGraph) { pullInputsOnRun_ = false; }
 
 /*
  * Definition (Virtuals)
@@ -21,20 +21,6 @@ std::string_view InputsNode::summary() const { return "Maps graph inputs to loca
 
 // Perform processing
 NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::ProcessResult::Success; }
-
-// Run the node, retrieving dependent inputs as necessary
-NodeConstants::ProcessResult InputsNode::run()
-{
-    // We have no processing to speak of, but need to update our version index and flag if we were invalidated (typically
-    // from an upstream node changing through a proxy edge)
-    if (!upToDate_ || versionIndex_ == NodeConstants::InvalidVersion)
-    {
-        ++versionIndex_;
-        upToDate_ = true;
-    }
-
-    return NodeConstants::ProcessResult::Success;
-}
 
 /*
  * Inputs, Outputs, and Options

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -22,6 +22,31 @@ std::string_view InputsNode::summary() const { return "Maps graph inputs to loca
 // Perform processing
 NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::ProcessResult::Success; }
 
+// Run the node, retrieving dependent inputs as necessary
+NodeConstants::ProcessResult InputsNode::run()
+{
+    // TODO Something else happens here!
+    return NodeConstants::ProcessResult::Success;
+}
+
+/*
+ * Inputs, Outputs, and Options
+ */
+
+// Add a proxy output, creating a loopback input for it at the same time
+bool InputsNode::addProxy(std::shared_ptr<ParameterBase> &output)
+{
+    // Own the output end of the proxy connection
+    if (!ownParameter(output, true))
+        return false;
+
+    // Create a loopback input of the same name
+    auto param = inputs_.emplace(std::make_pair(output->name(), output)).first->second;
+    param->setFlags(ParameterBase::ParameterFlags::Input);
+
+    return true;
+}
+
 /*
  * Serialisation
  */

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -25,8 +25,17 @@ NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::Proce
 // Run the node
 NodeConstants::ProcessResult InputsNode::run()
 {
+    // if (!pullInputEdges())
+    //     return NodeConstants::ProcessResult::Failed;
+
+    std::cout << std::format("{}InputsNode::run() - START upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(), upToDate_,
+                             versionIndex());
+
     upToDate_ = true;
     ++versionIndex_;
+
+    std::cout << std::format("{}InputsNode::run() - END upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(), upToDate_,
+                             versionIndex());
 
     // We never pull inputs and processing is zero so just return Success
     return NodeConstants::ProcessResult::Success;

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -3,7 +3,7 @@
 
 #include "nodes/inputs.h"
 
-InputsNode::InputsNode(Graph *parentGraph) : Node(parentGraph) { pullInputsOnRun_ = false; }
+InputsNode::InputsNode(Graph *parentGraph) : Node(parentGraph) { propagateUpdateRequests_ = false; }
 
 /*
  * Definition (Virtuals)
@@ -21,6 +21,16 @@ std::string_view InputsNode::summary() const { return "Maps graph inputs to loca
 
 // Perform processing
 NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::ProcessResult::Success; }
+
+// Run the node
+NodeConstants::ProcessResult InputsNode::run()
+{
+    upToDate_ = true;
+    ++versionIndex_;
+
+    // We never pull inputs and processing is zero so just return Success
+    return NodeConstants::ProcessResult::Success;
+}
 
 /*
  * Inputs, Outputs, and Options

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -25,19 +25,10 @@ NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::Proce
 // Run the node
 NodeConstants::ProcessResult InputsNode::run()
 {
-    // if (!pullInputEdges())
-    //     return NodeConstants::ProcessResult::Failed;
-
-    std::cout << std::format("{}InputsNode::run() - START upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(), upToDate_,
-                             versionIndex());
-
+    // We never pull inputs and processing is zero so just update and return Success
     upToDate_ = true;
     ++versionIndex_;
 
-    std::cout << std::format("{}InputsNode::run() - END upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(), upToDate_,
-                             versionIndex());
-
-    // We never pull inputs and processing is zero so just return Success
     return NodeConstants::ProcessResult::Success;
 }
 

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -25,7 +25,14 @@ NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::Proce
 // Run the node, retrieving dependent inputs as necessary
 NodeConstants::ProcessResult InputsNode::run()
 {
-    // TODO Something else happens here!
+    // We have no processing to speak of, but need to update our version index and flag if we were invalidated (typically
+    // from an upstream node changing through a proxy edge)
+    if (!upToDate_ || versionIndex_ == NodeConstants::InvalidVersion)
+    {
+        ++versionIndex_;
+        upToDate_ = true;
+    }
+
     return NodeConstants::ProcessResult::Success;
 }
 

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -28,6 +28,17 @@ class InputsNode : public Node
     // Perform processing
     NodeConstants::ProcessResult process() override;
 
+    public:
+    // Run the node, retrieving dependent inputs as necessary
+    NodeConstants::ProcessResult run() override;
+
+    /*
+     * Inputs, Outputs, and Options
+     */
+    public:
+    // Add a proxy output, creating a loopback input for it at the same time
+    bool addProxy(std::shared_ptr<ParameterBase> &output);
+
     /*
      * Serialisation
      */

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -28,10 +28,6 @@ class InputsNode : public Node
     // Perform processing
     NodeConstants::ProcessResult process() override;
 
-    public:
-    // Run the node, retrieving dependent inputs as necessary
-    NodeConstants::ProcessResult run() override;
-
     /*
      * Inputs, Outputs, and Options
      */

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -27,6 +27,8 @@ class InputsNode : public Node
     protected:
     // Perform processing
     NodeConstants::ProcessResult process() override;
+    // Run the node
+    NodeConstants::ProcessResult run() override;
 
     /*
      * Inputs, Outputs, and Options

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -8,8 +8,6 @@
 LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph)
 {
     addOption<Number>("Iterations", "Number of iterations to perform", iterations_);
-    addOption<bool>("LoopbackInvalidates", "Whether loopback edges cause iterations to be rerun on next call",
-                    loopbackInvalidates_);
 }
 
 /*
@@ -20,7 +18,7 @@ LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph)
 std::string_view LoopGraph::type() const { return "Loop"; }
 
 // Return short summary of the node's purpose
-std::string_view LoopGraph::summary() const { return "Loop the contained graph"; }
+std::string_view LoopGraph::summary() const { return "A graph which iterates"; }
 
 /*
  * Processing & Validity
@@ -29,8 +27,7 @@ std::string_view LoopGraph::summary() const { return "Loop the contained graph";
 // Perform processing
 NodeConstants::ProcessResult LoopGraph::process()
 {
-    // Could we have a map of inputs to the graph and when they were updated, which we maintain between runs? We can then decide
-    // whether to use current parameter values or pull from loopback edges.
+    //
     for (auto n = 0; n < iterations_.asInteger(); ++n)
     {
         std::cout << std::format("\nLoopGraph::process() - iteration {}\n\n", n);
@@ -62,17 +59,6 @@ NodeConstants::ProcessResult LoopGraph::process()
         if (result == NodeConstants::ProcessResult::Failed || result == NodeConstants::ProcessResult::InputsNotSatisfied)
             return NodeConstants::ProcessResult::Failed;
     }
-
-    // // If allowing loopback data to invalidate our status, check any loopback edges for changed data
-    // if (loopbackInvalidates_)
-    // {
-    //     for (auto &[inputName, edges] : proxyInputs_->inputEdges())
-    //     {
-    //         for (const auto edge : edges)
-    //             if (edge->requiresPull())
-    //                 return NodeConstants::ProcessResult::SuccessAndNotUpdated;
-    //     }
-    // }
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "nodes/loop.h"
+#include "nodes/inputs.h"
 #include "nodes/outputs.h"
 
 LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph) {}
@@ -56,4 +57,28 @@ NodeConstants::ProcessResult LoopGraph::process()
         }
 
     return outputsResult == terminalNodeResult ? outputsResult : NodeConstants::ProcessResult::Success;
+}
+
+NodeConstants::ProcessResult LoopGraph::testLoopBack()
+{
+    // For each defined InputsNode input, pull any edges...
+    // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
+    for (auto &[inputName, edges] : proxyInputs_->inputEdges())
+    {
+        for (const auto edge : edges)
+        {
+            std::cout << std::format("Pulling edge '{}'..\n", edge->definition().asString());
+            switch (edge->pull())
+            {
+                case (NodeConstants::ProcessResult::Failed):
+                case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                    return NodeConstants::ProcessResult::Failed;
+                case (NodeConstants::ProcessResult::Success):
+                case (NodeConstants::ProcessResult::Unchanged):
+                    break;
+            }
+        }
+    }
+
+    return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -34,7 +34,7 @@ NodeConstants::ProcessResult LoopGraph::process()
 
     for (auto n = 0; n < iterations_.asInteger(); ++n)
     {
-        std::cout << std::format("\nLoopGraph::process() - iteration {}\n\n", n);
+        debug("{}LoopGraph({})::process() - iteration {}", GraphDebug::indent(), name(), n);
 
         // Pull edges connected to our InputsNode *if*
         if (n > 0)
@@ -43,8 +43,7 @@ NodeConstants::ProcessResult LoopGraph::process()
             {
                 for (const auto edge : edges)
                 {
-                    std::cout << std::format("{}LoopGraph::process() - Pulling edge {}...\n", GraphDebug::indent(),
-                                             edge->definition().asString());
+                    debug("{}LoopGraph::process() - Pulling edge {}...\n", GraphDebug::indent(), edge->definition().asString());
                     switch (edge->pull())
                     {
                         case (NodeConstants::ProcessResult::Failed):

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -3,10 +3,12 @@
 
 #include "nodes/loop.h"
 #include "nodes/inputs.h"
+#include "nodes/edge.h"
 
 LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph)
 {
     addOption<Number>("Iterations", "Number of iterations to perform", iterations_);
+    addOption<bool>("LoopbackInvalidates", "Whether loopback edges cause iterations to be rerun on next call", loopbackInvalidates_);
 }
 
 /*
@@ -52,7 +54,16 @@ NodeConstants::ProcessResult LoopGraph::process()
             return NodeConstants::ProcessResult::Failed;
     }
 
+    // If allowing loopback data to invalidate our status, check any loopback edges for changed data
+    if (loopbackInvalidates_)
+    {
+        for (auto &[inputName, edges] : proxyInputs_->inputEdges())
+        {
+            for (const auto edge : edges)
+                if (edge->requiresPull())
+                    upToDate_ = false;
+        }
+    }
+
     return NodeConstants::ProcessResult::Success;
 }
-
-NodeConstants::ProcessResult LoopGraph::testLoopBack() { return NodeConstants::ProcessResult::Success; }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -3,9 +3,11 @@
 
 #include "nodes/loop.h"
 #include "nodes/inputs.h"
-#include "nodes/outputs.h"
 
-LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph) {}
+LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph)
+{
+    addOption<Number>("Iterations", "Number of iterations to perform", iterations_);
+}
 
 /*
  * Definitions (Virtuals)
@@ -24,61 +26,33 @@ std::string_view LoopGraph::summary() const { return "Loop the contained graph";
 // Perform processing
 NodeConstants::ProcessResult LoopGraph::process()
 {
-    /*
-     * Processing a Graph involves running any child nodes we have, but we can only detect the nodes that need to be run in
-     * one of two ways. Either 1) We cycle over Edge connections to inputs on our Outputs node and pull() those in, or 2) we
-     * look for any nodes that don't have any edge connections to their Outputs and try to run() them one at a time. The
-     * latter case is important if a Graph has no defined Outputs, and so no external dependence on running the child nodes.
-     */
-
-    // Pull proxy outputs first
-    auto outputsResult = proxyOutputs_->run();
-    if (outputsResult == NodeConstants::ProcessResult::Failed)
-        return outputsResult;
-
-    // Check each node for output edges - any that have zero output edges need to be run()
-    auto terminalNodeResult = NodeConstants::ProcessResult::Unchanged;
-    for (auto &&[nodeName, node] : nodes_)
-        if (!node->outputEdges().empty())
-        {
-            switch (node->run())
-            {
-                case (NodeConstants::ProcessResult::Failed):
-                    return NodeConstants::ProcessResult::Failed;
-                case (NodeConstants::ProcessResult::Success):
-                    terminalNodeResult = NodeConstants::ProcessResult::Success;
-                    break;
-                case (NodeConstants::ProcessResult::Unchanged):
-                    break;
-                case (NodeConstants::ProcessResult::InputsNotSatisfied):
-                    /* This should never happen? */
-                    break;
-            }
-        }
-
-    return outputsResult == terminalNodeResult ? outputsResult : NodeConstants::ProcessResult::Success;
-}
-
-NodeConstants::ProcessResult LoopGraph::testLoopBack()
-{
-    // For each defined InputsNode input, pull any edges...
-    // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
-    for (auto &[inputName, edges] : proxyInputs_->inputEdges())
+    for (auto n = 0; n < iterations_.asInteger(); ++n)
     {
-        for (const auto edge : edges)
-        {
-            std::cout << std::format("Pulling edge '{}'..\n", edge->definition().asString());
-            switch (edge->pull())
+        // Pull edges connected to our InputsNode (not on first iteration)
+        if (n > 0)
+            for (auto &[inputName, edges] : proxyInputs_->inputEdges())
             {
-                case (NodeConstants::ProcessResult::Failed):
-                case (NodeConstants::ProcessResult::InputsNotSatisfied):
-                    return NodeConstants::ProcessResult::Failed;
-                case (NodeConstants::ProcessResult::Success):
-                case (NodeConstants::ProcessResult::Unchanged):
-                    break;
+                for (const auto edge : edges)
+                {
+                    switch (edge->pull())
+                    {
+                        case (NodeConstants::ProcessResult::Failed):
+                        case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                            return NodeConstants::ProcessResult::Failed;
+                        case (NodeConstants::ProcessResult::Success):
+                        case (NodeConstants::ProcessResult::Unchanged):
+                            break;
+                    }
+                }
             }
-        }
+
+        // Process child nodes, returning early if we encounter an error
+        auto result = Graph::process();
+        if (result == NodeConstants::ProcessResult::Failed || result == NodeConstants::ProcessResult::InputsNotSatisfied)
+            return NodeConstants::ProcessResult::Failed;
     }
 
     return NodeConstants::ProcessResult::Success;
 }
+
+NodeConstants::ProcessResult LoopGraph::testLoopBack() { return NodeConstants::ProcessResult::Success; }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "nodes/loop.h"
+
+LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph) {}
+
+/*
+ * Definitions (Virtuals)
+ */
+
+// Return node name
+std::string_view LoopGraph::name() const { return "Loop"; }
+
+// Return type of the node
+std::string_view LoopGraph::type() const { return "Loop"; }
+
+// Return short summary of the node's purpose
+std::string_view LoopGraph::summary() const { return "Loop the contained graph"; }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -27,7 +27,11 @@ std::string_view LoopGraph::summary() const { return "A graph which iterates"; }
 // Perform processing
 NodeConstants::ProcessResult LoopGraph::process()
 {
-    //
+    // Before arriving here we will have pulled in any external input edges, and this is the data we should use on the
+    // first iteration of the loop. So, we only pull from inputs to our InputsNode (proxyInputs_) after the first
+    // iteration. Furthermore, we do this manually here rather than let InputsNode pull its own edges as otherwise we
+    // get into an infinite loop when the graph tries to run. In this sense the
+
     for (auto n = 0; n < iterations_.asInteger(); ++n)
     {
         std::cout << std::format("\nLoopGraph::process() - iteration {}\n\n", n);

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -2,13 +2,14 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "nodes/loop.h"
-#include "nodes/inputs.h"
 #include "nodes/edge.h"
+#include "nodes/inputs.h"
 
 LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph)
 {
     addOption<Number>("Iterations", "Number of iterations to perform", iterations_);
-    addOption<bool>("LoopbackInvalidates", "Whether loopback edges cause iterations to be rerun on next call", loopbackInvalidates_);
+    addOption<bool>("LoopbackInvalidates", "Whether loopback edges cause iterations to be rerun on next call",
+                    loopbackInvalidates_);
 }
 
 /*
@@ -28,14 +29,21 @@ std::string_view LoopGraph::summary() const { return "Loop the contained graph";
 // Perform processing
 NodeConstants::ProcessResult LoopGraph::process()
 {
+    // Could we have a map of inputs to the graph and when they were updated, which we maintain between runs? We can then decide
+    // whether to use current parameter values or pull from loopback edges.
     for (auto n = 0; n < iterations_.asInteger(); ++n)
     {
-        // Pull edges connected to our InputsNode (not on first iteration)
+        std::cout << std::format("\nLoopGraph::process() - iteration {}\n\n", n);
+
+        // Pull edges connected to our InputsNode *if*
         if (n > 0)
+        {
             for (auto &[inputName, edges] : proxyInputs_->inputEdges())
             {
                 for (const auto edge : edges)
                 {
+                    std::cout << std::format("{}LoopGraph::process() - Pulling edge {}...\n", GraphDebug::indent(),
+                                             edge->definition().asString());
                     switch (edge->pull())
                     {
                         case (NodeConstants::ProcessResult::Failed):
@@ -47,6 +55,7 @@ NodeConstants::ProcessResult LoopGraph::process()
                     }
                 }
             }
+        }
 
         // Process child nodes, returning early if we encounter an error
         auto result = Graph::process();
@@ -54,16 +63,16 @@ NodeConstants::ProcessResult LoopGraph::process()
             return NodeConstants::ProcessResult::Failed;
     }
 
-    // If allowing loopback data to invalidate our status, check any loopback edges for changed data
-    if (loopbackInvalidates_)
-    {
-        for (auto &[inputName, edges] : proxyInputs_->inputEdges())
-        {
-            for (const auto edge : edges)
-                if (edge->requiresPull())
-                    upToDate_ = false;
-        }
-    }
+    // // If allowing loopback data to invalidate our status, check any loopback edges for changed data
+    // if (loopbackInvalidates_)
+    // {
+    //     for (auto &[inputName, edges] : proxyInputs_->inputEdges())
+    //     {
+    //         for (const auto edge : edges)
+    //             if (edge->requiresPull())
+    //                 return NodeConstants::ProcessResult::SuccessAndNotUpdated;
+    //     }
+    // }
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2025 Team Dissolve and contributors
 
 #include "nodes/loop.h"
+#include "nodes/outputs.h"
 
 LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph) {}
 
@@ -14,3 +15,45 @@ std::string_view LoopGraph::type() const { return "Loop"; }
 
 // Return short summary of the node's purpose
 std::string_view LoopGraph::summary() const { return "Loop the contained graph"; }
+
+/*
+ * Processing & Validity
+ */
+
+// Perform processing
+NodeConstants::ProcessResult LoopGraph::process()
+{
+    /*
+     * Processing a Graph involves running any child nodes we have, but we can only detect the nodes that need to be run in
+     * one of two ways. Either 1) We cycle over Edge connections to inputs on our Outputs node and pull() those in, or 2) we
+     * look for any nodes that don't have any edge connections to their Outputs and try to run() them one at a time. The
+     * latter case is important if a Graph has no defined Outputs, and so no external dependence on running the child nodes.
+     */
+
+    // Pull proxy outputs first
+    auto outputsResult = proxyOutputs_->run();
+    if (outputsResult == NodeConstants::ProcessResult::Failed)
+        return outputsResult;
+
+    // Check each node for output edges - any that have zero output edges need to be run()
+    auto terminalNodeResult = NodeConstants::ProcessResult::Unchanged;
+    for (auto &&[nodeName, node] : nodes_)
+        if (!node->outputEdges().empty())
+        {
+            switch (node->run())
+            {
+                case (NodeConstants::ProcessResult::Failed):
+                    return NodeConstants::ProcessResult::Failed;
+                case (NodeConstants::ProcessResult::Success):
+                    terminalNodeResult = NodeConstants::ProcessResult::Success;
+                    break;
+                case (NodeConstants::ProcessResult::Unchanged):
+                    break;
+                case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                    /* This should never happen? */
+                    break;
+            }
+        }
+
+    return outputsResult == terminalNodeResult ? outputsResult : NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/loop.cpp
+++ b/src/nodes/loop.cpp
@@ -9,9 +9,6 @@ LoopGraph::LoopGraph(Graph *parentGraph) : Graph(parentGraph) {}
  * Definitions (Virtuals)
  */
 
-// Return node name
-std::string_view LoopGraph::name() const { return "Loop"; }
-
 // Return type of the node
 std::string_view LoopGraph::type() const { return "Loop"; }
 

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#pragma once
+
+#include "nodes/edge.h"
+#include "nodes/graph.h"
+#include "templates/doubleKeyedMap.h"
+
+// Loop Graph
+class LoopGraph : public Graph
+{
+    public:
+    LoopGraph(Graph *parentGraph);
+    ~LoopGraph() = default;
+
+    /*
+     * Definition (Virtuals)
+     */
+    public:
+    // Return node name
+    std::string_view name() const override;
+    // Return type of the node
+    std::string_view type() const override;
+    // Return short summary of the node's purpose
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    public:
+    /*
+     * Functions
+     */
+    public:
+};

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -24,10 +24,6 @@ class LoopGraph : public Graph
     /*
      * Data
      */
-    private:
-    // Whether changes to source parameters of loopback edges invalidates our status
-    bool loopbackInvalidates_{true};
-
     public:
     // Number of iterations to loop for
     Number iterations_{1};

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -24,9 +24,17 @@ class LoopGraph : public Graph
     std::string_view summary() const override;
 
     /*
+     * Data
+     */
+    public:
+    // Number of iterations to loop for
+    Number iterations_{1};
+
+    /*
      * Processing & Validity
      */
     public:
     // Perform processing
     NodeConstants::ProcessResult process();
+    NodeConstants::ProcessResult testLoopBack();
 };

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -18,8 +18,6 @@ class LoopGraph : public Graph
      * Definition (Virtuals)
      */
     public:
-    // Return node name
-    std::string_view name() const override;
     // Return type of the node
     std::string_view type() const override;
     // Return short summary of the node's purpose

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -24,12 +24,9 @@ class LoopGraph : public Graph
     std::string_view summary() const override;
 
     /*
-     * Data
-     */
-    private:
-    public:
-    /*
-     * Functions
+     * Processing & Validity
      */
     public:
+    // Perform processing
+    NodeConstants::ProcessResult process();
 };

--- a/src/nodes/loop.h
+++ b/src/nodes/loop.h
@@ -3,9 +3,7 @@
 
 #pragma once
 
-#include "nodes/edge.h"
 #include "nodes/graph.h"
-#include "templates/doubleKeyedMap.h"
 
 // Loop Graph
 class LoopGraph : public Graph
@@ -26,6 +24,10 @@ class LoopGraph : public Graph
     /*
      * Data
      */
+    private:
+    // Whether changes to source parameters of loopback edges invalidates our status
+    bool loopbackInvalidates_{true};
+
     public:
     // Number of iterations to loop for
     Number iterations_{1};
@@ -36,5 +38,4 @@ class LoopGraph : public Graph
     public:
     // Perform processing
     NodeConstants::ProcessResult process();
-    NodeConstants::ProcessResult testLoopBack();
 };

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -127,7 +127,6 @@ bool Node::pullInputEdges()
             {
                 debug("{}Node[{}]::pullInputEdges() - edge '{}' is up-to-date and doesn't require pull", GraphDebug::indent(),
                       name(), edge->definition().asString());
-                continue;
             }
 
             switch (edge->pull())

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -107,19 +107,22 @@ bool Node::inputsAreValid() const
 // Run the node, retrieving dependent inputs as necessary
 NodeConstants::ProcessResult Node::run()
 {
-    // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
-    for (auto &[inputName, edges] : inputEdges_)
+    if (pullInputsOnRun_)
     {
-        for (const auto edge : edges)
+        // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
+        for (auto &[inputName, edges] : inputEdges_)
         {
-            switch (edge->pull())
+            for (const auto edge : edges)
             {
-                case (NodeConstants::ProcessResult::Failed):
-                case (NodeConstants::ProcessResult::InputsNotSatisfied):
-                    return NodeConstants::ProcessResult::Failed;
-                case (NodeConstants::ProcessResult::Success):
-                case (NodeConstants::ProcessResult::Unchanged):
-                    break;
+                switch (edge->pull())
+                {
+                    case (NodeConstants::ProcessResult::Failed):
+                    case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                        return NodeConstants::ProcessResult::Failed;
+                    case (NodeConstants::ProcessResult::Success):
+                    case (NodeConstants::ProcessResult::Unchanged):
+                        break;
+                }
             }
         }
     }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -40,9 +40,6 @@ bool Node::hasMessages(MessageStatus status) const
     return std::any_of(messages_.cbegin(), messages_.cend(), [status](const auto &msg) { return msg.first == status; });
 }
 
-// Print latest message
-void Node::echo() { std::cout << messages_.back().second << std::endl; }
-
 /*
  * Processing & Validity
  */
@@ -120,8 +117,18 @@ bool Node::pullInputEdges()
     {
         for (const auto edge : edges)
         {
-            std::cout << std::format("{}Node[{}]::pullInputEdges() - pulling edge '{}'..\n", GraphDebug::indent(), name(),
-                                     edge->definition().asString());
+            if (edge->requiresPull())
+                debug(
+                    "{}Node[{}]::pullInputEdges() - edge '{}' needs updated data (versionIndex = {}, sourceNodeVersionIndex = "
+                    "{}, sourceNodeUpToData = {})",
+                    GraphDebug::indent(), name(), edge->definition().asString(), edge->sourceNodeVersionIndex(),
+                    edge->sourceNode().versionIndex(), edge->sourceNode().isUpToDate());
+            else
+            {
+                debug("{}Node[{}]::pullInputEdges() - edge '{}' is up-to-date and doesn't require pull", GraphDebug::indent(),
+                      name(), edge->definition().asString());
+                continue;
+            }
 
             switch (edge->pull())
             {
@@ -129,12 +136,10 @@ bool Node::pullInputEdges()
                 case (NodeConstants::ProcessResult::InputsNotSatisfied):
                     return false;
                 case (NodeConstants::ProcessResult::Success):
-                    std::cout << std::format("{}Node[{}]::pullInputEdges() - returned SUCCESS.\n", GraphDebug::indent(),
-                                             name());
+                    debug("{}Node[{}]::pullInputEdges() - returned SUCCESS", GraphDebug::indent(), name());
                     break;
                 case (NodeConstants::ProcessResult::Unchanged):
-                    std::cout << std::format("{}Node[{}]::pullInputEdges() - returned UNCHANGED.\n", GraphDebug::indent(),
-                                             name());
+                    debug("{}Node[{}]::pullInputEdges() - returned UNCHANGED", GraphDebug::indent(), name());
                     break;
             }
         }
@@ -146,10 +151,12 @@ bool Node::pullInputEdges()
 // Run processing if required
 NodeConstants::ProcessResult Node::processIfRequired()
 {
+    debug("{}Node[{}]::process() - START = upToDate = {}, versionIndex = {}", GraphDebug::indent(), name(), upToDate_,
+          versionIndex());
+
     // If input links have updated or we are currently flagged as invalid we must reprocess
     auto result = NodeConstants::ProcessResult::Unchanged;
-    std::cout << std::format("{}Node[{}]::process() - START = upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(),
-                             name(), upToDate_, versionIndex());
+
     if (!upToDate_ || versionIndex_ == NodeConstants::InvalidVersion)
     {
         result = process();
@@ -168,8 +175,8 @@ NodeConstants::ProcessResult Node::processIfRequired()
         }
     }
 
-    std::cout << std::format("{}Node[{}]::process() - COMPLETED = upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(),
-                             name(), upToDate_, versionIndex());
+    debug("{}Node[{}]::process() - COMPLETED = upToDate = {}, versionIndex = {}", GraphDebug::indent(), name(), upToDate_,
+          versionIndex());
 
     return result;
 }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -29,7 +29,10 @@ std::string_view Node::name() const { return parentGraph_ ? parentGraph_->nodeNa
  */
 
 // Print latest message
-bool Node::echo_ = false;
+bool Node::echo_ = true;
+
+// Set echo of output to stdout
+void Node::setEcho(bool on) { echo_ = on; }
 
 // Message store vector
 const Node::MessageStore &Node::messages() const { return messages_; }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -66,20 +66,23 @@ void Node::setUpdateRequired()
     upToDate_ = false;
 
     // Make sure all output edges propagate this information down
-    for (auto &&[outputName, edges] : outputEdges())
-        for (auto edge : edges)
-        {
-            auto &input = edge->targetInput();
+    if (propagateUpdateRequests_)
+    {
+        for (auto &&[outputName, edges] : outputEdges())
+            for (auto edge : edges)
+            {
+                auto &input = edge->targetInput();
 
-            if (input.flags().isSet(ParameterBase::ParameterFlags::NoUpdate))
-                continue;
+                if (input.flags().isSet(ParameterBase::ParameterFlags::NoUpdate))
+                    continue;
 
-            input.setParentUpdateRequired();
+                input.setParentUpdateRequired();
 
-            // If the target input is a vector, all edges to it must be marked for re-pull and its data cleared
-            if (input.isVector())
-                input.invalidateVector();
-        }
+                // If the target input is a vector, all edges to it must be marked for re-pull and its data cleared
+                if (input.isVector())
+                    input.invalidateVector();
+            }
+    }
 }
 
 // Return whether the node's data is up-to-date
@@ -104,38 +107,47 @@ bool Node::inputsAreValid() const
     return true;
 }
 
-// Run the node, retrieving dependent inputs as necessary
-NodeConstants::ProcessResult Node::run()
-{
-    GraphDebug::increaseIndent();
-    if (pullInputsOnRun_)
-    {
-        // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
-        for (auto &[inputName, edges] : inputEdges_)
-        {
-            for (const auto edge : edges)
-            {
-                std::cout << std::format("{}Node[{}]::run() - pulling edge '{}'..\n", GraphDebug::indent(), name(),
-                                         edge->definition().asString());
+// Perform processing
+NodeConstants::ProcessResult Node::process() { return NodeConstants::ProcessResult::Failed; }
 
-                switch (edge->pull())
-                {
-                    case (NodeConstants::ProcessResult::Failed):
-                    case (NodeConstants::ProcessResult::InputsNotSatisfied):
-                        return NodeConstants::ProcessResult::Failed;
-                    case (NodeConstants::ProcessResult::Success):
-                        std::cout << std::format("{}Node[{}]::run() - returned SUCCESS.\n", GraphDebug::indent(), name());
-                        break;
-                    case (NodeConstants::ProcessResult::Unchanged):
-                        std::cout << std::format("{}Node[{}]::run() - returned UNCHANGED.\n", GraphDebug::indent(), name());
-                        break;
-                }
+// Pull input edges
+bool Node::pullInputEdges()
+{
+    // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
+    for (auto &[inputName, edges] : inputEdges_)
+    {
+        for (const auto edge : edges)
+        {
+            std::cout << std::format("{}Node[{}]::pullInputEdges() - pulling edge '{}'..\n", GraphDebug::indent(), name(),
+                                     edge->definition().asString());
+
+            switch (edge->pull())
+            {
+                case (NodeConstants::ProcessResult::Failed):
+                case (NodeConstants::ProcessResult::InputsNotSatisfied):
+                    return false;
+                case (NodeConstants::ProcessResult::Success):
+                    std::cout << std::format("{}Node[{}]::pullInputEdges() - returned SUCCESS.\n", GraphDebug::indent(),
+                                             name());
+                    break;
+                case (NodeConstants::ProcessResult::Unchanged):
+                    std::cout << std::format("{}Node[{}]::pullInputEdges() - returned UNCHANGED.\n", GraphDebug::indent(),
+                                             name());
+                    break;
             }
         }
     }
 
+    return true;
+}
+
+// Run processing if required
+NodeConstants::ProcessResult Node::processIfRequired()
+{
     // If input links have updated or we are currently flagged as invalid we must reprocess
     auto result = NodeConstants::ProcessResult::Unchanged;
+    std::cout << std::format("{}Node[{}]::process() - START = upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(),
+                             name(), upToDate_, versionIndex());
     if (!upToDate_ || versionIndex_ == NodeConstants::InvalidVersion)
     {
         result = process();
@@ -145,8 +157,8 @@ NodeConstants::ProcessResult Node::run()
             case (NodeConstants::ProcessResult::InputsNotSatisfied):
                 break;
             case (NodeConstants::ProcessResult::Success):
-                ++versionIndex_;
                 upToDate_ = true;
+                ++versionIndex_;
                 break;
             case (NodeConstants::ProcessResult::Unchanged):
                 upToDate_ = true;
@@ -154,12 +166,27 @@ NodeConstants::ProcessResult Node::run()
         }
     }
 
-    GraphDebug::decreaseIndent();
+    std::cout << std::format("{}Node[{}]::process() - COMPLETED = upToDate = {}, versionIndex = {}.\n", GraphDebug::indent(),
+                             name(), upToDate_, versionIndex());
+
     return result;
 }
 
-// Perform processing
-NodeConstants::ProcessResult Node::process() { return NodeConstants::ProcessResult::Failed; }
+// Run the node
+NodeConstants::ProcessResult Node::run()
+{
+    GraphDebug::increaseIndent();
+
+    // Pull all our input edges
+    if (!pullInputEdges())
+        return NodeConstants::ProcessResult::Failed;
+
+    // Reprocess if required
+    auto result = processIfRequired();
+
+    GraphDebug::decreaseIndent();
+    return result;
+}
 
 /*
  * Inputs, Outputs & Options

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -107,6 +107,7 @@ bool Node::inputsAreValid() const
 // Run the node, retrieving dependent inputs as necessary
 NodeConstants::ProcessResult Node::run()
 {
+    GraphDebug::increaseIndent();
     if (pullInputsOnRun_)
     {
         // Pull all input edges. If any are out-of-date and get re-set this will automatically unset upToDate_
@@ -114,13 +115,19 @@ NodeConstants::ProcessResult Node::run()
         {
             for (const auto edge : edges)
             {
+                std::cout << std::format("{}Node[{}]::run() - pulling edge '{}'..\n", GraphDebug::indent(), name(),
+                                         edge->definition().asString());
+
                 switch (edge->pull())
                 {
                     case (NodeConstants::ProcessResult::Failed):
                     case (NodeConstants::ProcessResult::InputsNotSatisfied):
                         return NodeConstants::ProcessResult::Failed;
                     case (NodeConstants::ProcessResult::Success):
+                        std::cout << std::format("{}Node[{}]::run() - returned SUCCESS.\n", GraphDebug::indent(), name());
+                        break;
                     case (NodeConstants::ProcessResult::Unchanged):
+                        std::cout << std::format("{}Node[{}]::run() - returned UNCHANGED.\n", GraphDebug::indent(), name());
                         break;
                 }
             }
@@ -147,6 +154,7 @@ NodeConstants::ProcessResult Node::run()
         }
     }
 
+    GraphDebug::decreaseIndent();
     return result;
 }
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -5,6 +5,7 @@
 #include "base/sysFunc.h"
 #include "nodes/edge.h"
 #include "nodes/graph.h"
+#include "nodes/inputs.h"
 #include <algorithm>
 
 /*
@@ -66,23 +67,24 @@ void Node::setUpdateRequired()
     upToDate_ = false;
 
     // Make sure all output edges propagate this information down
-    if (propagateUpdateRequests_)
-    {
-        for (auto &&[outputName, edges] : outputEdges())
-            for (auto edge : edges)
-            {
-                auto &input = edge->targetInput();
+    for (auto &&[outputName, edges] : outputEdges())
+        for (auto edge : edges)
+        {
+            // Never propagate through edges which are loopbacks (connected to InputsNode inputs)
+            if (dynamic_cast<InputsNode *>(&edge->targetNode()))
+                continue;
 
-                if (input.flags().isSet(ParameterBase::ParameterFlags::NoUpdate))
-                    continue;
+            auto &input = edge->targetInput();
 
-                input.setParentUpdateRequired();
+            if (input.flags().isSet(ParameterBase::ParameterFlags::NoUpdate))
+                continue;
 
-                // If the target input is a vector, all edges to it must be marked for re-pull and its data cleared
-                if (input.isVector())
-                    input.invalidateVector();
-            }
-    }
+            input.setParentUpdateRequired();
+
+            // If the target input is a vector, all edges to it must be marked for re-pull and its data cleared
+            if (input.isVector())
+                input.invalidateVector();
+        }
 }
 
 // Return whether the node's data is up-to-date

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -105,6 +105,8 @@ class Node : public Serialisable<>
     }
 
     public:
+    // Set echo of output to stdout
+    static void setEcho(bool on = true);
     // Message store vector
     const MessageStore &messages() const;
     // Returns true if message with given status exists

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -104,13 +104,11 @@ class Node : public Serialisable<>
     /*
      * Processing & Validity
      */
-    private:
+    protected:
     // Version index for the node, bumped whenever result outputs change
     int versionIndex_{NodeConstants::InvalidVersion};
     // Whether the node's data is up-to-date
     bool upToDate_{false};
-
-    protected:
     // Whether to pull inputs in run()
     bool pullInputsOnRun_{true};
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -104,11 +104,15 @@ class Node : public Serialisable<>
     /*
      * Processing & Validity
      */
-    protected:
+    private:
     // Version index for the node, bumped whenever result outputs change
     int versionIndex_{NodeConstants::InvalidVersion};
     // Whether the node's data is up-to-date
     bool upToDate_{false};
+
+    protected:
+    // Whether to pull inputs in run()
+    bool pullInputsOnRun_{true};
 
     protected:
     // Perform processing
@@ -126,7 +130,7 @@ class Node : public Serialisable<>
     // Check that all required inputs are present, and that all inputs are valid
     bool inputsAreValid() const;
     // Run the node, retrieving dependent inputs as necessary
-    virtual NodeConstants::ProcessResult run();
+    NodeConstants::ProcessResult run();
 
     /*
      * Inputs, Outputs, and Options

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -104,7 +104,7 @@ class Node : public Serialisable<>
     /*
      * Processing & Validity
      */
-    private:
+    protected:
     // Version index for the node, bumped whenever result outputs change
     int versionIndex_{NodeConstants::InvalidVersion};
     // Whether the node's data is up-to-date

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -126,7 +126,7 @@ class Node : public Serialisable<>
     // Check that all required inputs are present, and that all inputs are valid
     bool inputsAreValid() const;
     // Run the node, retrieving dependent inputs as necessary
-    NodeConstants::ProcessResult run();
+    virtual NodeConstants::ProcessResult run();
 
     /*
      * Inputs, Outputs, and Options

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -109,12 +109,16 @@ class Node : public Serialisable<>
     int versionIndex_{NodeConstants::InvalidVersion};
     // Whether the node's data is up-to-date
     bool upToDate_{false};
-    // Whether to pull inputs in run()
-    bool pullInputsOnRun_{true};
+    // Whether to propagate update requests to connected nodes downstream (via outputs)
+    bool propagateUpdateRequests_{true};
 
     protected:
     // Perform processing
     virtual NodeConstants::ProcessResult process();
+    // Pull input edges
+    bool pullInputEdges();
+    // Run processing if required
+    NodeConstants::ProcessResult processIfRequired();
 
     public:
     // Return version index for the node, bumped whenever result outputs change
@@ -127,8 +131,8 @@ class Node : public Serialisable<>
     bool isUpToDate() const;
     // Check that all required inputs are present, and that all inputs are valid
     bool inputsAreValid() const;
-    // Run the node, retrieving dependent inputs as necessary
-    NodeConstants::ProcessResult run();
+    // Run the node
+    virtual NodeConstants::ProcessResult run();
 
     /*
      * Inputs, Outputs, and Options

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -50,50 +50,59 @@ class Node : public Serialisable<>
     /*
      * Node message
      */
-
+    public:
     // Enumeration for message status
     enum class MessageStatus
     {
         Info,
         Warn,
-        Error
+        Error,
+        Debug
     };
+    // Strings representing message status
+    const std::map<MessageStatus, std::string> messageStatusStrings = {{MessageStatus::Info, "INFO"},
+                                                                       {MessageStatus::Warn, "WARN"},
+                                                                       {MessageStatus::Error, "ERROR"},
+                                                                       {MessageStatus::Debug, "DEBUG"}};
 
+    private:
     using MessageStore = std::vector<std::pair<MessageStatus, std::string>>;
-    // Print latest message
-    static bool echo_;
-
-    protected:
     // Message store vector
     MessageStore messages_;
-    // Node message format
+    // Whether to echo messages as they come in
+    static bool echo_;
+    // Push message
+    void pushMessage(MessageStatus status, const std::string &message)
+    {
+        messages_.emplace_back(std::make_pair(status, message));
+
+        if (echo_)
+            std::cout << std::format("{} {}", messageStatusStrings.at(status), message) << std::endl;
+    }
+
+    protected:
+    // Push information message
     template <typename... Args> void message(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Info, std::format(format, std::forward<Args>(args)...)));
-
-        if (echo_)
-            echo();
+        pushMessage(MessageStatus::Info, std::format(format, std::forward<Args>(args)...));
     }
-    // Node warn format
+    // Push warning message
     template <typename... Args> void warn(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Warn, std::format(format, std::forward<Args>(args)...)));
-
-        if (echo_)
-            echo();
+        pushMessage(MessageStatus::Warn, std::format(format, std::forward<Args>(args)...));
     }
-    // Node error format
+    // Push error message
     template <typename... Args> NodeConstants::ProcessResult error(std::format_string<Args...> format, Args... args)
     {
-        messages_.emplace_back(std::make_pair(MessageStatus::Error, std::format(format, std::forward<Args>(args)...)));
-
-        if (echo_)
-            echo();
+        pushMessage(MessageStatus::Error, std::format(format, std::forward<Args>(args)...));
 
         return NodeConstants::ProcessResult::Failed;
     }
-    // Print latest message
-    void echo();
+    // Push debug message
+    template <typename... Args> void debug(std::format_string<Args...> format, Args... args)
+    {
+        pushMessage(MessageStatus::Debug, std::format(format, std::forward<Args>(args)...));
+    }
 
     public:
     // Message store vector

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -306,13 +306,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         // If the stored data types are the same then we can just do a straight assignment
         if (storedDataType_ == other->storedDataType())
         {
-            std::cout << std::format("Parameter::assign() from '{}' to '{}', type is {}\n", other->name(), name_,
-                                     storedDataType_.name());
-            if constexpr (std::is_same_v<DataClass, Number>)
-                std::cout << std::format("   --> current value is {}\n", data_.asInteger());
             setData(other->get<DataClass>());
-            if constexpr (std::is_same_v<DataClass, Number>)
-                std::cout << std::format("   --> new value assigned is {}\n", data_.asInteger());
         }
         else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -305,7 +305,15 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     {
         // If the stored data types are the same then we can just do a straight assignment
         if (storedDataType_ == other->storedDataType())
+        {
+            std::cout << std::format("Parameter::assign() from '{}' to '{}', type is {}\n", other->name(), name_,
+                                     storedDataType_.name());
+            if constexpr (std::is_same_v<DataClass, Number>)
+                std::cout << std::format("   --> current value is {}\n", data_.asInteger());
             setData(other->get<DataClass>());
+            if constexpr (std::is_same_v<DataClass, Number>)
+                std::cout << std::format("   --> new value assigned is {}\n", data_.asInteger());
+        }
         else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
             // If we represent a std::vector container we can conditionally check for a single data item being passed
@@ -374,8 +382,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         // Create an input and an output Parameter linked to the proxy data
         auto inputParameter = std::make_shared<Parameter<DataClass>>(nullptr, newName, newDescription, proxy);
         inputParameter->setFlags(ParameterBase::ParameterFlags::Input);
-
-        // Create a companion input on our Outputs node, again linked to the proxy data
         auto outputParameter = std::make_shared<Parameter<DataClass>>(nullptr, newName, newDescription, proxy);
         outputParameter->setFlags(ParameterBase::ParameterFlags::Output);
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -307,10 +307,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         if (storedDataType_ == other->storedDataType())
         {
             setData(other->get<DataClass>());
-
-            if constexpr (std::is_same_v<DataClass, Number>)
-                std::cout << std::format("{}  Parameter::assign() from '{}' to '{}', new value is {}\n", GraphDebug::indent(),
-                                         other->name(), name_, data_.asInteger());
         }
         else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -307,6 +307,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         if (storedDataType_ == other->storedDataType())
         {
             setData(other->get<DataClass>());
+
+            if constexpr (std::is_same_v<DataClass, Number>)
+                std::cout << std::format("{}  Parameter::assign() from '{}' to '{}', new value is {}\n", GraphDebug::indent(),
+                                         other->name(), name_, data_.asInteger());
         }
         else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -7,15 +7,15 @@
 #include "base/serialiser.h"
 #include "math/data1D.h"
 #include "math/function1D.h"
+#include "nodes/debug.h"
 #include "nodes/number.h"
 #include "templates/algorithms.h"
 #include "templates/flags.h"
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <typeindex>
 #include <vector>
-
-#include <iostream>
 
 // Forward Declarations
 class Node;

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -18,6 +18,7 @@
 #include "nodes/importConfigurationCoordinates.h"
 #include "nodes/insert.h"
 #include "nodes/integrator.h"
+#include "nodes/loop.h"
 #include "nodes/md/md.h"
 #include "nodes/multiply.h"
 #include "nodes/neutronSQ/neutronSQ.h"
@@ -59,6 +60,7 @@ void NodeRegistry::instantiateNodeProducers()
         {"ImportConfigurationCoordinates", makeDerivedNode<ImportConfigurationCoordinatesNode>()},
         {"Insert", makeDerivedNode<InsertNode>()},
         {"Integrator", makeDerivedNode<Integrator1DNode>()},
+        {"Loop", makeDerivedNode<LoopGraph>()},
         {"MD", makeDerivedNode<MDNode>()},
         {"Multiply", makeDerivedNode<MultiplyNode>()},
         {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
@@ -66,7 +68,7 @@ void NodeRegistry::instantiateNodeProducers()
         {"SQ", makeDerivedNode<SQNode>()},
         {"Subtract", makeDerivedNode<SubtractNode>()},
         {"Vec3Assembly", makeDerivedNode<Vec3AssemblyNode>()},
-        {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>()},
+        {"Vec3Decomposition", makeDerivedNode<Vec3DecompositionNode>()}
     };
 }
 

--- a/tests/nodes/CMakeLists.txt
+++ b/tests/nodes/CMakeLists.txt
@@ -1,6 +1,7 @@
 dissolve_add_test(SRC flow.cpp)
 dissolve_add_test(SRC graph.cpp)
 dissolve_add_test(SRC graph_argon.cpp)
+dissolve_add_test(SRC loop.cpp)
 dissolve_add_test(SRC number.cpp)
 dissolve_add_test(SRC parameters.cpp)
 dissolve_add_test(SRC subGraph.cpp)

--- a/tests/nodes/graph_argon.cpp
+++ b/tests/nodes/graph_argon.cpp
@@ -26,7 +26,7 @@ namespace UnitTest
 class GraphArgonTest : public ::testing::Test
 {
     public:
-    GraphArgonTest() : dissolve_(coreData_), root_(dissolve_) { Node::echo_ = true; }
+    GraphArgonTest() : dissolve_(coreData_), root_(dissolve_) { Node::setEcho(); }
 
     // Create a graph for testing
     void createGraph(bool advanced = false)

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -62,10 +62,6 @@ class LoopGraphTest : public ::testing::Test
         EXPECT_TRUE(loop_->addEdge({"x", "Result", "Inputs", "I"}));
         // - The output "C" of the loop graph then goes to input "A" of Add 'y'
         EXPECT_TRUE(root_.addEdge({"loop", "C", "y", "A"}));
-        /*
-         * TODO There is an obvious, smaller unit test to write here which tests the validity of trying to make a loopback
-         * connection to a named Input which doesn't exist.
-         */
     }
 
     protected:

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -23,14 +23,15 @@ class LoopGraphTest : public ::testing::Test
          *    Number (i)                      LoopGraph
          *    ------------------              ----------------------------------           Add (y)
          *    |               A-o--+          |                                |-OUT-\     ------------------
-         *    -----------------/    \    +-IN-|     Add (x)                +--o-->>>--o---o-A         result-o
+         *    -----------------/    \    +-IN-|     Add (x)                +--o---C---o---o-A         result-o
          *                           \   -    |     ------------------    /    |-----/    o-B (0)           |
          *                            +-o-->>>-o---o-A         result-o--+     |           -----------------/
-         *                               -    |    o-B (1)           |    \    |-LB--\
-         *                               -----|     -----------------/     \   |     |
-         *                                    |                             +-o-->IN |
-         *                                    |                                |-----/
-         *                                    ----------------------------------
+         *                               - |  |    o-B (1)           |    \    |-LB--\
+         *                               --+--|     -----------------/     \   |     |
+         *                                 |  |                             +-o-->IN----
+         *                                 |  |                                |-----/  \
+         *                                 \  ----------------------------------        |
+         *                                  \__________________________________________/
          */
         root_.x = 0;
         root_.y = 0;
@@ -86,6 +87,7 @@ TEST_F(LoopGraphTest, BasicLoop)
     y_->findInput("B")->set<Number>(1);
 
     // Run y - all nodes should update
+    printf("FIRST PULL\n");
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(x_->versionIndex(), 0);
     EXPECT_EQ(y_->versionIndex(), 0);
@@ -93,6 +95,33 @@ TEST_F(LoopGraphTest, BasicLoop)
     EXPECT_EQ(i_->getOutputValue<Number>("A").asInteger(), 0);
     EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 1);
     EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 2);
+
+    // Change number input 'i' and run y - all nodes should update again
+    printf("SECOND PULL\n");
+    i_->findOption("A")->set<Number>(5);
+    EXPECT_EQ(i_->getOutputValue<Number>("A").asInteger(), 5);
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 1);
+    EXPECT_EQ(y_->versionIndex(), 1);
+    EXPECT_EQ(i_->versionIndex(), 1);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 6);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 7);
+
+    // Test pulling the loopback edges - no versions should change
+    printf("LOOPBACK PULL\n");
+    EXPECT_EQ(loop_->testLoopBack(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 1);
+    EXPECT_EQ(y_->versionIndex(), 1);
+    EXPECT_EQ(i_->versionIndex(), 1);
+
+    // Run y again - x_ and y_ should update
+    printf("THIRD PULL\n");
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 2);
+    EXPECT_EQ(y_->versionIndex(), 2);
+    EXPECT_EQ(i_->versionIndex(), 1);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 7);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 8);
 };
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -88,7 +88,6 @@ TEST_F(LoopGraphTest, BasicLoop)
     x_->findInput("B")->set<Number>(1);
     y_->findInput("B")->set<Number>(1);
     loop_->findOption("Iterations")->set<Number>(iterations);
-    loop_->findOption("LoopbackInvalidates")->set(false);
 
     // Run y - all nodes should update
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -24,7 +24,7 @@ class LoopGraphTest : public ::testing::Test
          *    ------------------              ----------------------------------           Add (y)
          *    |               A-o--+          |                                |-OUT-\     ------------------
          *    -----------------/    \    +-IN-|     Add (x)                +--o---C---o---o-A         result-o
-         *                           \   -    |     ------------------    /    |-----/    o-B (0)           |
+         *                           \   -    |     ------------------    /    |-----/    o-B (1)           |
          *                            +-o-->>>-o---o-A         result-o--+     |           -----------------/
          *                               - |  |    o-B (1)           |    \    |-LB--\
          *                               --+--|     -----------------/     \   |     |
@@ -109,21 +109,21 @@ TEST_F(LoopGraphTest, BasicLoop)
     EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
     EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 
-    // Run y again - should be no change as no upstream data has changed, and loopback invalidation is off
-    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
-    EXPECT_EQ(x_->versionIndex(), 19);
-    EXPECT_EQ(y_->versionIndex(), 1);
-    EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
-    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
+    // // Run y again - should be no change as no upstream data has changed, and loopback invalidation is off
+    // EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
+    // EXPECT_EQ(x_->versionIndex(), 19);
+    // EXPECT_EQ(y_->versionIndex(), 1);
+    // EXPECT_EQ(i_->versionIndex(), 1);
+    // EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    // EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 
-    // Turn on loopback invalidation and run y again - this time everything should update starting from the current values
-    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
-    EXPECT_EQ(x_->versionIndex(), 19);
-    EXPECT_EQ(y_->versionIndex(), 1);
-    EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
-    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
+    // // Turn on loopback invalidation and run y again - this time everything should update starting from the current values
+    // EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
+    // EXPECT_EQ(x_->versionIndex(), 19);
+    // EXPECT_EQ(y_->versionIndex(), 1);
+    // EXPECT_EQ(i_->versionIndex(), 1);
+    // EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    // EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 };
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -84,10 +84,11 @@ TEST_F(LoopGraphTest, BasicLoop)
 
     const auto iterations = 10;
 
-    // Set some numbers
+    // Set some numbers, and set the loopback invalidates flag to false
     x_->findInput("B")->set<Number>(1);
     y_->findInput("B")->set<Number>(1);
     loop_->findOption("Iterations")->set<Number>(iterations);
+    loop_->findOption("LoopbackInvalidates")->set(false);
 
     // Run y - all nodes should update
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
@@ -108,7 +109,15 @@ TEST_F(LoopGraphTest, BasicLoop)
     EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
     EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 
-    // Run y again - should be no change as no upstream data has changed
+    // Run y again - should be no change as no upstream data has changed, and loopback invalidation is off
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
+    EXPECT_EQ(x_->versionIndex(), 19);
+    EXPECT_EQ(y_->versionIndex(), 1);
+    EXPECT_EQ(i_->versionIndex(), 1);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
+
+    // Turn on loopback invalidation and run y again - this time everything should update starting from the current values
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
     EXPECT_EQ(x_->versionIndex(), 19);
     EXPECT_EQ(y_->versionIndex(), 1);

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Team Dissolve and contributors
+
+#include "nodes/loop.h"
+#include "nodes/add.h"
+#include "nodes/dissolve.h"
+#include "nodes/numberNode.h"
+#include "nodes/registry.h"
+#include "tests/testData.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+class LoopGraphTest : public ::testing::Test
+{
+    public:
+    LoopGraphTest() : dissolve_(coreData_), root_(dissolve_) {}
+
+    // Create a graph for testing
+    void createGraph()
+    {
+        /*
+         *    Number (i)                      LoopGraph
+         *    ------------------              ----------------------------------           Add (y)
+         *    |          Number-o--+          |                                |-OUT-\     ------------------
+         *    -----------------/    \    +-IN-|     Add (x)                +--o-->>>--o---o-A         result-o
+         *                           \   -    |     ------------------    /    |-----/    o-B (0)           |
+         *                            +-o-->>>-o---o-A         result-o--+     |           -----------------/
+         *                               -    |    o-B (1)           |    \    |-LB--\
+         *                               -----|     -----------------/     \   |     |
+         *                                    |                             +-o-->IN |
+         *                                    |                                |-----/
+         *                                    ----------------------------------
+         */
+        root_.x = 0;
+        root_.y = 0;
+
+        // Create nodes
+        i_ = dynamic_cast<NumberNode *>(root_.createNode("Number", "i"));
+        loop_ = dynamic_cast<LoopGraph *>(root_.createNode("Loop", "loop"));
+        x_ = dynamic_cast<AddNode *>(loop_->createNode("Add", "x"));
+        y_ = dynamic_cast<AddNode *>(root_.createNode("Add", "y"));
+
+        ASSERT_TRUE(i_);
+        ASSERT_TRUE(x_);
+        ASSERT_TRUE(y_);
+        ASSERT_TRUE(loop_);
+
+        ASSERT_EQ(i_->name(), "i");
+        ASSERT_EQ(x_->name(), "x");
+        ASSERT_EQ(y_->name(), "y");
+        ASSERT_EQ(loop_->name(), "loop");
+
+        // Create edge connections
+        // - Number 'i' is a dynamic input to the LoopGraph - we'll call the input "I"
+        EXPECT_TRUE(root_.addEdge({"i", "A", "loop", "I"}));
+        // - Add 'x' takes the LoopGraph input "I" as its parameter "A"
+        EXPECT_TRUE(loop_->addEdge({"Inputs", "I", "x", "A"}));
+        // - Result from Add 'x' goes to graph output (which we will call "C") as well as loopback to "I"
+        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Outputs", "C"}));
+        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Loopback", "I"}));
+        // - The output "C" of the loop graph then goes to input "A" of Add 'y'
+        EXPECT_TRUE(root_.addEdge({"loop", "C", "y", "A"}));
+        /*
+         * TODO There is an obvious, smaller unit test to write here which tests the validity of trying to make a loopback
+         * connection to a named Input which doesn't exist.
+         */
+    }
+
+    protected:
+    // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
+    CoreData coreData_;
+    Dissolve dissolve_;
+    DissolveGraph root_;
+    NumberNode *i_{nullptr};
+    AddNode *x_{nullptr}, *y_{nullptr};
+    LoopGraph *loop_{nullptr};
+};
+
+TEST_F(LoopGraphTest, BasicLoop)
+{
+    createGraph();
+
+    CoreData cd;
+    Dissolve d(cd);
+    DissolveGraph copy(d);
+    auto serialised = root_.serialise();
+
+    SerialisedValue contents = toml::parse("dissolve/input/simple_addition_graph.toml");
+    UnitTest::compareToml("", serialised, contents);
+
+    std::cout << serialised << std::endl;
+    copy.deserialise(serialised);
+    auto repeat = copy.serialise();
+
+    UnitTest::compareToml("", repeat, contents);
+};
+
+} // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -109,21 +109,13 @@ TEST_F(LoopGraphTest, BasicLoop)
     EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
     EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 
-    // // Run y again - should be no change as no upstream data has changed, and loopback invalidation is off
-    // EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
-    // EXPECT_EQ(x_->versionIndex(), 19);
-    // EXPECT_EQ(y_->versionIndex(), 1);
-    // EXPECT_EQ(i_->versionIndex(), 1);
-    // EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
-    // EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
-
-    // // Turn on loopback invalidation and run y again - this time everything should update starting from the current values
-    // EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
-    // EXPECT_EQ(x_->versionIndex(), 19);
-    // EXPECT_EQ(y_->versionIndex(), 1);
-    // EXPECT_EQ(i_->versionIndex(), 1);
-    // EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
-    // EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
+    // Run y again - should be no change as no upstream data has changed
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
+    EXPECT_EQ(x_->versionIndex(), 19);
+    EXPECT_EQ(y_->versionIndex(), 1);
+    EXPECT_EQ(i_->versionIndex(), 1);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 };
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -82,46 +82,39 @@ TEST_F(LoopGraphTest, BasicLoop)
 {
     createGraph();
 
+    const auto iterations = 10;
+
     // Set some numbers
     x_->findInput("B")->set<Number>(1);
     y_->findInput("B")->set<Number>(1);
+    loop_->findOption("Iterations")->set<Number>(iterations);
 
     // Run y - all nodes should update
-    printf("FIRST PULL\n");
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(x_->versionIndex(), iterations - 1);
     EXPECT_EQ(y_->versionIndex(), 0);
     EXPECT_EQ(i_->versionIndex(), 0);
     EXPECT_EQ(i_->getOutputValue<Number>("A").asInteger(), 0);
-    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 1);
-    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 2);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 1);
 
     // Change number input 'i' and run y - all nodes should update again
-    printf("SECOND PULL\n");
     i_->findOption("A")->set<Number>(5);
     EXPECT_EQ(i_->getOutputValue<Number>("A").asInteger(), 5);
     EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(x_->versionIndex(), 1);
+    EXPECT_EQ(x_->versionIndex(), 19);
     EXPECT_EQ(y_->versionIndex(), 1);
     EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 6);
-    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 7);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 
-    // Test pulling the loopback edges - no versions should change
-    printf("LOOPBACK PULL\n");
-    EXPECT_EQ(loop_->testLoopBack(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(x_->versionIndex(), 1);
+    // Run y again - should be no change as no upstream data has changed
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Unchanged);
+    EXPECT_EQ(x_->versionIndex(), 19);
     EXPECT_EQ(y_->versionIndex(), 1);
     EXPECT_EQ(i_->versionIndex(), 1);
-
-    // Run y again - x_ and y_ should update
-    printf("THIRD PULL\n");
-    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(x_->versionIndex(), 2);
-    EXPECT_EQ(y_->versionIndex(), 2);
-    EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 7);
-    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 8);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
 };
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -77,23 +77,6 @@ class LoopGraphTest : public ::testing::Test
     LoopGraph *loop_{nullptr};
 };
 
-TEST_F(LoopGraphTest, BasicLoop)
-{
-    createGraph();
-
-    CoreData cd;
-    Dissolve d(cd);
-    DissolveGraph copy(d);
-    auto serialised = root_.serialise();
-
-    SerialisedValue contents = toml::parse("dissolve/input/simple_addition_graph.toml");
-    UnitTest::compareToml("", serialised, contents);
-
-    std::cout << serialised << std::endl;
-    copy.deserialise(serialised);
-    auto repeat = copy.serialise();
-
-    UnitTest::compareToml("", repeat, contents);
-};
+TEST_F(LoopGraphTest, BasicLoop) { createGraph(); };
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -22,7 +22,7 @@ class LoopGraphTest : public ::testing::Test
         /*
          *    Number (i)                      LoopGraph
          *    ------------------              ----------------------------------           Add (y)
-         *    |          Number-o--+          |                                |-OUT-\     ------------------
+         *    |               A-o--+          |                                |-OUT-\     ------------------
          *    -----------------/    \    +-IN-|     Add (x)                +--o-->>>--o---o-A         result-o
          *                           \   -    |     ------------------    /    |-----/    o-B (0)           |
          *                            +-o-->>>-o---o-A         result-o--+     |           -----------------/
@@ -58,7 +58,7 @@ class LoopGraphTest : public ::testing::Test
         EXPECT_TRUE(loop_->addEdge({"Inputs", "I", "x", "A"}));
         // - Result from Add 'x' goes to graph output (which we will call "C") as well as loopback to "I"
         EXPECT_TRUE(loop_->addEdge({"x", "Result", "Outputs", "C"}));
-        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Loopback", "I"}));
+        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Inputs", "I"}));
         // - The output "C" of the loop graph then goes to input "A" of Add 'y'
         EXPECT_TRUE(root_.addEdge({"loop", "C", "y", "A"}));
         /*
@@ -77,6 +77,22 @@ class LoopGraphTest : public ::testing::Test
     LoopGraph *loop_{nullptr};
 };
 
-TEST_F(LoopGraphTest, BasicLoop) { createGraph(); };
+TEST_F(LoopGraphTest, BasicLoop)
+{
+    createGraph();
+
+    // Set some numbers
+    x_->findInput("B")->set<Number>(1);
+    y_->findInput("B")->set<Number>(1);
+
+    // Run y - all nodes should update
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 0);
+    EXPECT_EQ(y_->versionIndex(), 0);
+    EXPECT_EQ(i_->versionIndex(), 0);
+    EXPECT_EQ(i_->getOutputValue<Number>("A").asInteger(), 0);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), 1);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), 2);
+};
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -115,6 +115,15 @@ TEST_F(LoopGraphTest, BasicLoop)
     EXPECT_EQ(i_->versionIndex(), 1);
     EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations + 5);
     EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations + 5 + 1);
+
+    // Change the inner node x and run y again - this time we should update
+    x_->findInput("B")->set<Number>(2);
+    EXPECT_EQ(y_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(x_->versionIndex(), 29);
+    EXPECT_EQ(y_->versionIndex(), 2);
+    EXPECT_EQ(i_->versionIndex(), 1);
+    EXPECT_EQ(x_->getOutputValue<Number>("Result").asInteger(), iterations * 2 + 5);
+    EXPECT_EQ(y_->getOutputValue<Number>("Result").asInteger(), iterations * 2 + 5 + 1);
 };
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR implements a `LoopGraph` node - a simple `Graph`-type node which iterates over its children a number of times. It changes the `InputsNode` to mirror its proxy output parameters to identically-named input parameters, allowing edges to be created to transfer data back to the beginning of the loop.

The actual data flow in this PR is worth explicitly stating.  In the unit test, when the node `y_` is pulled to start the processing the `LoopGraph` is activated and processes it's input edges (only one, from the node `i_`). It then proceeds to iterate its subgraph for the required number of cycles. Loopback edges are not pulled on the first iteration, only on every subsequent iteration in order to provide any new input data. This means that, unless the node `i_` is modified, calling the graph again (as is performed in the unit test) will result in it being `Unchanged`.

The loopback of data is achieved in practice by essentially disconnecting the `InputsNode` from natural node behaviour, principally overriding it's `run()` function to not automatically pull input edges (which would cause an infinite loop) and let `LoopGraph` handle this when necessary. Furthermore, propagation of "update required" flags is deliberately stopped at edges connecting to an input on an `InputsNode` as again this would cause an infinite loop.

Complicated, but hopefully a solid solution.  Thoughts please!