### PR TITLE
feat: Add ImportConfigurationTrajectory node

### DIFF
--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -16,7 +16,7 @@ CoordinateImportFileFormat::CoordinateImportFileFormat(std::string_view filename
     setUpKeywords();
 }
 
-// Return enum option info for AveragingScheme
+// Return enum option info for CoordinateImportFileFormat
 EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat> CoordinateImportFileFormat::coordinateImportFileFormat()
 {
     return EnumOptions<CoordinateImportFileFormat::CoordinateImportFormat>(

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -11,10 +11,22 @@ TrajectoryImportFileFormat::TrajectoryImportFileFormat(std::string_view filename
                                                        TrajectoryImportFileFormat::TrajectoryImportFormat format)
     : FileAndFormat(formats_, filename, (int)format)
 {
-    formats_ = EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>(
+    formats_ = trajectoryImportFileFormats();
+}
+
+// Return enum option info for TrajectoryImportFileFormat
+EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> TrajectoryImportFileFormat::trajectoryImportFileFormats()
+{
+    return EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>(
         "TrajectoryImportFileFormat",
         {{TrajectoryImportFormat::DLPOLYFormatted, "hisf", "Formatted DL_POLY Trajectory (no header)"},
          {TrajectoryImportFormat::XYZ, "xyz", "XYZ Trajectory"}});
+}
+
+EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>
+getEnumOptions(TrajectoryImportFileFormat::TrajectoryImportFormat)
+{
+    return TrajectoryImportFileFormat::trajectoryImportFileFormats();
 }
 
 /*

--- a/src/io/import/trajectory.h
+++ b/src/io/import/trajectory.h
@@ -24,6 +24,9 @@ class TrajectoryImportFileFormat : public FileAndFormat
                                         TrajectoryImportFormat format = TrajectoryImportFormat::XYZ);
     ~TrajectoryImportFileFormat() override = default;
 
+    // Return enum options for TrajectoryImportFileFormat
+    static EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat> trajectoryImportFileFormats();
+
     /*
      * Formats
      */
@@ -49,3 +52,6 @@ class TrajectoryImportFileFormat : public FileAndFormat
     // Import trajectory using supplied parser and current format
     bool importData(LineParser &parser, Configuration *cfg, std::optional<Matrix3> &unitCell);
 };
+
+EnumOptions<TrajectoryImportFileFormat::TrajectoryImportFormat>
+    getEnumOptions(TrajectoryImportFileFormat::TrajectoryImportFormat);

--- a/src/nodes/importConfigurationCoordinates.cpp
+++ b/src/nodes/importConfigurationCoordinates.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "nodes/importConfigurationCoordinates.h"
-#include "nodes/dissolve.h"
 
 ImportConfigurationCoordinatesNode::ImportConfigurationCoordinatesNode(Graph *parentGraph) : Node(parentGraph)
 {

--- a/src/nodes/importConfigurationCoordinates.h
+++ b/src/nodes/importConfigurationCoordinates.h
@@ -5,8 +5,8 @@
 
 #include "io/import/coordinates.h"
 #include "nodes/node.h"
-#include <memory>
 
+// Forward Declarations
 class Configuration;
 
 class ImportConfigurationCoordinatesNode : public Node

--- a/src/nodes/importConfigurationTrajectory.cpp
+++ b/src/nodes/importConfigurationTrajectory.cpp
@@ -21,7 +21,10 @@ ImportConfigurationTrajectoryNode::ImportConfigurationTrajectoryNode(Graph *pare
 
 std::string_view ImportConfigurationTrajectoryNode::type() const { return "ImportTrajectory"; }
 
-std::string_view ImportConfigurationTrajectoryNode::summary() const { return "Import Trajectory from a file."; }
+std::string_view ImportConfigurationTrajectoryNode::summary() const
+{
+    return "Import configuration coordinates from sequential frames of a trajectory.";
+}
 
 NodeConstants::ProcessResult ImportConfigurationTrajectoryNode::process()
 {

--- a/src/nodes/importConfigurationTrajectory.cpp
+++ b/src/nodes/importConfigurationTrajectory.cpp
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/importConfigurationTrajectory.h"
+
+ImportConfigurationTrajectoryNode::ImportConfigurationTrajectoryNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Inputs
+    addInput<Configuration *>("Configuration", "Configuration to which Trajectory will be imported", configuration_);
+
+    // Options
+    addOption<std::string>("FilePath", "File path", filePath_);
+    addOption<TrajectoryImportFileFormat::TrajectoryImportFormat>("FileFormat", "File format", format_);
+
+    // Outputs
+    addOutput<Configuration *>("Configuration", "Output configuration", configuration_);
+
+    // Serialisable data
+    addSerialisable("filePosition", filePosition_);
+}
+
+std::string_view ImportConfigurationTrajectoryNode::type() const { return "ImportTrajectory"; }
+
+std::string_view ImportConfigurationTrajectoryNode::summary() const { return "Import Trajectory from a file."; }
+
+NodeConstants::ProcessResult ImportConfigurationTrajectoryNode::process()
+{
+    TrajectoryImportFileFormat format(filePath_, format_);
+
+    message("Import: Reading trajectory file frame from '{}' into Configuration '{}'...\n", format.filename(),
+            configuration_->name());
+
+    // Open the file
+    LineParser parser;
+    if ((!parser.openInput(format.filename())) || (!parser.isFileGoodForReading()))
+    {
+        error("Couldn't open trajectory file '{}'.\n", format.filename());
+        return NodeConstants::ProcessResult::Failed;
+    }
+
+    // Seek to the next file position
+    parser.seekg(filePosition_);
+
+    // Read the frame
+    std::optional<Matrix3> unitCell;
+    if (!format.importData(parser, configuration_, unitCell))
+    {
+        error("Failed to read trajectory frame data.\n");
+        return NodeConstants::ProcessResult::Failed;
+    }
+
+    configuration_->notifyAtomicPositionsChanged();
+
+    // Store the new trajectory file position
+    filePosition_ = parser.tellg();
+
+    // Set the unit cell if one was read in
+    if (unitCell)
+        configuration_->createBox(unitCell.value());
+
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/importConfigurationTrajectory.h
+++ b/src/nodes/importConfigurationTrajectory.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "io/import/trajectory.h"
+#include "nodes/node.h"
+
+// Forward Declarations
+class Configuration;
+
+class ImportConfigurationTrajectoryNode : public Node
+{
+    public:
+    ImportConfigurationTrajectoryNode(Graph *parentGraph);
+    ~ImportConfigurationTrajectoryNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // File path
+    std::string filePath_;
+    // File format
+    TrajectoryImportFileFormat::TrajectoryImportFormat format_{TrajectoryImportFileFormat::TrajectoryImportFormat::XYZ};
+    // Last read file position (as int)
+    int filePosition_;
+    // Target configuration
+    Configuration *configuration_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -2,10 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "nodes/registry.h"
-#include "base/enumOptions.h"
-#include "base/enumOptionsBase.h"
 #include "math/averaging.h"
-#include "math/windowFunction.h"
 #include "nodes/add.h"
 #include "nodes/atomicMC/atomicMC.h"
 #include "nodes/configuration.h"
@@ -17,6 +14,7 @@
 #include "nodes/forcefield.h"
 #include "nodes/gr/gr.h"
 #include "nodes/importConfigurationCoordinates.h"
+#include "nodes/importConfigurationTrajectory.h"
 #include "nodes/insert.h"
 #include "nodes/integrator.h"
 #include "nodes/iterableGraph.h"
@@ -61,6 +59,7 @@ void NodeRegistry::instantiateNodeProducers()
         {"Graph", makeDerivedNode<Graph>()},
         {"GR", makeDerivedNode<GRNode>()},
         {"ImportConfigurationCoordinates", makeDerivedNode<ImportConfigurationCoordinatesNode>()},
+        {"ImportConfigurationTrajectory", makeDerivedNode<ImportConfigurationTrajectoryNode>()},
         {"Insert", makeDerivedNode<InsertNode>()},
         {"Integrator", makeDerivedNode<Integrator1DNode>()},
         {"Iterator", makeDerivedNode<IterableGraph>()},

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -176,7 +176,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     ValueChecker dataChecker_{[&]() { return true; }};
     // Resolver function for data
     using DataResolver = std::function<void(const std::map<std::string, const Species *> &)>;
-    DataResolver dataResolver_{[&]() { return; }};
+    DataResolver dataResolver_{[&](const std::map<std::string, const Species *> &reachableSpecies) {}};
 
     /*
      * Serialisation


### PR DESCRIPTION
As part of work towards reimplementing analysis modules as nodes, this PR adds the ability to import a trajectory (frame) using a node.  No unit test is added, as testing is performed implicitly by the analysis node testing.