### PR TITLE
fix: Wildcard matching caused iterator errors

### DIFF
--- a/src/base/sysFunc.cpp
+++ b/src/base/sysFunc.cpp
@@ -41,9 +41,9 @@ std::string_view DissolveSys::onOff(bool b) { return (b ? "On" : "Off"); }
 bool DissolveSys::wildCardMatch(std::string_view::const_iterator wild, std::string_view::const_iterator wildEnd,
                                 std::string_view::const_iterator s2, std::string_view::const_iterator s2End, bool caseSensitive)
 {
-    // If we reach at the end of both strings, the match was a success
-    if ((wild == wildEnd) && (s2 == s2End))
-        return true;
+    // If we reach the end of the wild string we have either gone too far (no match) or the match was a success (if s2 == s2End)
+    if (wild == wildEnd)
+        return s2 == s2End;
 
     // Handle wildcards '*' and '?'
     if (*wild == '*')


### PR DESCRIPTION
This PR fixes an issue highlighted by MSVC where an iterator object pointing to its end iterator was being wrongly dereferenced.  Both Clang and GCC don't seem to care, but MSVC in Debug mode certainly generates code that does.