### PR TITLE
refactor: Remove old Atom::masterTypeIndex_

### DIFF
--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -31,12 +31,6 @@ void Atom::setConfigurationTypeIndex(int id) { configurationTypeIndex_ = id; }
 // Return AtomType index in parent Configuration
 int Atom::configurationTypeIndex() const { return configurationTypeIndex_; }
 
-// Set master AtomType index
-void Atom::setMasterTypeIndex(int id) { masterTypeIndex_ = id; }
-
-// Return master AtomType index
-int Atom::masterTypeIndex() const { return masterTypeIndex_; }
-
 // Return global index of the atom
 int Atom::globalIndex() const
 {

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -24,8 +24,6 @@ class Atom
     Vector3 r_;
     // Assigned AtomType index, local to Configuration (for partial indexing etc.)
     int configurationTypeIndex_{-1};
-    // Assigned master AtomType index (for pair potential indexing)
-    int masterTypeIndex_{-1};
 
     public:
     // Set coordinates
@@ -44,10 +42,6 @@ class Atom
     void setConfigurationTypeIndex(int id);
     // Return AtomType index in parent Configuration
     int configurationTypeIndex() const;
-    // Set master AtomType index
-    void setMasterTypeIndex(int id);
-    // Return master AtomType index
-    int masterTypeIndex() const;
     // Return global index of the atom
     int globalIndex() const;
 

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -27,8 +27,9 @@ Atom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const std::shared_pt
     // Set the position
     newAtom.setCoordinates(r);
 
-    // Set master index for pair potential lookup
-    newAtom.setMasterTypeIndex(sourceAtom->atomType()->index());
+    // Set configuration type index for pair potential lookup
+    // TODO This can be removed once the Dissolve1 unit tests have been ported over to Dissolve2
+    newAtom.setConfigurationTypeIndex(sourceAtom->atomType()->index());
 
     return newAtom;
 }

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -148,7 +148,7 @@ double PotentialMap::energy(const Atom &i, const Atom &j, double r) const
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return pp->energy(r) + (PairPotential::includeCoulombPotential()
                                 ? 0
                                 : pp->analyticCoulombEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r));
@@ -162,7 +162,7 @@ double PotentialMap::energy(const Atom &i, const Atom &j, double r, double elecS
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->energy(r, elecScale, srScale)
                : pp->energy(r) * srScale +
@@ -203,7 +203,7 @@ double PotentialMap::analyticEnergy(const Atom &i, const Atom &j, double r) cons
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, 1.0, 1.0)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -216,7 +216,7 @@ double PotentialMap::analyticEnergy(const Atom &i, const Atom &j, double r, doub
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, elecScale, srScale)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);
@@ -227,7 +227,7 @@ double PotentialMap::force(const Atom &i, const Atom &j, double r) const
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r)
                : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r);
@@ -238,7 +238,7 @@ double PotentialMap::force(const Atom &i, const Atom &j, double r, double elecSc
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
                : pp->force(r) * srScale +
@@ -280,7 +280,7 @@ double PotentialMap::analyticForce(const Atom &i, const Atom &j, double r) const
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, 1.0, 1.0)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -294,7 +294,7 @@ double PotentialMap::analyticForce(const Atom &i, const Atom &j, double r, doubl
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.masterTypeIndex(), j.masterTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, elecScale, srScale)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -38,7 +38,7 @@ class PairPotentialsScaleFactorsTest : public ::testing::Test
         for (auto &&[molAtom, spAtom] : zip(molecule_.localAtoms(), fourSixthsBenzene_.atoms()))
         {
             molAtom.setCoordinates(spAtom.r());
-            molAtom.setMasterTypeIndex(spAtom.atomType()->index());
+            molAtom.setConfigurationTypeIndex(spAtom.atomType()->index());
         }
 
         // Set up the function wrapper


### PR DESCRIPTION
This removes the `masterTypeIndex_` member used by `Atom` in favour of the new, `Configuration`-indexed version.
Two explicit calls to `setConfigurationTypeIndex()` have been necessarily left in so as to maintain the current unit tests, but once these are moved to graphs they can be removed.