### PR TITLE
feat: Mermaid diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ aqtinstall.log
 *.gr
 *.sq
 *.rewrite
+*.mermaid
 tests/data/*.xml
 tests/epsr/D2O-ReferenceData.q
 tests/epsr/D2O-ReferenceData.r

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -6,7 +6,7 @@
 #include "nodes/inputs.h"
 #include "nodes/outputs.h"
 #include "nodes/registry.h"
-#include "species.h"
+#include <algorithm>
 
 Graph::Graph(Graph *parentGraph) : Node(parentGraph)
 {
@@ -274,4 +274,48 @@ void Graph::deserialise(const SerialisedValue &node)
               child->deserialise(value);
           });
     toVector(node, "edges", [this](const auto &value) { addEdge(toml::get<EdgeDefinition>(value)); });
+}
+
+static const std::vector<std::string> DATA_NAMES = {"Species", "Configuration", "Data1DImport"};
+static const std::vector<std::string> MATH_NAMES = {"Add", "Subtract", "Multiply", "Dot Product", "Integrator", "Derivative"};
+static const std::vector<std::string> GRAPH_NAMES = {"Dissolve", "Graph", "Iterator"};
+
+// Print as mermaid state diagram
+std::string Graph::to_mermaid(int depth) const
+{
+    std::string result{}, spacer{};
+    spacer.resize(depth);
+    std::ranges::fill(spacer, ' ');
+    for (auto &[k, v] : nodes_)
+    {
+        if (std::ranges::find(DATA_NAMES, v->type()) != DATA_NAMES.end())
+            result += spacer + std::string("class ") + std::string(v->name()) + " data\n";
+        else if (std::ranges::find(MATH_NAMES, v->type()) != MATH_NAMES.end())
+            result += spacer + std::string("class ") + std::string(v->name()) + " math\n";
+        else if (std::ranges::find(GRAPH_NAMES, v->type()) != GRAPH_NAMES.end())
+        {
+            result += spacer + std::string("state ") + std::string(v->name()) + " {\n";
+            auto casted = dynamic_cast<Graph *>(v.get());
+            if (casted)
+            {
+                result += casted->to_mermaid(depth + 4);
+            }
+            result += spacer + "}\n";
+        }
+    }
+    for (auto &edge : edges_)
+    {
+        result += spacer + std::string(edge->sourceNode().name()) + " --> " + std::string(edge->targetNode().name()) + ":" +
+                  std::string(edge->sourceOutput().name()) + "-" + std::string(edge->targetInput().name()) + "\n";
+    }
+    return result;
+}
+
+std::ostream &operator<<(std::ostream &stream, const Graph &node)
+{
+    stream << "stateDiagram-v2" << std::endl;
+    stream << "    classDef data fill:#FFD0D0" << std::endl;
+    stream << "    classDef math fill:#D0FFD0" << std::endl;
+    stream << node.to_mermaid(4);
+    return stream;
 }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -280,21 +280,38 @@ static const std::vector<std::string> DATA_NAMES = {"Species", "Configuration", 
 static const std::vector<std::string> MATH_NAMES = {"Add", "Subtract", "Multiply", "Dot Product", "Integrator", "Derivative"};
 static const std::vector<std::string> GRAPH_NAMES = {"Dissolve", "Graph", "Iterator"};
 
+// Generate random names for the mermaid conversion
+std::string randomName()
+{
+    const int length = 10;
+    const std::string characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    std::string result;
+
+    for (size_t i = 0; i < length; ++i)
+    {
+        result += characters[std::rand() % characters.size()];
+    }
+    return result;
+}
+
 // Print as mermaid state diagram
 std::string Graph::to_mermaid(int depth) const
 {
     std::string result{}, spacer{};
     spacer.resize(depth);
     std::ranges::fill(spacer, ' ');
+    std::map<Node *, std::string> pseudo_names;
     for (auto &[k, v] : nodes_)
     {
+        auto name = randomName();
+        pseudo_names[v.get()] = name;
         if (std::ranges::find(DATA_NAMES, v->type()) != DATA_NAMES.end())
-            result += spacer + std::string("class ") + std::string(v->name()) + " data\n";
+            result += spacer + std::string("class ") + name + " data\n";
         else if (std::ranges::find(MATH_NAMES, v->type()) != MATH_NAMES.end())
-            result += spacer + std::string("class ") + std::string(v->name()) + " math\n";
+            result += spacer + std::string("class ") + name + " math\n";
         else if (std::ranges::find(GRAPH_NAMES, v->type()) != GRAPH_NAMES.end())
         {
-            result += spacer + std::string("state ") + std::string(v->name()) + " {\n";
+            result += spacer + std::string("state ") + name + " {\n";
             auto casted = dynamic_cast<Graph *>(v.get());
             if (casted)
             {
@@ -302,10 +319,11 @@ std::string Graph::to_mermaid(int depth) const
             }
             result += spacer + "}\n";
         }
+        result += spacer + name + " : " + std::string(v->name()) + "\n";
     }
     for (auto &edge : edges_)
     {
-        result += spacer + std::string(edge->sourceNode().name()) + " --> " + std::string(edge->targetNode().name()) + ":" +
+        result += spacer + pseudo_names[&edge->sourceNode()] + " --> " + pseudo_names[&edge->targetNode()] + ":" +
                   edge->sourceOutput().storedDataType().name() + "\n";
     }
     return result;

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -7,6 +7,7 @@
 #include "nodes/outputs.h"
 #include "nodes/registry.h"
 #include <algorithm>
+#include <codecvt>
 
 Graph::Graph(Graph *parentGraph) : Node(parentGraph)
 {
@@ -276,8 +277,15 @@ void Graph::deserialise(const SerialisedValue &node)
     toVector(node, "edges", [this](const auto &value) { addEdge(toml::get<EdgeDefinition>(value)); });
 }
 
+/*
+ *Mermaid processing code
+ */
+
+// Node types that represent data sources
 static const std::vector<std::string> DATA_NAMES = {"Species", "Configuration", "Data1DImport"};
+// Node types that represent math operations
 static const std::vector<std::string> MATH_NAMES = {"Add", "Subtract", "Multiply", "Dot Product", "Integrator", "Derivative"};
+// Node types that contain subgraphs
 static const std::vector<std::string> GRAPH_NAMES = {"Dissolve", "Graph", "Iterator"};
 
 // Generate random names for the mermaid conversion
@@ -332,8 +340,8 @@ std::string Graph::to_mermaid(int depth) const
 std::ostream &operator<<(std::ostream &stream, const Graph &node)
 {
     stream << "stateDiagram-v2" << std::endl;
-    stream << "    classDef data fill:#FFD0D0" << std::endl;
-    stream << "    classDef math fill:#D0FFD0" << std::endl;
+    stream << "    classDef data fill:#FFD0D0,color:#000000" << std::endl;
+    stream << "    classDef math fill:#D0FFD0,color:#000000" << std::endl;
     stream << node.to_mermaid(4);
     return stream;
 }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -292,12 +292,13 @@ static const std::vector<std::string> GRAPH_NAMES = {"Dissolve", "Graph", "Itera
 std::string randomName()
 {
     std::string result(10, ' ');
-    std::ranges::generate(result, []{ return std::string_view("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").at(rand() % 52); });
+    std::ranges::generate(result, []
+                          { return std::string_view("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").at(rand() % 52); });
     return result;
 }
 
 // Print as mermaid state diagram
-std::string Graph::to_mermaid(int depth) const
+std::string Graph::toMermaid(int depth) const
 {
     std::string result{}, spacer{};
     spacer.resize(depth);
@@ -317,7 +318,7 @@ std::string Graph::to_mermaid(int depth) const
             auto casted = dynamic_cast<Graph *>(v.get());
             if (casted)
             {
-                result += casted->to_mermaid(depth + 4);
+                result += casted->toMermaid(depth + 4);
             }
             result += spacer + "}\n";
         }
@@ -336,6 +337,6 @@ std::ostream &operator<<(std::ostream &stream, const Graph &node)
     stream << "stateDiagram-v2" << std::endl;
     stream << "    classDef data fill:#FFD0D0,color:#000000" << std::endl;
     stream << "    classDef math fill:#D0FFD0,color:#000000" << std::endl;
-    stream << node.to_mermaid(4);
+    stream << node.toMermaid(4);
     return stream;
 }

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -291,14 +291,8 @@ static const std::vector<std::string> GRAPH_NAMES = {"Dissolve", "Graph", "Itera
 // Generate random names for the mermaid conversion
 std::string randomName()
 {
-    const int length = 10;
-    const std::string characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
-    std::string result;
-
-    for (size_t i = 0; i < length; ++i)
-    {
-        result += characters[std::rand() % characters.size()];
-    }
+    std::string result(10, ' ');
+    std::ranges::generate(result, []{ return std::string_view("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz").at(rand() % 52); });
     return result;
 }
 

--- a/src/nodes/graph.cpp
+++ b/src/nodes/graph.cpp
@@ -306,7 +306,7 @@ std::string Graph::to_mermaid(int depth) const
     for (auto &edge : edges_)
     {
         result += spacer + std::string(edge->sourceNode().name()) + " --> " + std::string(edge->targetNode().name()) + ":" +
-                  std::string(edge->sourceOutput().name()) + "-" + std::string(edge->targetInput().name()) + "\n";
+                  edge->sourceOutput().storedDataType().name() + "\n";
     }
     return result;
 }

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -107,7 +107,7 @@ class Graph : public Node
     // Return a path to this graph from the root
     std::string location() const;
     // Print as mermaid state diagram
-    std::string to_mermaid(int depth) const;
+    std::string toMermaid(int depth) const;
     friend std::ostream &operator<<(std::ostream &stream, const Graph &node);
 
     /*

--- a/src/nodes/graph.h
+++ b/src/nodes/graph.h
@@ -106,6 +106,9 @@ class Graph : public Node
     Edges &edges();
     // Return a path to this graph from the root
     std::string location() const;
+    // Print as mermaid state diagram
+    std::string to_mermaid(int depth) const;
+    friend std::ostream &operator<<(std::ostream &stream, const Graph &node);
 
     /*
      * Serialisation

--- a/tests/mermaid.h
+++ b/tests/mermaid.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "nodes/graph.h"
+#include <gtest/gtest.h>
+#include <optional>
+#include <string>
+
+namespace UnitTest
+{
+
+void export_mermaid_graph(Graph &graph, std::optional<std::string> context = {})
+{
+    auto suite = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();
+    auto name = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+    std::string filename = std::format("{}-{}.mermaid", suite, name);
+    if (context)
+        filename = std::format("{}-{}-{}.mermaid", suite, name, filename);
+
+    std::ofstream myfile;
+    myfile.open(filename);
+    myfile << graph;
+    myfile.close();
+}
+} // namespace UnitTest

--- a/tests/nodes/angle.cpp
+++ b/tests/nodes/angle.cpp
@@ -7,7 +7,6 @@
 #include "math/rangedVector3.h"
 #include "nodes/iterableGraph.h"
 #include "tests/graphData.h"
-#include "tests/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -61,7 +60,6 @@ TEST(AngleNodeTest, Water)
                                                 {"dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.angle.norm",
                                                  Data1DImportFileFormat::Data1DImportFormat::XY},
                                                 6.0e-5));
-    export_mermaid_graph(data.graphRoot);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/angle.cpp
+++ b/tests/nodes/angle.cpp
@@ -7,6 +7,7 @@
 #include "math/rangedVector3.h"
 #include "nodes/iterableGraph.h"
 #include "tests/graphData.h"
+#include "tests/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -60,6 +61,7 @@ TEST(AngleNodeTest, Water)
                                                 {"dlpoly/water267-analysis/water-267-298K.dahist1_02_1_01_02.angle.norm",
                                                  Data1DImportFileFormat::Data1DImportFormat::XY},
                                                 6.0e-5));
+    export_mermaid_graph(data.graphRoot);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -12,6 +12,7 @@
 #include "nodes/iterableGraph.h"
 #include "nodes/numberNode.h"
 #include "nodes/species.h"
+#include "tests/mermaid.h"
 #include "tests/speciesData.h"
 #include "tests/testData.h"
 #include <array>
@@ -90,6 +91,7 @@ TEST(AtomShakeTest, Water)
     EXPECT_NEAR(rMin01, 1.0, 1.0e-4);
     EXPECT_NEAR(rMin02, 1.0, 1.0e-4);
     EXPECT_NEAR(angle102, 113.24, 1.7e-3);
+    export_mermaid_graph(root);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -12,7 +12,7 @@
 #include "nodes/iterableGraph.h"
 #include "nodes/numberNode.h"
 #include "nodes/species.h"
-#include "tests/mermaid.h"
+#include "tests/nodes/mermaid.h"
 #include "tests/speciesData.h"
 #include "tests/testData.h"
 #include <array>

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -91,7 +91,7 @@ TEST(AtomShakeTest, Water)
     EXPECT_NEAR(rMin01, 1.0, 1.0e-4);
     EXPECT_NEAR(rMin02, 1.0, 1.0e-4);
     EXPECT_NEAR(angle102, 113.24, 1.7e-3);
-    export_mermaid_graph(root);
+    exportMermaidGraph(root);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -6,6 +6,7 @@
 #include "nodes/graph.h"
 #include "nodes/number.h"
 #include "nodes/numberNode.h"
+#include "tests/mermaid.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -230,6 +231,7 @@ TEST_F(GraphFlowTest, RemoveEdges)
     x2a->set(Number{20});
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(z_->findOutput("Result")->get<Number>().asInteger(), 30);
+    export_mermaid_graph(graph_);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -231,7 +231,7 @@ TEST_F(GraphFlowTest, RemoveEdges)
     x2a->set(Number{20});
     EXPECT_EQ(z_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(z_->findOutput("Result")->get<Number>().asInteger(), 30);
-    export_mermaid_graph(graph_);
+    exportMermaidGraph(graph_);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/flow.cpp
+++ b/tests/nodes/flow.cpp
@@ -6,7 +6,7 @@
 #include "nodes/graph.h"
 #include "nodes/number.h"
 #include "nodes/numberNode.h"
-#include "tests/mermaid.h"
+#include "tests/nodes/mermaid.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -4,6 +4,7 @@
 #include "nodes/gr/gr.h"
 #include "math/windowFunction.h"
 #include "tests/graphData.h"
+#include "tests/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -35,6 +36,7 @@ TEST(GRNodeTest, Methods)
     auto rawGRCells = *grNode->getOutputValue<PartialSet *>("RawGR");
     ASSERT_EQ(grNode->versionIndex(), 2);
     ASSERT_TRUE(DissolveSystemTest::checkPartialSet(rawGRBaseline, rawGRCells, 1.0e-8));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(GRNodeTest, Water)
@@ -79,6 +81,7 @@ TEST(GRNodeTest, Water)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         rawGR->boundPartials().get(DoubleKeyedMapKey("HW", "HW")), "HW-HW Bound Partial",
         {"epsr25/water1000-neutron/water.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 1.5e-2));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(GRNodeTest, WaterMethanol)
@@ -251,6 +254,7 @@ TEST(GRNodeTest, WaterMethanol)
         rawGR->boundPartials().get(DoubleKeyedMapKey("HO", "HO")), "HO-HO Bound Partial",
         {"epsr25/water300methanol600/watermeth.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 42}, 1.0e-5,
         Error::ErrorType::RMSEError));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(GRNodeTest, Benzene)
@@ -292,6 +296,7 @@ TEST(GRNodeTest, Benzene)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         rawGR->boundPartials().get(DoubleKeyedMapKey("HA", "HA")), "HA-HA Bound Partial",
         {"epsr25/benzene200-neutron/benzene.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 9.0e-2));
+    export_mermaid_graph(data.graphRoot);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -4,7 +4,7 @@
 #include "nodes/gr/gr.h"
 #include "math/windowFunction.h"
 #include "tests/graphData.h"
-#include "tests/mermaid.h"
+#include "tests/nodes/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -36,7 +36,7 @@ TEST(GRNodeTest, Methods)
     auto rawGRCells = *grNode->getOutputValue<PartialSet *>("RawGR");
     ASSERT_EQ(grNode->versionIndex(), 2);
     ASSERT_TRUE(DissolveSystemTest::checkPartialSet(rawGRBaseline, rawGRCells, 1.0e-8));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(GRNodeTest, Water)
@@ -81,7 +81,7 @@ TEST(GRNodeTest, Water)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         rawGR->boundPartials().get(DoubleKeyedMapKey("HW", "HW")), "HW-HW Bound Partial",
         {"epsr25/water1000-neutron/water.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 1.5e-2));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(GRNodeTest, WaterMethanol)
@@ -254,7 +254,7 @@ TEST(GRNodeTest, WaterMethanol)
         rawGR->boundPartials().get(DoubleKeyedMapKey("HO", "HO")), "HO-HO Bound Partial",
         {"epsr25/water300methanol600/watermeth.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 42}, 1.0e-5,
         Error::ErrorType::RMSEError));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(GRNodeTest, Benzene)
@@ -296,7 +296,7 @@ TEST(GRNodeTest, Benzene)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         rawGR->boundPartials().get(DoubleKeyedMapKey("HA", "HA")), "HA-HA Bound Partial",
         {"epsr25/benzene200-neutron/benzene.EPSR.y01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 9.0e-2));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -5,6 +5,7 @@
 #include "nodes/dissolve.h"
 #include "nodes/registry.h"
 #include "tests/graphData.h"
+#include "tests/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -114,20 +115,4 @@ TEST_F(GraphCoreTest, NodeCreation)
     // Wrong case in existing node type (succeeds with non-strict type name checking)
     EXPECT_EQ(NodeRegistry::getNodeTypesFuzzy("prod")[0], "DotProduct");
 }
-
-TEST_F(GraphCoreTest, NodePrinting)
-{
-    using namespace std::string_literals;
-    GraphTestData data;
-    createArgonGraph(&data.graphRoot, 1000,
-                     CoordinateImportFileFormat("dissolve2/argon/Ar_bulk_step1000.xyz",
-                                                CoordinateImportFileFormat::CoordinateImportFormat::XYZ));
-
-    std::stringstream str;
-    str << data.graphRoot;
-    ASSERT_EQ(str.str(),
-              "stateDiagram-v2\n    classDef data fill:#FFD0D0\n    classDef math fill:#D0FFD0\n    class Argon data\n    class Bulk data\n    class Yarnell data\n    Argon --> Insert:Species-Species\n    Bulk --> Insert:Configuration-Configuration\n    Insert --> Import:Configuration-Configuration\n    Import --> GR:Configuration-Configuration\n    GR --> SQ:UnweightedGR-UnweightedGR\n    SQ --> NeutronSQ:UnweightedGR-UnweightedGR\n    SQ --> NeutronSQ:UnweightedSQ-UnweightedSQ\n    Yarnell --> NeutronSQ:Data-ReferenceData\n"s
-                );
 }
-
-} // namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -4,6 +4,7 @@
 #include "nodes/add.h"
 #include "nodes/dissolve.h"
 #include "nodes/registry.h"
+#include "tests/graphData.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -112,6 +113,21 @@ TEST_F(GraphCoreTest, NodeCreation)
 
     // Wrong case in existing node type (succeeds with non-strict type name checking)
     EXPECT_EQ(NodeRegistry::getNodeTypesFuzzy("prod")[0], "DotProduct");
+}
+
+TEST_F(GraphCoreTest, NodePrinting)
+{
+    using namespace std::string_literals;
+    GraphTestData data;
+    createArgonGraph(&data.graphRoot, 1000,
+                     CoordinateImportFileFormat("dissolve2/argon/Ar_bulk_step1000.xyz",
+                                                CoordinateImportFileFormat::CoordinateImportFormat::XYZ));
+
+    std::stringstream str;
+    str << data.graphRoot;
+    ASSERT_EQ(str.str(),
+              "stateDiagram-v2\n    classDef data fill:#FFD0D0\n    classDef math fill:#D0FFD0\n    class Argon data\n    class Bulk data\n    class Yarnell data\n    Argon --> Insert:Species-Species\n    Bulk --> Insert:Configuration-Configuration\n    Insert --> Import:Configuration-Configuration\n    Import --> GR:Configuration-Configuration\n    GR --> SQ:UnweightedGR-UnweightedGR\n    SQ --> NeutronSQ:UnweightedGR-UnweightedGR\n    SQ --> NeutronSQ:UnweightedSQ-UnweightedSQ\n    Yarnell --> NeutronSQ:Data-ReferenceData\n"s
+                );
 }
 
 } // namespace UnitTest

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -5,7 +5,7 @@
 #include "nodes/dissolve.h"
 #include "nodes/registry.h"
 #include "tests/graphData.h"
-#include "tests/mermaid.h"
+#include "tests/nodes/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -115,4 +115,4 @@ TEST_F(GraphCoreTest, NodeCreation)
     // Wrong case in existing node type (succeeds with non-strict type name checking)
     EXPECT_EQ(NodeRegistry::getNodeTypesFuzzy("prod")[0], "DotProduct");
 }
-}
+} // namespace UnitTest

--- a/tests/nodes/mermaid.h
+++ b/tests/nodes/mermaid.h
@@ -11,6 +11,7 @@
 namespace UnitTest
 {
 
+// Save the graph in Mermaid format to a file named after the unit test
 void export_mermaid_graph(Graph &graph, std::optional<std::string> context = {})
 {
     auto suite = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();

--- a/tests/nodes/mermaid.h
+++ b/tests/nodes/mermaid.h
@@ -12,7 +12,7 @@ namespace UnitTest
 {
 
 // Save the graph in Mermaid format to a file named after the unit test
-void export_mermaid_graph(Graph &graph, std::optional<std::string> context = {})
+void exportMermaidGraph(Graph &graph, std::optional<std::string> context = {})
 {
     auto suite = ::testing::UnitTest::GetInstance()->current_test_info()->test_suite_name();
     auto name = ::testing::UnitTest::GetInstance()->current_test_info()->name();

--- a/tests/nodes/neutronSQ.cpp
+++ b/tests/nodes/neutronSQ.cpp
@@ -4,7 +4,7 @@
 #include "math/windowFunction.h"
 #include "nodes/gr/gr.h"
 #include "tests/graphData.h"
-#include "tests/mermaid.h"
+#include "tests/nodes/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 

--- a/tests/nodes/neutronSQ.cpp
+++ b/tests/nodes/neutronSQ.cpp
@@ -50,7 +50,7 @@ TEST(NeutronSQNodeTest, Water)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         HDO->getOutputValue<PartialSet *>("WeightedSQ")->total(), "Total F(Q)",
         {"epsr25/water1000-neutron/water.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 2.0e-5));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, WaterReferenceFT)
@@ -92,7 +92,7 @@ TEST(NeutronSQNodeTest, WaterReferenceFT)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         HDO->getOutputValue<Data1D>("ReferenceGR"), "HDO Reference G(r)",
         {"epsr25/water1000-neutron-xray/water.EPSR.w01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 5.0e-5));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, WaterMethanol)
@@ -179,7 +179,7 @@ TEST(NeutronSQNodeTest, WaterMethanol)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         DDD->getOutputValue<PartialSet *>("WeightedSQ")->total(), "DDD Total F(Q)",
         {"epsr25/water300methanol600/watermeth.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 16}, 5.0e-4));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, Benzene)
@@ -225,7 +225,7 @@ TEST(NeutronSQNodeTest, Benzene)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         FiftyFifty->getOutputValue<PartialSet *>("WeightedSQ")->total(), "5050 Total F(Q)",
         {"epsr25/benzene200-neutron/benzene.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 2.0e-3));
-    export_mermaid_graph(data.graphRoot);
+    exportMermaidGraph(data.graphRoot);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/neutronSQ.cpp
+++ b/tests/nodes/neutronSQ.cpp
@@ -4,6 +4,7 @@
 #include "math/windowFunction.h"
 #include "nodes/gr/gr.h"
 #include "tests/graphData.h"
+#include "tests/mermaid.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -49,6 +50,7 @@ TEST(NeutronSQNodeTest, Water)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         HDO->getOutputValue<PartialSet *>("WeightedSQ")->total(), "Total F(Q)",
         {"epsr25/water1000-neutron/water.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 2.0e-5));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, WaterReferenceFT)
@@ -90,6 +92,7 @@ TEST(NeutronSQNodeTest, WaterReferenceFT)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         HDO->getOutputValue<Data1D>("ReferenceGR"), "HDO Reference G(r)",
         {"epsr25/water1000-neutron-xray/water.EPSR.w01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 5.0e-5));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, WaterMethanol)
@@ -176,6 +179,7 @@ TEST(NeutronSQNodeTest, WaterMethanol)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         DDD->getOutputValue<PartialSet *>("WeightedSQ")->total(), "DDD Total F(Q)",
         {"epsr25/water300methanol600/watermeth.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 16}, 5.0e-4));
+    export_mermaid_graph(data.graphRoot);
 }
 
 TEST(NeutronSQNodeTest, Benzene)
@@ -221,6 +225,7 @@ TEST(NeutronSQNodeTest, Benzene)
     EXPECT_TRUE(DissolveSystemTest::checkData1D(
         FiftyFifty->getOutputValue<PartialSet *>("WeightedSQ")->total(), "5050 Total F(Q)",
         {"epsr25/benzene200-neutron/benzene.EPSR.u01", Data1DImportFileFormat::Data1DImportFormat::XY, 1, 6}, 2.0e-3));
+    export_mermaid_graph(data.graphRoot);
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
When a node graph is sent to an ostream, it will produce a mermaid diagram of the graph, including subgraphs.  I've also written a little utility so that several of our unit tests can export their graphs, mostly so that I had some examples that I could post.

## AtomShakeTest-Water
```mermaid
stateDiagram-v2
    classDef data fill:#FFD0D0,color:#000000
    classDef math fill:#D0FFD0,color:#000000
    class nWlrBbmQBh data
    nWlrBbmQBh : Bulk
    CDarzOwKkY : Inputs
    HIDdqSCDXr : Insert
    state JmOWFrxsjy {
        BldbEFSArC : AtomicMC
        BynEcdyGgx : Inputs
        xpkLoRellN : LoopBacks
        MPapqfWkHO : Outputs
        BynEcdyGgx --> BldbEFSArC:P13Configuration
        BldbEFSArC --> MPapqfWkHO:P13Configuration
        BynEcdyGgx --> BldbEFSArC:6Number
    }
    JmOWFrxsjy : Iterator
    PkMCoQHnWn : Outputs
    kUEwHsqmGb : Temperature
    class buqCLJJiVs data
    buqCLJJiVs : Water
    buqCLJJiVs --> HIDdqSCDXr:PK7Species
    nWlrBbmQBh --> HIDdqSCDXr:P13Configuration
    HIDdqSCDXr --> JmOWFrxsjy:P13Configuration
    kUEwHsqmGb --> JmOWFrxsjy:6Number
```

##GraphFlowTest-RemoveEdges
```mermaid
stateDiagram-v2
    classDef data fill:#FFD0D0,color:#000000
    classDef math fill:#D0FFD0,color:#000000
    nWlrBbmQBh : Inputs
    CDarzOwKkY : Outputs
    class HIDdqSCDXr math
    HIDdqSCDXr : x
    class JmOWFrxsjy math
    JmOWFrxsjy : x2
    class BldbEFSArC math
    BldbEFSArC : y
    class BynEcdyGgx math
    BynEcdyGgx : z
    BldbEFSArC --> BynEcdyGgx:6Number
    HIDdqSCDXr --> JmOWFrxsjy:6Number
    JmOWFrxsjy --> BynEcdyGgx:6Number
```

##GRNodeTest-Water
```mermaid
stateDiagram-v2
    classDef data fill:#FFD0D0,color:#000000
    classDef math fill:#D0FFD0,color:#000000
    class nWlrBbmQBh data
    nWlrBbmQBh : Bulk
    CDarzOwKkY : D2O
    class HIDdqSCDXr data
    HIDdqSCDXr : D2O-Reference
    JmOWFrxsjy : GR
    BldbEFSArC : H2O
    class BynEcdyGgx data
    BynEcdyGgx : H2O-Reference
    xpkLoRellN : H2Ox
    class MPapqfWkHO data
    MPapqfWkHO : H2Ox-Reference
    PkMCoQHnWn : HDO
    class kUEwHsqmGb data
    kUEwHsqmGb : HDO-Reference
    buqCLJJiVs : Import
    wMdkqtBxIX : Inputs
    MVTRRbljpT : Insert
    nsNFWZqfjM : Outputs
    AfAdrrWsof : SQ
    class sBcnuVqHFf data
    sBcnuVqHFf : Water
    sBcnuVqHFf --> MVTRRbljpT:PK7Species
    nWlrBbmQBh --> MVTRRbljpT:P13Configuration
    MVTRRbljpT --> buqCLJJiVs:P13Configuration
    buqCLJJiVs --> JmOWFrxsjy:P13Configuration
    JmOWFrxsjy --> AfAdrrWsof:P10PartialSet
    AfAdrrWsof --> BldbEFSArC:P10PartialSet
    AfAdrrWsof --> BldbEFSArC:P10PartialSet
    BynEcdyGgx --> BldbEFSArC:St8optionalI6Data1DE
    AfAdrrWsof --> CDarzOwKkY:P10PartialSet
    AfAdrrWsof --> CDarzOwKkY:P10PartialSet
    HIDdqSCDXr --> CDarzOwKkY:St8optionalI6Data1DE
    AfAdrrWsof --> PkMCoQHnWn:P10PartialSet
    AfAdrrWsof --> PkMCoQHnWn:P10PartialSet
    kUEwHsqmGb --> PkMCoQHnWn:St8optionalI6Data1DE
    AfAdrrWsof --> xpkLoRellN:P10PartialSet
    AfAdrrWsof --> xpkLoRellN:P10PartialSet
    MPapqfWkHO --> xpkLoRellN:St8optionalI6Data1DE
```

##NeutronSQNodeTest-Water
```mermaid
stateDiagram-v2
    classDef data fill:#FFD0D0,color:#000000
    classDef math fill:#D0FFD0,color:#000000
    class nWlrBbmQBh data
    nWlrBbmQBh : Bulk
    CDarzOwKkY : D2O
    class HIDdqSCDXr data
    HIDdqSCDXr : D2O-Reference
    JmOWFrxsjy : GR
    BldbEFSArC : H2O
    class BynEcdyGgx data
    BynEcdyGgx : H2O-Reference
    xpkLoRellN : H2Ox
    class MPapqfWkHO data
    MPapqfWkHO : H2Ox-Reference
    PkMCoQHnWn : HDO
    class kUEwHsqmGb data
    kUEwHsqmGb : HDO-Reference
    buqCLJJiVs : Import
    wMdkqtBxIX : Inputs
    MVTRRbljpT : Insert
    nsNFWZqfjM : Outputs
    AfAdrrWsof : SQ
    class sBcnuVqHFf data
    sBcnuVqHFf : Water
    sBcnuVqHFf --> MVTRRbljpT:PK7Species
    nWlrBbmQBh --> MVTRRbljpT:P13Configuration
    MVTRRbljpT --> buqCLJJiVs:P13Configuration
    buqCLJJiVs --> JmOWFrxsjy:P13Configuration
    JmOWFrxsjy --> AfAdrrWsof:P10PartialSet
    AfAdrrWsof --> BldbEFSArC:P10PartialSet
    AfAdrrWsof --> BldbEFSArC:P10PartialSet
    BynEcdyGgx --> BldbEFSArC:St8optionalI6Data1DE
    AfAdrrWsof --> CDarzOwKkY:P10PartialSet
    AfAdrrWsof --> CDarzOwKkY:P10PartialSet
    HIDdqSCDXr --> CDarzOwKkY:St8optionalI6Data1DE
    AfAdrrWsof --> PkMCoQHnWn:P10PartialSet
    AfAdrrWsof --> PkMCoQHnWn:P10PartialSet
    kUEwHsqmGb --> PkMCoQHnWn:St8optionalI6Data1DE
    AfAdrrWsof --> xpkLoRellN:P10PartialSet
    AfAdrrWsof --> xpkLoRellN:P10PartialSet
    MPapqfWkHO --> xpkLoRellN:St8optionalI6Data1DE
```