### PR TITLE
fix: Iterable graph bug on Graph::process empty/non-empty edges

### DIFF
--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -46,7 +46,7 @@ NodeConstants::ProcessResult Graph::process()
     // Check each node for output edges - any that have zero output edges need to be run()
     auto terminalNodeResult = NodeConstants::ProcessResult::Unchanged;
     for (auto &&[nodeName, node] : nodes_)
-        if (!node->outputEdges().empty())
+        if (node->outputEdges().empty())
         {
             switch (node->run())
             {

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -66,7 +66,7 @@ bool IterableGraph::addEdge(const EdgeDefinition &definition)
 
         loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
 
-        addOutputEdge(definition.sourceOutput, loopEdges_.back().get());
+        addOutputLoopEdge(definition.sourceOutput, loopEdges_.back().get());
 
         return true;
     }
@@ -85,7 +85,7 @@ bool IterableGraph::removeEdge(const EdgeDefinition &definition)
         else
             return false;
 
-        removeOutputEdge(definition.sourceOutput, static_cast<Edge *>(loopEdge));
+        removeOutputLoopEdge(definition.sourceOutput, static_cast<Edge *>(loopEdge));
     }
     return true;
 }
@@ -119,7 +119,7 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
 }
 
 // Add edge to node map
-Edge *IterableGraph::addOutputEdge(std::string_view nodeName, Edge *edge)
+Edge *IterableGraph::addOutputLoopEdge(std::string_view nodeName, Edge *edge)
 {
     auto &outputEdgeMap = loopBacks()->outputEdges();
     auto outputEdges = outputEdgeMap.find(nodeName);
@@ -138,7 +138,7 @@ Edge *IterableGraph::addOutputEdge(std::string_view nodeName, Edge *edge)
 }
 
 // Remove edge from node map
-Edge *IterableGraph::removeOutputEdge(std::string_view nodeName, Edge *edge)
+Edge *IterableGraph::removeOutputLoopEdge(std::string_view nodeName, Edge *edge)
 {
     auto outputEdgeMap = loopBacks()->outputEdges();
     auto outputEdges = outputEdgeMap.find(nodeName);

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -119,10 +119,12 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
 }
 
 // Add edge to node map
-Edge *IterableGraph::addOutputLoopEdge(std::string_view nodeName, Edge *edge)
+Edge *IterableGraph::addOutputLoopEdge(std::string_view sourceOutput, Edge *edge)
 {
     auto &outputEdgeMap = loopBacks()->outputEdges();
-    auto outputEdges = outputEdgeMap.find(nodeName);
+    auto outputEdges = outputEdgeMap.find(sourceOutput);
+
+    // If source not in edge map, insert it, otherwise push new edge to current source node
     if (outputEdges != outputEdgeMap.end())
     {
         outputEdges->second.push_back(edge);
@@ -130,7 +132,7 @@ Edge *IterableGraph::addOutputLoopEdge(std::string_view nodeName, Edge *edge)
     }
     else
     {
-        outputEdgeMap.insert({nodeName, {edge}});
+        outputEdgeMap.insert({sourceOutput, {edge}});
         return edge;
     }
 
@@ -138,10 +140,10 @@ Edge *IterableGraph::addOutputLoopEdge(std::string_view nodeName, Edge *edge)
 }
 
 // Remove edge from node map
-Edge *IterableGraph::removeOutputLoopEdge(std::string_view nodeName, Edge *edge)
+Edge *IterableGraph::removeOutputLoopEdge(std::string_view sourceOutput, Edge *edge)
 {
     auto outputEdgeMap = loopBacks()->outputEdges();
-    auto outputEdges = outputEdgeMap.find(nodeName);
+    auto outputEdges = outputEdgeMap.find(sourceOutput);
     if (outputEdges != outputEdgeMap.end())
     {
         auto removedEdge = std::remove(outputEdges->second.begin(), outputEdges->second.end(), edge);

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -66,6 +66,8 @@ bool IterableGraph::addEdge(const EdgeDefinition &definition)
 
         loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
 
+        addOutputEdge(definition.sourceOutput, loopEdges_.back().get());
+
         return true;
     }
 
@@ -82,6 +84,8 @@ bool IterableGraph::removeEdge(const EdgeDefinition &definition)
             releaseLoopBack(definition.targetInput);
         else
             return false;
+
+        removeOutputEdge(definition.sourceOutput, static_cast<Edge *>(loopEdge));
     }
     return true;
 }
@@ -112,6 +116,40 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
         return static_cast<LoopEdge *>(it->get());
 
     return {};
+}
+
+// Add edge to node map
+Edge *IterableGraph::addOutputEdge(std::string_view nodeName, Edge *edge)
+{
+    auto &outputEdgeMap = loopBacks()->outputEdges();
+    auto outputEdges = outputEdgeMap.find(nodeName);
+    if (outputEdges != outputEdgeMap.end())
+    {
+        outputEdges->second.push_back(edge);
+        return edge;
+    }
+    else
+    {
+        outputEdgeMap.insert({nodeName, {edge}});
+        return edge;
+    }
+
+    return nullptr;
+}
+
+// Remove edge from node map
+Edge *IterableGraph::removeOutputEdge(std::string_view nodeName, Edge *edge)
+{
+    auto outputEdgeMap = loopBacks()->outputEdges();
+    auto outputEdges = outputEdgeMap.find(nodeName);
+    if (outputEdges != outputEdgeMap.end())
+    {
+        auto removedEdge = std::remove(outputEdges->second.begin(), outputEdges->second.end(), edge);
+        outputEdges->second.erase(removedEdge, outputEdges->second.end());
+        return edge;
+    }
+
+    return nullptr;
 }
 
 /*

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -64,6 +64,12 @@ class IterableGraph : public Graph
     // Find loop edge between nodes
     LoopEdge *findLoopEdge(const EdgeDefinition &definition) const;
 
+    private:
+    // Add edge to node map
+    Edge *addOutputEdge(std::string_view nodeName, Edge *edge);
+    // Remove edge from node map
+    Edge *removeOutputEdge(std::string_view nodeName, Edge *edge);
+
     /*
      * Processing & Validity
      */

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -66,9 +66,9 @@ class IterableGraph : public Graph
 
     private:
     // Add edge to node map
-    Edge *addOutputEdge(std::string_view nodeName, Edge *edge);
+    Edge *addOutputLoopEdge(std::string_view nodeName, Edge *edge);
     // Remove edge from node map
-    Edge *removeOutputEdge(std::string_view nodeName, Edge *edge);
+    Edge *removeOutputLoopEdge(std::string_view nodeName, Edge *edge);
 
     /*
      * Processing & Validity

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -66,9 +66,9 @@ class IterableGraph : public Graph
 
     private:
     // Add edge to node map
-    Edge *addOutputLoopEdge(std::string_view nodeName, Edge *edge);
+    Edge *addOutputLoopEdge(std::string_view sourceOutput, Edge *edge);
     // Remove edge from node map
-    Edge *removeOutputLoopEdge(std::string_view nodeName, Edge *edge);
+    Edge *removeOutputLoopEdge(std::string_view sourceOutput, Edge *edge);
 
     /*
      * Processing & Validity

--- a/src/nodes/loopBack.cpp
+++ b/src/nodes/loopBack.cpp
@@ -65,10 +65,6 @@ Node::EdgeMap &LoopBacksNode::outputEdges()
         loopEdges_.insert_or_assign(output, edges);
     }
 
-    std::vector<Edge *> edges;
-    for (const auto &edge : loop->loopEdges())
-        edges.push_back(edge.get());
-
     return loopEdges_;
 }
 

--- a/src/nodes/loopBack.cpp
+++ b/src/nodes/loopBack.cpp
@@ -46,6 +46,32 @@ NodeConstants::ProcessResult LoopBacksNode::run()
     return status;
 }
 
+// Get the outgoing edges from this node
+Node::EdgeMap &LoopBacksNode::outputEdges()
+{
+    auto loop = static_cast<IterableGraph *>(parentGraph_);
+
+    for (const auto &edge : loop->loopEdges())
+    {
+        auto output = edge->sourceOutput().name();
+        auto it = loopEdges_.find(output);
+
+        std::vector<Edge *> edges;
+        if (it != loopEdges_.end())
+            edges = it->second;
+
+        edges.push_back(edge.get());
+
+        loopEdges_.insert_or_assign(output, edges);
+    }
+
+    std::vector<Edge *> edges;
+    for (const auto &edge : loop->loopEdges())
+        edges.push_back(edge.get());
+
+    return loopEdges_;
+}
+
 // Flag that the node data needs to be updated
 void LoopBacksNode::setUpdateRequired()
 {

--- a/src/nodes/loopBack.cpp
+++ b/src/nodes/loopBack.cpp
@@ -47,26 +47,7 @@ NodeConstants::ProcessResult LoopBacksNode::run()
 }
 
 // Get the outgoing edges from this node
-Node::EdgeMap &LoopBacksNode::outputEdges()
-{
-    auto loop = static_cast<IterableGraph *>(parentGraph_);
-
-    for (const auto &edge : loop->loopEdges())
-    {
-        auto output = edge->sourceOutput().name();
-        auto it = loopEdges_.find(output);
-
-        std::vector<Edge *> edges;
-        if (it != loopEdges_.end())
-            edges = it->second;
-
-        edges.push_back(edge.get());
-
-        loopEdges_.insert_or_assign(output, edges);
-    }
-
-    return loopEdges_;
-}
+Node::EdgeMap &LoopBacksNode::outputEdges() { return loopEdges_; }
 
 // Flag that the node data needs to be updated
 void LoopBacksNode::setUpdateRequired()

--- a/src/nodes/loopBack.h
+++ b/src/nodes/loopBack.h
@@ -32,6 +32,12 @@ class LoopBacksNode : public Node
     // Run the node, retrieving dependent inputs as necessary
     NodeConstants::ProcessResult run() override;
 
+    // Get the outgoing edges from this node
+    Node::EdgeMap &outputEdges() override;
+
+    private:
+    Node::EdgeMap loopEdges_;
+
     public:
     // Flag that the node data needs to be updated
     void setUpdateRequired() override;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -292,7 +292,7 @@ class Node : public Serialisable<>
     // Get the incoming edges to this node
     EdgeMap &inputEdges();
     // Get the outgoing edges from this node
-    EdgeMap &outputEdges();
+    virtual EdgeMap &outputEdges();
     // Mark incoming edges to the specified parameter as needing a re-pull
     void markIncomingEdgesForPull(const ParameterBase *toParameter) const;
     // Returns the node parent graph

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -73,7 +73,7 @@ class IterableGraphTest : public ::testing::Test
     IterableGraph *loop_{nullptr};
 };
 
-TEST_F(IterableGraphTest, NoInternalConnections)
+TEST_F(IterableGraphTest, BasicNonLoopingSeries)
 {
     CoreData coreData;
     Dissolve dissolve(coreData);
@@ -99,7 +99,11 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
     auto res1 = a->getOutputValue<Number>("Result").asInteger();
     EXPECT_TRUE(a->versionIndex() == 0);
+    EXPECT_TRUE(loop->versionIndex() == 0);
     ASSERT_EQ(res1, 2);
+
+    // No loopbacks occur
+    EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
 
     /*
      * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3
@@ -110,7 +114,11 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     auto res2 = b->getOutputValue<Number>("Result").asInteger();
     EXPECT_TRUE(a->versionIndex() == 1);
     EXPECT_TRUE(b->versionIndex() == 0);
+    EXPECT_TRUE(loop->versionIndex() == 1);
     ASSERT_EQ(res2, 3);
+
+    // No loopbacks occur
+    EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
 
     /*
      * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3 -> itC, 3 + 1 = 4
@@ -122,7 +130,11 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     EXPECT_TRUE(a->versionIndex() == 2);
     EXPECT_TRUE(b->versionIndex() == 1);
     EXPECT_TRUE(c->versionIndex() == 0);
+    EXPECT_TRUE(loop->versionIndex() == 2);
     ASSERT_EQ(res3, 4);
+
+    // No loopbacks occur
+    EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
 
     // Run 100 times
     ASSERT_TRUE(loop->setOption<Number>("N", 100));
@@ -130,6 +142,13 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     ASSERT_EQ(a->getOutputValue<Number>("Result").asInteger(), 2);
     ASSERT_EQ(b->getOutputValue<Number>("Result").asInteger(), 3);
     ASSERT_EQ(c->getOutputValue<Number>("Result").asInteger(), 4);
+    EXPECT_TRUE(a->versionIndex() == 3);
+    EXPECT_TRUE(b->versionIndex() == 2);
+    EXPECT_TRUE(c->versionIndex() == 1);
+    EXPECT_TRUE(loop->versionIndex() == 3);
+
+    // No loopbacks occur
+    EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
 }
 
 TEST_F(IterableGraphTest, NoRun)

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -73,6 +73,44 @@ class IterableGraphTest : public ::testing::Test
     IterableGraph *loop_{nullptr};
 };
 
+TEST_F(IterableGraphTest, NoInternalConnections)
+{
+    CoreData coreData;
+    Dissolve dissolve(coreData);
+    auto root = std::make_unique<DissolveGraph>(dissolve);
+    auto loop = dynamic_cast<IterableGraph *>(root->createNode("Iterator", "Iterator"));
+    auto i = dynamic_cast<NumberNode *>(root->createNode("Number", "i"));
+    auto a = dynamic_cast<AddNode *>(loop->createNode("Add", "a"));
+    auto b = dynamic_cast<AddNode *>(loop->createNode("Add", "b"));
+    ASSERT_TRUE(loop->setOption<Number>("N", 1));
+    EXPECT_TRUE(root->addEdge({"i", "X", "Iterator", "I"}));
+
+    /*
+     * i, 1 -> itA, 1 + 1 = 2
+     */
+
+    // This should actually result in the sole internal node not being run
+    i->setOption<Number>("X", 1);
+    a->setInput<Number>("Y", 1);
+    b->setInput<Number>("Y", 1);
+    EXPECT_TRUE(loop->addEdge({"Inputs", "I", "a", "X"}));
+    EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
+    auto res1 = a->getOutputValue<Number>("Result").asInteger();
+    EXPECT_TRUE(a->versionIndex() == 0);
+    ASSERT_EQ(res1, 2); // Should be 2
+
+    /*
+     * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3
+     */
+    EXPECT_TRUE(loop->addEdge({"a", "Result", "b", "X"}));
+    ASSERT_TRUE(loop->setOption<Number>("N", 1));
+    EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
+    auto res2 = b->getOutputValue<Number>("Result").asInteger();
+    EXPECT_TRUE(a->versionIndex() == 1);
+    EXPECT_TRUE(b->versionIndex() == 0);
+    ASSERT_EQ(res2, 3);
+}
+
 TEST_F(IterableGraphTest, NoRun)
 {
     createGraph();

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -82,6 +82,7 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     auto i = dynamic_cast<NumberNode *>(root->createNode("Number", "i"));
     auto a = dynamic_cast<AddNode *>(loop->createNode("Add", "a"));
     auto b = dynamic_cast<AddNode *>(loop->createNode("Add", "b"));
+    auto c = dynamic_cast<AddNode *>(loop->createNode("Add", "c"));
     ASSERT_TRUE(loop->setOption<Number>("N", 1));
     EXPECT_TRUE(root->addEdge({"i", "X", "Iterator", "I"}));
 
@@ -93,11 +94,12 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     i->setOption<Number>("X", 1);
     a->setInput<Number>("Y", 1);
     b->setInput<Number>("Y", 1);
+    c->setInput<Number>("Y", 1);
     EXPECT_TRUE(loop->addEdge({"Inputs", "I", "a", "X"}));
     EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
     auto res1 = a->getOutputValue<Number>("Result").asInteger();
     EXPECT_TRUE(a->versionIndex() == 0);
-    ASSERT_EQ(res1, 2); // Should be 2
+    ASSERT_EQ(res1, 2);
 
     /*
      * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3
@@ -109,6 +111,25 @@ TEST_F(IterableGraphTest, NoInternalConnections)
     EXPECT_TRUE(a->versionIndex() == 1);
     EXPECT_TRUE(b->versionIndex() == 0);
     ASSERT_EQ(res2, 3);
+
+    /*
+     * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3 -> itC, 3 + 1 = 4
+     */
+    EXPECT_TRUE(loop->addEdge({"b", "Result", "c", "X"}));
+    ASSERT_TRUE(loop->setOption<Number>("N", 1));
+    EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
+    auto res3 = c->getOutputValue<Number>("Result").asInteger();
+    EXPECT_TRUE(a->versionIndex() == 2);
+    EXPECT_TRUE(b->versionIndex() == 1);
+    EXPECT_TRUE(c->versionIndex() == 0);
+    ASSERT_EQ(res3, 4);
+
+    // Run 100 times
+    ASSERT_TRUE(loop->setOption<Number>("N", 100));
+    EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(a->getOutputValue<Number>("Result").asInteger(), 2);
+    ASSERT_EQ(b->getOutputValue<Number>("Result").asInteger(), 3);
+    ASSERT_EQ(c->getOutputValue<Number>("Result").asInteger(), 4);
 }
 
 TEST_F(IterableGraphTest, NoRun)

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -121,7 +121,7 @@ TEST_F(IterableGraphTest, BasicNonLoopingSeries)
     EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
 
     /*
-     * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3 -> itC, 3 + 1 = 4
+     * i, 1 -> itA, 1 + 1 = 2 -> itB, 1 + 2 = 3 -> itC, 1 + 3 = 4
      */
     EXPECT_TRUE(loop->addEdge({"b", "Result", "c", "X"}));
     ASSERT_TRUE(loop->setOption<Number>("N", 1));
@@ -146,6 +146,27 @@ TEST_F(IterableGraphTest, BasicNonLoopingSeries)
     EXPECT_TRUE(b->versionIndex() == 2);
     EXPECT_TRUE(c->versionIndex() == 1);
     EXPECT_TRUE(loop->versionIndex() == 3);
+
+    // No loopbacks occur
+    EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);
+
+    // Upstream node change
+    i->setOption<Number>("X", 2);
+
+    /*
+     * i, 2 -> itA, 1 + 2 = 3 -> itB, 1 + 3 = 4 -> itC, 1 + 4 = 5
+     */
+
+    // Run again
+    ASSERT_TRUE(loop->setOption<Number>("N", 1));
+    EXPECT_EQ(loop->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(a->getOutputValue<Number>("Result").asInteger(), 3);
+    ASSERT_EQ(b->getOutputValue<Number>("Result").asInteger(), 4);
+    ASSERT_EQ(c->getOutputValue<Number>("Result").asInteger(), 5);
+    EXPECT_TRUE(a->versionIndex() == 4);
+    EXPECT_TRUE(b->versionIndex() == 3);
+    EXPECT_TRUE(c->versionIndex() == 2);
+    EXPECT_TRUE(loop->versionIndex() == 4);
 
     // No loopbacks occur
     EXPECT_TRUE(loop->loopBacks()->versionIndex() == -1);


### PR DESCRIPTION
This PR addresses the seemingly odd behaviour of `IterableGraph`, in which a series of nodes internal to the graph and connected _only_ to the graph's proxy inputs, leads to the execution of all but the last node in the series. 

Turns out this was caused by the requirement for a node's [output edges to be empty](https://github.com/disorderedmaterials/dissolve/pull/2313/files#:~:text=if%20(!node%2D%3E,node%2D%3EoutputEdges().empty())) in order to process the node (akin to traversing the node graph until a node is found that is not a dependency for another node), which was actually incorrectly coded and itself has been addressed in this PR.

The previous state of the logic meant that the final node in the chain was never processed. Additionally, the `Graph::outputEdges` method had to be overridden for the `LoopBacksNode`, since the loopBacks do not show up in the `outputEdges_` member, which caused nodes in connected `IterableGraph`s to fail in the same way.
