### PR TITLE
fix: Allow error addition to Data1D if it wasn't already there

### DIFF
--- a/src/math/data1D.cpp
+++ b/src/math/data1D.cpp
@@ -117,6 +117,13 @@ void Data1D::addPoint(double x, double value)
 // Add new data point with error
 void Data1D::addPoint(double x, double value, double error)
 {
+    // If the arrays are all empty we can allow errors to be added if they weren't specified before.
+    if (x_.empty() && !hasError_)
+    {
+        errors_.clear();
+        hasError_ = true;
+    }
+
     assert(hasError_);
 
     x_.push_back(x);


### PR DESCRIPTION
Confusing title, but a quick PR to fix a failing test (only failing in Debug mode because of the assertion).