### PR TITLE
feat: POD History

### DIFF
--- a/src/math/history.h
+++ b/src/math/history.h
@@ -6,6 +6,7 @@
 #include "base/serialiser.h"
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 // Serialisable Data History
@@ -99,13 +100,12 @@ template <class T> class PODHistory : public Serialisable<>
     T average() const
     {
         // Perform averaging of the datasets that we have
-        T averaged = T();
+        T averaged = std::accumulate(history_.begin(), history_.end(), T());
 
-        auto weight = 1.0 / history_.size();
         for (auto &data : history_)
-            averaged += data * weight;
+            averaged += data;
 
-        return averaged;
+        return averaged / history_.size();
     }
     // Return the history data vector
     const std::vector<T> &history() const { return history_; }

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -99,13 +99,7 @@ template <class T> class PODHistory : public Serialisable<>
     // Return the current average value
     T average() const
     {
-        // Perform averaging of the datasets that we have
-        T averaged = std::accumulate(history_.begin(), history_.end(), T());
-
-        for (auto &data : history_)
-            averaged += data;
-
-        return averaged / history_.size();
+        return std::accumulate(history_.begin(), history_.end(), T()) / history_.size();
     }
     // Return the history data vector
     const std::vector<T> &history() const { return history_; }

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -107,6 +107,8 @@ template <class T> class PODHistory : public Serialisable<>
 
         return averaged;
     }
+    // Return the history data vector
+    const std::vector<T> &history() const { return history_; }
 
     /*
      * Serialisation

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -97,10 +97,7 @@ template <class T> class PODHistory : public Serialisable<>
         return average();
     }
     // Return the current average value
-    T average() const
-    {
-        return std::accumulate(history_.begin(), history_.end(), T()) / history_.size();
-    }
+    T average() const { return std::accumulate(history_.begin(), history_.end(), T()) / history_.size(); }
     // Return the history data vector
     const std::vector<T> &history() const { return history_; }
 

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -103,7 +103,7 @@ template <class T> class PODHistory : public Serialisable<>
 
         auto weight = 1.0 / history_.size();
         for (auto &data : history_)
-            averaged += *data * weight;
+            averaged += data * weight;
 
         return averaged;
     }

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -69,3 +69,58 @@ template <class T> class History : public Serialisable<>
                                       });
     }
 };
+
+// Serialisable POD Data History
+// History for PODs, e.g. double, int
+template <class T> class PODHistory : public Serialisable<>
+{
+    private:
+    // Stored historical data
+    std::vector<T> history_;
+
+    public:
+    // Push data into the history
+    void push(const T &data, int averagingLength)
+    {
+        // Push the current data onto the history stack
+        history_.emplace_back(data);
+
+        // Prune old data to get to the averagingLength
+        while (history_.size() > averagingLength)
+            history_.erase(history_.begin());
+    }
+    // Push data into the history and return current average
+    T pushAndAverage(const T &data, int averagingLength)
+    {
+        push(data, averagingLength);
+        return average();
+    }
+    // Return the current average value
+    T average() const
+    {
+        // Perform averaging of the datasets that we have
+        T averaged = T();
+
+        auto weight = 1.0 / history_.size();
+        for (auto &data : history_)
+            averaged += *data * weight;
+
+        return averaged;
+    }
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const
+    {
+        if (history_.empty())
+            return;
+
+        SerialisedValue data = {{"history", history_}};
+        target[tag] = data;
+    }
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override { history_ = toml::find<std::vector<T>>(node, "history"); }
+};

--- a/tests/classes/history.cpp
+++ b/tests/classes/history.cpp
@@ -18,6 +18,14 @@ TEST(History, SimpleIntegerNumbers)
         EXPECT_EQ(i.push(value, 5).asInteger(), value);
 }
 
+TEST(PODHistory, SimpleIntegerNumbers)
+{
+    PODHistory<int> i;
+    const auto value = 12345;
+    for (auto n = 0; n < 10; ++n)
+        EXPECT_EQ(i.pushAndAverage(value, 5), value);
+}
+
 TEST(History, SimpleDoubleNumbers)
 {
     History<Number> d;
@@ -27,6 +35,17 @@ TEST(History, SimpleDoubleNumbers)
     EXPECT_DOUBLE_EQ(d.push(3.0, avgLength).asDouble(), (1 + 2 + 3) / 3.0);
     EXPECT_DOUBLE_EQ(d.push(4.0, avgLength).asDouble(), (2 + 3 + 4) / 3.0);
     EXPECT_DOUBLE_EQ(d.push(5.0, avgLength).asDouble(), (3 + 4 + 5) / 3.0);
+}
+
+TEST(PODHistory, SimpleDoubleNumbers)
+{
+    PODHistory<double> d;
+    const auto avgLength = 3;
+    EXPECT_DOUBLE_EQ(d.pushAndAverage(1.0, avgLength), 1.0);
+    EXPECT_DOUBLE_EQ(d.pushAndAverage(2.0, avgLength), (1 + 2) / 2.0);
+    EXPECT_DOUBLE_EQ(d.pushAndAverage(3.0, avgLength), (1 + 2 + 3) / 3.0);
+    EXPECT_DOUBLE_EQ(d.pushAndAverage(4.0, avgLength), (2 + 3 + 4) / 3.0);
+    EXPECT_DOUBLE_EQ(d.pushAndAverage(5.0, avgLength), (3 + 4 + 5) / 3.0);
 }
 
 TEST(History, SimpleDeserialisation)


### PR DESCRIPTION
This PR adds a lightweight, principally numeric POD history class to sit alongside the existing one. The intended use is for tracking simple quantities such as energy values for some period of time during a simulation.