### PR TITLE
chore: Fix nix bundle version

### DIFF
--- a/.github/workflows/build/linux/action.yml
+++ b/.github/workflows/build/linux/action.yml
@@ -105,7 +105,7 @@ runs:
     run: |
       set -ex
 
-      nix bundle -L .#${{ inputs.target }} -o binary
+      nix bundle --bundler .#default -L .#${{ inputs.target }} -o binary
 
       # Assemble artifacts
       mkdir packages-binary

--- a/flake.lock
+++ b/flake.lock
@@ -2,41 +2,28 @@
   "nodes": {
     "bundlers": {
       "inputs": {
-        "nix-bundle": "nix-bundle",
-        "nix-utils": "nix-utils",
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": [
+          "outdated"
+        ],
+        "utils": "utils"
       },
       "locked": {
-        "lastModified": 1696517060,
-        "narHash": "sha256-V296JCORatNg44vQnNCkZASOmElY8NFT15OQ45a1ACQ=",
-        "owner": "NixOS",
-        "repo": "bundlers",
-        "rev": "00762a03a3d862a2ca6272a21fdc50bda5d36c42",
+        "lastModified": 1756736056,
+        "narHash": "sha256-8YFhvulVX3iS4TYnKisA9zSImJeFN21G75HOUUFjzuE=",
+        "owner": "nix-community",
+        "repo": "nix-bundle",
+        "rev": "eff01593f62794d458ec714090091419194ab64d",
         "type": "github"
       },
       "original": {
-        "id": "bundlers",
-        "type": "indirect"
+        "owner": "nix-community",
+        "repo": "nix-bundle",
+        "type": "github"
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "inputs": {
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -53,7 +40,7 @@
     },
     "home-manager": {
       "inputs": {
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1702423270,
@@ -66,43 +53,6 @@
       "original": {
         "id": "home-manager",
         "type": "indirect"
-      }
-    },
-    "nix-bundle": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1626704917,
-        "narHash": "sha256-cJ73kxY5ZCPWQeQZyCSdvkBqjqJkU5wgETBNaXfqF18=",
-        "owner": "matthewbauer",
-        "repo": "nix-bundle",
-        "rev": "223f4ffc4179aa318c34dc873a08cb00090db829",
-        "type": "github"
-      },
-      "original": {
-        "owner": "matthewbauer",
-        "repo": "nix-bundle",
-        "type": "github"
-      }
-    },
-    "nix-utils": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1632973430,
-        "narHash": "sha256-9G8zo+0nfYAALV5umCyQR/2hVUFNH10JropBkyxZGGw=",
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "rev": "b44e1ffd726aa03056db9df469efb497d8b9871b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "type": "github"
       }
     },
     "nixGL-src": {
@@ -123,49 +73,6 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-20.03-small",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1629252929,
-        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3788c68def67ca7949e0864c27638d484389363d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1634782485,
-        "narHash": "sha256-psfh4OQSokGXG0lpq3zKFbhOo3QfoeudRcaUnwMRkQo=",
-        "path": "/nix/store/p53cz6rh27q40g9i0q98k3vfrz6lm12w-source",
-        "rev": "34ad3ffe08adfca17fcb4e4a47bb5f3b113687be",
-        "type": "path"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1701718080,
         "narHash": "sha256-6ovz0pG76dE0P170pmmZex1wWcQoeiomUZGggfH9XPs=",
         "owner": "NixOS",
@@ -180,7 +87,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1755704039,
         "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
@@ -215,10 +122,10 @@
     "root": {
       "inputs": {
         "bundlers": "bundlers",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "home-manager": "home-manager",
         "nixGL-src": "nixGL-src",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_2",
         "outdated": "outdated"
       }
     },
@@ -234,6 +141,39 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,28 +2,41 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
     outdated.url = "github:NixOS/nixpkgs/nixos-24.05";
+    bundlers.url = "github:nix-community/nix-bundle";
+    bundlers.inputs.nixpkgs.follows = "outdated";
     nixGL-src.url = "github:guibou/nixGL";
     nixGL-src.flake = false;
   };
   outputs =
-    { self, nixpkgs, outdated, home-manager, flake-utils, bundlers, nixGL-src }:
+    {
+      self,
+      nixpkgs,
+      outdated,
+      home-manager,
+      flake-utils,
+      bundlers,
+      nixGL-src,
+    }:
     let
 
       toml = pkgs: ((import ./nix/toml11.nix) { inherit pkgs; });
-      onedpl = pkgs:
+      onedpl =
+        pkgs:
         ((import ./nix/onedpl.nix) {
-          inherit (pkgs) lib stdenv fetchFromGitHub fetchpatch cmake;
+          inherit (pkgs)
+            lib
+            stdenv
+            fetchFromGitHub
+            fetchpatch
+            cmake
+            ;
           tbb = pkgs.tbb_2021_11;
         });
-      exe-name = gui:
-        if gui then
-          "dissolve-gui"
-        else
-          "dissolve";
+      exe-name = gui: if gui then "dissolve-gui" else "dissolve";
       cmake-bool = x: if x then "ON" else "OFF";
       version = "1.8.0";
-      base_libs = pkgs:
-        with pkgs; [
+      base_libs =
+        pkgs: with pkgs; [
           antlr4
           antlr4.runtime.cpp
           antlr4.runtime.cpp.dev
@@ -39,36 +52,42 @@
           pugixml
           (toml pkgs)
         ];
-      gui_libs = system: pkgs: qt:
-        [
-          pkgs.glib
-          pkgs.freetype
-          pkgs.ftgl
-          pkgs.libGL.dev
-          pkgs.libglvnd
-          pkgs.libglvnd.dev
-          qt.qt3d
-          qt.qtbase
-          qt.qtbase.dev
-          qt.qtquick3d
-          qt.qtsvg
-          qt.qtshadertools
-          qt.qttools
-          qt.qtdeclarative
-          qt.qtdeclarative.dev
-          qt.wrapQtAppsHook
-        ];
+      gui_libs = system: pkgs: qt: [
+        pkgs.glib
+        pkgs.freetype
+        pkgs.ftgl
+        pkgs.libGL.dev
+        pkgs.libglvnd
+        pkgs.libglvnd.dev
+        qt.qt3d
+        qt.qtbase
+        qt.qtbase.dev
+        qt.qtquick3d
+        qt.qtsvg
+        qt.qtshadertools
+        qt.qttools
+        qt.qtdeclarative
+        qt.qtdeclarative.dev
+        qt.wrapQtAppsHook
+      ];
       check_libs = pkgs: with pkgs; [ gtest ];
 
-    in flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (system:
+    in
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ] (
+      system:
 
       let
         pkgs = import nixpkgs { inherit system; };
         old = import outdated { inherit system; };
         nixGL = import nixGL-src { inherit pkgs; };
         qt = old.qt6;
-        dissolve = { gui ? false, threading ? true, checks ? true
-          , benchmarks ? false }:
+        dissolve =
+          {
+            gui ? false,
+            threading ? true,
+            checks ? true,
+            benchmarks ? false,
+          }:
           pkgs.stdenv.mkDerivation ({
             inherit version;
             pname = exe-name gui;
@@ -76,7 +95,8 @@
               path = ./.;
               name = "dissolve-src";
             };
-            buildInputs = base_libs pkgs
+            buildInputs =
+              base_libs pkgs
               ++ pkgs.lib.optionals gui (gui_libs system pkgs qt)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optionals threading [
@@ -110,22 +130,29 @@
               # license = licenses.unlicense;
               maintainers = [ maintainers.rprospero ];
             };
-          }) // (if checks then { QT_QPA_PLATFORM = "offscreen"; } else { });
-        mkSingularity = { gui ? false, threading ? true }:
+          })
+          // (if checks then { QT_QPA_PLATFORM = "offscreen"; } else { });
+        mkSingularity =
+          {
+            gui ? false,
+            threading ? true,
+          }:
           outdated.legacyPackages.${system}.singularity-tools.buildImage {
             name = "${exe-name gui}-${version}";
             diskSize = 1024 * 50;
             contents = [ (dissolve { inherit gui threading; }) ];
-            runScript = if gui then
-              "${nixGL.nixGLIntel}/bin/nixGLIntel ${
-                dissolve { inherit gui threading; }
-              }/bin/${exe-name gui} $@"
-            else
-              "${dissolve { inherit gui threading; }}/bin/${
-                exe-name gui
-              } $@";
+            runScript =
+              if gui then
+                "${nixGL.nixGLIntel}/bin/nixGLIntel ${dissolve { inherit gui threading; }}/bin/${exe-name gui} $@"
+              else
+                "${dissolve { inherit gui threading; }}/bin/${exe-name gui} $@";
           };
-      in {
+      in
+      {
+        bundlers = {
+          default = bundlers.bundlers.${system}.nix-bundle;
+        };
+
         checks.dissolve = dissolve { checks = true; };
         checks.dissolve-gui = dissolve {
           gui = true;
@@ -141,8 +168,11 @@
 
         devShells.default = pkgs.mkShell {
           name = "dissolve-shell";
-          buildInputs = base_libs pkgs ++ gui_libs system pkgs qt
-            ++ check_libs pkgs ++ (with pkgs; [
+          buildInputs =
+            base_libs pkgs
+            ++ gui_libs system pkgs qt
+            ++ check_libs pkgs
+            ++ (with pkgs; [
               llvmPackages_20.clang-tools
 
               (onedpl pkgs)
@@ -165,22 +195,12 @@
             ]);
           shellHook = ''
             export XDG_DATA_DIRS=$GSETTINGS_SCHEMAS_PATH:$XDG_DATA_DIRS
-            export LIBGL_DRIVERS_PATH=${
-              pkgs.lib.makeSearchPathOutput "lib" "lib/dri"
-              [ pkgs.mesa ]
-            }
-            export LIBVA_DRIVERS_PATH=${
-              pkgs.lib.makeSearchPathOutput "out" "lib/dri"
-              [ pkgs.mesa ]
-            }
+            export LIBGL_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "lib" "lib/dri" [ pkgs.mesa ]}
+            export LIBVA_DRIVERS_PATH=${pkgs.lib.makeSearchPathOutput "out" "lib/dri" [ pkgs.mesa ]}
             export __EGL_VENDOR_LIBRARY_FILENAMES=${pkgs.mesa}/share/glvnd/egl_vendor.d/50_mesa.json
-            export LD_LIBRARY_PATH=${
-              pkgs.lib.makeLibraryPath [ pkgs.mesa ]
-            }:${
+            export LD_LIBRARY_PATH=${pkgs.lib.makeLibraryPath [ pkgs.mesa ]}:${
               pkgs.lib.makeSearchPathOutput "lib" "lib/vdpau" [ pkgs.libvdpau ]
-            }:${
-              pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]
-            }"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+            }:${pkgs.lib.makeLibraryPath [ pkgs.libglvnd ]}"''${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
             # export QT_PLUGIN_PATH="${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
             export QT_PLUGIN_PATH="${qt.qtquick3d}/lib/qt-6/plugins:${qt.qt3d}/lib/qt-6/plugins:${qt.qtsvg}/lib/qt-6/plugins:$QT_PLUGIN_PATH"
           '';
@@ -190,55 +210,55 @@
           CMAKE_CXX_FLAGS_DEBUG = "-g -O0";
           CXXL = "${pkgs.stdenv.cc.cc.lib}";
           Qt6Quick3D_DIR = "${qt.qtquick3d}/lib/";
-          QML_IMPORT_PATH =
-            "${qt.qtquick3d}/lib/qt-6/qml:${qt.qtdeclarative}/lib/qt-6/qml/";
-          QML2_IMPORT_PATH =
-            "$\${qt.qtquick3d}/lib/qt-6/qml:{qt.qtdeclarative}/lib/qt-6/qml/";
+          QML_IMPORT_PATH = "${qt.qtquick3d}/lib/qt-6/qml:${qt.qtdeclarative}/lib/qt-6/qml/";
+          QML2_IMPORT_PATH = "$\${qt.qtquick3d}/lib/qt-6/qml:{qt.qtdeclarative}/lib/qt-6/qml/";
         };
 
         apps = {
           benchmarks = {
             type = "app";
-            program = toString (pkgs.writeScript "benchmark.sh" ''
-              #!/bin/sh
-              set -e
-              export TMP=$(mktemp -d)
-              for bm in ${self.packages.${system}.benchmarks}/bin/benchmark_*
-              do
-                export BENCHNAME=$(basename ${"$"}{bm})_result.json
-                >&2 echo Running ${"$"}{BENCHNAME}
-                ${"$"}{bm} --benchmark_format=json > $TMP/${"$"}{BENCHNAME}
-              done
-              ${pkgs.jq}/bin/jq -s '[.[] | to_entries] | flatten | reduce .[] as $dot ({}; .[$dot.key] += $dot.value)' $TMP/benchmark_*.json > $TMP/all_benchmark_results.json
-              cat $TMP/all_benchmark_results.json
-            '');
+            program = toString (
+              pkgs.writeScript "benchmark.sh" ''
+                #!/bin/sh
+                set -e
+                export TMP=$(mktemp -d)
+                for bm in ${self.packages.${system}.benchmarks}/bin/benchmark_*
+                do
+                  export BENCHNAME=$(basename ${"$"}{bm})_result.json
+                  >&2 echo Running ${"$"}{BENCHNAME}
+                  ${"$"}{bm} --benchmark_format=json > $TMP/${"$"}{BENCHNAME}
+                done
+                ${pkgs.jq}/bin/jq -s '[.[] | to_entries] | flatten | reduce .[] as $dot ({}; .[$dot.key] += $dot.value)' $TMP/benchmark_*.json > $TMP/all_benchmark_results.json
+                cat $TMP/all_benchmark_results.json
+              ''
+            );
           };
-          dissolve-app =
-            flake-utils.lib.mkApp { drv = self.packages.${system}.dissolve; };
+          dissolve-app = flake-utils.lib.mkApp { drv = self.packages.${system}.dissolve; };
           dissolve-gui-app = flake-utils.lib.mkApp {
             drv = self.packages.${system}.dissolve-gui;
           };
           uploader = {
             type = "app";
-            program = toString (pkgs.writeScript "upload.sh" ''
-              #!/bin/sh
-              set -e
-              if [ "$#" -ne 4 ] ; then
-                echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
-                exit 1
-              fi
-              ${
-                outdated.legacyPackages.${system}.singularity
-              }/bin/singularity remote login --username $1 --password $2 docker://harbor.stfc.ac.uk
-              ${
-                outdated.legacyPackages.${system}.singularity
-              }/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
-            '');
+            program = toString (
+              pkgs.writeScript "upload.sh" ''
+                #!/bin/sh
+                set -e
+                if [ "$#" -ne 4 ] ; then
+                  echo "Usage: nix run .#uploader HARBOR_USER HARBOR_SECRET IMAGE TAG" >&2
+                  exit 1
+                fi
+                ${
+                  outdated.legacyPackages.${system}.singularity
+                }/bin/singularity remote login --username $1 --password $2 docker://harbor.stfc.ac.uk
+                ${
+                  outdated.legacyPackages.${system}.singularity
+                }/bin/singularity push $3 oras://harbor.stfc.ac.uk/isis_disordered_materials/dissolve:$4
+              ''
+            );
           };
         };
 
-        defaultApp =
-          flake-utils.lib.mkApp { drv = self.defaultPackage.${system}; };
+        defaultApp = flake-utils.lib.mkApp { drv = self.defaultPackage.${system}; };
 
         packages = {
           benchmarks = dissolve {
@@ -282,6 +302,9 @@
           };
         };
 
-        homeManagerModule = { user-env = import ./nix/user-env.nix; };
-      });
+        homeManagerModule = {
+          user-env = import ./nix/user-env.nix;
+        };
+      }
+    );
 }


### PR DESCRIPTION
As was performed on the main branch, this PR tells nix to use a fixed, constant version of the bundler.  This will ensure that the bundler will not update from beneath us and break (like it did back in December).