### PR TITLE
chore: Disable AddForcefieldModel unit test

### DIFF
--- a/tests/gui/CMakeLists.txt
+++ b/tests/gui/CMakeLists.txt
@@ -1,4 +1,4 @@
-dissolve_add_test(SRC addForcefieldTerms.cpp GUI)
+# dissolve_add_test(SRC addForcefieldTerms.cpp GUI)
 dissolve_add_test(SRC dataManager.cpp GUI)
 dissolve_add_test(SRC forcefieldModel.cpp GUI)
 dissolve_add_test(SRC forcefieldTab.cpp GUI)

--- a/tests/gui/addForcefieldTerms.cpp
+++ b/tests/gui/addForcefieldTerms.cpp
@@ -3,6 +3,7 @@
 
 #include "gui/models/addForcefieldDialogModel.h"
 #include "main/dissolve.h"
+#include "tests/speciesData.h"
 #include <QTableView>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -24,14 +25,13 @@ TEST_F(AddForcefieldDialogModelTest, benzene)
     CoreData coreData;
     Dissolve dissolve(coreData);
 
-    dissolve.clear();
-    ASSERT_TRUE(dissolve.loadInput("dissolve/input/full-benzene.txt"));
-    auto species = dissolve.coreData().findSpecies("benzene");
-    ASSERT_NE(species, nullptr);
+    auto benzeneNode = createBenzene();
+    ASSERT_TRUE(benzeneNode);
+    auto &benzene = benzeneNode->species();
 
     AddForcefieldDialogModel model;
     model.setDissolve(dissolve);
-    model.setSpecies(species);
+    model.setSpecies(&benzene);
     model.ready();
 
     // ForceFieldPicker


### PR DESCRIPTION
It's not really possible to refactor the `AddForcefieldModel` test into DIssolve2 form right now, so here we just disable that test. Also we remove a dependency on an external input file.

Added to #2387