### PR TITLE
feat: Species site node

### DIFF
--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -26,8 +26,8 @@ SpeciesSite::SpeciesSite(const Species *parent, std::string name, SiteType type)
 // Enum of types
 EnumOptions<SpeciesSite::SiteType> SpeciesSite::siteTypes()
 {
-    return EnumOptions<SiteType>(
-        "SiteType", {{SiteType::Static, "Static"}, {SiteType::Dynamic, "Dynamic"}, {SiteType::Fragment, "Fragment"}});
+    // Call getEnumOptions on *any* of the enum values
+    return getEnumOptions(SiteType::Static);
 }
 
 // Set name of site
@@ -505,20 +505,7 @@ std::vector<std::shared_ptr<Site>> SpeciesSite::createFromParent() const
  */
 
 // Return enum option info for SiteKeyword
-EnumOptions<SpeciesSite::SiteKeyword> SpeciesSite::keywords()
-{
-    return EnumOptions<SpeciesSite::SiteKeyword>("SiteKeyword",
-                                                 {{SpeciesSite::AtomTypeKeyword, "AtomType", OptionArguments::OneOrMore},
-                                                  {SpeciesSite::DynamicKeyword, "Dynamic"},
-                                                  {SpeciesSite::ElementKeyword, "Element", OptionArguments::OneOrMore},
-                                                  {SpeciesSite::FragmentKeyword, "Fragment"},
-                                                  {SpeciesSite::DescriptionKeyword, "Description", 1},
-                                                  {SpeciesSite::EndSiteKeyword, "EndSite"},
-                                                  {SpeciesSite::OriginKeyword, "Origin", OptionArguments::OneOrMore},
-                                                  {SpeciesSite::OriginMassWeightedKeyword, "OriginMassWeighted", 1},
-                                                  {SpeciesSite::XAxisKeyword, "XAxis", OptionArguments::OneOrMore},
-                                                  {SpeciesSite::YAxisKeyword, "YAxis", OptionArguments::OneOrMore}});
-}
+EnumOptions<SpeciesSite::SiteKeyword> SpeciesSite::keywords() { return getEnumOptions(SpeciesSite::AtomTypeKeyword); }
 
 // Read site definition from specified LineParser
 bool SpeciesSite::read(LineParser &parser, const CoreData &coreData)
@@ -787,4 +774,28 @@ void SpeciesSite::deserialise(const SerialisedValue &node, CoreData &coreData)
     originMassWeighted_ = toml::find_or<bool>(node, "originMassWeighted", false);
 
     generateInstances();
+}
+
+EnumOptions<SpeciesSite::SiteType> getEnumOptions(SpeciesSite::SiteType _unused)
+{
+
+    return EnumOptions<SpeciesSite::SiteType>("SiteType", {{SpeciesSite::SiteType::Static, "Static"},
+                                                           {SpeciesSite::SiteType::Dynamic, "Dynamic"},
+                                                           {SpeciesSite::SiteType::Fragment, "Fragment"}});
+}
+
+EnumOptions<SpeciesSite::SiteKeyword> getEnumOptions(SpeciesSite::SiteKeyword _unused)
+{
+
+    return EnumOptions<SpeciesSite::SiteKeyword>("SiteKeyword",
+                                                 {{SpeciesSite::AtomTypeKeyword, "AtomType", OptionArguments::OneOrMore},
+                                                  {SpeciesSite::DynamicKeyword, "Dynamic"},
+                                                  {SpeciesSite::ElementKeyword, "Element", OptionArguments::OneOrMore},
+                                                  {SpeciesSite::FragmentKeyword, "Fragment"},
+                                                  {SpeciesSite::DescriptionKeyword, "Description", 1},
+                                                  {SpeciesSite::EndSiteKeyword, "EndSite"},
+                                                  {SpeciesSite::OriginKeyword, "Origin", OptionArguments::OneOrMore},
+                                                  {SpeciesSite::OriginMassWeightedKeyword, "OriginMassWeighted", 1},
+                                                  {SpeciesSite::XAxisKeyword, "XAxis", OptionArguments::OneOrMore},
+                                                  {SpeciesSite::YAxisKeyword, "YAxis", OptionArguments::OneOrMore}});
 }

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -210,3 +210,6 @@ class SpeciesSite : public Serialisable<CoreData &>
     void serialise(std::string tag, SerialisedValue &target) const override;
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };
+
+EnumOptions<SpeciesSite::SiteType> getEnumOptions(SpeciesSite::SiteType);
+EnumOptions<SpeciesSite::SiteKeyword> getEnumOptions(SpeciesSite::SiteKeyword);

--- a/src/gui/models/nodeGraph/enumRegistry.cpp
+++ b/src/gui/models/nodeGraph/enumRegistry.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "enumRegistry.h"
+#include "classes/speciesSite.h"
 #include "data/structureFactors.h"
 #include "gui/models/nodeGraph/enumOptionsModel.h"
 #include "math/averaging.h"
@@ -39,5 +40,7 @@ void EnumRegistry::instantiateOptions()
                 {typeid(GRNode::PartialsMethod), wrap(GRNode::partialsMethods())},
                 {typeid(MDNode::TimestepType), wrap(MDNode::timestepType())},
                 {typeid(WindowFunction::Form), wrap(WindowFunction::forms())},
+                {typeid(SpeciesSite::SiteType), wrap(SpeciesSite::siteTypes())},
+                {typeid(SpeciesSite::SiteKeyword), wrap(SpeciesSite::keywords())},
                 {typeid(Averaging::AveragingScheme), wrap(Averaging::averagingSchemes())}};
 }

--- a/src/gui/qml/nodeGraph/GraphView.qml
+++ b/src/gui/qml/nodeGraph/GraphView.qml
@@ -138,6 +138,11 @@ Pane {
                         graphModel: graphRoot.rootModel
                     }
                 }
+                MenuItem {
+                    text: "Species Site"
+
+                    onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "SpeciesSite", "New Species Site")
+                }
             }
         }
     }

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -23,6 +23,7 @@
 #include "nodes/neutronSQ/neutronSQ.h"
 #include "nodes/numberNode.h"
 #include "nodes/species.h"
+#include "nodes/speciesSite.h"
 #include "nodes/sq/sq.h"
 #include "nodes/subtract.h"
 #include "nodes/vec3Assembly.h"
@@ -67,6 +68,7 @@ void NodeRegistry::instantiateNodeProducers()
                   {"Multiply", makeDerivedNode<MultiplyNode>()},
                   {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
                   {"Number", makeDerivedNode<NumberNode>()},
+                  {"SpeciesSite", makeDerivedNode<SpeciesSiteNode>()},
                   {"SQ", makeDerivedNode<SQNode>()},
                   {"Species", makeDerivedNode<SpeciesNode>()},
                   {"Subtract", makeDerivedNode<SubtractNode>()},

--- a/src/nodes/speciesSite.cpp
+++ b/src/nodes/speciesSite.cpp
@@ -6,9 +6,9 @@
 
 SpeciesSiteNode::SpeciesSiteNode(Graph *parentGraph) : Node(parentGraph), speciesSite_(species_, type_)
 {
-  addInput("Species", "Species on which the site is located", species_);
-  addOption("Type", "The kind of site", type_);
-  addPointerOutput("SpeciesSite", "The Species Site", speciesSite_);
+    addInput("Species", "Species on which the site is located", species_);
+    addOption("Type", "The kind of site", type_);
+    addPointerOutput("SpeciesSite", "The Species Site", speciesSite_);
 }
 
 std::string_view SpeciesSiteNode::type() const { return "SpeciesSite"; }
@@ -17,7 +17,7 @@ std::string_view SpeciesSiteNode::summary() const { return "Species Site"; }
 NodeConstants::ProcessResult SpeciesSiteNode::process()
 {
     if (!species_)
-      return NodeConstants::ProcessResult::Failed;
+        return NodeConstants::ProcessResult::Failed;
     speciesSite_ = SpeciesSite(species_, type_);
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/speciesSite.cpp
+++ b/src/nodes/speciesSite.cpp
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/speciesSite.h"
+#include "constants.h"
+
+SpeciesSiteNode::SpeciesSiteNode(Graph *parentGraph) : Node(parentGraph), speciesSite_(species_, type_)
+{
+  addInput("Species", "Species on which the site is located", species_);
+  addOption("Type", "The kind of site", type_);
+  addPointerOutput("SpeciesSite", "The Species Site", speciesSite_);
+}
+
+std::string_view SpeciesSiteNode::type() const { return "SpeciesSite"; }
+std::string_view SpeciesSiteNode::summary() const { return "Species Site"; }
+
+NodeConstants::ProcessResult SpeciesSiteNode::process()
+{
+    if (!species_)
+      return NodeConstants::ProcessResult::Failed;
+    speciesSite_ = SpeciesSite(species_, type_);
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/speciesSite.h
+++ b/src/nodes/speciesSite.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/speciesSite.h"
+#include "nodes/node.h"
+
+// SpeciesSite Node
+class SpeciesSiteNode : public Node
+{
+    public:
+    SpeciesSiteNode(Graph *parentGraph);
+    ~SpeciesSiteNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // SpeciesSite object
+    SpeciesSite speciesSite_;
+    // Species source
+    Species *species_;
+    // Species type
+    SpeciesSite::SiteType type_;
+
+    /*
+     * Accessors
+     */
+    public:
+    // Access the species information (Needed for SpeciesModel)
+    SpeciesSite &speciesSite();
+    const SpeciesSite &speciesSite() const;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};


### PR DESCRIPTION
This adds a node for SpeciesSite, since it will be needed for AvgMol.  I considered just having the AvgMol node construct the site itself, but I figured that it would be better to make the node once instead of writing that boilerplate for every node which needs a species site. 