### PR TITLE
fix: AtomicMC energy updates

### DIFF
--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -31,12 +31,6 @@ void Atom::setConfigurationTypeIndex(int id) { configurationTypeIndex_ = id; }
 // Return AtomType index in parent Configuration
 int Atom::configurationTypeIndex() const { return configurationTypeIndex_; }
 
-// Set master AtomType index
-void Atom::setMasterTypeIndex(int id) { masterTypeIndex_ = id; }
-
-// Return master AtomType index
-int Atom::masterTypeIndex() const { return masterTypeIndex_; }
-
 // Return global index of the atom
 int Atom::globalIndex() const
 {

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -24,8 +24,6 @@ class Atom
     Vector3 r_;
     // Assigned AtomType index, local to Configuration (for partial indexing etc.)
     int configurationTypeIndex_{-1};
-    // Assigned master AtomType index (for pair potential indexing)
-    int masterTypeIndex_{-1};
 
     public:
     // Set coordinates
@@ -44,10 +42,6 @@ class Atom
     void setConfigurationTypeIndex(int id);
     // Return AtomType index in parent Configuration
     int configurationTypeIndex() const;
-    // Set master AtomType index
-    void setMasterTypeIndex(int id);
-    // Return master AtomType index
-    int masterTypeIndex() const;
     // Return global index of the atom
     int globalIndex() const;
 

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -27,8 +27,9 @@ Atom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const std::shared_pt
     // Set the position
     newAtom.setCoordinates(r);
 
-    // Set master index for pair potential lookup
-    newAtom.setMasterTypeIndex(sourceAtom->atomType()->index());
+    // Set configuration type index for pair potential lookup
+    // TODO This can be removed once the Dissolve1 unit tests have been ported over to Dissolve2
+    newAtom.setConfigurationTypeIndex(sourceAtom->atomType()->index());
 
     return newAtom;
 }

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -148,7 +148,7 @@ double PotentialMap::energy(const Atom &i, const Atom &j, double r) const
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return pp->energy(r) + (PairPotential::includeCoulombPotential()
                                 ? 0
                                 : pp->analyticCoulombEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r));
@@ -162,7 +162,7 @@ double PotentialMap::energy(const Atom &i, const Atom &j, double r, double elecS
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->energy(r, elecScale, srScale)
                : pp->energy(r) * srScale +
@@ -203,7 +203,7 @@ double PotentialMap::analyticEnergy(const Atom &i, const Atom &j, double r) cons
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, 1.0, 1.0)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -216,7 +216,7 @@ double PotentialMap::analyticEnergy(const Atom &i, const Atom &j, double r, doub
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, elecScale, srScale)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);
@@ -227,7 +227,7 @@ double PotentialMap::force(const Atom &i, const Atom &j, double r) const
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r)
                : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r);
@@ -238,7 +238,7 @@ double PotentialMap::force(const Atom &i, const Atom &j, double r, double elecSc
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
                : pp->force(r) * srScale +
@@ -280,7 +280,7 @@ double PotentialMap::analyticForce(const Atom &i, const Atom &j, double r) const
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, 1.0, 1.0)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -294,7 +294,7 @@ double PotentialMap::analyticForce(const Atom &i, const Atom &j, double r, doubl
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, elecScale, srScale)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -349,12 +349,6 @@ double Species::totalCharge(bool useAtomTypes) const
 // Apply random noise to atoms
 void Species::randomiseCoordinates(double maxDisplacement)
 {
-    Vector3 deltaR;
-
     for (auto &i : atoms_)
-    {
-        deltaR.randomUnit();
-        deltaR *= maxDisplacement;
-        i.translateCoordinates(deltaR);
-    }
+        i.translateCoordinates(Vector3::randomUnit() * maxDisplacement);
 }

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -405,14 +405,13 @@ void Vector3::orthogonalise(const Vector3 &reference1, const Vector3 &reference2
 // Prints the contents of the vector
 void Vector3::print() const { std::cout << std::format("{} {} {}", x, y, z) << std::endl; }
 
-// Generate random unit vector
-void Vector3::randomUnit()
+// Generate random unit vector (on a unit sphere)
+Vector3 Vector3::randomUnit()
 {
-    // Generates a random unit vector
-    x = DissolveMath::random() - 0.5;
-    y = DissolveMath::random() - 0.5;
-    z = DissolveMath::random() - 0.5;
-    normalise();
+    auto y = 2.0 * (DissolveMath::random() - 0.5);
+    auto r = sqrt(1 - y * y);
+    auto lambda = M_PI * (DissolveMath::random() - 0.5);
+    return {r * sin(lambda), y, r * cos(lambda)};
 }
 
 // Convert spherical who,phi,theta coordinates into cartesian x,y,z

--- a/src/math/vector3.cpp
+++ b/src/math/vector3.cpp
@@ -410,7 +410,7 @@ Vector3 Vector3::randomUnit()
 {
     auto y = 2.0 * (DissolveMath::random() - 0.5);
     auto r = sqrt(1 - y * y);
-    auto lambda = M_PI * (DissolveMath::random() - 0.5);
+    auto lambda = 2.0 * M_PI * (DissolveMath::random() - 0.5);
     return {r * sin(lambda), y, r * cos(lambda)};
 }
 

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -113,7 +113,7 @@ class Vector3 : public Serialisable<>
     // Prints the contents of the vector
     void print() const;
     // Generate random unit vector
-    void randomUnit();
+    static Vector3 randomUnit();
     // Convert spherical who,phi,theta coordinates into cartesian x,y,z
     void toCartesian();
     // Convert cartesian x,y,z coordinates into spherical (rho,phi/zenith,theta/azimuthal)

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -35,10 +35,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
     auto kernel = dissolveGraph()->prepareEnergyCalculation(targetConfiguration_);
 
     auto nAttempts = 0, nAccepted = 0;
-    bool accept;
-    double currentEnergy, currentIntraEnergy, newEnergy, newIntraEnergy, delta, totalDelta = 0.0;
-    Vector3 rDelta;
-    EnergyResult er;
+    auto totalDelta = 0.0;
 
     Timer timer;
     // Loop over target Molecules
@@ -52,31 +49,24 @@ NodeConstants::ProcessResult AtomicMCNode::process()
         for (const auto &i : mol->atoms())
         {
             // Calculate reference energies for the Atom
-            er = kernel->totalEnergy(*i);
-            currentEnergy = er.totalUnbound();
-            currentIntraEnergy = er.geometry() * termScale;
+            auto eCurrent = kernel->totalEnergy(*i);
 
             // Loop over number of shakes per Atom
             for (auto n = 0; n < nShakesPerAtom; ++n)
             {
                 auto moveInitialPos = i->r();
 
-                // Create a random translation vector
-                rDelta.set(DissolveMath::randomPlusMinusOne() * stepSize, DissolveMath::randomPlusMinusOne() * stepSize,
-                           DissolveMath::randomPlusMinusOne() * stepSize);
-
-                // Translate Atom and update its Cell position
-                i->translateCoordinates(rDelta);
+                // Translate Atom randomly according to the stepsize and update its Cell position
+                i->translateCoordinates(Vector3::randomUnit() * stepSize);
                 targetConfiguration_->updateAtomLocation(i);
 
                 // Calculate new energy
-                er = kernel->totalEnergy(*i);
-                newEnergy = er.totalUnbound();
-                newIntraEnergy = er.geometry() * termScale;
+                auto eNew = kernel->totalEnergy(*i);
 
                 // Trial the transformed Atom position
-                delta = (newEnergy + newIntraEnergy) - (currentEnergy + currentIntraEnergy);
-                accept = delta < 0 ? true : (DissolveMath::random() < exp(-delta * rRT));
+                auto delta = (eNew.totalUnbound() + eNew.geometry() * termScale) -
+                             (eCurrent.totalUnbound() + eCurrent.geometry() * termScale);
+                auto accept = delta < 0 ? true : (DissolveMath::random() < exp(-delta * rRT));
 
                 // Increase attempt counters
                 if (accept)

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -68,10 +68,13 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                              (eCurrent.totalUnbound() + eCurrent.geometry() * termScale);
                 auto accept = delta < 0 ? true : (DissolveMath::random() < exp(-delta * rRT));
 
-                // Increase attempt counters
                 if (accept)
                 {
+                    // Store incremental total energy and new reference energy
                     totalDelta += delta;
+                    eCurrent = eNew;
+
+                    // Increase attempt counter
                     ++nAccepted;
                 }
                 else

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -38,7 +38,7 @@ class PairPotentialsScaleFactorsTest : public ::testing::Test
         for (auto &&[molAtom, spAtom] : zip(molecule_.localAtoms(), fourSixthsBenzene_.atoms()))
         {
             molAtom.setCoordinates(spAtom.r());
-            molAtom.setMasterTypeIndex(spAtom.atomType()->index());
+            molAtom.setConfigurationTypeIndex(spAtom.atomType()->index());
         }
 
         // Set up the function wrapper


### PR DESCRIPTION
Fixes an issue when running `AtomicMC` with more than one shake per atom and updates random unit vector generation.