### PR TITLE
refactor: Parameter context

### DIFF
--- a/benchmark/modules/forces.cpp
+++ b/benchmark/modules/forces.cpp
@@ -2,7 +2,6 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "modules/forces/forces.h"
-#include "classes/cell.h"
 #include "common/problems.h"
 #include "kernels/producer.h"
 #include <benchmark/benchmark.h>
@@ -64,8 +63,8 @@ static void BM_CalculateForces_TotalIntraMolecular(benchmark::State &state)
     std::vector<Vector3> forces(cfg->nAtoms());
     auto forceKernel = createForceKernel(problemDef);
     for (auto _ : state)
-        forceKernel->totalForces(
-            forces, forces, {Kernel::ExcludeInterMolecularPairPotential, Kernel::ExcludeIntraMolecularPairPotential});
+        forceKernel->totalForces(forces, forces,
+                                 {Kernel::ExcludeInterMolecularPairPotential, Kernel::ExcludeIntraMolecularPairPotential});
 }
 
 template <SpeciesType speciesType, SpeciesPopulation population>

--- a/src/base/context.h
+++ b/src/base/context.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include <string>
+#include <variant>
+
+template <typename T> struct Context
+{
+  using type = std::monostate;
+};

--- a/src/base/context.h
+++ b/src/base/context.h
@@ -3,10 +3,9 @@
 
 #pragma once
 
-#include <string>
 #include <variant>
 
 template <typename T> struct Context
 {
-  using type = std::monostate;
+    using type = std::monostate;
 };

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -15,6 +15,7 @@
 #include <vector>
 
 // Forward Declarations
+class Configuration;
 class LineParser;
 class Site;
 class Species;
@@ -213,8 +214,6 @@ class SpeciesSite : public Serialisable<CoreData &>
     void serialise(std::string tag, SerialisedValue &target) const override;
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
 };
-
-class Configuration;
 
 template <> struct Context<const SpeciesSite *>
 {

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -12,7 +12,6 @@
 #include "data/elements.h"
 #include "math/vector3.h"
 #include "neta/neta.h"
-#include <map>
 #include <vector>
 
 // Forward Declarations
@@ -217,8 +216,7 @@ class SpeciesSite : public Serialisable<CoreData &>
 
 class Configuration;
 
-template <>
-struct Context<const SpeciesSite *>
+template <> struct Context<const SpeciesSite *>
 {
     using type = Configuration *;
 };

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/context.h"
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
 #include "base/version.h"
@@ -212,4 +213,12 @@ class SpeciesSite : public Serialisable<CoreData &>
 
     void serialise(std::string tag, SerialisedValue &target) const override;
     void deserialise(const SerialisedValue &node, CoreData &coreData) override;
+};
+
+class Configuration;
+
+template <>
+struct Context<const SpeciesSite *>
+{
+    using type = Configuration *;
 };

--- a/src/gui/models/nodeGraph/parameterModel.cpp
+++ b/src/gui/models/nodeGraph/parameterModel.cpp
@@ -65,6 +65,7 @@ QVariant ParameterModel::data(const QModelIndex &index, int role) const
         case MODEL:
             if (EnumRegistry::hasEnumOption(it->second->storedDataType()))
                 return QVariant::fromValue(EnumRegistry::options(it->second->storedDataType()).get());
+            return {};
 
         default:
             return {};

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -228,8 +228,8 @@ class Node : public Serialisable<>
             Messenger::exception("Output parameter '{}' already exists, and can't be added again.", outputName);
 
         auto param = outputs_
-                         .emplace(std::make_pair(
-                                                 outputName, ParameterFactory::createPointer<ClassObject>(this, outputName, description, object, {})))
+                         .emplace(std::make_pair(outputName, ParameterFactory::createPointer<ClassObject>(
+                                                                 this, outputName, description, object, {})))
                          .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Output);
         return param;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/context.h"
 #include "base/messenger.h"
 #include "base/serialiser.h"
 #include "module/module.h"
@@ -228,7 +229,7 @@ class Node : public Serialisable<>
 
         auto param = outputs_
                          .emplace(std::make_pair(
-                             outputName, ParameterFactory::createPointer<ClassObject>(this, outputName, description, object)))
+                                                 outputName, ParameterFactory::createPointer<ClassObject>(this, outputName, description, object, {})))
                          .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Output);
         return param;

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -4,8 +4,10 @@
 #include "nodes/parameter.h"
 #include "nodes/node.h"
 
-ParameterBase::ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType)
-    : parent_(parent), name_(name), description_(description), storedDataType_(storedDataType)
+ParameterBase::ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType,
+                             std::type_index contextDataType)
+    : parent_(parent), name_(name), description_(description), storedDataType_(storedDataType),
+      contextDataType_(contextDataType)
 {
 }
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -135,7 +135,7 @@ class ParameterBase : public Serialisable<>
             throw(std::runtime_error(std::format("ParameterBase::get() failed to cast, name = {}.\n", name_)));
         return cast->getData();
     }
-    // Get the parameter's value
+    // Get the parameter's context
     template <typename DataClass> Context<DataClass>::type context()
     {
         // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
@@ -299,7 +299,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     protected:
     // Reference to target data
     DataClass &data_;
-    // Reference to target data
+    // Reference to target context
     Context<DataClass>::type context_;
     // Specialised container for local pointer referencing, if relevant
     std::conditional_t<std::is_pointer_v<DataClass>, DataClass, bool> localPointer_;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/context.h"
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
 #include "classes/coreData.h"
@@ -13,14 +14,13 @@
 #include <stdexcept>
 #include <string>
 #include <typeindex>
-#include <variant>
 #include <vector>
 
 // Forward Declarations
 class Node;
 class ParameterBase;
-template <typename T, typename C = std::monostate> class Parameter;
-template <typename T, typename C = std::monostate> class SerialisableParameter;
+template <typename T> class Parameter;
+template <typename T> class SerialisableParameter;
 
 // Parameter Proxy
 template <class T> class ParameterProxy
@@ -136,16 +136,16 @@ class ParameterBase : public Serialisable<>
         return cast->getData();
     }
     // Get the parameter's value
-    template <typename DataClass, typename ContextClass> ContextClass context()
+    template <typename DataClass> Context<DataClass>::type context()
     {
         // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
-        if (std::type_index(typeid(ContextClass)) != contextDataType_)
-            throw(
-                std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
-                                               std::type_index(typeid(ContextClass)).name(), contextDataType_.name(), name_)));
+        if (std::type_index(typeid(typename Context<DataClass>::type)) != contextDataType_)
+            throw(std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
+                                                 std::type_index(typeid(typename Context<DataClass>::type)).name(),
+                                                 contextDataType_.name(), name_)));
 
         // Upcast to Parameter<T> (common base of all parameter types)
-        auto cast = dynamic_cast<Parameter<DataClass, ContextClass> *>(this);
+        auto cast = dynamic_cast<Parameter<DataClass> *>(this);
         if (!cast)
             throw(std::runtime_error(std::format("ParameterBase::context() failed to cast, name = {}.\n", name_)));
         return cast->getData();
@@ -182,21 +182,23 @@ class ParameterBase : public Serialisable<>
 namespace ParameterFactory
 {
 template <typename DataClass>
-std::shared_ptr<ParameterBase> create(Node *parent, std::string_view name, std::string_view description, DataClass &value)
+std::shared_ptr<ParameterBase> create(Node *parent, std::string_view name, std::string_view description, DataClass &value,
+                                      typename Context<DataClass>::type context = {})
 {
-    return std::make_shared<Parameter<DataClass>>(parent, name, description, value);
+    return std::make_shared<Parameter<DataClass>>(parent, name, description, value, context);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createPointer(Node *parent, std::string_view name, std::string_view description,
-                                             DataClass &fromObject)
+                                             DataClass &fromObject, typename Context<DataClass>::type context = {})
 {
-    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromObject);
+    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromObject, context);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createPointer(Node *parent, std::string_view name, std::string_view description,
-                                             std::optional<DataClass> &fromOptional)
+                                             std::optional<DataClass> &fromOptional,
+                                             typename Context<DataClass>::type context = {})
 {
-    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromOptional);
+    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromOptional, context);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view name, std::string_view description,
@@ -207,50 +209,51 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 }; // namespace ParameterFactory
 
 // Primary type for a Parameter to a specific DataClass
-template <typename DataClass, typename Context>
-class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
+template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
 {
     public:
-    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
+    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
+              typename Context<DataClass>::type context)
         requires(is_instance_of_v<DataClass, std::vector>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
+                        std::type_index(typeid(typename Context<DataClass>::type))),
           data_(value), default_(value)
     {
     }
-    Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value)
+    Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value,
+              typename Context<DataClass>::type context)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
+                        std::type_index(typeid(typename Context<DataClass>::type))),
           data_(localPointer_), default_(nullptr), dataGetter_([&]() { return &value; }),
-          dataSetter_([](const DataClass &value) { return false; }), context_(std::monostate{})
+          dataSetter_([](const DataClass &value) { return false; }), context_(context)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
-              std::optional<std::remove_pointer_t<DataClass>> &targetData)
+              std::optional<std::remove_pointer_t<DataClass>> &targetData, typename Context<DataClass>::type context)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
+                        std::type_index(typeid(typename Context<DataClass>::type))),
           data_(localPointer_), default_(nullptr),
           dataGetter_([&]() { return targetData.has_value() ? &targetData.value() : nullptr; }),
-          dataSetter_([](const DataClass &value) { return false; }), context_(std::monostate{})
+          dataSetter_([](const DataClass &value) { return false; }), context_(context)
     {
     }
-    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
-          data_(value), default_(value), context_(std::monostate{})
+    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
+              typename Context<DataClass>::type context)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
+                        std::type_index(typeid(typename Context<DataClass>::type))),
+          data_(value), default_(value), context_(context)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::shared_ptr<ParameterProxy<DataClass>> &proxy)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
-          data_(proxy->data), default_(proxy->data), context_(std::monostate{})
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
+                        std::type_index(typeid(typename Context<DataClass>::type))),
+          data_(proxy->data), default_(proxy->data), context_{}
     {
         // Store the proxy data smart pointer to preserve the lifetime of the data
         proxyData_ = proxy;
-    }
-    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value, Context &context)
-        requires(is_instance_of_v<DataClass, std::vector>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
-          data_(value), default_(value), context_(context)
-    {
     }
     virtual ~Parameter() = default;
 
@@ -297,7 +300,7 @@ class Parameter : public ParameterBase, public std::enable_shared_from_this<Para
     // Reference to target data
     DataClass &data_;
     // Reference to target data
-    Context context_;
+    Context<DataClass>::type context_;
     // Specialised container for local pointer referencing, if relevant
     std::conditional_t<std::is_pointer_v<DataClass>, DataClass, bool> localPointer_;
     // Getter for target data, defaulting so simple return of data_ reference member
@@ -416,11 +419,12 @@ class Parameter : public ParameterBase, public std::enable_shared_from_this<Para
 };
 
 // Primary type for a Parameter to a specific DataClass
-template <typename DataClass, typename Context> class SerialisableParameter : public Parameter<DataClass>
+template <typename DataClass> class SerialisableParameter : public Parameter<DataClass>
 {
     public:
-    SerialisableParameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
-        : Parameter<DataClass, Context>(parent, name, description, value)
+    SerialisableParameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
+                          typename Context<DataClass>::type context = {})
+        : Parameter<DataClass>(parent, name, description, value, context)
     {
     }
     // Helper templates for handling serialisation

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -7,7 +7,6 @@
 #include "base/serialiser.h"
 #include "classes/coreData.h"
 #include "math/data1D.h"
-#include "math/function1D.h"
 #include "nodes/number.h"
 #include "templates/algorithms.h"
 #include "templates/flags.h"
@@ -21,8 +20,8 @@
 // Forward Declarations
 class Node;
 class ParameterBase;
-template <typename T> class Parameter;
-template <typename T> class SerialisableParameter;
+template <typename T, typename C = void> class Parameter;
+template <typename T, typename C = void> class SerialisableParameter;
 
 // Parameter Proxy
 template <class T> class ParameterProxy
@@ -44,7 +43,8 @@ struct ParameterLink
 class ParameterBase : public Serialisable<>
 {
     public:
-    ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType);
+    ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType,
+                  std::type_index contextDataType);
     virtual ~ParameterBase() = default;
 
     // Parameter Flags
@@ -76,6 +76,8 @@ class ParameterBase : public Serialisable<>
     std::string description_;
     // Stored data type in the parameter
     std::type_index storedDataType_;
+    // Stored data type of the context
+    std::type_index contextDataType_;
     // Flags for the parameter
     Flags<ParameterBase::ParameterFlags> flags_;
 
@@ -132,6 +134,20 @@ class ParameterBase : public Serialisable<>
         auto cast = dynamic_cast<Parameter<DataClass> *>(this);
         if (!cast)
             throw(std::runtime_error(std::format("ParameterBase::get() failed to cast, name = {}.\n", name_)));
+        return cast->getData();
+    }
+    // Get the parameter's value
+    template <typename DataClass, typename ContextClass> ContextClass context()
+    {
+        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
+        if (std::type_index(typeid(ContextClass)) != contextDataType_)
+            throw(std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
+                                                 std::type_index(typeid(ContextClass)).name(), storedDataType_.name(), name_)));
+
+        // Upcast to Parameter<T> (common base of all parameter types)
+        auto cast = dynamic_cast<Parameter<DataClass, ContextClass> *>(this);
+        if (!cast)
+            throw(std::runtime_error(std::format("ParameterBase::context() failed to cast, name = {}.\n", name_)));
         return cast->getData();
     }
     // Set the parameter's value
@@ -191,36 +207,41 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 }; // namespace ParameterFactory
 
 // Primary type for a Parameter to a specific DataClass
-template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
+template <typename DataClass, typename Context>
+class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
 {
     public:
     Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
         requires(is_instance_of_v<DataClass, std::vector>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(value), default_(value)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+          data_(value), default_(value)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(localPointer_), default_(nullptr),
-          dataGetter_([&]() { return &value; }), dataSetter_([](const DataClass &value) { return false; })
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+          data_(localPointer_), default_(nullptr), dataGetter_([&]() { return &value; }),
+          dataSetter_([](const DataClass &value) { return false; })
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::optional<std::remove_pointer_t<DataClass>> &targetData)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(localPointer_), default_(nullptr),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+          data_(localPointer_), default_(nullptr),
           dataGetter_([&]() { return targetData.has_value() ? &targetData.value() : nullptr; }),
           dataSetter_([](const DataClass &value) { return false; })
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(value), default_(value)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+          data_(value), default_(value)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::shared_ptr<ParameterProxy<DataClass>> &proxy)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(proxy->data),
-          default_(proxy->data)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+          data_(proxy->data), default_(proxy->data)
     {
         // Store the proxy data smart pointer to preserve the lifetime of the data
         proxyData_ = proxy;
@@ -387,11 +408,11 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 };
 
 // Primary type for a Parameter to a specific DataClass
-template <typename DataClass> class SerialisableParameter : public Parameter<DataClass>
+template <typename DataClass, typename Context> class SerialisableParameter : public Parameter<DataClass>
 {
     public:
     SerialisableParameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
-        : Parameter<DataClass>(parent, name, description, value)
+        : Parameter<DataClass, Context>(parent, name, description, value)
     {
     }
     // Helper templates for handling serialisation

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -13,15 +13,14 @@
 #include <stdexcept>
 #include <string>
 #include <typeindex>
+#include <variant>
 #include <vector>
-
-#include <iostream>
 
 // Forward Declarations
 class Node;
 class ParameterBase;
-template <typename T, typename C = void> class Parameter;
-template <typename T, typename C = void> class SerialisableParameter;
+template <typename T, typename C = std::monostate> class Parameter;
+template <typename T, typename C = std::monostate> class SerialisableParameter;
 
 // Parameter Proxy
 template <class T> class ParameterProxy
@@ -141,8 +140,9 @@ class ParameterBase : public Serialisable<>
     {
         // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
         if (std::type_index(typeid(ContextClass)) != contextDataType_)
-            throw(std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
-                                                 std::type_index(typeid(ContextClass)).name(), storedDataType_.name(), name_)));
+            throw(
+                std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
+                                               std::type_index(typeid(ContextClass)).name(), contextDataType_.name(), name_)));
 
         // Upcast to Parameter<T> (common base of all parameter types)
         auto cast = dynamic_cast<Parameter<DataClass, ContextClass> *>(this);
@@ -213,38 +213,44 @@ class Parameter : public ParameterBase, public std::enable_shared_from_this<Para
     public:
     Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
         requires(is_instance_of_v<DataClass, std::vector>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
           data_(value), default_(value)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
           data_(localPointer_), default_(nullptr), dataGetter_([&]() { return &value; }),
-          dataSetter_([](const DataClass &value) { return false; })
+          dataSetter_([](const DataClass &value) { return false; }), context_(std::monostate{})
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::optional<std::remove_pointer_t<DataClass>> &targetData)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
           data_(localPointer_), default_(nullptr),
           dataGetter_([&]() { return targetData.has_value() ? &targetData.value() : nullptr; }),
-          dataSetter_([](const DataClass &value) { return false; })
+          dataSetter_([](const DataClass &value) { return false; }), context_(std::monostate{})
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
-          data_(value), default_(value)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+          data_(value), default_(value), context_(std::monostate{})
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::shared_ptr<ParameterProxy<DataClass>> &proxy)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(void))),
-          data_(proxy->data), default_(proxy->data)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+          data_(proxy->data), default_(proxy->data), context_(std::monostate{})
     {
         // Store the proxy data smart pointer to preserve the lifetime of the data
         proxyData_ = proxy;
+    }
+    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value, Context &context)
+        requires(is_instance_of_v<DataClass, std::vector>)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)), std::type_index(typeid(Context))),
+          data_(value), default_(value), context_(context)
+    {
     }
     virtual ~Parameter() = default;
 
@@ -290,6 +296,8 @@ class Parameter : public ParameterBase, public std::enable_shared_from_this<Para
     protected:
     // Reference to target data
     DataClass &data_;
+    // Reference to target data
+    Context context_;
     // Specialised container for local pointer referencing, if relevant
     std::conditional_t<std::is_pointer_v<DataClass>, DataClass, bool> localPointer_;
     // Getter for target data, defaulting so simple return of data_ reference member


### PR DESCRIPTION
Allows types to define a context type.  Declaring the parameter then requires that the context be passed in, if and only if there *is* a context.

I went with `std::monostate` for two reasons.  First, it's the "official" type of empty data.  As such, it includes such niceties as default and copy constructors.  Secondly, as the official empty data type, it will take up zero bytes the moment that that is possible.  It also gives the compiler the best opportunity to optimise out the context call in the parameter.