### PR TITLE
fix: Node retrieval function in new ForcefieldNode and test

### DIFF
--- a/src/gui/models/simpleForcefieldModel.cpp
+++ b/src/gui/models/simpleForcefieldModel.cpp
@@ -34,7 +34,7 @@ void SimpleForcefieldModel::create(int x, int y)
 {
     auto name = ff_->name();
     graphModel_->emplace_back(x, y, "Forcefield", QString::fromStdString(std::string(name)));
-    auto ff = dynamic_cast<ForcefieldNode *>(graphModel_->graph()->node(name));
+    auto ff = dynamic_cast<ForcefieldNode *>(graphModel_->graph()->findNode(name));
     if (ff)
         ff->forcefield() = ff_;
 }

--- a/tests/gui/forcefieldModel.cpp
+++ b/tests/gui/forcefieldModel.cpp
@@ -24,7 +24,7 @@ TEST(ForcefieldModel, Basic)
     model.create(0, 0);
 
     ASSERT_EQ(graph.nodes().size(), 3);
-    auto node = dynamic_cast<ForcefieldNode *>(graph.node("Kulmala2010"));
+    auto node = dynamic_cast<ForcefieldNode *>(graph.findNode("Kulmala2010"));
     ASSERT_TRUE(node);
     EXPECT_EQ(node->forcefield().get(), ForcefieldLibrary::forcefield("Kulmala2010").get());
 }


### PR DESCRIPTION
Two-line PR to fix the new `ForcefieldNode` mode and unit test which were using `Graph::node()` rather than the (very recently introduced) `Graph::findNode()`.