### PR TITLE
refactor:change serialisation

### DIFF
--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -66,7 +66,7 @@ template <typename... Contexts> class Serialisable
     // Wrapper for deserialise that toml11 will check for
     void from_toml(const toml::value &node) { deserialise(node); }
     // Wrapper for serialise that toml11 will check for
-    toml::value into_toml() const
+    SerialisedValue into_toml() const
     {
         SerialisedValue result;
         serialize("inner", result);

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -38,14 +38,13 @@ template <typename... Contexts> class Serialisable
 {
     public:
     // Express as a serialisable value
-    virtual SerialisedValue serialise() const {
+    virtual SerialisedValue serialise() const
+    {
         SerialisedValue result;
         serialize("inner", result);
         return result["inner"];
     }
-    virtual void serialize(std::string tag, SerialisedValue &target) const {
-        target[tag] = serialise();
-    }
+    virtual void serialize(std::string tag, SerialisedValue &target) const { target[tag] = serialise(); }
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 
@@ -99,7 +98,7 @@ template <typename... Contexts> class Serialisable
     {
         SerialisedValue group;
         for (const auto &value : vector)
-            group[getName(value)] = value->serialise();
+            value->serialize(getName(value), group);
         return group;
     };
     // A helper function to add elements of a KeyedVector to a node
@@ -183,7 +182,7 @@ template <typename... Contexts> class Serialisable
             if constexpr (serialisablePointer<V>)
                 result[std::string(key)] = value->serialise();
             else if constexpr (std::is_base_of_v<Serialisable, V>)
-                result[std::string(key)] = value.serialise();
+                value.serialize(key, result);
             else
                 // We use the direct value (with casting) instead of
                 // value.serialise() to handle the case where the value

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -66,7 +66,12 @@ template <typename... Contexts> class Serialisable
     // Wrapper for deserialise that toml11 will check for
     void from_toml(const toml::value &node) { deserialise(node); }
     // Wrapper for serialise that toml11 will check for
-    toml::value into_toml() const { return serialise(); }
+    toml::value into_toml() const
+    {
+        SerialisedValue result;
+        serialize("inner", result);
+        return result["inner"];
+    }
 
     // Perform an action on a child node in a table if the node exists.
     // This cuts out quite a bit of boilerplate.

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -16,7 +16,7 @@ using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::Orde
 // We need a way at compile time to detect all the types of smart
 // pointers for things that can be serialised
 template <typename T>
-concept serialisablePointer = requires(T a, std::string tag, SerialisedValue target) { a->serialize(tag, target); };
+concept serialisablePointer = requires(T a, std::string tag, SerialisedValue target) { a->serialise(tag, target); };
 
 // The associated context for type T This type does double duty.
 // First, since the struct has not actual members, it is a Unit type
@@ -38,7 +38,7 @@ template <typename... Contexts> class Serialisable
 {
     public:
     // Express as a serialisable value
-    virtual void serialize(std::string tag, SerialisedValue &target) const = 0;
+    virtual void serialise(std::string tag, SerialisedValue &target) const = 0;
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 
@@ -63,7 +63,7 @@ template <typename... Contexts> class Serialisable
     SerialisedValue into_toml() const
     {
         SerialisedValue result;
-        serialize("inner", result);
+        serialise("inner", result);
         return result["inner"];
     }
 
@@ -97,7 +97,7 @@ template <typename... Contexts> class Serialisable
     {
         SerialisedValue group;
         for (const auto &value : vector)
-            value->serialize(getName(value), group);
+            value->serialise(getName(value), group);
         return group;
     };
     // A helper function to add elements of a KeyedVector to a node
@@ -149,7 +149,7 @@ template <typename... Contexts> class Serialisable
                    [](const auto &item)
                    {
                        SerialisedValue outer;
-                       item->serialize("inner", outer);
+                       item->serialise("inner", outer);
                        return outer["inner"];
                    });
     }
@@ -166,7 +166,7 @@ template <typename... Contexts> class Serialisable
                    [](const auto &item)
                    {
                        SerialisedValue outer;
-                       item.serialize("inner", outer);
+                       item.serialise("inner", outer);
                        return outer["inner"];
                    });
     }
@@ -193,7 +193,7 @@ template <typename... Contexts> class Serialisable
             if constexpr (serialisablePointer<V>)
                 value->serialise(std::string(key), result);
             else if constexpr (std::is_base_of_v<Serialisable, V>)
-                value.serialize(key, result);
+                value.serialise(key, result);
             else
                 // We use the direct value (with casting) instead of
                 // value.serialise() to handle the case where the value
@@ -215,7 +215,7 @@ template <typename... Contexts> class Serialisable
                 continue;
             changed = true;
             if constexpr (serialisablePointer<V>)
-                value->serialize(std::string(key), result);
+                value->serialise(std::string(key), result);
             else
                 // We use the direct value (with casting) instead of
                 // value.serialise() to handle the case where the value

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -10,13 +10,13 @@
 #include <map>
 #include <vector>
 
+// The type we use for the nodes of our serialisation tree
+using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::OrderedMap, std::vector>;
+
 // We need a way at compile time to detect all the types of smart
 // pointers for things that can be serialised
 template <typename T>
-concept serialisablePointer = requires(T a) { a->serialise(); };
-
-// The type we use for the nodes of our serialisation tree
-using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::OrderedMap, std::vector>;
+concept serialisablePointer = requires(T a, std::string tag, SerialisedValue target) { a->serialize(tag, target); };
 
 // The associated context for type T This type does double duty.
 // First, since the struct has not actual members, it is a Unit type
@@ -38,7 +38,14 @@ template <typename... Contexts> class Serialisable
 {
     public:
     // Express as a serialisable value
-    virtual SerialisedValue serialise() const = 0;
+    virtual SerialisedValue serialise() const {
+        SerialisedValue result;
+        serialize("inner", result);
+        return result["inner"];
+    }
+    virtual void serialize(std::string tag, SerialisedValue &target) const {
+        target[tag] = serialise();
+    }
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -80,14 +80,8 @@ template <typename... Contexts> class Serialisable
     }
 
     // A helper function to add elements of a vector to a node under the named heading
-    template <typename T>
-    static void fromVectorToTable(const std::vector<std::shared_ptr<T>> &vector, std::string name, SerialisedValue &node)
-    {
-        fromVectorToTable(vector, name, node, [](const auto &item) { return item->name().data(); });
-    }
-    // A helper function to add elements of a vector to a node under the named heading
-    template <typename T>
-    static void fromVectorToTable(const std::vector<std::unique_ptr<T>> &vector, std::string name, SerialisedValue &node)
+    template <serialisablePointer T>
+    static void fromVectorToTable(const std::vector<T> &vector, std::string name, SerialisedValue &node)
     {
         fromVectorToTable(vector, name, node, [](const auto &item) { return item->name().data(); });
     }

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -38,13 +38,7 @@ template <typename... Contexts> class Serialisable
 {
     public:
     // Express as a serialisable value
-    virtual SerialisedValue serialise() const
-    {
-        SerialisedValue result;
-        serialize("inner", result);
-        return result["inner"];
-    }
-    virtual void serialize(std::string tag, SerialisedValue &target) const { target[tag] = serialise(); }
+    virtual void serialize(std::string tag, SerialisedValue &target) const = 0;
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
 
@@ -151,7 +145,13 @@ template <typename... Contexts> class Serialisable
     template <typename T>
     static void fromVector(const std::vector<std::unique_ptr<T>> &vector, std::string name, SerialisedValue &node)
     {
-        fromVector(vector, name, node, [](const auto &item) { return item->serialise(); });
+        fromVector(vector, name, node,
+                   [](const auto &item)
+                   {
+                       SerialisedValue outer;
+                       item->serialize("inner", outer);
+                       return outer["inner"];
+                   });
     }
     // A helper function to add the elements of a vector to a node under a name
     template <typename T>
@@ -162,7 +162,13 @@ template <typename... Contexts> class Serialisable
     // A helper function to add the elements of a vector to a node under a name
     template <typename T> static void fromVector(const std::vector<T> &vector, std::string name, SerialisedValue &node)
     {
-        fromVector(vector, name, node, [](const auto &item) { return item.serialise(); });
+        fromVector(vector, name, node,
+                   [](const auto &item)
+                   {
+                       SerialisedValue outer;
+                       item.serialize("inner", outer);
+                       return outer["inner"];
+                   });
     }
     // A helper function to add the elements of a vector to a node under a name
     template <typename T, typename Lambda>
@@ -185,7 +191,7 @@ template <typename... Contexts> class Serialisable
         SerialisedValue result;
         for (auto &[key, value] : map)
             if constexpr (serialisablePointer<V>)
-                result[std::string(key)] = value->serialise();
+                value->serialise(std::string(key), result);
             else if constexpr (std::is_base_of_v<Serialisable, V>)
                 value.serialize(key, result);
             else
@@ -209,7 +215,7 @@ template <typename... Contexts> class Serialisable
                 continue;
             changed = true;
             if constexpr (serialisablePointer<V>)
-                result[std::string(key)] = value->serialise();
+                value->serialize(std::string(key), result);
             else
                 // We use the direct value (with casting) instead of
                 // value.serialise() to handle the case where the value

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -64,7 +64,7 @@ bool AtomType::sameParametersAs(const AtomType *other, bool checkCharge)
 }
 
 // Express as a serialisable value
-void AtomType::serialize(std::string tag, SerialisedValue &target) const
+void AtomType::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &atomType = target[tag];
 

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -64,9 +64,9 @@ bool AtomType::sameParametersAs(const AtomType *other, bool checkCharge)
 }
 
 // Express as a serialisable value
-SerialisedValue AtomType::serialise() const
+void AtomType::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue atomType;
+    auto &atomType = target[tag];
 
     atomType["z"] = Z_;
     atomType["charge"] = charge_;
@@ -81,8 +81,6 @@ SerialisedValue AtomType::serialise() const
             atomTypeParameters[parameter] = value;
         atomType["parameters"] = atomTypeParameters;
     }
-
-    return atomType;
 }
 
 // Read values from a serialisable value

--- a/src/classes/atomType.h
+++ b/src/classes/atomType.h
@@ -75,7 +75,7 @@ class AtomType : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(SerialisedValue node);
 };

--- a/src/classes/atomType.h
+++ b/src/classes/atomType.h
@@ -75,7 +75,7 @@ class AtomType : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(SerialisedValue node);
 };

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -387,11 +387,10 @@ Vector3 Box::scaleFactors(double requestedVolume, const std::array<bool, 3> &sca
 }
 
 // Express as a serialisable value
-SerialisedValue Box::serialise() const
+void Box::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue box;
+    auto &box = target[tag];
     box["lengths"] = {a_, b_, c_};
     box["angles"] = {alpha_, beta_, gamma_};
     box["nonPeriodic"] = {!std::get<0>(periodic_), !std::get<1>(periodic_), !std::get<2>(periodic_)};
-    return box;
 }

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -387,7 +387,7 @@ Vector3 Box::scaleFactors(double requestedVolume, const std::array<bool, 3> &sca
 }
 
 // Express as a serialisable value
-void Box::serialize(std::string tag, SerialisedValue &target) const
+void Box::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &box = target[tag];
     box["lengths"] = {a_, b_, c_};

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -173,7 +173,7 @@ class Box : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };
 
 // Single Image Box Definition

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -173,7 +173,7 @@ class Box : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
 };
 
 // Single Image Box Definition

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -122,9 +122,9 @@ void Configuration::setTemperature(double t) { temperature_ = t; }
 double Configuration::temperature() const { return temperature_; }
 
 // Express as a serialisable value
-SerialisedValue Configuration::serialise() const
+void Configuration::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue configuration;
+    auto &configuration = target[tag];
 
     if (requestedCellDivisionLength_ != defaultCellDivisionLength_)
         configuration["cellDivisionLength"] = requestedCellDivisionLength_;
@@ -133,9 +133,7 @@ SerialisedValue Configuration::serialise() const
     if (temperature_ != defaultTemperature_)
         configuration["temperature"] = temperature_;
 
-    configuration["generator"] = generator_;
-
-    return configuration;
+    generator_.serialize("generator", configuration);
 }
 
 // Read values from a serialisable value

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -122,7 +122,7 @@ void Configuration::setTemperature(double t) { temperature_ = t; }
 double Configuration::temperature() const { return temperature_; }
 
 // Express as a serialisable value
-void Configuration::serialize(std::string tag, SerialisedValue &target) const
+void Configuration::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &configuration = target[tag];
 
@@ -133,7 +133,7 @@ void Configuration::serialize(std::string tag, SerialisedValue &target) const
     if (temperature_ != defaultTemperature_)
         configuration["temperature"] = temperature_;
 
-    generator_.serialize("generator", configuration);
+    generator_.serialise("generator", configuration);
 }
 
 // Read values from a serialisable value

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -268,7 +268,7 @@ class Configuration : public Serialisable<const CoreData &>
     // Read from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData, double pairPotentialRange, bool hasPotentials);
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -268,7 +268,7 @@ class Configuration : public Serialisable<const CoreData &>
     // Read from specified LineParser
     bool deserialise(LineParser &parser, const CoreData &coreData, double pairPotentialRange, bool hasPotentials);
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -689,7 +689,7 @@ void CoreData::setInputFilename(std::string_view filename) { inputFilename_ = fi
 std::string_view CoreData::inputFilename() const { return inputFilename_; }
 
 // Express as a serialisable value
-void CoreData::Masters::serialize(std::string tag, SerialisedValue &target) const
+void CoreData::Masters::serialise(std::string tag, SerialisedValue &target) const
 {
     if (bonds.empty() && angles.empty() && torsions.empty() && impropers.empty())
         return;
@@ -715,7 +715,7 @@ void CoreData::Masters::deserialise(const SerialisedValue &node)
 }
 
 // Express Master terms as serialisable value
-void CoreData::serialiseMaster(std::string tag, SerialisedValue &target) const { masters_.serialize(tag, target); }
+void CoreData::serialiseMaster(std::string tag, SerialisedValue &target) const { masters_.serialise(tag, target); }
 
 // Read Master values from serialisable value
 void CoreData::deserialiseMaster(const SerialisedValue &node) { masters_.deserialise(node); }

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -689,15 +689,15 @@ void CoreData::setInputFilename(std::string_view filename) { inputFilename_ = fi
 std::string_view CoreData::inputFilename() const { return inputFilename_; }
 
 // Express as a serialisable value
-SerialisedValue CoreData::Masters::serialise() const
+void CoreData::Masters::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue::table_type table;
-    SerialisedValue node = table;
+    if (bonds.empty() && angles.empty() && torsions.empty() && impropers.empty())
+        return;
+    auto &node = target[tag];
     Serialisable::fromVectorToTable<>(bonds, "bonds", node);
     Serialisable::fromVectorToTable<>(angles, "angles", node);
     Serialisable::fromVectorToTable<>(torsions, "torsions", node);
     Serialisable::fromVectorToTable<>(impropers, "impropers", node);
-    return node;
 }
 
 // Read values from a serialisable value
@@ -715,7 +715,7 @@ void CoreData::Masters::deserialise(const SerialisedValue &node)
 }
 
 // Express Master terms as serialisable value
-SerialisedValue CoreData::serialiseMaster() const { return masters_.serialise(); }
+void CoreData::serialiseMaster(std::string tag, SerialisedValue &target) const { masters_.serialize(tag, target); }
 
 // Read Master values from serialisable value
 void CoreData::deserialiseMaster(const SerialisedValue &node) { masters_.deserialise(node); }

--- a/src/classes/coreData.h
+++ b/src/classes/coreData.h
@@ -93,7 +93,7 @@ class CoreData
         std::vector<std::shared_ptr<MasterImproper>> impropers;
 
         // Express as a serialisable value
-        void serialize(std::string tag, SerialisedValue &target) const override;
+        void serialise(std::string tag, SerialisedValue &target) const override;
         // Read values from a serialisable value
         void deserialise(const SerialisedValue &node) override;
     };

--- a/src/classes/coreData.h
+++ b/src/classes/coreData.h
@@ -93,7 +93,7 @@ class CoreData
         std::vector<std::shared_ptr<MasterImproper>> impropers;
 
         // Express as a serialisable value
-        SerialisedValue serialise() const override;
+        void serialize(std::string tag, SerialisedValue &target) const override;
         // Read values from a serialisable value
         void deserialise(const SerialisedValue &node) override;
     };
@@ -102,7 +102,7 @@ class CoreData
 
     public:
     // Express Master terms as serialisable value
-    SerialisedValue serialiseMaster() const;
+    void serialiseMaster(std::string tag, SerialisedValue &target) const;
     // Read Master values from serialisable value
     void deserialiseMaster(const SerialisedValue &node);
     // Add new master Bond parameters

--- a/src/classes/dataSource.h
+++ b/src/classes/dataSource.h
@@ -220,7 +220,7 @@ template <typename DataType> class DataSource : public Serialisable<const CoreDa
         return true;
     }
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const
+    void serialise(std::string tag, SerialisedValue &target) const
     {
         if (dataSourceType_ == Internal)
         {
@@ -229,7 +229,7 @@ template <typename DataType> class DataSource : public Serialisable<const CoreDa
         else
         {
             target[tag] = {{"dataSourceType", dataSourceTypes().keyword(dataSourceType_)}};
-            externalDataSource_.serialize("source", target[tag]);
+            externalDataSource_.serialise("source", target[tag]);
         }
     }
 };

--- a/src/classes/dataSource.h
+++ b/src/classes/dataSource.h
@@ -220,16 +220,16 @@ template <typename DataType> class DataSource : public Serialisable<const CoreDa
         return true;
     }
     // Express as a serialisable value
-    SerialisedValue serialise() const
+    void serialize(std::string tag, SerialisedValue &target) const
     {
         if (dataSourceType_ == Internal)
         {
-            return {{"dataSourceType", dataSourceTypes().keyword(dataSourceType_)}, {"source", internalDataSource_}};
+            target[tag] = {{"dataSourceType", dataSourceTypes().keyword(dataSourceType_)}, {"source", internalDataSource_}};
         }
         else
         {
-            return {{"dataSourceType", dataSourceTypes().keyword(dataSourceType_)},
-                    {"source", externalDataSource_.serialise()}};
+            target[tag] = {{"dataSourceType", dataSourceTypes().keyword(dataSourceType_)}};
+            externalDataSource_.serialize("source", target[tag]);
         }
     }
 };

--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -67,12 +67,11 @@ const KeyedVector<const AtomType *, Sears91::Isotope> &Isotopologue::isotopes() 
  */
 
 // Express as a serialisable value
-SerialisedValue Isotopologue::serialise() const
+void Isotopologue::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue::table_type result;
+    auto &result = target[tag];
     for (auto &&[type, isotope] : isotopes_)
         result[type->name().data()] = Sears91::A(isotope);
-    return result;
 }
 
 void Isotopologue::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/classes/isotopologue.cpp
+++ b/src/classes/isotopologue.cpp
@@ -67,7 +67,7 @@ const KeyedVector<const AtomType *, Sears91::Isotope> &Isotopologue::isotopes() 
  */
 
 // Express as a serialisable value
-void Isotopologue::serialize(std::string tag, SerialisedValue &target) const
+void Isotopologue::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &result = target[tag];
     for (auto &&[type, isotope] : isotopes_)

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -68,7 +68,7 @@ class Isotopologue : public Serialisable<const CoreData &>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -68,7 +68,7 @@ class Isotopologue : public Serialisable<const CoreData &>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/classes/isotopologueSet.cpp
+++ b/src/classes/isotopologueSet.cpp
@@ -116,7 +116,7 @@ bool IsotopologueSet::write(LineParser &parser)
 }
 
 // Express as a serialisable value
-void IsotopologueSet::serialize(std::string tag, SerialisedValue &target) const { target[tag] = isotopologues_; }
+void IsotopologueSet::serialise(std::string tag, SerialisedValue &target) const { target[tag] = isotopologues_; }
 
 // Read values from a serialisable value
 void IsotopologueSet::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/classes/isotopologueSet.cpp
+++ b/src/classes/isotopologueSet.cpp
@@ -116,7 +116,7 @@ bool IsotopologueSet::write(LineParser &parser)
 }
 
 // Express as a serialisable value
-SerialisedValue IsotopologueSet::serialise() const { return isotopologues_; }
+void IsotopologueSet::serialize(std::string tag, SerialisedValue &target) const { target[tag] = isotopologues_; }
 
 // Read values from a serialisable value
 void IsotopologueSet::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/classes/isotopologueSet.h
+++ b/src/classes/isotopologueSet.h
@@ -58,7 +58,7 @@ class IsotopologueSet : public Serialisable<const CoreData &>
     // Write data through specified LineParser
     bool write(LineParser &parser);
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/classes/isotopologueSet.h
+++ b/src/classes/isotopologueSet.h
@@ -58,7 +58,7 @@ class IsotopologueSet : public Serialisable<const CoreData &>
     // Write data through specified LineParser
     bool write(LineParser &parser);
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -102,7 +102,7 @@ bool Isotopologues::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void Isotopologues::serialize(std::string tag, SerialisedValue &target) const
+void Isotopologues::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"name", species_->name()}, {"population", speciesPopulation_}};
 

--- a/src/classes/isotopologues.cpp
+++ b/src/classes/isotopologues.cpp
@@ -102,7 +102,7 @@ bool Isotopologues::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue Isotopologues::serialise() const
+void Isotopologues::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"name", species_->name()}, {"population", speciesPopulation_}};
 
@@ -112,7 +112,7 @@ SerialisedValue Isotopologues::serialise() const
 
     result["mix"] = mix;
 
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -57,5 +57,5 @@ class Isotopologues : public Serialisable<const CoreData &>
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/classes/isotopologues.h
+++ b/src/classes/isotopologues.h
@@ -57,5 +57,5 @@ class Isotopologues : public Serialisable<const CoreData &>
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -396,7 +396,7 @@ void PairPotential::setAdditionalPotential(Data1D &newUAdditional)
  */
 
 // Express as a serialisable value
-void PairPotential::serialize(std::string tag, SerialisedValue &target) const
+void PairPotential::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &result = target[tag];
     result["nameI"] = nameI_;

--- a/src/classes/pairPotential.cpp
+++ b/src/classes/pairPotential.cpp
@@ -396,9 +396,9 @@ void PairPotential::setAdditionalPotential(Data1D &newUAdditional)
  */
 
 // Express as a serialisable value
-SerialisedValue PairPotential::serialise() const
+void PairPotential::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result;
+    auto &result = target[tag];
     result["nameI"] = nameI_;
     result["nameJ"] = nameJ_;
     result["form"] = Functions1D::forms().keyword(interactionPotential_.form());
@@ -412,7 +412,6 @@ SerialisedValue PairPotential::serialise() const
             potentialParameters[parameter] = value;
         result["parameters"] = potentialParameters;
     }
-    return result;
 }
 
 // Read values from a serialisable value

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -193,7 +193,7 @@ class PairPotential : Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -193,7 +193,7 @@ class PairPotential : Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/classes/pairPotentialOverride.cpp
+++ b/src/classes/pairPotentialOverride.cpp
@@ -49,7 +49,7 @@ const InteractionPotential<Functions1D> &PairPotentialOverride::interactionPoten
  */
 
 // Express as a serialisable value
-void PairPotentialOverride::serialize(std::string tag, SerialisedValue &target) const
+void PairPotentialOverride::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &value = target[tag];
 

--- a/src/classes/pairPotentialOverride.cpp
+++ b/src/classes/pairPotentialOverride.cpp
@@ -49,9 +49,9 @@ const InteractionPotential<Functions1D> &PairPotentialOverride::interactionPoten
  */
 
 // Express as a serialisable value
-SerialisedValue PairPotentialOverride::serialise() const
+void PairPotentialOverride::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue value;
+    auto &value = target[tag];
 
     value["matchI"] = matchI_;
     value["matchJ"] = matchJ_;
@@ -67,8 +67,6 @@ SerialisedValue PairPotentialOverride::serialise() const
             interactionParameters[parameter] = value;
         value["parameters"] = interactionParameters;
     }
-
-    return value;
 }
 
 // Read values from a serialisable value

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -56,7 +56,7 @@ class PairPotentialOverride : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -56,7 +56,7 @@ class PairPotentialOverride : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/classes/partialSet.cpp
+++ b/src/classes/partialSet.cpp
@@ -581,21 +581,19 @@ bool PartialSet::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue PartialSet::serialise() const
+void PartialSet::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result;
+    auto &result = target[tag];
 
     result["realSpeciesPopulations"] = Serialisable::fromVectorToTable(realSpeciesPopulations_);
 
-    result["partials"] = partials_.serialise();
-    result["boundPartials"] = boundPartials_.serialise();
-    result["unboundPartials"] = unboundPartials_.serialise();
+    partials_.serialize("partials", result);
+    boundPartials_.serialize("boundPartials", result);
+    unboundPartials_.serialize("unboundPartials", result);
 
     result["total"] = total_;
     result["boundTotal"] = boundTotal_;
     result["unboundTotal"] = unboundTotal_;
-
-    return result;
 }
 
 // Read values from a serialisable value

--- a/src/classes/partialSet.cpp
+++ b/src/classes/partialSet.cpp
@@ -581,15 +581,15 @@ bool PartialSet::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void PartialSet::serialize(std::string tag, SerialisedValue &target) const
+void PartialSet::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &result = target[tag];
 
     result["realSpeciesPopulations"] = Serialisable::fromVectorToTable(realSpeciesPopulations_);
 
-    partials_.serialize("partials", result);
-    boundPartials_.serialize("boundPartials", result);
-    unboundPartials_.serialize("unboundPartials", result);
+    partials_.serialise("partials", result);
+    boundPartials_.serialise("boundPartials", result);
+    unboundPartials_.serialise("unboundPartials", result);
 
     result["total"] = total_;
     result["boundTotal"] = boundTotal_;

--- a/src/classes/partialSet.h
+++ b/src/classes/partialSet.h
@@ -118,7 +118,7 @@ class PartialSet : public Serialisable<>, ResolvableContext
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(SerialisedValue node);
     // Resolve internal resolvable name references with supplied data

--- a/src/classes/partialSet.h
+++ b/src/classes/partialSet.h
@@ -118,7 +118,7 @@ class PartialSet : public Serialisable<>, ResolvableContext
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(SerialisedValue node);
     // Resolve internal resolvable name references with supplied data

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -206,9 +206,12 @@ void Species::print() const
 int Species::version() const { return version_; }
 
 // Express as a serialisable value
-SerialisedValue Species::serialise() const
+void Species::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result;
+    if (forcefield_ == nullptr && atoms_.empty() && bonds_.empty() && angles_.empty() && torsions_.empty() &&
+        isotopologues_.empty() && sites_.empty())
+        return;
+    auto &result = target[tag];
     if (forcefield_ != nullptr)
         result["forcefield"] = forcefield_->name().data();
 
@@ -219,8 +222,6 @@ SerialisedValue Species::serialise() const
     Serialisable::fromVector<>(impropers_, "impropers", result);
     Serialisable::fromVectorToTable<>(isotopologues_, "isotopologues", result);
     Serialisable::fromVectorToTable<>(sites_, "sites", result);
-
-    return result;
 }
 
 // Read values from a serialisable value

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -206,7 +206,7 @@ void Species::print() const
 int Species::version() const { return version_; }
 
 // Express as a serialisable value
-void Species::serialize(std::string tag, SerialisedValue &target) const
+void Species::serialise(std::string tag, SerialisedValue &target) const
 {
     if (forcefield_ == nullptr && atoms_.empty() && bonds_.empty() && angles_.empty() && torsions_.empty() &&
         isotopologues_.empty() && sites_.empty())

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -372,7 +372,7 @@ class Species : public Serialisable<const CoreData &>
     bool write(LineParser &parser, std::string_view prefix);
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -372,7 +372,7 @@ class Species : public Serialisable<const CoreData &>
     bool write(LineParser &parser, std::string_view prefix);
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -293,9 +293,9 @@ double SpeciesAngle::force(double theta) const
 }
 
 // Express as a serialisable value
-void SpeciesAngle::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesAngle::serialise(std::string tag, SerialisedValue &target) const
 {
-    SpeciesIntra<SpeciesAngle, AngleFunctions>::serialize(tag, target);
+    SpeciesIntra<SpeciesAngle, AngleFunctions>::serialise(tag, target);
     auto &angle = target[tag];
     if (i_ != nullptr)
         angle["i"] = i_->userIndex();

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -293,17 +293,16 @@ double SpeciesAngle::force(double theta) const
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesAngle::serialise() const
+void SpeciesAngle::serialize(std::string tag, SerialisedValue &target) const
 {
-    auto angle = SpeciesIntra<SpeciesAngle, AngleFunctions>::serialise();
+    SpeciesIntra<SpeciesAngle, AngleFunctions>::serialize(tag, target);
+    auto &angle = target[tag];
     if (i_ != nullptr)
         angle["i"] = i_->userIndex();
     if (j_ != nullptr)
         angle["j"] = j_->userIndex();
     if (k_ != nullptr)
         angle["k"] = k_->userIndex();
-
-    return angle;
 }
 // This method populates the object's members with values read from an 'angle' TOML node
 void SpeciesAngle::deserialise(const SerialisedValue &node, CoreData &coreData)

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -78,7 +78,7 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     double force(double theta) const;
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -78,7 +78,7 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     double force(double theta) const;
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -484,9 +484,9 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesAtom::serialise() const
+void SpeciesAtom::serialize(std::string tag, SerialisedValue &target) const
 {
-    return {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"charge", charge_}, {"type", atomType_->name().data()}};
+    target[tag] = {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"charge", charge_}, {"type", atomType_->name().data()}};
 }
 void SpeciesAtom::deserialise(const SerialisedValue &node, CoreData &coreData)
 {

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -484,7 +484,7 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
 }
 
 // Express as a serialisable value
-void SpeciesAtom::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"charge", charge_}, {"type", atomType_->name().data()}};
 }

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -214,7 +214,7 @@ class SpeciesAtom : public Serialisable<CoreData &>
     static int guessOxidationState(const SpeciesAtom *i);
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -214,7 +214,7 @@ class SpeciesAtom : public Serialisable<CoreData &>
     static int guessOxidationState(const SpeciesAtom *i);
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -313,9 +313,9 @@ double SpeciesBond::force(double distance) const
 }
 
 // Express as a serialisable value
-void SpeciesBond::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesBond::serialise(std::string tag, SerialisedValue &target) const
 {
-    SpeciesIntra<SpeciesBond, BondFunctions>::serialize(tag, target);
+    SpeciesIntra<SpeciesBond, BondFunctions>::serialise(tag, target);
     auto &bond = target[tag];
     if (i_ != nullptr)
         bond["i"] = i_->userIndex();

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -313,15 +313,14 @@ double SpeciesBond::force(double distance) const
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesBond::serialise() const
+void SpeciesBond::serialize(std::string tag, SerialisedValue &target) const
 {
-    auto bond = SpeciesIntra<SpeciesBond, BondFunctions>::serialise();
+    SpeciesIntra<SpeciesBond, BondFunctions>::serialize(tag, target);
+    auto &bond = target[tag];
     if (i_ != nullptr)
         bond["i"] = i_->userIndex();
     if (j_ != nullptr)
         bond["j"] = j_->userIndex();
-
-    return bond;
 }
 
 // This method populates the object's members with values read from a 'bond' TOML node

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -107,7 +107,7 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     double force(double distance) const;
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -107,7 +107,7 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     double force(double distance) const;
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -219,9 +219,12 @@ double SpeciesImproper::force(double phi) const
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesImproper::serialise() const
+void SpeciesImproper::serialize(std::string tag, SerialisedValue &target) const
 {
-    auto improper = SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialise();
+    // if (i_ == nullptr && j_ == nullptr && k_ == nullptr && l_ == nullptr)
+    //     return;
+    SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialize(tag, target);
+    auto &improper = target.at(tag);
     if (i_ != nullptr)
         improper["i"] = i_->userIndex();
     if (j_ != nullptr)
@@ -230,9 +233,8 @@ SerialisedValue SpeciesImproper::serialise() const
         improper["k"] = k_->userIndex();
     if (l_ != nullptr)
         improper["l"] = l_->userIndex();
-
-    return improper;
 }
+
 // This method populates the object's members with values read from an 'improper' TOML node
 void SpeciesImproper::deserialise(const SerialisedValue &node, CoreData &coreData)
 {

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -221,8 +221,6 @@ double SpeciesImproper::force(double phi) const
 // Express as a serialisable value
 void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
 {
-    // if (i_ == nullptr && j_ == nullptr && k_ == nullptr && l_ == nullptr)
-    //     return;
     SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialise(tag, target);
     auto &improper = target.at(tag);
     if (i_ != nullptr)

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -219,11 +219,11 @@ double SpeciesImproper::force(double phi) const
 }
 
 // Express as a serialisable value
-void SpeciesImproper::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
 {
     // if (i_ == nullptr && j_ == nullptr && k_ == nullptr && l_ == nullptr)
     //     return;
-    SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialize(tag, target);
+    SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialise(tag, target);
     auto &improper = target.at(tag);
     if (i_ != nullptr)
         improper["i"] = i_->userIndex();

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -86,7 +86,7 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     double force(double phi) const;
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -86,7 +86,7 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     double force(double phi) const;
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -211,7 +211,7 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     }
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         auto &result = target[tag];
 

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -211,9 +211,9 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     }
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
-        SerialisedValue result;
+        auto &result = target[tag];
 
         if (masterTerm_ != nullptr)
             result["form"] = std::format("@{}", masterTerm_->name());
@@ -232,7 +232,5 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
                     parametersNode[parameters[parameterIndex]] = values[parameterIndex];
             result["parameters"] = parametersNode;
         }
-
-        return result;
     }
 };

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -733,9 +733,9 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesSite::serialise() const
+void SpeciesSite::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue site;
+    auto &site = target[tag];
     if (type_ != SiteType::Static)
         site["type"] = siteTypes().serialise(type_);
     if (originMassWeighted_)
@@ -757,7 +757,6 @@ SerialisedValue SpeciesSite::serialise() const
             Serialisable::fromVector(dynamicAtomTypes_, "atomTypes", site, [](const auto &item) { return item->name(); });
             break;
     }
-    return site;
 }
 
 void SpeciesSite::deserialise(const SerialisedValue &node, CoreData &coreData)

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -733,7 +733,7 @@ bool SpeciesSite::write(LineParser &parser, std::string_view prefix)
 }
 
 // Express as a serialisable value
-void SpeciesSite::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesSite::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &site = target[tag];
     if (type_ != SiteType::Static)

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -207,6 +207,6 @@ class SpeciesSite : public Serialisable<CoreData &>
     // Write site definition to specified LineParser
     bool write(LineParser &parser, std::string_view prefix);
 
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -207,6 +207,6 @@ class SpeciesSite : public Serialisable<CoreData &>
     // Write site definition to specified LineParser
     bool write(LineParser &parser, std::string_view prefix);
 
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -523,9 +523,9 @@ double SpeciesTorsion::force(double phi) const
 }
 
 // Express as a serialisable value
-void SpeciesTorsion::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesTorsion::serialise(std::string tag, SerialisedValue &target) const
 {
-    SpeciesIntra<SpeciesTorsion, TorsionFunctions>::serialize(tag, target);
+    SpeciesIntra<SpeciesTorsion, TorsionFunctions>::serialise(tag, target);
     auto &torsion = target[tag];
     if (i_ != nullptr)
         torsion["i"] = i_->userIndex();

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -523,9 +523,10 @@ double SpeciesTorsion::force(double phi) const
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesTorsion::serialise() const
+void SpeciesTorsion::serialize(std::string tag, SerialisedValue &target) const
 {
-    auto torsion = SpeciesIntra<SpeciesTorsion, TorsionFunctions>::serialise();
+    SpeciesIntra<SpeciesTorsion, TorsionFunctions>::serialize(tag, target);
+    auto &torsion = target[tag];
     if (i_ != nullptr)
         torsion["i"] = i_->userIndex();
     if (j_ != nullptr)
@@ -537,8 +538,6 @@ SerialisedValue SpeciesTorsion::serialise() const
 
     torsion["q14"] = electrostatic14Scaling_;
     torsion["v14"] = vdw14Scaling_;
-
-    return torsion;
 }
 
 // This method populates the object's members with values read from a 'torsion' TOML node

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -102,7 +102,7 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     double force(double phi) const;
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -102,7 +102,7 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     double force(double phi) const;
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData);
 };

--- a/src/classes/valueStore.cpp
+++ b/src/classes/valueStore.cpp
@@ -45,7 +45,7 @@ OptionalReferenceWrapper<const std::vector<double>> ValueStore::data(std::string
 const std::list<std::tuple<std::string, std::vector<double>, ValueImportFileFormat>> &ValueStore::data() const { return data_; }
 
 // Express as a serialisable value
-void ValueStore::serialize(std::string tag, SerialisedValue &node) const
+void ValueStore::serialise(std::string tag, SerialisedValue &node) const
 {
     SerialisedValue result = SerialisedValue::array_type{};
     for (auto &[tag, data, format] : data_)

--- a/src/classes/valueStore.cpp
+++ b/src/classes/valueStore.cpp
@@ -45,12 +45,12 @@ OptionalReferenceWrapper<const std::vector<double>> ValueStore::data(std::string
 const std::list<std::tuple<std::string, std::vector<double>, ValueImportFileFormat>> &ValueStore::data() const { return data_; }
 
 // Express as a serialisable value
-SerialisedValue ValueStore::serialise() const
+void ValueStore::serialize(std::string tag, SerialisedValue &node) const
 {
     SerialisedValue result = SerialisedValue::array_type{};
     for (auto &[tag, data, format] : data_)
         result.push_back({{"tag", tag}, {"values", data}, {"format", format}});
-    return result;
+    node[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/classes/valueStore.h
+++ b/src/classes/valueStore.h
@@ -34,7 +34,7 @@ class ValueStore : public Serialisable<const CoreData &>
     // Return vector of all data
     const std::list<std::tuple<std::string, std::vector<double>, ValueImportFileFormat>> &data() const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &node) const override;
+    void serialise(std::string tag, SerialisedValue &node) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/classes/valueStore.h
+++ b/src/classes/valueStore.h
@@ -34,7 +34,7 @@ class ValueStore : public Serialisable<const CoreData &>
     // Return vector of all data
     const std::list<std::tuple<std::string, std::vector<double>, ValueImportFileFormat>> &data() const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &node) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -134,7 +134,7 @@ bool ExpressionValue::bothDoubles(const ExpressionValue &a, const ExpressionValu
 }
 
 // Express as a serialisable value
-void ExpressionValue::serialize(std::string tag, SerialisedValue &target) const
+void ExpressionValue::serialise(std::string tag, SerialisedValue &target) const
 {
     if (type_ == ValueType::Integer)
         target[tag] = valueI_;

--- a/src/expression/value.cpp
+++ b/src/expression/value.cpp
@@ -134,12 +134,12 @@ bool ExpressionValue::bothDoubles(const ExpressionValue &a, const ExpressionValu
 }
 
 // Express as a serialisable value
-SerialisedValue ExpressionValue::serialise() const
+void ExpressionValue::serialize(std::string tag, SerialisedValue &target) const
 {
     if (type_ == ValueType::Integer)
-        return valueI_;
+        target[tag] = valueI_;
     else
-        return valueD_;
+        target[tag] = valueD_;
 }
 
 // Read values from a serialisable value

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -67,7 +67,7 @@ class ExpressionValue : public Serialisable<>
     // Return the supplied ExpressionValues both contain double types
     static bool bothDoubles(const ExpressionValue &a, const ExpressionValue &b);
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -67,7 +67,7 @@ class ExpressionValue : public Serialisable<>
     // Return the supplied ExpressionValues both contain double types
     static bool bothDoubles(const ExpressionValue &a, const ExpressionValue &b);
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -59,7 +59,7 @@ const ExpressionValue &ExpressionVariable::value() const { return value_; }
 ExpressionValue *ExpressionVariable::valuePointer() { return &value_; }
 
 // Express as a serialisable value
-SerialisedValue ExpressionVariable::serialise() const { return {{"name", baseName_}, {"value", value_}}; }
+void ExpressionVariable::serialize(std::string tag, SerialisedValue &target) const { target[tag] = {{"name", baseName_}, {"value", value_}}; }
 
 // Read values from a serialisable value
 void ExpressionVariable::deserialise(const SerialisedValue &node)

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -59,7 +59,10 @@ const ExpressionValue &ExpressionVariable::value() const { return value_; }
 ExpressionValue *ExpressionVariable::valuePointer() { return &value_; }
 
 // Express as a serialisable value
-void ExpressionVariable::serialize(std::string tag, SerialisedValue &target) const { target[tag] = {{"name", baseName_}, {"value", value_}}; }
+void ExpressionVariable::serialise(std::string tag, SerialisedValue &target) const
+{
+    target[tag] = {{"name", baseName_}, {"value", value_}};
+}
 
 // Read values from a serialisable value
 void ExpressionVariable::deserialise(const SerialisedValue &node)

--- a/src/expression/variable.h
+++ b/src/expression/variable.h
@@ -46,7 +46,7 @@ class ExpressionVariable : public Serialisable<>
     // Return pointer to value
     ExpressionValue *valuePointer();
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/expression/variable.h
+++ b/src/expression/variable.h
@@ -46,7 +46,7 @@ class ExpressionVariable : public Serialisable<>
     // Return pointer to value
     ExpressionValue *valuePointer();
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/generator/generator.cpp
+++ b/src/generator/generator.cpp
@@ -70,7 +70,7 @@ bool Generator::deserialise(LineParser &parser, const CoreData &coreData)
 bool Generator::serialise(LineParser &parser, std::string_view prefix) { return rootSequence_.serialise(parser, prefix); }
 
 // Express as a serialisable value
-SerialisedValue Generator::serialise() const { return rootSequence_.serialise(); }
+void Generator::serialize(std::string tag, SerialisedValue &target) const { rootSequence_.serialize(tag, target); }
 
 // Read values from a serialisable value
 void Generator::deserialise(const SerialisedValue &node, const CoreData &data) { rootSequence_.deserialise(node, data); }

--- a/src/generator/generator.cpp
+++ b/src/generator/generator.cpp
@@ -70,7 +70,7 @@ bool Generator::deserialise(LineParser &parser, const CoreData &coreData)
 bool Generator::serialise(LineParser &parser, std::string_view prefix) { return rootSequence_.serialise(parser, prefix); }
 
 // Express as a serialisable value
-void Generator::serialize(std::string tag, SerialisedValue &target) const { rootSequence_.serialize(tag, target); }
+void Generator::serialise(std::string tag, SerialisedValue &target) const { rootSequence_.serialise(tag, target); }
 
 // Read values from a serialisable value
 void Generator::deserialise(const SerialisedValue &node, const CoreData &data) { rootSequence_.deserialise(node, data); }

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -63,7 +63,7 @@ class Generator : public Serialisable<const CoreData &>
     // Write generator to specified LineParser
     bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value.
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/generator/generator.h
+++ b/src/generator/generator.h
@@ -63,7 +63,7 @@ class Generator : public Serialisable<const CoreData &>
     // Write generator to specified LineParser
     bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value.
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/generator/node.cpp
+++ b/src/generator/node.cpp
@@ -255,12 +255,12 @@ bool GeneratorNode::serialise(LineParser &parser, std::string_view prefix)
 }
 
 // Express as a serialisable value
-SerialisedValue GeneratorNode::serialise() const
+void GeneratorNode::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"type", nodeTypes().keyword(type_)}};
     if (mustBeNamed())
         result["name"] = name_;
-    return keywords_.serialiseOnto(result);
+    target[tag] = keywords_.serialiseOnto(result);
 }
 
 // Read values from a serialisable value

--- a/src/generator/node.cpp
+++ b/src/generator/node.cpp
@@ -255,7 +255,7 @@ bool GeneratorNode::serialise(LineParser &parser, std::string_view prefix)
 }
 
 // Express as a serialisable value
-void GeneratorNode::serialize(std::string tag, SerialisedValue &target) const
+void GeneratorNode::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"type", nodeTypes().keyword(type_)}};
     if (mustBeNamed())

--- a/src/generator/node.h
+++ b/src/generator/node.h
@@ -156,7 +156,7 @@ class GeneratorNode : public std::enable_shared_from_this<GeneratorNode>, public
     // Write node data to specified LineParser
     virtual bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/generator/node.h
+++ b/src/generator/node.h
@@ -156,7 +156,7 @@ class GeneratorNode : public std::enable_shared_from_this<GeneratorNode>, public
     // Write node data to specified LineParser
     virtual bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/generator/nodeValue.cpp
+++ b/src/generator/nodeValue.cpp
@@ -125,18 +125,21 @@ std::string NodeValue::asString(bool addQuotesIfRequired) const
 }
 
 // Express as a serialisable value
-SerialisedValue NodeValue::serialise() const
+void NodeValue::serialize(std::string tag, SerialisedValue &target) const
 {
     switch (type_)
     {
         case IntegerNodeValue:
-            return valueI_;
+            target[tag] = valueI_;
+            break;
         case DoubleNodeValue:
-            return valueD_;
+            target[tag] = valueD_;
+            break;
         case ExpressionNodeValue:
-            return expression_.expressionString();
+            target[tag] = expression_.expressionString();
+            break;
         default:
-            throw(std::runtime_error("Unhandled NodeValue type in serialise().\n"));
+            throw(std::runtime_error("Unhandled NodeValue type in serialise).\n"));
     }
 }
 
@@ -228,13 +231,13 @@ std::string NodeValueProxy::asString(bool addQuotesIfRequired) const
 Vector3NodeValue::Vector3NodeValue(const NodeValue &xx, const NodeValue &yy, const NodeValue &zz) : x(xx), y(yy), z(zz) {}
 
 // Express as a serialisable value
-SerialisedValue Vector3NodeValue::serialise() const
+void Vector3NodeValue::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);
     result.push_back(y);
     result.push_back(z);
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/generator/nodeValue.cpp
+++ b/src/generator/nodeValue.cpp
@@ -125,7 +125,7 @@ std::string NodeValue::asString(bool addQuotesIfRequired) const
 }
 
 // Express as a serialisable value
-void NodeValue::serialize(std::string tag, SerialisedValue &target) const
+void NodeValue::serialise(std::string tag, SerialisedValue &target) const
 {
     switch (type_)
     {
@@ -231,7 +231,7 @@ std::string NodeValueProxy::asString(bool addQuotesIfRequired) const
 Vector3NodeValue::Vector3NodeValue(const NodeValue &xx, const NodeValue &yy, const NodeValue &zz) : x(xx), y(yy), z(zz) {}
 
 // Express as a serialisable value
-void Vector3NodeValue::serialize(std::string tag, SerialisedValue &target) const
+void Vector3NodeValue::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);

--- a/src/generator/nodeValue.h
+++ b/src/generator/nodeValue.h
@@ -71,7 +71,7 @@ class NodeValue : public Serialisable<std::vector<std::shared_ptr<ExpressionVari
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, std::vector<std::shared_ptr<ExpressionVariable>> params) override;
 };
@@ -110,7 +110,7 @@ class Vector3NodeValue : public Serialisable<std::vector<std::shared_ptr<Express
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, std::vector<std::shared_ptr<ExpressionVariable>> params) override;
 };

--- a/src/generator/nodeValue.h
+++ b/src/generator/nodeValue.h
@@ -71,7 +71,7 @@ class NodeValue : public Serialisable<std::vector<std::shared_ptr<ExpressionVari
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, std::vector<std::shared_ptr<ExpressionVariable>> params) override;
 };
@@ -110,7 +110,7 @@ class Vector3NodeValue : public Serialisable<std::vector<std::shared_ptr<Express
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, std::vector<std::shared_ptr<ExpressionVariable>> params) override;
 };

--- a/src/generator/parameters.cpp
+++ b/src/generator/parameters.cpp
@@ -33,7 +33,7 @@ bool ParametersGeneratorNode::execute(const GeneratorContext &generatorContext) 
  */
 
 // Express as a serialisable value
-void ParametersGeneratorNode::serialize(std::string tag, SerialisedValue &target) const
+void ParametersGeneratorNode::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     for (auto &param : parameters_)

--- a/src/generator/parameters.cpp
+++ b/src/generator/parameters.cpp
@@ -33,12 +33,12 @@ bool ParametersGeneratorNode::execute(const GeneratorContext &generatorContext) 
  */
 
 // Express as a serialisable value
-SerialisedValue ParametersGeneratorNode::serialise() const
+void ParametersGeneratorNode::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     for (auto &param : parameters_)
         result[std::string(param->baseName())] = param->value();
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/generator/parameters.h
+++ b/src/generator/parameters.h
@@ -37,7 +37,7 @@ class ParametersGeneratorNode : public GeneratorNode
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/generator/parameters.h
+++ b/src/generator/parameters.h
@@ -37,7 +37,7 @@ class ParametersGeneratorNode : public GeneratorNode
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/generator/sequence.cpp
+++ b/src/generator/sequence.cpp
@@ -509,15 +509,17 @@ bool GeneratorNodeSequence::QueryRange::empty() { return start_ == stop_; }
 void GeneratorNodeSequence::QueryRange::next() { start_++; }
 
 // Express as a serialisable value
-SerialisedValue GeneratorNodeSequence::serialise() const
+void GeneratorNodeSequence::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(sequence_,
-                      [](const auto item)
-                      {
-                          SerialisedValue node = item->serialise();
-                          node["type"] = item->nodeTypes().serialise(item->type());
-                          return node;
-                      });
+    target[tag] = fromVector(sequence_,
+                             [](const auto item)
+                             {
+                                 SerialisedValue outer;
+                                 item->serialize("inner", outer);
+                                 auto &node = outer["inner"];
+                                 node["type"] = item->nodeTypes().serialise(item->type());
+                                 return node;
+                             });
 }
 
 // Read values from a serialisable value

--- a/src/generator/sequence.cpp
+++ b/src/generator/sequence.cpp
@@ -509,13 +509,13 @@ bool GeneratorNodeSequence::QueryRange::empty() { return start_ == stop_; }
 void GeneratorNodeSequence::QueryRange::next() { start_++; }
 
 // Express as a serialisable value
-void GeneratorNodeSequence::serialize(std::string tag, SerialisedValue &target) const
+void GeneratorNodeSequence::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(sequence_,
                              [](const auto item)
                              {
                                  SerialisedValue outer;
-                                 item->serialize("inner", outer);
+                                 item->serialise("inner", outer);
                                  auto &node = outer["inner"];
                                  node["type"] = item->nodeTypes().serialise(item->type());
                                  return node;

--- a/src/generator/sequence.h
+++ b/src/generator/sequence.h
@@ -134,7 +134,7 @@ class GeneratorNodeSequence : public Serialisable<const CoreData &>
     // Write structure to specified LineParser
     bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/generator/sequence.h
+++ b/src/generator/sequence.h
@@ -134,7 +134,7 @@ class GeneratorNodeSequence : public Serialisable<const CoreData &>
     // Write structure to specified LineParser
     bool serialise(LineParser &parser, std::string_view prefix);
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/io/fileAndFormat.cpp
+++ b/src/io/fileAndFormat.cpp
@@ -150,7 +150,7 @@ bool FileAndFormat::writeBlock(LineParser &parser, std::string_view prefix) cons
 }
 
 // Express as a serialisable value
-SerialisedValue FileAndFormat::serialise() const
+void FileAndFormat::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"filename", filename_},
                               {"format", formatIndex_ ? formats_.keywordByIndex(*formatIndex_) : "???"}};
@@ -158,7 +158,7 @@ SerialisedValue FileAndFormat::serialise() const
     keywords = keywords_.serialiseOnto(keywords);
     if (!keywords.is_uninitialized())
         result["keywords"] = keywords;
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/io/fileAndFormat.cpp
+++ b/src/io/fileAndFormat.cpp
@@ -150,7 +150,7 @@ bool FileAndFormat::writeBlock(LineParser &parser, std::string_view prefix) cons
 }
 
 // Express as a serialisable value
-void FileAndFormat::serialize(std::string tag, SerialisedValue &target) const
+void FileAndFormat::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"filename", filename_},
                               {"format", formatIndex_ ? formats_.keywordByIndex(*formatIndex_) : "???"}};

--- a/src/io/fileAndFormat.h
+++ b/src/io/fileAndFormat.h
@@ -96,7 +96,7 @@ class FileAndFormat : public Serialisable<const CoreData &>
     // Write options and end block
     bool writeBlock(LineParser &parser, std::string_view prefix) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/io/fileAndFormat.h
+++ b/src/io/fileAndFormat.h
@@ -96,7 +96,7 @@ class FileAndFormat : public Serialisable<const CoreData &>
     // Write options and end block
     bool writeBlock(LineParser &parser, std::string_view prefix) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/atomTypeVector.cpp
+++ b/src/keywords/atomTypeVector.cpp
@@ -74,7 +74,7 @@ void AtomTypeVectorKeyword::removeReferencesTo(std::shared_ptr<AtomType> at)
 }
 
 // Express as a serialisable value
-void AtomTypeVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void AtomTypeVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto &item) { return item->name(); });
 }

--- a/src/keywords/atomTypeVector.cpp
+++ b/src/keywords/atomTypeVector.cpp
@@ -74,9 +74,9 @@ void AtomTypeVectorKeyword::removeReferencesTo(std::shared_ptr<AtomType> at)
 }
 
 // Express as a serialisable value
-SerialisedValue AtomTypeVectorKeyword::serialise() const
+void AtomTypeVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto &item) { return item->name(); });
+    target[tag] = fromVector(data_, [](const auto &item) { return item->name(); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/atomTypeVector.h
+++ b/src/keywords/atomTypeVector.h
@@ -36,7 +36,7 @@ class AtomTypeVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/atomTypeVector.h
+++ b/src/keywords/atomTypeVector.h
@@ -36,7 +36,7 @@ class AtomTypeVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -71,7 +71,7 @@ class KeywordBase : public Serialisable<CoreData const &>
     // Serialise data to specified LineParser
     virtual bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix = "") const = 0;
     // Express as a serialisable value
-    virtual void serialize(std::string tag, SerialisedValue &target) const override = 0;
+    virtual void serialise(std::string tag, SerialisedValue &target) const override = 0;
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, const CoreData &coreData) override {};
 

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -71,7 +71,7 @@ class KeywordBase : public Serialisable<CoreData const &>
     // Serialise data to specified LineParser
     virtual bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix = "") const = 0;
     // Express as a serialisable value
-    virtual SerialisedValue serialise() const override = 0;
+    virtual void serialize(std::string tag, SerialisedValue &target) const override = 0;
     // Read values from a serialisable value
     virtual void deserialise(const SerialisedValue &node, const CoreData &coreData) override {};
 

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -53,7 +53,7 @@ bool BoolKeyword::serialise(LineParser &parser, std::string_view keywordName, st
 }
 
 // Express as a serialisable value
-void BoolKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void BoolKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void BoolKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_boolean(); }

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -53,7 +53,7 @@ bool BoolKeyword::serialise(LineParser &parser, std::string_view keywordName, st
 }
 
 // Express as a serialisable value
-SerialisedValue BoolKeyword::serialise() const { return data_; }
+void BoolKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void BoolKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_boolean(); }

--- a/src/keywords/bool.h
+++ b/src/keywords/bool.h
@@ -40,7 +40,7 @@ class BoolKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/bool.h
+++ b/src/keywords/bool.h
@@ -40,7 +40,7 @@ class BoolKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/configuration.cpp
+++ b/src/keywords/configuration.cpp
@@ -52,12 +52,12 @@ void ConfigurationKeyword::removeReferencesTo(Configuration *cfg)
 }
 
 // Express as a serialisable value
-SerialisedValue ConfigurationKeyword::serialise() const
+void ConfigurationKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
     // isDefault is checked before serialisation of keywords
     // so we have checked for the null pointer
     assert(data_);
-    return data_->name();
+    target[tag] = data_->name();
 }
 
 // Read values from a serialisable value

--- a/src/keywords/configuration.cpp
+++ b/src/keywords/configuration.cpp
@@ -52,7 +52,7 @@ void ConfigurationKeyword::removeReferencesTo(Configuration *cfg)
 }
 
 // Express as a serialisable value
-void ConfigurationKeyword::serialize(std::string tag, SerialisedValue &target) const
+void ConfigurationKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     // isDefault is checked before serialisation of keywords
     // so we have checked for the null pointer

--- a/src/keywords/configuration.h
+++ b/src/keywords/configuration.h
@@ -36,7 +36,7 @@ class ConfigurationKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/configuration.h
+++ b/src/keywords/configuration.h
@@ -36,7 +36,7 @@ class ConfigurationKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/configurationVector.cpp
+++ b/src/keywords/configurationVector.cpp
@@ -69,9 +69,9 @@ void ConfigurationVectorKeyword::removeReferencesTo(Configuration *cfg)
 }
 
 // Express as a serialisable value
-SerialisedValue ConfigurationVectorKeyword::serialise() const
+void ConfigurationVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto &cfg) { return std::string(cfg->name()); });
+    target[tag] = fromVector(data_, [](const auto &cfg) { return std::string(cfg->name()); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/configurationVector.cpp
+++ b/src/keywords/configurationVector.cpp
@@ -69,7 +69,7 @@ void ConfigurationVectorKeyword::removeReferencesTo(Configuration *cfg)
 }
 
 // Express as a serialisable value
-void ConfigurationVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void ConfigurationVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto &cfg) { return std::string(cfg->name()); });
 }

--- a/src/keywords/configurationVector.h
+++ b/src/keywords/configurationVector.h
@@ -47,7 +47,7 @@ class ConfigurationVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/configurationVector.h
+++ b/src/keywords/configurationVector.h
@@ -47,7 +47,7 @@ class ConfigurationVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/dataSource.h
+++ b/src/keywords/dataSource.h
@@ -162,16 +162,16 @@ template <class DataType> class DataSourceKeyword : public DataSourceKeywordBase
         return true;
     }
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         target[tag] = fromVector(dataSources_,
                                  [](const auto &item) -> SerialisedValue
                                  {
                                      auto &[dataSourceA, dataSourceB] = item;
                                      SerialisedValue result;
-                                     dataSourceA->serialize("dataSourceA", result);
+                                     dataSourceA->serialise("dataSourceA", result);
                                      if (dataSourceB->dataExists())
-                                         dataSourceB->serialize("dataSourceB", result);
+                                         dataSourceB->serialise("dataSourceB", result);
                                      return result;
                                  });
     }

--- a/src/keywords/dataSource.h
+++ b/src/keywords/dataSource.h
@@ -162,18 +162,18 @@ template <class DataType> class DataSourceKeyword : public DataSourceKeywordBase
         return true;
     }
     // Express as a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
-        return fromVector(dataSources_,
-                          [](const auto &item) -> SerialisedValue
-                          {
-                              auto &[dataSourceA, dataSourceB] = item;
-                              SerialisedValue result;
-                              dataSourceA->serialize("dataSourceA", result);
-                              if (dataSourceB->dataExists())
-                                  dataSourceB->serialize("dataSourceB", result);
-                              return result;
-                          });
+        target[tag] = fromVector(dataSources_,
+                                 [](const auto &item) -> SerialisedValue
+                                 {
+                                     auto &[dataSourceA, dataSourceB] = item;
+                                     SerialisedValue result;
+                                     dataSourceA->serialize("dataSourceA", result);
+                                     if (dataSourceB->dataExists())
+                                         dataSourceB->serialize("dataSourceB", result);
+                                     return result;
+                                 });
     }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override

--- a/src/keywords/dataSource.h
+++ b/src/keywords/dataSource.h
@@ -168,14 +168,11 @@ template <class DataType> class DataSourceKeyword : public DataSourceKeywordBase
                           [](const auto &item) -> SerialisedValue
                           {
                               auto &[dataSourceA, dataSourceB] = item;
+                              SerialisedValue result;
+                              dataSourceA->serialize("dataSourceA", result);
                               if (dataSourceB->dataExists())
-                              {
-                                  return {{"dataSourceA", dataSourceA->serialise()}, {"dataSourceB", dataSourceB->serialise()}};
-                              }
-                              else
-                              {
-                                  return {{"dataSourceA", dataSourceA->serialise()}};
-                              }
+                                  dataSourceB->serialize("dataSourceB", result);
+                              return result;
                           });
     }
     // Read values from a serialisable value

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -74,7 +74,7 @@ bool DoubleKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 }
 
 // Express as a serialisable value
-void DoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void DoubleKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = toml::get<double>(node); }

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -74,7 +74,7 @@ bool DoubleKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 }
 
 // Express as a serialisable value
-SerialisedValue DoubleKeyword::serialise() const { return data_; }
+void DoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = toml::get<double>(node); }

--- a/src/keywords/double.h
+++ b/src/keywords/double.h
@@ -48,7 +48,7 @@ class DoubleKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/double.h
+++ b/src/keywords/double.h
@@ -48,7 +48,7 @@ class DoubleKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/elementVector.cpp
+++ b/src/keywords/elementVector.cpp
@@ -56,4 +56,4 @@ bool ElementVectorKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-SerialisedValue ElementVectorKeyword::serialise() const { throw std::runtime_error("Cannot serialise ElementVectorKeyword"); }
+void ElementVectorKeyword::serialize(std::string tag, SerialisedValue &target) const { throw std::runtime_error("Cannot serialise ElementVectorKeyword"); }

--- a/src/keywords/elementVector.cpp
+++ b/src/keywords/elementVector.cpp
@@ -56,4 +56,7 @@ bool ElementVectorKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-void ElementVectorKeyword::serialize(std::string tag, SerialisedValue &target) const { throw std::runtime_error("Cannot serialise ElementVectorKeyword"); }
+void ElementVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
+{
+    throw std::runtime_error("Cannot serialise ElementVectorKeyword");
+}

--- a/src/keywords/elementVector.h
+++ b/src/keywords/elementVector.h
@@ -36,5 +36,5 @@ class ElementVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/elementVector.h
+++ b/src/keywords/elementVector.h
@@ -36,5 +36,5 @@ class ElementVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/enumOptions.h
+++ b/src/keywords/enumOptions.h
@@ -111,7 +111,7 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword
     // Has not changed from initial value
     bool isDefault() const override { return data_ == default_; }
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override { target[tag] = optionData_.keyword(data_); }
+    void serialise(std::string tag, SerialisedValue &target) const override { target[tag] = optionData_.keyword(data_); }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override { data_ = optionData_.deserialise(node); }
 };

--- a/src/keywords/enumOptions.h
+++ b/src/keywords/enumOptions.h
@@ -111,7 +111,7 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword
     // Has not changed from initial value
     bool isDefault() const override { return data_ == default_; }
     // Express as a serialisable value
-    SerialisedValue serialise() const override { return optionData_.keyword(data_); }
+    void serialize(std::string tag, SerialisedValue &target) const override { target[tag] = optionData_.keyword(data_); }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override { data_ = optionData_.deserialise(node); }
 };

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -40,7 +40,7 @@ bool ExpressionKeyword::serialise(LineParser &parser, std::string_view keywordNa
 }
 
 // Express as a serialisable value
-void ExpressionKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.expressionString(); }
+void ExpressionKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_.expressionString(); }
 
 // Read values from a serialisable value
 void ExpressionKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -40,7 +40,7 @@ bool ExpressionKeyword::serialise(LineParser &parser, std::string_view keywordNa
 }
 
 // Express as a serialisable value
-SerialisedValue ExpressionKeyword::serialise() const { return data_.expressionString(); }
+void ExpressionKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.expressionString(); }
 
 // Read values from a serialisable value
 void ExpressionKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -42,7 +42,7 @@ class ExpressionKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -42,7 +42,7 @@ class ExpressionKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/expressionVariableVector.cpp
+++ b/src/keywords/expressionVariableVector.cpp
@@ -81,12 +81,12 @@ bool ExpressionVariableVectorKeyword::serialise(LineParser &parser, std::string_
 bool ExpressionVariableVectorKeyword::isDefault() const { return data_.empty(); }
 
 // Express as a serialisable value
-SerialisedValue ExpressionVariableVectorKeyword::serialise() const
+void ExpressionVariableVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     for (auto &i : data_)
         result[std::string(i->baseName())] = i->value();
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/keywords/expressionVariableVector.cpp
+++ b/src/keywords/expressionVariableVector.cpp
@@ -81,7 +81,7 @@ bool ExpressionVariableVectorKeyword::serialise(LineParser &parser, std::string_
 bool ExpressionVariableVectorKeyword::isDefault() const { return data_.empty(); }
 
 // Express as a serialisable value
-void ExpressionVariableVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void ExpressionVariableVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     for (auto &i : data_)

--- a/src/keywords/expressionVariableVector.h
+++ b/src/keywords/expressionVariableVector.h
@@ -48,7 +48,7 @@ class ExpressionVariableVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/expressionVariableVector.h
+++ b/src/keywords/expressionVariableVector.h
@@ -48,7 +48,7 @@ class ExpressionVariableVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/fileAndFormat.cpp
+++ b/src/keywords/fileAndFormat.cpp
@@ -61,7 +61,7 @@ bool FileAndFormatKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-void FileAndFormatKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void FileAndFormatKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void FileAndFormatKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/fileAndFormat.cpp
+++ b/src/keywords/fileAndFormat.cpp
@@ -61,7 +61,7 @@ bool FileAndFormatKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-SerialisedValue FileAndFormatKeyword::serialise() const { return data_; }
+void FileAndFormatKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void FileAndFormatKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/fileAndFormat.h
+++ b/src/keywords/fileAndFormat.h
@@ -47,7 +47,7 @@ class FileAndFormatKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/fileAndFormat.h
+++ b/src/keywords/fileAndFormat.h
@@ -47,7 +47,7 @@ class FileAndFormatKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -62,7 +62,7 @@ bool Function1DKeyword::serialise(LineParser &parser, std::string_view keywordNa
 }
 
 // Express as a serialisable value
-void Function1DKeyword::serialize(std::string tag, SerialisedValue &target) const
+void Function1DKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"type", Functions1D::forms().serialise(data_.form())}, {"parameters", data_.parameters()}};
 }

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -62,9 +62,9 @@ bool Function1DKeyword::serialise(LineParser &parser, std::string_view keywordNa
 }
 
 // Express as a serialisable value
-SerialisedValue Function1DKeyword::serialise() const
+void Function1DKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return {{"type", Functions1D::forms().serialise(data_.form())}, {"parameters", data_.parameters()}};
+    target[tag] = {{"type", Functions1D::forms().serialise(data_.form())}, {"parameters", data_.parameters()}};
 }
 
 // Read values from a serialisable value

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -41,7 +41,7 @@ class Function1DKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -41,7 +41,7 @@ class Function1DKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/generator.cpp
+++ b/src/keywords/generator.cpp
@@ -54,7 +54,12 @@ bool GeneratorKeyword::serialise(LineParser &parser, std::string_view keywordNam
 }
 
 // Express as a serialisable value
-SerialisedValue GeneratorKeyword::serialise() const { return data_.serialise(); }
+SerialisedValue GeneratorKeyword::serialise() const
+{
+    SerialisedValue outer;
+    data_.serialize("inner", outer);
+    return outer["inner"];
+}
 
 // Read values from a serialisable value
 void GeneratorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node, coreData); }

--- a/src/keywords/generator.cpp
+++ b/src/keywords/generator.cpp
@@ -54,12 +54,7 @@ bool GeneratorKeyword::serialise(LineParser &parser, std::string_view keywordNam
 }
 
 // Express as a serialisable value
-SerialisedValue GeneratorKeyword::serialise() const
-{
-    SerialisedValue outer;
-    data_.serialize("inner", outer);
-    return outer["inner"];
-}
+void GeneratorKeyword::serialize(std::string tag, SerialisedValue &target) const { data_.serialize(tag, target); }
 
 // Read values from a serialisable value
 void GeneratorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node, coreData); }

--- a/src/keywords/generator.cpp
+++ b/src/keywords/generator.cpp
@@ -54,7 +54,7 @@ bool GeneratorKeyword::serialise(LineParser &parser, std::string_view keywordNam
 }
 
 // Express as a serialisable value
-void GeneratorKeyword::serialize(std::string tag, SerialisedValue &target) const { data_.serialize(tag, target); }
+void GeneratorKeyword::serialise(std::string tag, SerialisedValue &target) const { data_.serialise(tag, target); }
 
 // Read values from a serialisable value
 void GeneratorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node, coreData); }

--- a/src/keywords/generator.h
+++ b/src/keywords/generator.h
@@ -38,7 +38,7 @@ class GeneratorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/generator.h
+++ b/src/keywords/generator.h
@@ -38,7 +38,7 @@ class GeneratorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -74,7 +74,7 @@ bool IntegerKeyword::serialise(LineParser &parser, std::string_view keywordName,
 }
 
 // Express as a serialisable value
-SerialisedValue IntegerKeyword::serialise() const { return data_; }
+void IntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_integer(); }

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -74,7 +74,7 @@ bool IntegerKeyword::serialise(LineParser &parser, std::string_view keywordName,
 }
 
 // Express as a serialisable value
-void IntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void IntegerKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_integer(); }

--- a/src/keywords/integer.h
+++ b/src/keywords/integer.h
@@ -45,7 +45,7 @@ class IntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/integer.h
+++ b/src/keywords/integer.h
@@ -45,7 +45,7 @@ class IntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/interactionPotential.h
+++ b/src/keywords/interactionPotential.h
@@ -39,7 +39,10 @@ class InteractionPotentialBaseKeyword : public KeywordBase
     // Set parameters from supplied string
     virtual bool setParameters(std::string parameters) = 0;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override { throw std::runtime_error("Cannot serialise InteractionPotentialBaseKeyword"); }
+    void serialise(std::string tag, SerialisedValue &target) const override
+    {
+        throw std::runtime_error("Cannot serialise InteractionPotentialBaseKeyword");
+    }
 };
 
 // Keyword based on InteractionPotential

--- a/src/keywords/interactionPotential.h
+++ b/src/keywords/interactionPotential.h
@@ -39,7 +39,7 @@ class InteractionPotentialBaseKeyword : public KeywordBase
     // Set parameters from supplied string
     virtual bool setParameters(std::string parameters) = 0;
     // Express as a serialisable value
-    SerialisedValue serialise() const override { throw std::runtime_error("Cannot serialise InteractionPotentialBaseKeyword"); }
+    void serialize(std::string tag, SerialisedValue &target) const override { throw std::runtime_error("Cannot serialise InteractionPotentialBaseKeyword"); }
 };
 
 // Keyword based on InteractionPotential

--- a/src/keywords/isotopologueSet.cpp
+++ b/src/keywords/isotopologueSet.cpp
@@ -71,7 +71,7 @@ void IsotopologueSetKeyword::removeReferencesTo(Species *sp) { data_.remove(sp);
 void IsotopologueSetKeyword::removeReferencesTo(Isotopologue *iso) { data_.remove(iso); }
 
 // Express as a serialisable value
-void IsotopologueSetKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void IsotopologueSetKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void IsotopologueSetKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/isotopologueSet.cpp
+++ b/src/keywords/isotopologueSet.cpp
@@ -71,7 +71,7 @@ void IsotopologueSetKeyword::removeReferencesTo(Species *sp) { data_.remove(sp);
 void IsotopologueSetKeyword::removeReferencesTo(Isotopologue *iso) { data_.remove(iso); }
 
 // Express as a serialisable value
-SerialisedValue IsotopologueSetKeyword::serialise() const { return data_; }
+void IsotopologueSetKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void IsotopologueSetKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/isotopologueSet.h
+++ b/src/keywords/isotopologueSet.h
@@ -15,7 +15,7 @@ class IsotopologueSetKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/isotopologueSet.h
+++ b/src/keywords/isotopologueSet.h
@@ -15,7 +15,7 @@ class IsotopologueSetKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/layer.cpp
+++ b/src/keywords/layer.cpp
@@ -51,9 +51,8 @@ void LayerKeyword::deserialise(const SerialisedValue &node, const CoreData &core
 }
 
 // Express as a serialisable value
-SerialisedValue LayerKeyword::serialise() const
+void LayerKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
     if (data_)
-        return data_->name();
-    return {};
+        target[tag] = data_->name();
 }

--- a/src/keywords/layer.cpp
+++ b/src/keywords/layer.cpp
@@ -51,7 +51,7 @@ void LayerKeyword::deserialise(const SerialisedValue &node, const CoreData &core
 }
 
 // Express as a serialisable value
-void LayerKeyword::serialize(std::string tag, SerialisedValue &target) const
+void LayerKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     if (data_)
         target[tag] = data_->name();

--- a/src/keywords/layer.h
+++ b/src/keywords/layer.h
@@ -39,5 +39,5 @@ class LayerKeyword : public KeywordBase
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/layer.h
+++ b/src/keywords/layer.h
@@ -39,5 +39,5 @@ class LayerKeyword : public KeywordBase
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -99,7 +99,7 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
     }
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         if (data_)
             target[tag] = data_->name();

--- a/src/keywords/module.h
+++ b/src/keywords/module.h
@@ -99,11 +99,10 @@ template <class M> class ModuleKeyword : public ModuleKeywordBase
     }
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
         if (data_)
-            return data_->name();
-        return {};
+            target[tag] = data_->name();
     }
 
     // Read values from a serialisable value

--- a/src/keywords/moduleVector.cpp
+++ b/src/keywords/moduleVector.cpp
@@ -89,9 +89,9 @@ void ModuleVectorKeyword::removeReferencesTo(Module *module)
 }
 
 // Express as a serialisable value
-SerialisedValue ModuleVectorKeyword::serialise() const
+void ModuleVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto *item) { return item->name(); });
+    target[tag] = fromVector(data_, [](const auto *item) { return item->name(); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/moduleVector.cpp
+++ b/src/keywords/moduleVector.cpp
@@ -89,7 +89,7 @@ void ModuleVectorKeyword::removeReferencesTo(Module *module)
 }
 
 // Express as a serialisable value
-void ModuleVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void ModuleVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto *item) { return item->name(); });
 }

--- a/src/keywords/moduleVector.h
+++ b/src/keywords/moduleVector.h
@@ -55,7 +55,7 @@ class ModuleVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/moduleVector.h
+++ b/src/keywords/moduleVector.h
@@ -55,7 +55,7 @@ class ModuleVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -109,7 +109,7 @@ template <class N> class NodeKeyword : public NodeKeywordBase
     // Has not changed from initial value
     bool isDefault() const override { return data_ == nullptr; }
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override { target[tag] = data_->name(); }
+    void serialise(std::string tag, SerialisedValue &target) const override { target[tag] = data_->name(); }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override
     {

--- a/src/keywords/node.h
+++ b/src/keywords/node.h
@@ -109,7 +109,7 @@ template <class N> class NodeKeyword : public NodeKeywordBase
     // Has not changed from initial value
     bool isDefault() const override { return data_ == nullptr; }
     // Express as a serialisable value
-    SerialisedValue serialise() const override { return data_->name(); }
+    void serialize(std::string tag, SerialisedValue &target) const override { target[tag] = data_->name(); }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override
     {

--- a/src/keywords/nodeBranch.cpp
+++ b/src/keywords/nodeBranch.cpp
@@ -52,7 +52,7 @@ bool NodeBranchKeyword::isDefault() const { return data_.nNodes() == 0; }
 void NodeBranchKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     if (isDefault())
-      return;
+        return;
     data_.serialise(tag, target);
 }
 

--- a/src/keywords/nodeBranch.cpp
+++ b/src/keywords/nodeBranch.cpp
@@ -49,11 +49,11 @@ bool NodeBranchKeyword::serialise(LineParser &parser, std::string_view keywordNa
 bool NodeBranchKeyword::isDefault() const { return data_.nNodes() == 0; }
 
 // Express as a serialisable value
-void NodeBranchKeyword::serialize(std::string tag, SerialisedValue &target) const
+void NodeBranchKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     if (isDefault())
       return;
-    data_.serialize(tag, target);
+    data_.serialise(tag, target);
 }
 
 // Read values from a serialisable value

--- a/src/keywords/nodeBranch.cpp
+++ b/src/keywords/nodeBranch.cpp
@@ -53,7 +53,9 @@ SerialisedValue NodeBranchKeyword::serialise() const
 {
     if (isDefault())
         return {};
-    return data_.serialise();
+    SerialisedValue outer;
+    data_.serialize("inner", outer);
+    return outer["inner"];
 }
 
 // Read values from a serialisable value

--- a/src/keywords/nodeBranch.cpp
+++ b/src/keywords/nodeBranch.cpp
@@ -49,13 +49,11 @@ bool NodeBranchKeyword::serialise(LineParser &parser, std::string_view keywordNa
 bool NodeBranchKeyword::isDefault() const { return data_.nNodes() == 0; }
 
 // Express as a serialisable value
-SerialisedValue NodeBranchKeyword::serialise() const
+void NodeBranchKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
     if (isDefault())
-        return {};
-    SerialisedValue outer;
-    data_.serialize("inner", outer);
-    return outer["inner"];
+      return;
+    data_.serialize(tag, target);
 }
 
 // Read values from a serialisable value

--- a/src/keywords/nodeBranch.h
+++ b/src/keywords/nodeBranch.h
@@ -39,7 +39,7 @@ class NodeBranchKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &);
 };

--- a/src/keywords/nodeBranch.h
+++ b/src/keywords/nodeBranch.h
@@ -39,7 +39,7 @@ class NodeBranchKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &);
 };

--- a/src/keywords/nodeValue.cpp
+++ b/src/keywords/nodeValue.cpp
@@ -54,7 +54,7 @@ bool NodeValueKeyword::serialise(LineParser &parser, std::string_view keywordNam
 }
 
 // Express as a serialisable value
-SerialisedValue NodeValueKeyword::serialise() const { return data_; }
+void NodeValueKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void NodeValueKeyword::deserialise(const SerialisedValue &node, const CoreData &data)

--- a/src/keywords/nodeValue.cpp
+++ b/src/keywords/nodeValue.cpp
@@ -54,7 +54,7 @@ bool NodeValueKeyword::serialise(LineParser &parser, std::string_view keywordNam
 }
 
 // Express as a serialisable value
-void NodeValueKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void NodeValueKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void NodeValueKeyword::deserialise(const SerialisedValue &node, const CoreData &data)

--- a/src/keywords/nodeValue.h
+++ b/src/keywords/nodeValue.h
@@ -46,7 +46,7 @@ class NodeValueKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &cordeData) override;
     // Has not changed from initial value

--- a/src/keywords/nodeValue.h
+++ b/src/keywords/nodeValue.h
@@ -46,7 +46,7 @@ class NodeValueKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &cordeData) override;
     // Has not changed from initial value

--- a/src/keywords/nodeValueEnumOptions.h
+++ b/src/keywords/nodeValueEnumOptions.h
@@ -122,10 +122,10 @@ template <class E> class NodeValueEnumOptionsKeyword : public NodeValueEnumOptio
     }
 
     // Read values from a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         SerialisedValue result;
-        data_.first.serialize("value", result);
+        data_.first.serialise("value", result);
         result["option"] = optionData_.serialise(data_.second);
         target[tag] = result;
     }

--- a/src/keywords/nodeValueEnumOptions.h
+++ b/src/keywords/nodeValueEnumOptions.h
@@ -122,9 +122,12 @@ template <class E> class NodeValueEnumOptionsKeyword : public NodeValueEnumOptio
     }
 
     // Read values from a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
-        return {{"value", data_.first.serialise()}, {"option", optionData_.serialise(data_.second)}};
+        SerialisedValue result;
+        data_.first.serialize("value", result);
+        result["option"] = optionData_.serialise(data_.second);
+        target[tag] = result;
     }
 
     // Read values from a serialisable value

--- a/src/keywords/nodeVector.h
+++ b/src/keywords/nodeVector.h
@@ -41,7 +41,7 @@ class NodeVectorKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 
         return oldData.size() == nodes().size();
     }
-    SerialisedValue serialise() const override { throw std::runtime_error("Cannot serialise NodeVectorKeywordBase"); }
+    void serialize(std::string tag, SerialisedValue &target) const override { throw std::runtime_error("Cannot serialise NodeVectorKeywordBase"); }
 };
 
 // Keyword managing vector of GeneratorNode
@@ -150,9 +150,9 @@ template <class N> class NodeVectorKeyword : public NodeVectorKeywordBase
     }
 
     // Express as a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
-        return fromVector(data_, [](const auto &item) { return item->name(); });
+        target[tag] = fromVector(data_, [](const auto &item) { return item->name(); });
     }
 
     // Read values from a serialisable value

--- a/src/keywords/nodeVector.h
+++ b/src/keywords/nodeVector.h
@@ -41,7 +41,10 @@ class NodeVectorKeywordBase : public NodeKeywordUnderlay, public KeywordBase
 
         return oldData.size() == nodes().size();
     }
-    void serialize(std::string tag, SerialisedValue &target) const override { throw std::runtime_error("Cannot serialise NodeVectorKeywordBase"); }
+    void serialise(std::string tag, SerialisedValue &target) const override
+    {
+        throw std::runtime_error("Cannot serialise NodeVectorKeywordBase");
+    }
 };
 
 // Keyword managing vector of GeneratorNode
@@ -150,7 +153,7 @@ template <class N> class NodeVectorKeyword : public NodeVectorKeywordBase
     }
 
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         target[tag] = fromVector(data_, [](const auto &item) { return item->name(); });
     }

--- a/src/keywords/optionalDouble.cpp
+++ b/src/keywords/optionalDouble.cpp
@@ -91,7 +91,7 @@ bool OptionalDoubleKeyword::serialise(LineParser &parser, std::string_view keywo
 }
 
 // Express as a serialisable value
-SerialisedValue OptionalDoubleKeyword::serialise() const { return data_.value_or(minimumLimit_); }
+void OptionalDoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.value_or(minimumLimit_); }
 
 // Read values from a serialisable value
 void OptionalDoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/optionalDouble.cpp
+++ b/src/keywords/optionalDouble.cpp
@@ -91,7 +91,10 @@ bool OptionalDoubleKeyword::serialise(LineParser &parser, std::string_view keywo
 }
 
 // Express as a serialisable value
-void OptionalDoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.value_or(minimumLimit_); }
+void OptionalDoubleKeyword::serialise(std::string tag, SerialisedValue &target) const
+{
+    target[tag] = data_.value_or(minimumLimit_);
+}
 
 // Read values from a serialisable value
 void OptionalDoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/optionalDouble.h
+++ b/src/keywords/optionalDouble.h
@@ -54,7 +54,7 @@ class OptionalDoubleKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/optionalDouble.h
+++ b/src/keywords/optionalDouble.h
@@ -54,7 +54,7 @@ class OptionalDoubleKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/optionalInt.cpp
+++ b/src/keywords/optionalInt.cpp
@@ -91,7 +91,10 @@ bool OptionalIntegerKeyword::serialise(LineParser &parser, std::string_view keyw
 }
 
 // Express as a serialisable value
-void OptionalIntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.value_or(minimumLimit_); }
+void OptionalIntegerKeyword::serialise(std::string tag, SerialisedValue &target) const
+{
+    target[tag] = data_.value_or(minimumLimit_);
+}
 
 // Read values from a serialisable value
 void OptionalIntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/optionalInt.cpp
+++ b/src/keywords/optionalInt.cpp
@@ -91,7 +91,7 @@ bool OptionalIntegerKeyword::serialise(LineParser &parser, std::string_view keyw
 }
 
 // Express as a serialisable value
-SerialisedValue OptionalIntegerKeyword::serialise() const { return data_.value_or(minimumLimit_); }
+void OptionalIntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_.value_or(minimumLimit_); }
 
 // Read values from a serialisable value
 void OptionalIntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/optionalInt.h
+++ b/src/keywords/optionalInt.h
@@ -54,7 +54,7 @@ class OptionalIntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/optionalInt.h
+++ b/src/keywords/optionalInt.h
@@ -54,7 +54,7 @@ class OptionalIntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -112,7 +112,7 @@ bool RangeKeyword::serialise(LineParser &parser, std::string_view keywordName, s
 }
 
 // Express as a serialisable value
-SerialisedValue RangeKeyword::serialise() const { return data_; }
+void RangeKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void RangeKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -112,7 +112,7 @@ bool RangeKeyword::serialise(LineParser &parser, std::string_view keywordName, s
 }
 
 // Express as a serialisable value
-void RangeKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void RangeKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void RangeKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/range.h
+++ b/src/keywords/range.h
@@ -59,7 +59,7 @@ class RangeKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/range.h
+++ b/src/keywords/range.h
@@ -59,7 +59,7 @@ class RangeKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/rangeVector.cpp
+++ b/src/keywords/rangeVector.cpp
@@ -65,7 +65,7 @@ bool RangeVectorKeyword::serialise(LineParser &parser, std::string_view keywordN
 // Express as a serialisable value
 void RangeVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue { return item.serialise(); });
+    target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue { return item.into_toml(); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/rangeVector.cpp
+++ b/src/keywords/rangeVector.cpp
@@ -63,9 +63,9 @@ bool RangeVectorKeyword::serialise(LineParser &parser, std::string_view keywordN
  */
 
 // Express as a serialisable value
-SerialisedValue RangeVectorKeyword::serialise() const
+void RangeVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto &item) -> SerialisedValue { return item.serialise(); });
+    target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue { return item.serialise(); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/rangeVector.cpp
+++ b/src/keywords/rangeVector.cpp
@@ -63,7 +63,7 @@ bool RangeVectorKeyword::serialise(LineParser &parser, std::string_view keywordN
  */
 
 // Express as a serialisable value
-void RangeVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void RangeVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue { return item.into_toml(); });
 }

--- a/src/keywords/rangeVector.h
+++ b/src/keywords/rangeVector.h
@@ -39,7 +39,7 @@ class RangeVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/rangeVector.h
+++ b/src/keywords/rangeVector.h
@@ -39,7 +39,7 @@ class RangeVectorKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -52,7 +52,7 @@ void SpeciesKeyword::removeReferencesTo(Species *sp)
 }
 
 // Express as a serialisable value
-void SpeciesKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_->name(); }
+void SpeciesKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_->name(); }
 
 // Read values from a serialisable value
 void SpeciesKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -52,7 +52,7 @@ void SpeciesKeyword::removeReferencesTo(Species *sp)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesKeyword::serialise() const { return data_->name(); }
+void SpeciesKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_->name(); }
 
 // Read values from a serialisable value
 void SpeciesKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/species.h
+++ b/src/keywords/species.h
@@ -36,7 +36,7 @@ class SpeciesKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/species.h
+++ b/src/keywords/species.h
@@ -36,7 +36,7 @@ class SpeciesKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/speciesSite.cpp
+++ b/src/keywords/speciesSite.cpp
@@ -88,7 +88,7 @@ void SpeciesSiteKeyword::removeReferencesTo(SpeciesSite *spSite)
 }
 
 // Express as a serialisable value
-void SpeciesSiteKeyword::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesSiteKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"species", data_->parent()->name()}, {"site", data_->name()}};
 }

--- a/src/keywords/speciesSite.cpp
+++ b/src/keywords/speciesSite.cpp
@@ -88,9 +88,9 @@ void SpeciesSiteKeyword::removeReferencesTo(SpeciesSite *spSite)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesSiteKeyword::serialise() const
+void SpeciesSiteKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return {{"species", data_->parent()->name()}, {"site", data_->name()}};
+    target[tag] = {{"species", data_->parent()->name()}, {"site", data_->name()}};
 }
 
 // Read values from a serialisable value

--- a/src/keywords/speciesSite.h
+++ b/src/keywords/speciesSite.h
@@ -44,7 +44,7 @@ class SpeciesSiteKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/speciesSite.h
+++ b/src/keywords/speciesSite.h
@@ -44,7 +44,7 @@ class SpeciesSiteKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -96,10 +96,10 @@ void SpeciesSiteVectorKeyword::removeReferencesTo(SpeciesSite *spSite)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesSiteVectorKeyword::serialise() const
+void SpeciesSiteVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto item) -> SerialisedValue
-                      { return {{"site", item->name()}, {"species", item->parent()->name()}}; });
+    target[tag] = fromVector(data_, [](const auto item) -> SerialisedValue
+                             { return {{"site", item->name()}, {"species", item->parent()->name()}}; });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -96,7 +96,7 @@ void SpeciesSiteVectorKeyword::removeReferencesTo(SpeciesSite *spSite)
 }
 
 // Express as a serialisable value
-void SpeciesSiteVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesSiteVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto item) -> SerialisedValue
                              { return {{"site", item->name()}, {"species", item->parent()->name()}}; });

--- a/src/keywords/speciesSiteVector.h
+++ b/src/keywords/speciesSiteVector.h
@@ -55,7 +55,7 @@ class SpeciesSiteVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/speciesSiteVector.h
+++ b/src/keywords/speciesSiteVector.h
@@ -55,7 +55,7 @@ class SpeciesSiteVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/speciesVector.cpp
+++ b/src/keywords/speciesVector.cpp
@@ -61,9 +61,9 @@ void SpeciesVectorKeyword::removeReferencesTo(Species *sp)
 }
 
 // Express as a serialisable value
-SerialisedValue SpeciesVectorKeyword::serialise() const
+void SpeciesVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto *item) { return item->name(); });
+    target[tag] = fromVector(data_, [](const auto *item) { return item->name(); });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/speciesVector.cpp
+++ b/src/keywords/speciesVector.cpp
@@ -61,7 +61,7 @@ void SpeciesVectorKeyword::removeReferencesTo(Species *sp)
 }
 
 // Express as a serialisable value
-void SpeciesVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void SpeciesVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto *item) { return item->name(); });
 }

--- a/src/keywords/speciesVector.h
+++ b/src/keywords/speciesVector.h
@@ -51,5 +51,5 @@ class SpeciesVectorKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/speciesVector.h
+++ b/src/keywords/speciesVector.h
@@ -51,5 +51,5 @@ class SpeciesVectorKeyword : public KeywordBase
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
 };

--- a/src/keywords/stdString.cpp
+++ b/src/keywords/stdString.cpp
@@ -39,7 +39,7 @@ bool StringKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 }
 
 // Express as a serialisable value
-void StringKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void StringKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void StringKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_string(); }

--- a/src/keywords/stdString.cpp
+++ b/src/keywords/stdString.cpp
@@ -39,7 +39,7 @@ bool StringKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 }
 
 // Express as a serialisable value
-SerialisedValue StringKeyword::serialise() const { return data_; }
+void StringKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void StringKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_string(); }

--- a/src/keywords/stdString.h
+++ b/src/keywords/stdString.h
@@ -35,7 +35,7 @@ class StringKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/stdString.h
+++ b/src/keywords/stdString.h
@@ -35,7 +35,7 @@ class StringKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -301,7 +301,9 @@ SerialisedValue KeywordStore::serialiseOnto(SerialisedValue node) const
             for (const auto &[keyword, keywordType] : group.keywords())
                 if (!keyword->isDefault())
                 {
-                    auto value = keyword->serialise();
+                    SerialisedValue outer;
+                    keyword->serialize("inner", outer);
+                    auto &value = outer["inner"];
                     if (keywordType != KeywordBase::KeywordType::Deprecated && !value.is_uninitialized())
                         node[toml_format(keyword->name())] = value;
                 }

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -302,7 +302,7 @@ SerialisedValue KeywordStore::serialiseOnto(SerialisedValue node) const
                 if (!keyword->isDefault())
                 {
                     SerialisedValue outer;
-                    keyword->serialize("inner", outer);
+                    keyword->serialise("inner", outer);
                     auto &value = outer["inner"];
                     if (keywordType != KeywordBase::KeywordType::Deprecated && !value.is_uninitialized())
                         node[toml_format(keyword->name())] = value;

--- a/src/keywords/vec3Double.cpp
+++ b/src/keywords/vec3Double.cpp
@@ -101,7 +101,7 @@ bool Vec3DoubleKeyword::serialise(LineParser &parser, std::string_view keywordNa
 bool Vec3DoubleKeyword::isDefault() const { return data_ == default_; }
 
 // Express as a serialisable value
-SerialisedValue Vec3DoubleKeyword::serialise() const { return data_.serialise(); }
+void Vec3DoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { data_.serialize(tag, target); }
 
 // Read values from a serialisable value
 void Vec3DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/vec3Double.cpp
+++ b/src/keywords/vec3Double.cpp
@@ -101,7 +101,7 @@ bool Vec3DoubleKeyword::serialise(LineParser &parser, std::string_view keywordNa
 bool Vec3DoubleKeyword::isDefault() const { return data_ == default_; }
 
 // Express as a serialisable value
-void Vec3DoubleKeyword::serialize(std::string tag, SerialisedValue &target) const { data_.serialize(tag, target); }
+void Vec3DoubleKeyword::serialise(std::string tag, SerialisedValue &target) const { data_.serialise(tag, target); }
 
 // Read values from a serialisable value
 void Vec3DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/vec3Double.h
+++ b/src/keywords/vec3Double.h
@@ -66,7 +66,7 @@ class Vec3DoubleKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/vec3Double.h
+++ b/src/keywords/vec3Double.h
@@ -66,7 +66,7 @@ class Vec3DoubleKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/vec3Integer.cpp
+++ b/src/keywords/vec3Integer.cpp
@@ -94,7 +94,7 @@ bool Vec3IntegerKeyword::serialise(LineParser &parser, std::string_view keywordN
 }
 
 // Express as a serialisable value
-SerialisedValue Vec3IntegerKeyword::serialise() const { return data_; }
+void Vec3IntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void Vec3IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/vec3Integer.cpp
+++ b/src/keywords/vec3Integer.cpp
@@ -94,7 +94,7 @@ bool Vec3IntegerKeyword::serialise(LineParser &parser, std::string_view keywordN
 }
 
 // Express as a serialisable value
-void Vec3IntegerKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void Vec3IntegerKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void Vec3IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }

--- a/src/keywords/vec3Integer.h
+++ b/src/keywords/vec3Integer.h
@@ -64,7 +64,7 @@ class Vec3IntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/vec3Integer.h
+++ b/src/keywords/vec3Integer.h
@@ -64,7 +64,7 @@ class Vec3IntegerKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/vec3NodeValue.cpp
+++ b/src/keywords/vec3NodeValue.cpp
@@ -88,7 +88,7 @@ bool Vec3NodeValueKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-void Vec3NodeValueKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
+void Vec3NodeValueKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void Vec3NodeValueKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/vec3NodeValue.cpp
+++ b/src/keywords/vec3NodeValue.cpp
@@ -88,7 +88,7 @@ bool Vec3NodeValueKeyword::serialise(LineParser &parser, std::string_view keywor
 }
 
 // Express as a serialisable value
-SerialisedValue Vec3NodeValueKeyword::serialise() const { return data_; }
+void Vec3NodeValueKeyword::serialize(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
 void Vec3NodeValueKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)

--- a/src/keywords/vec3NodeValue.h
+++ b/src/keywords/vec3NodeValue.h
@@ -57,7 +57,7 @@ class Vec3NodeValueKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/vec3NodeValue.h
+++ b/src/keywords/vec3NodeValue.h
@@ -57,7 +57,7 @@ class Vec3NodeValueKeyword : public KeywordBase
     // Serialise data to specified LineParser
     bool serialise(LineParser &parser, std::string_view keywordName, std::string_view prefix) const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
 };

--- a/src/keywords/weightedModuleVector.cpp
+++ b/src/keywords/weightedModuleVector.cpp
@@ -82,10 +82,10 @@ void WeightedModuleVectorKeyword::removeReferencesTo(Module *module)
 }
 
 // Express as a serialisable value
-SerialisedValue WeightedModuleVectorKeyword::serialise() const
+void WeightedModuleVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
 {
-    return fromVector(data_, [](const auto &item) -> SerialisedValue
-                      { return {{"target", item.first->name()}, {"weight", item.second}}; });
+    target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue
+                             { return {{"target", item.first->name()}, {"weight", item.second}}; });
 }
 
 // Read values from a serialisable value

--- a/src/keywords/weightedModuleVector.cpp
+++ b/src/keywords/weightedModuleVector.cpp
@@ -82,7 +82,7 @@ void WeightedModuleVectorKeyword::removeReferencesTo(Module *module)
 }
 
 // Express as a serialisable value
-void WeightedModuleVectorKeyword::serialize(std::string tag, SerialisedValue &target) const
+void WeightedModuleVectorKeyword::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = fromVector(data_, [](const auto &item) -> SerialisedValue
                              { return {{"target", item.first->name()}, {"weight", item.second}}; });

--- a/src/keywords/weightedModuleVector.h
+++ b/src/keywords/weightedModuleVector.h
@@ -50,7 +50,7 @@ class WeightedModuleVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/keywords/weightedModuleVector.h
+++ b/src/keywords/weightedModuleVector.h
@@ -50,7 +50,7 @@ class WeightedModuleVectorKeyword : public KeywordBase
 
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
     // Has not changed from initial value

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int args, char **argv)
             result = dissolve.saveInput(options.writeInputFilename().value());
         else
         {
-            auto toml = dissolve.serialise();
+            auto toml = dissolve.into_toml();
             std::ofstream outfile(options.toTomlFile().value());
             outfile << toml;
             outfile.close();

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -201,7 +201,7 @@ class Dissolve : public Serialisable<>
     // Express pair potentials as a serialisable value
     SerialisedValue serialisePairPotentials() const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Load restart file
     bool loadRestart(std::string_view filename);
     // Save restart file

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -201,7 +201,7 @@ class Dissolve : public Serialisable<>
     // Express pair potentials as a serialisable value
     SerialisedValue serialisePairPotentials() const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Load restart file
     bool loadRestart(std::string_view filename);
     // Save restart file

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -163,9 +163,9 @@ SerialisedValue Dissolve::serialisePairPotentials() const
 }
 
 // Express as a serialisable value
-SerialisedValue Dissolve::serialise() const
+void Dissolve::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue root;
+    auto &root = target[tag];
 
     root["version"] = Version::semantic();
 
@@ -184,8 +184,6 @@ SerialisedValue Dissolve::serialise() const
     Serialisable::fromVectorToTable(coreData_.configurations(), "configurations", root);
 
     Serialisable::fromVectorToTable(coreData_.processingLayers(), "layers", root);
-
-    return root;
 }
 
 // This method populates the object's members with values read from a 'pairPotentials' TOML node

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -151,7 +151,9 @@ SerialisedValue Dissolve::serialisePairPotentials() const
                                  [](const auto &term)
                                  {
                                      const auto &[at1, at2, pot] = term;
-                                     auto value = pot->serialise();
+                                     SerialisedValue target;
+                                     pot->serialize("inner", target);
+                                     auto &value = target["inner"];
                                      value["atomTypeI"] = at1->name();
                                      value["atomTypeJ"] = at2->name();
                                      return value;
@@ -169,7 +171,7 @@ SerialisedValue Dissolve::serialise() const
 
     if (!coreData_.masterBonds().empty() || !coreData_.masterAngles().empty() || !coreData_.masterTorsions().empty() ||
         !coreData_.masterImpropers().empty())
-        root["master"] = coreData_.serialiseMaster();
+        coreData_.serialiseMaster("master", root);
 
     Serialisable::fromVectorToTable<>(coreData_.species(), "species", root);
 

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -177,7 +177,7 @@ void Dissolve::serialize(std::string tag, SerialisedValue &target) const
 
     root["pairPotentials"] = serialisePairPotentials();
 
-    root["graph"] = graphNode_->serialise();
+    graphNode_->serialize("graph", root);
 
     Serialisable::fromVector<>(coreData_.pairPotentialOverrides(), "pairPotentialOverrides", root);
 
@@ -330,7 +330,7 @@ bool Dissolve::saveToml(std::string_view filename) const
 {
     std::ofstream outfile;
     outfile.open(std::string(filename));
-    outfile << serialise() << std::endl;
+    outfile << into_toml() << std::endl;
     outfile.close();
     return true;
 }

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -152,7 +152,7 @@ SerialisedValue Dissolve::serialisePairPotentials() const
                                  {
                                      const auto &[at1, at2, pot] = term;
                                      SerialisedValue target;
-                                     pot->serialize("inner", target);
+                                     pot->serialise("inner", target);
                                      auto &value = target["inner"];
                                      value["atomTypeI"] = at1->name();
                                      value["atomTypeJ"] = at2->name();
@@ -163,7 +163,7 @@ SerialisedValue Dissolve::serialisePairPotentials() const
 }
 
 // Express as a serialisable value
-void Dissolve::serialize(std::string tag, SerialisedValue &target) const
+void Dissolve::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &root = target[tag];
 
@@ -177,7 +177,7 @@ void Dissolve::serialize(std::string tag, SerialisedValue &target) const
 
     root["pairPotentials"] = serialisePairPotentials();
 
-    graphNode_->serialize("graph", root);
+    graphNode_->serialise("graph", root);
 
     Serialisable::fromVector<>(coreData_.pairPotentialOverrides(), "pairPotentialOverrides", root);
 

--- a/src/math/data1D.cpp
+++ b/src/math/data1D.cpp
@@ -467,12 +467,12 @@ bool Data1D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue Data1D::serialise() const
+void Data1D::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"tag", tag_}, {"x", x_}, {"y", values_}};
     if (hasError_)
         result["errors"] = errors_;
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/math/data1D.cpp
+++ b/src/math/data1D.cpp
@@ -467,7 +467,7 @@ bool Data1D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void Data1D::serialize(std::string tag, SerialisedValue &target) const
+void Data1D::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"tag", tag_}, {"x", x_}, {"y", values_}};
     if (hasError_)

--- a/src/math/data1D.h
+++ b/src/math/data1D.h
@@ -119,7 +119,7 @@ class Data1D : public Data1DBase, public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/data1D.h
+++ b/src/math/data1D.h
@@ -119,7 +119,7 @@ class Data1D : public Data1DBase, public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/data2D.cpp
+++ b/src/math/data2D.cpp
@@ -421,7 +421,7 @@ bool Data2D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void Data2D::serialize(std::string tag, SerialisedValue &target) const
+void Data2D::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"tag", tag_}, {"x", x_}, {"y", y_}, {"values", values_.linearArray()}};
     if (hasError_)

--- a/src/math/data2D.cpp
+++ b/src/math/data2D.cpp
@@ -421,12 +421,11 @@ bool Data2D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue Data2D::serialise() const
+void Data2D::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result = {{"tag", tag_}, {"x", x_}, {"y", y_}, {"values", values_.linearArray()}};
+    target[tag] = {{"tag", tag_}, {"x", x_}, {"y", y_}, {"values", values_.linearArray()}};
     if (hasError_)
-        result["errors"] = errors_.linearArray();
-    return result;
+        target[tag]["errors"] = errors_.linearArray();
 }
 
 // Read values from a serialisable value

--- a/src/math/data2D.h
+++ b/src/math/data2D.h
@@ -113,7 +113,7 @@ class Data2D : public Data2DBase, public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/data2D.h
+++ b/src/math/data2D.h
@@ -113,7 +113,7 @@ class Data2D : public Data2DBase, public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -578,7 +578,7 @@ double Function1DWrapper::normalisation(double omega) const
 }
 
 // Express as a serialisable value
-void Function1DWrapper::serialize(std::string tag, SerialisedValue &target) const
+void Function1DWrapper::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &result = target[tag];
 

--- a/src/math/function1D.cpp
+++ b/src/math/function1D.cpp
@@ -578,15 +578,13 @@ double Function1DWrapper::normalisation(double omega) const
 }
 
 // Express as a serialisable value
-SerialisedValue Function1DWrapper::serialise() const
+void Function1DWrapper::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result;
+    auto &result = target[tag];
 
     result["form"] = Functions1D::forms().keywordByIndex(static_cast<int>(form_));
 
     Serialisable::fromVector(parameters_, "parameters", result, [](const auto &x) { return x; });
-
-    return result;
 }
 
 // Read values from a serialisable value

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -164,7 +164,7 @@ class Function1DWrapper : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -164,7 +164,7 @@ class Function1DWrapper : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/histogram1D.cpp
+++ b/src/math/histogram1D.cpp
@@ -246,7 +246,7 @@ bool Histogram1D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void Histogram1D::serialize(std::string tag, SerialisedValue &target) const
+void Histogram1D::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"minimum", minimum_}, {"maximum", maximum_}, {"binWidth", binWidth_},
                    {"nBinned", nBinned_}, {"nMissed", nMissed_}, {"averages", averages_}};

--- a/src/math/histogram1D.cpp
+++ b/src/math/histogram1D.cpp
@@ -246,10 +246,10 @@ bool Histogram1D::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue Histogram1D::serialise() const
+void Histogram1D::serialize(std::string tag, SerialisedValue &target) const
 {
-    return {{"minimum", minimum_}, {"maximum", maximum_}, {"binWidth", binWidth_},
-            {"nBinned", nBinned_}, {"nMissed", nMissed_}, {"averages", averages_}};
+    target[tag] = {{"minimum", minimum_}, {"maximum", maximum_}, {"binWidth", binWidth_},
+                   {"nBinned", nBinned_}, {"nMissed", nMissed_}, {"averages", averages_}};
 }
 
 // Read values from a serialisable value

--- a/src/math/histogram1D.h
+++ b/src/math/histogram1D.h
@@ -94,7 +94,7 @@ class Histogram1D : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/histogram1D.h
+++ b/src/math/histogram1D.h
@@ -94,7 +94,7 @@ class Histogram1D : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -52,7 +52,7 @@ template <class T> class History : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const
+    void serialise(std::string tag, SerialisedValue &target) const
     {
         return Serialisable::fromVector(history_, tag, target, [&](const auto &itemPtr) { return itemPtr->into_toml(); });
     }

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -52,9 +52,9 @@ template <class T> class History : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const
+    void serialize(std::string tag, SerialisedValue &target) const
     {
-        return Serialisable::fromVector(history_, [&](const auto &itemPtr) { return itemPtr->serialise(); });
+        return Serialisable::fromVector(history_, tag, target, [&](const auto &itemPtr) { return itemPtr->into_toml(); });
     }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override

--- a/src/math/range.cpp
+++ b/src/math/range.cpp
@@ -49,7 +49,10 @@ bool Range::contains(double d) const { return isDefined() && (d >= minimum_) && 
 bool Range::isDefined() const { return (minimum_ && maximum_); }
 
 // Express as a serialisable value
-void Range::serialize(std::string tag, SerialisedValue &target) const { target[tag] = {{"min", minimum()}, {"max", maximum()}}; }
+void Range::serialise(std::string tag, SerialisedValue &target) const
+{
+    target[tag] = {{"min", minimum()}, {"max", maximum()}};
+}
 
 // Read values from a serialisable value
 void Range::deserialise(const SerialisedValue &node)

--- a/src/math/range.cpp
+++ b/src/math/range.cpp
@@ -49,7 +49,7 @@ bool Range::contains(double d) const { return isDefined() && (d >= minimum_) && 
 bool Range::isDefined() const { return (minimum_ && maximum_); }
 
 // Express as a serialisable value
-SerialisedValue Range::serialise() const { return {{"min", minimum()}, {"max", maximum()}}; }
+void Range::serialize(std::string tag, SerialisedValue &target) const { target[tag] = {{"min", minimum()}, {"max", maximum()}}; }
 
 // Read values from a serialisable value
 void Range::deserialise(const SerialisedValue &node)

--- a/src/math/range.h
+++ b/src/math/range.h
@@ -40,7 +40,7 @@ class Range : public Serialisable<>
     // Return whether or not the range has been fully defined
     bool isDefined() const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
     bool operator==(const Range &rhs) const;

--- a/src/math/range.h
+++ b/src/math/range.h
@@ -40,7 +40,7 @@ class Range : public Serialisable<>
     // Return whether or not the range has been fully defined
     bool isDefined() const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
     bool operator==(const Range &rhs) const;

--- a/src/math/sampledData1D.cpp
+++ b/src/math/sampledData1D.cpp
@@ -211,13 +211,10 @@ bool SampledData1D::serialise(LineParser &parser) const
 bool SampledData1D::serialiseValues(LineParser &parser) const { return values_.serialise(parser); }
 
 // Express as a serialisable value
-SerialisedValue SampledData1D::serialise() const
+void SampledData1D::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result;
-    result["x"] = x_;
-    result["values"] = values_.serialise();
-
-    return result;
+    target[tag] = {{"x", x_}};
+    values_.serialize("values", target[tag]);
 }
 
 // Read values from a serialisable value

--- a/src/math/sampledData1D.cpp
+++ b/src/math/sampledData1D.cpp
@@ -211,10 +211,10 @@ bool SampledData1D::serialise(LineParser &parser) const
 bool SampledData1D::serialiseValues(LineParser &parser) const { return values_.serialise(parser); }
 
 // Express as a serialisable value
-void SampledData1D::serialize(std::string tag, SerialisedValue &target) const
+void SampledData1D::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"x", x_}};
-    values_.serialize("values", target[tag]);
+    values_.serialise("values", target[tag]);
 }
 
 // Read values from a serialisable value

--- a/src/math/sampledData1D.h
+++ b/src/math/sampledData1D.h
@@ -91,7 +91,7 @@ class SampledData1D : public Data1DBase, public Serialisable<>
     // Write value data only through specified LineParser
     bool serialiseValues(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/sampledData1D.h
+++ b/src/math/sampledData1D.h
@@ -91,7 +91,7 @@ class SampledData1D : public Data1DBase, public Serialisable<>
     // Write value data only through specified LineParser
     bool serialiseValues(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/sampledDouble.cpp
+++ b/src/math/sampledDouble.cpp
@@ -157,7 +157,7 @@ bool SampledDouble::deserialise(LineParser &parser)
 bool SampledDouble::serialise(LineParser &parser) const { return parser.writeLineF("{}  {}  {}\n", mean_, count_, m2_); }
 
 // Express as a serialisable value
-void SampledDouble::serialize(std::string tag, SerialisedValue &target) const
+void SampledDouble::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"mean", mean_}, {"count", count_}, {"m2", m2_}};
 }

--- a/src/math/sampledDouble.cpp
+++ b/src/math/sampledDouble.cpp
@@ -157,7 +157,10 @@ bool SampledDouble::deserialise(LineParser &parser)
 bool SampledDouble::serialise(LineParser &parser) const { return parser.writeLineF("{}  {}  {}\n", mean_, count_, m2_); }
 
 // Express as a serialisable value
-SerialisedValue SampledDouble::serialise() const { return {{"mean", mean_}, {"count", count_}, {"m2", m2_}}; }
+void SampledDouble::serialize(std::string tag, SerialisedValue &target) const
+{
+    target[tag] = {{"mean", mean_}, {"count", count_}, {"m2", m2_}};
+}
 
 // Read values from a serialisable value
 void SampledDouble::deserialise(const SerialisedValue &value)

--- a/src/math/sampledDouble.h
+++ b/src/math/sampledDouble.h
@@ -66,7 +66,7 @@ class SampledDouble : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/sampledDouble.h
+++ b/src/math/sampledDouble.h
@@ -66,7 +66,7 @@ class SampledDouble : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/sampledVector.cpp
+++ b/src/math/sampledVector.cpp
@@ -209,7 +209,7 @@ bool SampledVector::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-void SampledVector::serialize(std::string tag, SerialisedValue &target) const
+void SampledVector::serialise(std::string tag, SerialisedValue &target) const
 {
     target[tag] = {{"count", count_}, {"mean", mean_}, {"stDev", stDev_}, {"m2", m2_}};
 }

--- a/src/math/sampledVector.cpp
+++ b/src/math/sampledVector.cpp
@@ -209,9 +209,9 @@ bool SampledVector::serialise(LineParser &parser) const
 }
 
 // Express as a serialisable value
-SerialisedValue SampledVector::serialise() const
+void SampledVector::serialize(std::string tag, SerialisedValue &target) const
 {
-    return {{"count", count_}, {"mean", mean_}, {"stDev", stDev_}, {"m2", m2_}};
+    target[tag] = {{"count", count_}, {"mean", mean_}, {"stDev", stDev_}, {"m2", m2_}};
 }
 
 // Read values from a serialisable value

--- a/src/math/sampledVector.h
+++ b/src/math/sampledVector.h
@@ -68,7 +68,7 @@ class SampledVector : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/sampledVector.h
+++ b/src/math/sampledVector.h
@@ -68,7 +68,7 @@ class SampledVector : public Serialisable<>
     // Write data through specified LineParser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -495,13 +495,13 @@ double Vector3::angleInDegrees(const Vector3 &to) const { return DissolveMath::t
  */
 
 // Express as a serialisable value
-SerialisedValue Vector3::serialise() const
+void Vector3::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);
     result.push_back(y);
     result.push_back(z);
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -495,7 +495,7 @@ double Vector3::angleInDegrees(const Vector3 &to) const { return DissolveMath::t
  */
 
 // Express as a serialisable value
-void Vector3::serialize(std::string tag, SerialisedValue &target) const
+void Vector3::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -138,7 +138,7 @@ class Vector3 : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -138,7 +138,7 @@ class Vector3 : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/vector3i.cpp
+++ b/src/math/vector3i.cpp
@@ -345,7 +345,7 @@ void Vector3i::swap(int a, int b)
  */
 
 // Express as a serialisable value
-void Vector3i::serialize(std::string tag, SerialisedValue &target) const
+void Vector3i::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);

--- a/src/math/vector3i.cpp
+++ b/src/math/vector3i.cpp
@@ -345,13 +345,13 @@ void Vector3i::swap(int a, int b)
  */
 
 // Express as a serialisable value
-SerialisedValue Vector3i::serialise() const
+void Vector3i::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue::array_type result;
     result.push_back(x);
     result.push_back(y);
     result.push_back(z);
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/math/vector3i.h
+++ b/src/math/vector3i.h
@@ -113,7 +113,7 @@ class Vector3i : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/math/vector3i.h
+++ b/src/math/vector3i.h
@@ -113,7 +113,7 @@ class Vector3i : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
 };

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -189,7 +189,7 @@ std::vector<Configuration *> ModuleLayer::allTargetedConfigurations() const
 }
 
 // Express as a serialisable value
-void ModuleLayer::serialize(std::string tag, SerialisedValue &target) const
+void ModuleLayer::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"frequency", frequency_}};
     if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::Disabled))

--- a/src/module/layer.cpp
+++ b/src/module/layer.cpp
@@ -189,7 +189,7 @@ std::vector<Configuration *> ModuleLayer::allTargetedConfigurations() const
 }
 
 // Express as a serialisable value
-SerialisedValue ModuleLayer::serialise() const
+void ModuleLayer::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"frequency", frequency_}};
     if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::Disabled))
@@ -199,7 +199,7 @@ SerialisedValue ModuleLayer::serialise() const
     if (runControlFlags_.isSet(ModuleLayer::RunControlFlag::SizeFactors))
         result["requireSizeFactors"] = true;
     Serialisable::fromVectorToTable(modules_, "modules", result);
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -105,7 +105,7 @@ class ModuleLayer : public Serialisable<CoreData &>
     // Return all configurations targeted by modules in the layer
     std::vector<Configuration *> allTargetedConfigurations() const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/module/layer.h
+++ b/src/module/layer.h
@@ -105,7 +105,7 @@ class ModuleLayer : public Serialisable<CoreData &>
     // Return all configurations targeted by modules in the layer
     std::vector<Configuration *> allTargetedConfigurations() const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -316,7 +316,7 @@ bool Module::readProcessTimes(LineParser &parser) { return processTimes_.deseria
  */
 
 // Express as a serialisable value
-void Module::serialize(std::string tag, SerialisedValue &target) const
+void Module::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result = {{"type", ModuleTypes::moduleType(type_)}, {"frequency", frequency_}};
     if (!enabled_)

--- a/src/module/module.cpp
+++ b/src/module/module.cpp
@@ -316,12 +316,13 @@ bool Module::readProcessTimes(LineParser &parser) { return processTimes_.deseria
  */
 
 // Express as a serialisable value
-SerialisedValue Module::serialise() const
+void Module::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result{{"type", ModuleTypes::moduleType(type_)}, {"frequency", frequency_}};
+    SerialisedValue result = {{"type", ModuleTypes::moduleType(type_)}, {"frequency", frequency_}};
     if (!enabled_)
         result["disabled"] = true;
-    return keywords_.serialiseOnto(result);
+    result = keywords_.serialiseOnto(result);
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -127,7 +127,7 @@ class Module : public Serialisable<const CoreData &>
 
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/module/module.h
+++ b/src/module/module.h
@@ -127,7 +127,7 @@ class Module : public Serialisable<const CoreData &>
 
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node, const CoreData &data) override;
 };

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -174,14 +174,14 @@ std::string EdgeDefinition::asString() const
  */
 
 // Express as a serialisable value
-SerialisedValue EdgeDefinition::serialise() const
+void EdgeDefinition::serialize(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     result["sourceNode"] = sourceNode;
     result["sourceOutput"] = sourceOutput;
     result["targetNode"] = targetNode;
     result["targetInput"] = targetInput;
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value
@@ -231,7 +231,7 @@ void Edge::forceNextPull() { sourceNodeVersionIndex_ = NodeConstants::InvalidVer
  */
 
 // Express as a serialisable value
-SerialisedValue Edge::serialise() const { return definition().serialise(); }
+void Edge::serialize(std::string tag, SerialisedValue &target) const { return definition().serialize(tag, target); }
 
 // Read values from a serialisable value. This is required for the
 // SerialisableValue type implementation, but we actually deserialise

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -174,7 +174,7 @@ std::string EdgeDefinition::asString() const
  */
 
 // Express as a serialisable value
-void EdgeDefinition::serialize(std::string tag, SerialisedValue &target) const
+void EdgeDefinition::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     result["sourceNode"] = sourceNode;
@@ -231,7 +231,7 @@ void Edge::forceNextPull() { sourceNodeVersionIndex_ = NodeConstants::InvalidVer
  */
 
 // Express as a serialisable value
-void Edge::serialize(std::string tag, SerialisedValue &target) const { return definition().serialize(tag, target); }
+void Edge::serialise(std::string tag, SerialisedValue &target) const { return definition().serialise(tag, target); }
 
 // Read values from a serialisable value. This is required for the
 // SerialisableValue type implementation, but we actually deserialise

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -23,7 +23,7 @@ class EdgeDefinition : public Serialisable<>
     // Return as a string
     std::string asString() const;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };
@@ -79,7 +79,7 @@ class Edge : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -23,7 +23,7 @@ class EdgeDefinition : public Serialisable<>
     // Return as a string
     std::string asString() const;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };
@@ -79,7 +79,7 @@ class Edge : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -250,9 +250,9 @@ std::string Graph::location() const
  */
 
 // Express as a serialisable value
-void Graph::serialize(std::string tag, SerialisedValue &target) const
+void Graph::serialise(std::string tag, SerialisedValue &target) const
 {
-    Node::serialize(tag, target);
+    Node::serialise(tag, target);
     auto &result = target[tag];
     fromMap(nodes_, "nodes", result, [](const auto key, const auto &value) { return value->shouldSerialise(); });
     fromVector(edges_, "edges", result);

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -250,12 +250,12 @@ std::string Graph::location() const
  */
 
 // Express as a serialisable value
-SerialisedValue Graph::serialise() const
+void Graph::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result = Node::serialise();
+    Node::serialize(tag, target);
+    auto &result = target[tag];
     fromMap(nodes_, "nodes", result, [](const auto key, const auto &value) { return value->shouldSerialise(); });
     fromVector(edges_, "edges", result);
-    return result;
 }
 
 // Read values from a serialisable value

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -108,7 +108,7 @@ class Graph : public Node
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -108,7 +108,7 @@ class Graph : public Node
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -30,7 +30,7 @@ NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::Proce
 bool InputsNode::shouldSerialise() const { return false; }
 
 // Express as a serialisable value
-SerialisedValue InputsNode::serialise() const { return {}; }
+void InputsNode::serialize(std::string tag, SerialisedValue &target) const {}
 
 // Read values from a serialisable value
 void InputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/nodes/inputs.cpp
+++ b/src/nodes/inputs.cpp
@@ -30,7 +30,7 @@ NodeConstants::ProcessResult InputsNode::process() { return NodeConstants::Proce
 bool InputsNode::shouldSerialise() const { return false; }
 
 // Express as a serialisable value
-void InputsNode::serialize(std::string tag, SerialisedValue &target) const {}
+void InputsNode::serialise(std::string tag, SerialisedValue &target) const {}
 
 // Read values from a serialisable value
 void InputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -35,7 +35,7 @@ class InputsNode : public Node
     // Is it appropriate to bother serialising this node?
     bool shouldSerialise() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/inputs.h
+++ b/src/nodes/inputs.h
@@ -35,7 +35,7 @@ class InputsNode : public Node
     // Is it appropriate to bother serialising this node?
     bool shouldSerialise() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -320,7 +320,7 @@ SampledDouble Node::timing() const { return timing_; }
  */
 
 // Express as a serialisable value
-void Node::serialize(std::string tag, SerialisedValue &target) const
+void Node::serialise(std::string tag, SerialisedValue &target) const
 {
     SerialisedValue result;
     result["name"] = name();
@@ -358,7 +358,7 @@ void Node::deserialise(const SerialisedValue &node)
 SerialisedValue Node::serialiseData() const
 {
     SerialisedValue result;
-    timing_.serialize("timing", result);
+    timing_.serialise("timing", result);
 
     for (auto &[key, serialisable] : serialisables_)
         if (serialisable->canSerialise())

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -358,7 +358,7 @@ void Node::deserialise(const SerialisedValue &node)
 SerialisedValue Node::serialiseData() const
 {
     SerialisedValue result;
-    result["timing"] = timing_.serialise();
+    timing_.serialize("timing", result);
 
     for (auto &[key, serialisable] : serialisables_)
         if (serialisable->canSerialise())

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -320,15 +320,15 @@ SampledDouble Node::timing() const { return timing_; }
  */
 
 // Express as a serialisable value
-SerialisedValue Node::serialise() const
+void Node::serialize(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result, inputs, outputs, options;
+    SerialisedValue result;
     result["name"] = name();
     result["type"] = type();
     result["x"] = x;
     result["y"] = y;
 
-    return result;
+    target[tag] = result;
 }
 
 // Read values from a serialisable value

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -312,7 +312,7 @@ class Node : public Serialisable<>
         serialisables_[std::string(key)] = std::make_shared<SerialisableClass<DataClass>>(key, data);
     }
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
     // Express persistent data as a serialisable value

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -312,7 +312,7 @@ class Node : public Serialisable<>
         serialisables_[std::string(key)] = std::make_shared<SerialisableClass<DataClass>>(key, data);
     }
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
     // Express persistent data as a serialisable value

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -161,12 +161,12 @@ std::string Number::asString(bool addQuotesIfRequired) const
 }
 
 // Express as a serialisable value
-SerialisedValue Number::serialise() const
+void Number::serialize(std::string tag, SerialisedValue &target) const
 {
     if (std::holds_alternative<int>(value_))
-        return std::get<int>(value_);
+        target[tag] = std::get<int>(value_);
     else
-        return std::get<double>(value_);
+        target[tag] = std::get<double>(value_);
 }
 
 // Read values from a serialisable value

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -161,7 +161,7 @@ std::string Number::asString(bool addQuotesIfRequired) const
 }
 
 // Express as a serialisable value
-void Number::serialize(std::string tag, SerialisedValue &target) const
+void Number::serialise(std::string tag, SerialisedValue &target) const
 {
     if (std::holds_alternative<int>(value_))
         target[tag] = std::get<int>(value_);

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -86,7 +86,7 @@ class Number : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -86,7 +86,7 @@ class Number : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/outputs.cpp
+++ b/src/nodes/outputs.cpp
@@ -45,7 +45,7 @@ void OutputsNode::setUpdateRequired()
 bool OutputsNode::shouldSerialise() const { return false; }
 
 // Express as a serialisable value
-SerialisedValue OutputsNode::serialise() const { return {}; }
+void OutputsNode::serialize(std::string tag, SerialisedValue &target) const {}
 
 // Read values from a serialisable value
 void OutputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/nodes/outputs.cpp
+++ b/src/nodes/outputs.cpp
@@ -45,7 +45,7 @@ void OutputsNode::setUpdateRequired()
 bool OutputsNode::shouldSerialise() const { return false; }
 
 // Express as a serialisable value
-void OutputsNode::serialize(std::string tag, SerialisedValue &target) const {}
+void OutputsNode::serialise(std::string tag, SerialisedValue &target) const {}
 
 // Read values from a serialisable value
 void OutputsNode::deserialise(const SerialisedValue &node) {};

--- a/src/nodes/outputs.h
+++ b/src/nodes/outputs.h
@@ -39,7 +39,7 @@ class OutputsNode : public Node
     // Is it appropriate to bother serialising this node?
     bool shouldSerialise() const override;
     // Express as a serialisable value
-    SerialisedValue serialise() const override;
+    void serialize(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/outputs.h
+++ b/src/nodes/outputs.h
@@ -39,7 +39,7 @@ class OutputsNode : public Node
     // Is it appropriate to bother serialising this node?
     bool shouldSerialise() const override;
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -419,7 +419,7 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
      */
     public:
     // Express as a serialised value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
         SerialisedValue result = {};
 
@@ -436,11 +436,11 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
                 result["data"] = *Parameter<DataClass>::data_;
         }
         else if constexpr (serialisablePointer<DataClass>)
-            result["data"] = Parameter<DataClass>::data_->serialise();
+          Parameter<DataClass>::data_->serialize("data", result);
         else
             result["data"] = Parameter<DataClass>::data_;
 
-        return result;
+        target[tag] = result;
     };
     // Read from a serialised value
     void deserialise(const SerialisedValue &node) override

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -157,7 +157,7 @@ class ParameterBase : public Serialisable<>
      */
     public:
     // Express as a serialised value
-    virtual void serialize(std::string tag, SerialisedValue &target) const override {}
+    virtual void serialise(std::string tag, SerialisedValue &target) const override {}
     // Read from a serialised value
     virtual void deserialise(const SerialisedValue &node) override { return; }
 };
@@ -419,7 +419,7 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
      */
     public:
     // Express as a serialised value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         SerialisedValue result = {};
 
@@ -436,7 +436,7 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
                 result["data"] = *Parameter<DataClass>::data_;
         }
         else if constexpr (serialisablePointer<DataClass>)
-          Parameter<DataClass>::data_->serialize("data", result);
+            Parameter<DataClass>::data_->serialise("data", result);
         else
             result["data"] = Parameter<DataClass>::data_;
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -157,7 +157,7 @@ class ParameterBase : public Serialisable<>
      */
     public:
     // Express as a serialised value
-    virtual SerialisedValue serialise() const override { return {}; }
+    virtual void serialize(std::string tag, SerialisedValue &target) const override {}
     // Read from a serialised value
     virtual void deserialise(const SerialisedValue &node) override { return; }
 };

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -50,7 +50,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
                                                                                   [&](const auto &item)
                                                                                   {
                                                                                       SerialisedValue outer;
-                                                                                      item.serialize("inner", outer);
+                                                                                      item.serialise("inner", outer);
                                                                                       return outer["inner"];
                                                                                   });
               }),
@@ -101,7 +101,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
                                                              [&](const auto &item)
                                                              {
                                                                  SerialisedValue outer;
-                                                                 item.serialize("inner", outer);
+                                                                 item.serialise("inner", outer);
                                                                  return outer["inner"];
                                                              });
               }),
@@ -165,7 +165,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     DataSerialiser dataSerialiser_{[&]()
                                    {
                                        SerialisedValue target;
-                                       data_.serialize("inner", target);
+                                       data_.serialise("inner", target);
                                        return target["inner"];
                                    }};
     // Deserialiser for target data

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -69,7 +69,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     // Optional Serialisable
     SerialisableClass(std::string_view key, DataClass &targetData)
         requires(is_optional<DataClass> && std::is_base_of_v<Serialisable<>, typename DataClass::value_type>)
-        : SerialisableData(key), data_(targetData), dataSerialiser_([&]() { return data_.value().serialise(); }),
+        : SerialisableData(key), data_(targetData), dataSerialiser_([&]() { return data_.value().into_toml(); }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
               {
@@ -148,7 +148,12 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     DataClass &data_;
     // Serialiser for target data
     using DataSerialiser = std::function<SerialisedValue()>;
-    DataSerialiser dataSerialiser_{[&]() { return data_.serialise(); }};
+    DataSerialiser dataSerialiser_{[&]()
+                                   {
+                                       SerialisedValue target;
+                                       data_.serialize("inner", target);
+                                       return target["inner"];
+                                   }};
     // Deserialiser for target data
     using DataDeserialiser = std::function<void(const SerialisedValue &value)>;
     DataDeserialiser dataDeserialiser_{[&](const SerialisedValue &value) { data_.deserialise(value); }};

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -46,8 +46,13 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
           dataSerialiser_(
               [&]()
               {
-                  return Serialisable<typename DataClass::value_type>::fromVector(data_.value(), [&](const auto &item)
-                                                                                  { return item.serialise(); });
+                  return Serialisable<typename DataClass::value_type>::fromVector(data_.value(),
+                                                                                  [&](const auto &item)
+                                                                                  {
+                                                                                      SerialisedValue outer;
+                                                                                      item.serialize("inner", outer);
+                                                                                      return outer["inner"];
+                                                                                  });
               }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
@@ -90,7 +95,16 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
         requires(is_instance_of_v<DataClass, std::vector> && std::is_base_of_v<Serialisable<>, typename DataClass::value_type>)
         : SerialisableData(key), data_(targetData),
           dataSerialiser_(
-              [&]() { return Serialisable<DataClass>::fromVector(data_, [&](const auto &item) { return item.serialise(); }); }),
+              [&]()
+              {
+                  return Serialisable<DataClass>::fromVector(data_,
+                                                             [&](const auto &item)
+                                                             {
+                                                                 SerialisedValue outer;
+                                                                 item.serialize("inner", outer);
+                                                                 return outer["inner"];
+                                                             });
+              }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
               {

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -168,7 +168,7 @@ template <typename ValueClass> class DoubleKeyedMap : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    void serialize(std::string tag, SerialisedValue &target) const override
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         SerialisedValue result;
         Serialisable::fromMap(data_, "map", result);

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -168,11 +168,11 @@ template <typename ValueClass> class DoubleKeyedMap : public Serialisable<>
      */
     public:
     // Express as a serialisable value
-    SerialisedValue serialise() const override
+    void serialize(std::string tag, SerialisedValue &target) const override
     {
         SerialisedValue result;
         Serialisable::fromMap(data_, "map", result);
-        return result;
+        target[tag] = result;
     };
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node)

--- a/tests/io/version.cpp
+++ b/tests/io/version.cpp
@@ -35,7 +35,7 @@ TEST(VersionTest, VersionInfo)
     CoreData coreData;
     Dissolve dissolve(coreData);
     dissolve.loadInput("dissolve/input/rdfMethod.txt");
-    auto serialised = dissolve.serialise();
+    auto serialised = dissolve.into_toml();
 
     Version::DissolveVersion fileVersion(serialised["version"].as_string().str), actual(Version::semantic());
 

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -71,14 +71,14 @@ TEST_F(GraphCoreTest, Serialisation)
     CoreData cd;
     Dissolve d(cd);
     DissolveGraph copy(d);
-    auto serialised = root_.serialise();
+    auto serialised = root_.into_toml();
 
     SerialisedValue contents = toml::parse("dissolve/input/simple_addition_graph.toml");
     UnitTest::compareToml("", serialised, contents);
 
     std::cout << serialised << std::endl;
     copy.deserialise(serialised);
-    auto repeat = copy.serialise();
+    auto repeat = copy.into_toml();
 
     UnitTest::compareToml("", repeat, contents);
 };

--- a/tests/testData.h
+++ b/tests/testData.h
@@ -151,12 +151,12 @@ class DissolveSystemTest
                 if (!otherDissolve.prepare())
                     throw(std::runtime_error("Failed to prepare simulation.\n"));
 
-                toml = otherDissolve.serialise();
+                toml = otherDissolve.into_toml();
             }
 
             dissolve_.deserialise(toml);
             dissolve_.setInputFilename(std::string(inputFile));
-            auto repeat = dissolve_.serialise();
+            auto repeat = dissolve_.into_toml();
 
             // Run any other additional setup functions
             if (additionalSetUp_)


### PR DESCRIPTION
TOML officially does not support null values.  Instead, the recommended method of handling nulls is to not include the associated key.  This is a problem for our current setup, where the `serialise` method returns a value that is then added to a key.

This PR changes `serialise` so that it is passed in a node onto which to serialise the data as well as a key for where to serialise the information.  In other words, what had once been

```cpp
result[key] = data.serialise()
```

is now

```cpp
data.serialise(key, result)
```

The primary advantage of this scenario is that the `serialise` method can now detect when it would return a null value and choose to do nothing.  This is preferable to *every call site* needing to perform testing for null values.

Honestly, the best solution would have been for the original function to return a `Option<SerialisedValue>` and for the TOML library to correctly handle assignment from an option, but there's a reason that the library is named toml11 and not toml17