### PR TITLE
refactor: Disable Generator unit tests, fixup CompareModule tests

### DIFF
--- a/tests/data/dissolve/input/epsr-benzene-3n.txt
+++ b/tests/data/dissolve/input/epsr-benzene-3n.txt
@@ -173,11 +173,6 @@ Module  NeutronSQ  '5050'
   Frequency  1
 EndModule
 
-# Calculate energy of the Configuration
-Module Energy
-  Configuration  'Liquid'
-EndModule
-
 # Refine potentials
 Module  EPSR  'EPSR01'
   Target  'C6H6'

--- a/tests/generator/CMakeLists.txt
+++ b/tests/generator/CMakeLists.txt
@@ -1,3 +1,3 @@
-dissolve_add_test(SRC procedure.cpp)
-dissolve_add_test(SRC rotateFragment.cpp)
-dissolve_add_test(SRC select.cpp)
+#dissolve_add_test(SRC procedure.cpp)
+#dissolve_add_test(SRC rotateFragment.cpp)
+#dissolve_add_test(SRC select.cpp)

--- a/tests/generator/CMakeLists.txt
+++ b/tests/generator/CMakeLists.txt
@@ -1,3 +1,1 @@
-#dissolve_add_test(SRC procedure.cpp)
-#dissolve_add_test(SRC rotateFragment.cpp)
-#dissolve_add_test(SRC select.cpp)
+# dissolve_add_test(SRC procedure.cpp) dissolve_add_test(SRC rotateFragment.cpp) dissolve_add_test(SRC select.cpp)


### PR DESCRIPTION
A quick PR to disable the `Generator`-related tests which currently have no transition plan into Dissolve2, and a quick fix to the input file used by the `CompareModule` tests to fix a crash in upcoming #2349.