### PR TITLE
test: TestGraph track internals

### DIFF
--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -16,12 +16,11 @@ TEST(CellsTest, Basic)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode =
-        testGraph.createConfiguration("Box", {{[]() { return createAtomic(Elements::Ar); }, 1}, {createWaterDLPoly, 267}}, 0.1,
-                                      Units::DensityUnits::AtomsPerAngstromUnits);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("dlpoly/solvated_atom/solvated-argon-rcut5.CONFIG",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
+    ASSERT_TRUE(testGraph.createConfiguration("Box",
+                                              {{[]() { return createAtomic(Elements::Ar); }, 1}, {createWaterDLPoly, 267}}, 0.1,
+                                              Units::DensityUnits::AtomsPerAngstromUnits));
+    ASSERT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "dlpoly/solvated_atom/solvated-argon-rcut5.CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Set all charge and short-range interaction potentials to zero
     auto arSpeciesNode = dynamic_cast<SpeciesNode *>(testGraph.findNode("Ar"));
@@ -48,11 +47,11 @@ TEST(CellsTest, Basic)
                                        {Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166"});
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create an energy kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
 
     // Test consistency of energy calculation with DL_POLY reference energies over a range of cutoffs / cell sizes
     std::vector<std::tuple<double, double, double>> states = {

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -46,7 +46,7 @@ TEST(CellsTest, Basic)
     testGraph.addPairPotentialOverride("Ar", "OW", PairPotentialOverride::PairPotentialOverrideType::Replace,
                                        {Functions1D::Form::LennardJones126, "epsilon=0.35 sigma=2.166"});
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 

--- a/tests/classes/cells3.cpp
+++ b/tests/classes/cells3.cpp
@@ -38,7 +38,7 @@ class CellsEnergyTest : public ::testing::Test
         EXPECT_TRUE(testGraph_.appendImportCoordinates(
             CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
-        // Run the graph from the Import node to set up the configuration
+        // Run the graph from the head node to set up the configuration
         EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
         EXPECT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 

--- a/tests/classes/cells3.cpp
+++ b/tests/classes/cells3.cpp
@@ -26,29 +26,28 @@ class CellsEnergyTest : public ::testing::Test
     // Set up graph
     Configuration *setUp(const Vector3 &lengths, const Vector3 &angles, int nMolecules, std::string referenceCoordinates)
     {
-        auto lastNode =
-            testGraph_.createConfiguration("Box",
-                                           {{[]()
-                                             {
-                                                 return createAtomic(Elements::Ar, {ShortRangeFunctions::Form::LennardJones,
-                                                                                    "epsilon=0.774040 sigma=3.445996"});
-                                             },
-                                             nMolecules}},
-                                           lengths, angles);
-        auto importNode = testGraph_.appendImportCoordinates(
-            lastNode,
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
+        EXPECT_TRUE(testGraph_.createConfiguration("Box",
+                                                   {{[]()
+                                                     {
+                                                         return createAtomic(Elements::Ar,
+                                                                             {ShortRangeFunctions::Form::LennardJones,
+                                                                              "epsilon=0.774040 sigma=3.445996"});
+                                                     },
+                                                     nMolecules}},
+                                                   lengths, angles));
+        EXPECT_TRUE(testGraph_.appendImportCoordinates(
+            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
         // Run the graph from the Import node to set up the configuration
-        EXPECT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-        EXPECT_EQ(importNode->versionIndex(), 0);
+        EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+        EXPECT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 
         // Get the species atom type for pair potential generation
         auto arSpeciesNode = dynamic_cast<SpeciesNode *>(testGraph_.findNode("Ar"));
         EXPECT_TRUE(arSpeciesNode);
         atomType_ = arSpeciesNode->species().atom(0).atomType();
 
-        return importNode->getOutputValue<Configuration *>("Configuration");
+        return testGraph_.fetchHead()->getOutputValue<Configuration *>("Configuration");
     }
     // Calculate tabulated energy directly (without using Cells)
     double tabulatedEnergyNoCells(Configuration *cfg, const PairPotential &pairPotential, double cutoffSq)

--- a/tests/classes/cells4.cpp
+++ b/tests/classes/cells4.cpp
@@ -26,24 +26,23 @@ class CellsMIMTest : public ::testing::Test
     // Set up graph
     Configuration *setUp(const Vector3 &lengths, const Vector3 &angles, int nMolecules, std::string referenceCoordinates)
     {
-        auto lastNode =
-            testGraph_.createConfiguration("Box",
-                                           {{[]()
-                                             {
-                                                 return createAtomic(Elements::Ar, {ShortRangeFunctions::Form::LennardJones,
-                                                                                    "epsilon=0.774040 sigma=3.445996"});
-                                             },
-                                             nMolecules}},
-                                           lengths, angles);
-        auto importNode = testGraph_.appendImportCoordinates(
-            lastNode,
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
+        EXPECT_TRUE(testGraph_.createConfiguration("Box",
+                                                   {{[]()
+                                                     {
+                                                         return createAtomic(Elements::Ar,
+                                                                             {ShortRangeFunctions::Form::LennardJones,
+                                                                              "epsilon=0.774040 sigma=3.445996"});
+                                                     },
+                                                     nMolecules}},
+                                                   lengths, angles));
+        EXPECT_TRUE(testGraph_.appendImportCoordinates(
+            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
         // Run the graph from the Import node to set up the configuration
-        EXPECT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-        EXPECT_EQ(importNode->versionIndex(), 0);
+        EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+        EXPECT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 
-        return importNode->getOutputValue<Configuration *>("Configuration");
+        return testGraph_.fetchHead()->getOutputValue<Configuration *>("Configuration");
     }
     // Count number of atoms within range of a target atom in the box without using cells
     int atomsWithRangeNoCells(Configuration *cfg, int fromIndex, double cutoff)

--- a/tests/classes/cells4.cpp
+++ b/tests/classes/cells4.cpp
@@ -38,7 +38,7 @@ class CellsMIMTest : public ::testing::Test
         EXPECT_TRUE(testGraph_.appendImportCoordinates(
             CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
-        // Run the graph from the Import node to set up the configuration
+        // Run the graph from the head node to set up the configuration
         EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
         EXPECT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 

--- a/tests/ff/benzene.cpp
+++ b/tests/ff/benzene.cpp
@@ -14,15 +14,13 @@ class BenzeneForcefieldTest : public ::testing::Test
     public:
     void setUp(std::string referenceCoordinates)
     {
-        auto lastNode = testGraph_.createConfiguration("Box",
-                                                       {
-                                                           {createBenzene, 181},
-                                                       },
-                                                       {29.925089931, 29.925089931, 29.925089931});
-        auto importNode = testGraph_.appendImportCoordinates(
-            lastNode,
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-        ASSERT_TRUE(importNode);
+        ASSERT_TRUE(testGraph_.createConfiguration("Box",
+                                                   {
+                                                       {createBenzene, 181},
+                                                   },
+                                                   {29.925089931, 29.925089931, 29.925089931}));
+        ASSERT_TRUE(testGraph_.appendImportCoordinates(
+            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
         // Adjust pair potential properties
         PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -30,11 +28,11 @@ class BenzeneForcefieldTest : public ::testing::Test
         PairPotential::setRange(12.0, 1.0e-4);
 
         // Run the graph from the Import node to set up the configuration
-        ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-        ASSERT_EQ(importNode->versionIndex(), 0);
+        ASSERT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+        ASSERT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 
         // Get the configuration
-        configuration_ = importNode->getOutputValue<Configuration *>("Configuration");
+        configuration_ = testGraph_.fetchHead()->getOutputValue<Configuration *>("Configuration");
     }
 
     protected:

--- a/tests/ff/benzene.cpp
+++ b/tests/ff/benzene.cpp
@@ -27,7 +27,7 @@ class BenzeneForcefieldTest : public ::testing::Test
         PairPotential::setChargeSource(PairPotential::ChargeSource::AtomTypes);
         PairPotential::setRange(12.0, 1.0e-4);
 
-        // Run the graph from the Import node to set up the configuration
+        // Run the graph from the head node to set up the configuration
         ASSERT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
         ASSERT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 

--- a/tests/ff/hexane.cpp
+++ b/tests/ff/hexane.cpp
@@ -28,7 +28,7 @@ class HexaneForcefieldTest : public ::testing::Test
         PairPotential::setChargeSource(PairPotential::ChargeSource::SpeciesAtoms);
         PairPotential::setRange(12.0, 1.0e-4);
 
-        // Run the graph from the Import node to set up the configuration
+        // Run the graph from the head node to set up the configuration
         ASSERT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
         ASSERT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 

--- a/tests/ff/hexane.cpp
+++ b/tests/ff/hexane.cpp
@@ -14,15 +14,13 @@ class HexaneForcefieldTest : public ::testing::Test
     public:
     void setUp(int nMols, std::string_view referenceCoordinates)
     {
-        auto lastNode = testGraph_.createConfiguration("Box",
-                                                       {
-                                                           {createHexane, nMols},
-                                                       },
-                                                       {30.769064857500, 46.153597286200, 30.769064857500});
-        auto importNode = testGraph_.appendImportCoordinates(
-            lastNode,
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-        ASSERT_TRUE(importNode);
+        ASSERT_TRUE(testGraph_.createConfiguration("Box",
+                                                   {
+                                                       {createHexane, nMols},
+                                                   },
+                                                   {30.769064857500, 46.153597286200, 30.769064857500}));
+        ASSERT_TRUE(testGraph_.appendImportCoordinates(
+            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
         // Adjust pair potential properties
         PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -31,11 +29,11 @@ class HexaneForcefieldTest : public ::testing::Test
         PairPotential::setRange(12.0, 1.0e-4);
 
         // Run the graph from the Import node to set up the configuration
-        ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-        ASSERT_EQ(importNode->versionIndex(), 0);
+        ASSERT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+        ASSERT_EQ(testGraph_.fetchHead()->versionIndex(), 0);
 
         // Get the configuration
-        configuration_ = importNode->getOutputValue<Configuration *>("Configuration");
+        configuration_ = testGraph_.fetchHead()->getOutputValue<Configuration *>("Configuration");
     }
 
     protected:

--- a/tests/ff/water-1000.cpp
+++ b/tests/ff/water-1000.cpp
@@ -13,22 +13,20 @@ TEST(Water1000EnergyTest, Full)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
     PairPotential::setRange(15.0, 1.0e-4);
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create an energy kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createEnergyKernel(cfg);
 
     // Check consistency between production and test energies
@@ -47,22 +45,20 @@ TEST(Water1000ForceTest, Full)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/full.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "dlpoly/water1000/full.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
     PairPotential::setRange(15.0, 1.0e-4);
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create a force kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createForceKernel(cfg);
 
     // Check consistency between production and test forces
@@ -83,11 +79,9 @@ TEST(Water1000EnergyTest, ShortRangeOnly)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -104,11 +98,11 @@ TEST(Water1000EnergyTest, ShortRangeOnly)
     ow->setCharge(0.0);
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create an energy kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createEnergyKernel(cfg);
 
     // Check consistency between production and test energies
@@ -122,11 +116,9 @@ TEST(Water1000ForceTest, ShortRangeOnly)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/vdw.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/vdw.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -143,11 +135,11 @@ TEST(Water1000ForceTest, ShortRangeOnly)
     ow->setCharge(0.0);
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create a force kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createForceKernel(cfg);
 
     // Check consistency between production and test forces
@@ -163,11 +155,9 @@ TEST(Water1000EnergyTest, ShiftedCoulombOnly)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -181,11 +171,11 @@ TEST(Water1000EnergyTest, ShiftedCoulombOnly)
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=3.0");
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create an energy kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createEnergyKernel(cfg);
 
     // Check consistency between production and test energies
@@ -199,11 +189,9 @@ TEST(Water1000ForceTest, CoulombOnly)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setCoulombTruncationScheme(PairPotential::CoulombTruncationScheme::NoCoulombTruncation);
@@ -217,11 +205,11 @@ TEST(Water1000ForceTest, CoulombOnly)
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create a force kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createForceKernel(cfg);
 
     // Check consistency between production and test forces
@@ -244,11 +232,9 @@ TEST(Water1000ForceTest, ShiftedCoulombOnly)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setRange(15.0, 1.0e-4);
@@ -262,11 +248,11 @@ TEST(Water1000ForceTest, ShiftedCoulombOnly)
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration and create a force kernel
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
     auto kernel = testGraph.createForceKernel(cfg);
 
     // Check consistency between production and test forces

--- a/tests/ff/water-1000.cpp
+++ b/tests/ff/water-1000.cpp
@@ -21,7 +21,7 @@ TEST(Water1000EnergyTest, Full)
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
     PairPotential::setRange(15.0, 1.0e-4);
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -53,7 +53,7 @@ TEST(Water1000ForceTest, Full)
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
     PairPotential::setRange(15.0, 1.0e-4);
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -97,7 +97,7 @@ TEST(Water1000EnergyTest, ShortRangeOnly)
     hw->setCharge(0.0);
     ow->setCharge(0.0);
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -134,7 +134,7 @@ TEST(Water1000ForceTest, ShortRangeOnly)
     hw->setCharge(0.0);
     ow->setCharge(0.0);
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -170,7 +170,7 @@ TEST(Water1000EnergyTest, ShiftedCoulombOnly)
     ASSERT_TRUE(ow);
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=3.0");
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -204,7 +204,7 @@ TEST(Water1000ForceTest, CoulombOnly)
     ASSERT_TRUE(ow);
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -247,7 +247,7 @@ TEST(Water1000ForceTest, ShiftedCoulombOnly)
     ASSERT_TRUE(hw && ow);
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -37,31 +37,26 @@ class TestGraph : public DissolveGraph
     /*
      * Graph Creation Helpers
      */
-    private:
-    // Update pointer to current top node in graph
-    bool updateHead(Node *node)
-    {
-        head_ = node;
-        return true;
-    }
-
     public:
     // Returns pointer to current top node in graph
     Node *fetchHead() const { return head_; }
     // Returns reference to current top node in graph, cast to the known node type
     template <class NodeType> NodeType *head() const { return static_cast<NodeType *>(head_); }
-    // Add next (or, current "last") node in graph
-    bool nextNode(const std::string &nodeType, const std::optional<std::string> &name = {})
+    // Append new node to the graph
+    Node *appendNode(const std::string &nodeType, const std::optional<std::string> &name = {})
     {
         auto node = name.has_value() ? createNode(nodeType, *name) : createNode(nodeType);
 
         if (!node)
-            return false;
+            return nullptr;
 
-        return updateHead(node);
+        head_ = node;
+
+        return node;
     }
     // Create species insertion node chain
-    Node *insertSpecies(Node *cfgSourceNode, const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
+    Node *insertSpecies(Node *cfgSourceNode,
+                        const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
                         Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits,
                         InsertNode::BoxActionStyle boxActionStyle = InsertNode::BoxActionStyle::AddVolume)
     {
@@ -76,7 +71,7 @@ class TestGraph : public DissolveGraph
             addNode(std::move(speciesUnique), speciesNode.name());
 
             auto insertNodeName = std::format("Insert-{}", speciesNode.name());
-            EXPECT_TRUE(nextNode("Insert", insertNodeName));
+            EXPECT_TRUE(appendNode("Insert", insertNodeName));
             EXPECT_TRUE(fetchHead()->setInput<Number>("Population", population));
             EXPECT_TRUE(fetchHead()->setInput<Number>("Density", rho));
             EXPECT_TRUE(fetchHead()->setOption("BoxAction", boxActionStyle));
@@ -97,8 +92,8 @@ class TestGraph : public DissolveGraph
                               double rho, Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits)
     {
         // Create configuration and SetCell nodes
-        EXPECT_TRUE(nextNode("Configuration", name));
-        EXPECT_TRUE(nextNode("SetCell"));
+        EXPECT_TRUE(appendNode("Configuration", name));
+        EXPECT_TRUE(appendNode("SetCell"));
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
@@ -111,21 +106,22 @@ class TestGraph : public DissolveGraph
                               const Vector3 &cellLengths, const Vector3 &cellAngles = {90.0, 90.0, 90.0})
     {
         // Create configuration and SetCell nodes
-        EXPECT_TRUE(nextNode("Configuration", name));
-        EXPECT_TRUE(nextNode("SetCell"));
+        EXPECT_TRUE(appendNode("Configuration", name));
+        EXPECT_TRUE(appendNode("SetCell"));
         fetchHead()->setOption<Vector3>("Lengths", cellLengths);
         fetchHead()->setOption<Vector3>("Angles", cellAngles);
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(fetchHead(), species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits, InsertNode::BoxActionStyle::None);
+        return insertSpecies(fetchHead(), species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
+                             InsertNode::BoxActionStyle::None);
     }
     // Append an import coordinates node
     Node *appendImportCoordinates(CoordinateImportFileFormat fileFormat, bool supercell = false)
     {
         const auto cfgSourceNode = fetchHead();
 
-        EXPECT_TRUE(nextNode("ImportConfigurationCoordinates"));
+        EXPECT_TRUE(appendNode("ImportConfigurationCoordinates"));
         EXPECT_TRUE(fetchHead()->setOption<std::string>("FilePath", std::string(fileFormat.filename())));
         EXPECT_TRUE(fetchHead()->setOption<CoordinateImportFileFormat::CoordinateImportFormat>(
             "FileFormat",
@@ -186,7 +182,7 @@ class TestGraph : public DissolveGraph
             isotopologueSet.add(isotopologue, relativeWeight);
         }
 
-        EXPECT_TRUE(nextNode("NeutronSQ", name));
+        EXPECT_TRUE(appendNode("NeutronSQ", name));
         EXPECT_TRUE(fetchHead()->setOption("Isotopologues", isotopologueSet));
         EXPECT_TRUE(fetchHead()->setOption("Exchangeables", exchangeables));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedGR", name, "UnweightedGR"}));
@@ -208,7 +204,7 @@ class TestGraph : public DissolveGraph
     // Create an XRaySQ node with optional reference data
     XRaySQNode *appendXRaySQ(SQNode *sqNode, std::string name, Data1DImportFileFormat referenceData = Data1DImportFileFormat())
     {
-        EXPECT_TRUE(nextNode("XRaySQ", name));
+        EXPECT_TRUE(appendNode("XRaySQ", name));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedGR", name, "UnweightedGR"}));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedSQ", name, "UnweightedSQ"}));
 

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -29,16 +29,42 @@ class TestGraph : public DissolveGraph
     CoreData coreData;
     Dissolve dissolve;
 
+    private:
+    // Current top node in graph
+    Node *head_{nullptr};
+
     /*
      * Graph Creation Helpers
      */
     private:
+    // Update pointer to current top node in graph
+    bool updateHead(Node *node)
+    {
+        head_ = node;
+        return true;
+    }
+
+    public:
+    // Returns pointer to current top node in graph
+    Node *fetchHead() const { return head_; }
+    // Returns reference to current top node in graph, cast to the known node type
+    template <class NodeType> NodeType *head() const { return static_cast<NodeType *>(head_); }
+    // Add next (or, current "last") node in graph
+    bool nextNode(const std::string &nodeType, const std::optional<std::string> &name = {})
+    {
+        auto node = name.has_value() ? createNode(nodeType, *name) : createNode(nodeType);
+
+        if (!node)
+            return false;
+
+        return updateHead(node);
+    }
     // Create species insertion node chain
-    Node *insertSpecies(Node *lastNode,
-                        const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
+    Node *insertSpecies(const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
                         Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits,
                         InsertNode::BoxActionStyle boxActionStyle = InsertNode::BoxActionStyle::AddVolume)
     {
+        // Add Species and Insert nodes
         for (auto &[speciesCreator, population] : species)
         {
             // Create the species node and get the species pointer
@@ -49,20 +75,16 @@ class TestGraph : public DissolveGraph
             addNode(std::move(speciesUnique), speciesNode.name());
 
             auto insertNodeName = std::format("Insert-{}", speciesNode.name());
-            auto insertNode = createNode("Insert", insertNodeName);
-
-            EXPECT_TRUE(insertNode);
-            EXPECT_TRUE(insertNode->setInput<Number>("Population", population));
-            EXPECT_TRUE(insertNode->setInput<Number>("Density", rho));
-            EXPECT_TRUE(insertNode->setOption("BoxAction", boxActionStyle));
-            EXPECT_TRUE(insertNode->setOption<Units::DensityUnits>("DensityUnits", rhoUnits));
+            EXPECT_TRUE(nextNode("Insert", insertNodeName));
+            EXPECT_TRUE(fetchHead()->setInput<Number>("Population", population));
+            EXPECT_TRUE(fetchHead()->setInput<Number>("Density", rho));
+            EXPECT_TRUE(fetchHead()->setOption("BoxAction", boxActionStyle));
+            EXPECT_TRUE(fetchHead()->setOption<Units::DensityUnits>("DensityUnits", rhoUnits));
             EXPECT_TRUE(addEdge({std::string(speciesNode.name()), "Species", insertNodeName, "Species"}));
-            EXPECT_TRUE(addEdge({std::string(lastNode->name()), "Configuration", insertNodeName, "Configuration"}));
-
-            lastNode = insertNode;
+            EXPECT_TRUE(addEdge({std::string(fetchHead()->name()), "Configuration", insertNodeName, "Configuration"}));
         }
 
-        return lastNode;
+        return fetchHead();
     }
 
     public:
@@ -72,14 +94,12 @@ class TestGraph : public DissolveGraph
                               double rho, Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits)
     {
         // Create configuration and SetCell nodes
-        auto lastNode = createNode("Configuration", name);
-        EXPECT_TRUE(lastNode);
-        lastNode = createNode("SetCell");
-        EXPECT_TRUE(lastNode);
+        EXPECT_TRUE(createNode("Configuration", name));
+        EXPECT_TRUE(createNode("SetCell"));
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(lastNode, species, rho, rhoUnits, InsertNode::BoxActionStyle::AddVolume);
+        return insertSpecies(species, rho, rhoUnits, InsertNode::BoxActionStyle::AddVolume);
     }
 
     // Create basic configuration graph, returning the last node
@@ -88,34 +108,32 @@ class TestGraph : public DissolveGraph
                               const Vector3 &cellLengths, const Vector3 &cellAngles = {90.0, 90.0, 90.0})
     {
         // Create configuration and SetCell nodes
-        auto lastNode = createNode("Configuration", name);
-        EXPECT_TRUE(lastNode);
-        lastNode = createNode("SetCell");
-        lastNode->setOption<Vector3>("Lengths", cellLengths);
-        lastNode->setOption<Vector3>("Angles", cellAngles);
-        EXPECT_TRUE(lastNode);
+        EXPECT_TRUE(nextNode("Configuration", name));
+        EXPECT_TRUE(nextNode("SetCell"));
+        fetchHead()->setOption<Vector3>("Lengths", cellLengths);
+        fetchHead()->setOption<Vector3>("Angles", cellAngles);
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(lastNode, species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
+        return insertSpecies(species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
                              InsertNode::BoxActionStyle::None);
     }
     // Append an import coordinates node
-    Node *appendImportCoordinates(Node *lastNode, CoordinateImportFileFormat fileFormat, bool supercell = false)
+    Node *appendImportCoordinates(CoordinateImportFileFormat fileFormat, bool supercell = false)
     {
         auto importCoordinates = createNode("ImportConfigurationCoordinates");
         EXPECT_TRUE(importCoordinates->setOption<std::string>("FilePath", std::string(fileFormat.filename())));
         EXPECT_TRUE(importCoordinates->setOption<CoordinateImportFileFormat::CoordinateImportFormat>(
             "FileFormat",
             CoordinateImportFileFormat::coordinateImportFileFormat().enumerationByIndex(fileFormat.formatIndex())));
-        EXPECT_TRUE(addEdge({std::string(lastNode->name()), supercell ? "SupercellConfiguration" : "Configuration",
+        EXPECT_TRUE(addEdge({std::string(fetchHead()->name()), supercell ? "SupercellConfiguration" : "Configuration",
                              "ImportConfigurationCoordinates", "Configuration"}));
 
         return importCoordinates;
     }
 
     // Append GR and SQ nodes
-    std::pair<GRNode *, SQNode *> appendGRSQ(Node *lastNode, bool noAveraging = false, bool noIntraBroadening = false)
+    std::pair<GRNode *, SQNode *> appendGRSQ(bool noAveraging = false, bool noIntraBroadening = false)
     {
         // Create and setup the GR node
         auto grNode = dynamic_cast<GRNode *>(createNode("GR"));
@@ -125,7 +143,7 @@ class TestGraph : public DissolveGraph
         if (noIntraBroadening)
             EXPECT_TRUE(grNode->setOption("IntraBroadening", Function1DWrapper()));
 
-        EXPECT_TRUE(addEdge({std::string(lastNode->name()), "Configuration", "GR", "Configuration"}));
+        EXPECT_TRUE(addEdge({std::string(fetchHead()->name()), "Configuration", "GR", "Configuration"}));
 
         // Create the SQ node
         auto sqNode = dynamic_cast<SQNode *>(createNode("SQ"));
@@ -164,31 +182,28 @@ class TestGraph : public DissolveGraph
             isotopologueSet.add(isotopologue, relativeWeight);
         }
 
-        auto neutronSQNode = dynamic_cast<NeutronSQNode *>(createNode("NeutronSQ", name));
-        EXPECT_TRUE(neutronSQNode);
-        EXPECT_TRUE(neutronSQNode->setOption("Isotopologues", isotopologueSet));
-        EXPECT_TRUE(neutronSQNode->setOption("Exchangeables", exchangeables));
+        EXPECT_TRUE(nextNode("NeutronSQ", name));
+        EXPECT_TRUE(fetchHead()->setOption("Isotopologues", isotopologueSet));
+        EXPECT_TRUE(fetchHead()->setOption("Exchangeables", exchangeables));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedGR", name, "UnweightedGR"}));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedSQ", name, "UnweightedSQ"}));
 
         // Set reference F(Q) data
         if (referenceData.hasFilename())
         {
-            auto data1DImportNode = createNode("Data1DImport", std::format("Reference-{}", name));
-            EXPECT_TRUE(data1DImportNode);
-            EXPECT_TRUE(data1DImportNode->setOption<std::string>("FilePath", std::string(referenceData.filename())));
-            EXPECT_TRUE(data1DImportNode->setOption<Data1DImportFileFormat::Data1DImportFormat>(
+            EXPECT_TRUE(nextNode("Data1DImport", std::format("Reference-{}", name)));
+            EXPECT_TRUE(fetchHead()->setOption<std::string>("FilePath", std::string(referenceData.filename())));
+            EXPECT_TRUE(fetchHead()->setOption<Data1DImportFileFormat::Data1DImportFormat>(
                 "ImportFormat", Data1DImportFileFormat::data1DImportFormat().enumerationByIndex(referenceData.formatIndex())));
             EXPECT_TRUE(addEdge({std::format("Reference-{}", name), "Data", name, "ReferenceData"}));
         }
 
-        return neutronSQNode;
+        return head<NeutronSQNode>();
     }
     // Create an XRaySQ node with optional reference data
     XRaySQNode *appendXRaySQ(SQNode *sqNode, std::string name, Data1DImportFileFormat referenceData = Data1DImportFileFormat())
     {
-        auto xRaySQNode = dynamic_cast<XRaySQNode *>(createNode("XRaySQ", name));
-        EXPECT_TRUE(xRaySQNode);
+        EXPECT_TRUE(nextNode("XRaySQ", name));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedGR", name, "UnweightedGR"}));
         EXPECT_TRUE(addEdge({std::string(sqNode->name()), "UnweightedSQ", name, "UnweightedSQ"}));
 
@@ -202,7 +217,7 @@ class TestGraph : public DissolveGraph
                 "ImportFormat", Data1DImportFileFormat::data1DImportFormat().enumerationByIndex(referenceData.formatIndex())));
             EXPECT_TRUE(addEdge({std::format("Reference-{}", name), "Data", name, "ReferenceData"}));
         }
-        return xRaySQNode;
+        return head<XRaySQNode>();
     }
 
     /*

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -11,6 +11,7 @@
 #include "nodes/bragg.h"
 #include "nodes/configuration.h"
 #include "nodes/dissolve.h"
+#include "nodes/importConfigurationCoordinates.h"
 #include "nodes/insert.h"
 #include "nodes/neutronSQ/neutronSQ.h"
 #include "nodes/sq/sq.h"
@@ -64,6 +65,8 @@ class TestGraph : public DissolveGraph
                         Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits,
                         InsertNode::BoxActionStyle boxActionStyle = InsertNode::BoxActionStyle::AddVolume)
     {
+        const auto cfgSourceNode = fetchHead();
+
         // Add Species and Insert nodes
         for (auto &[speciesCreator, population] : species)
         {
@@ -81,7 +84,7 @@ class TestGraph : public DissolveGraph
             EXPECT_TRUE(fetchHead()->setOption("BoxAction", boxActionStyle));
             EXPECT_TRUE(fetchHead()->setOption<Units::DensityUnits>("DensityUnits", rhoUnits));
             EXPECT_TRUE(addEdge({std::string(speciesNode.name()), "Species", insertNodeName, "Species"}));
-            EXPECT_TRUE(addEdge({std::string(fetchHead()->name()), "Configuration", insertNodeName, "Configuration"}));
+            EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), "Configuration", insertNodeName, "Configuration"}));
         }
 
         return fetchHead();
@@ -94,8 +97,8 @@ class TestGraph : public DissolveGraph
                               double rho, Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits)
     {
         // Create configuration and SetCell nodes
-        EXPECT_TRUE(createNode("Configuration", name));
-        EXPECT_TRUE(createNode("SetCell"));
+        EXPECT_TRUE(nextNode("Configuration", name));
+        EXPECT_TRUE(nextNode("SetCell"));
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
@@ -115,21 +118,22 @@ class TestGraph : public DissolveGraph
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
-                             InsertNode::BoxActionStyle::None);
+        return insertSpecies(species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits, InsertNode::BoxActionStyle::None);
     }
     // Append an import coordinates node
     Node *appendImportCoordinates(CoordinateImportFileFormat fileFormat, bool supercell = false)
     {
-        auto importCoordinates = createNode("ImportConfigurationCoordinates");
-        EXPECT_TRUE(importCoordinates->setOption<std::string>("FilePath", std::string(fileFormat.filename())));
-        EXPECT_TRUE(importCoordinates->setOption<CoordinateImportFileFormat::CoordinateImportFormat>(
+        const auto cfgSourceNode = fetchHead();
+
+        EXPECT_TRUE(nextNode("ImportConfigurationCoordinates"));
+        EXPECT_TRUE(fetchHead()->setOption<std::string>("FilePath", std::string(fileFormat.filename())));
+        EXPECT_TRUE(fetchHead()->setOption<CoordinateImportFileFormat::CoordinateImportFormat>(
             "FileFormat",
             CoordinateImportFileFormat::coordinateImportFileFormat().enumerationByIndex(fileFormat.formatIndex())));
-        EXPECT_TRUE(addEdge({std::string(fetchHead()->name()), supercell ? "SupercellConfiguration" : "Configuration",
+        EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), supercell ? "SupercellConfiguration" : "Configuration",
                              "ImportConfigurationCoordinates", "Configuration"}));
 
-        return importCoordinates;
+        return head<ImportConfigurationCoordinatesNode>();
     }
 
     // Append GR and SQ nodes

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -31,7 +31,7 @@ class TestGraph : public DissolveGraph
     Dissolve dissolve;
 
     private:
-    // Current top node in graph
+    // Current most recently appended node in graph
     Node *head_{nullptr};
 
     /*

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -61,12 +61,10 @@ class TestGraph : public DissolveGraph
         return updateHead(node);
     }
     // Create species insertion node chain
-    Node *insertSpecies(const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
+    Node *insertSpecies(Node *cfgSourceNode, const std::vector<std::pair<std::function<std::unique_ptr<SpeciesNode>()>, int>> &species, double rho,
                         Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits,
                         InsertNode::BoxActionStyle boxActionStyle = InsertNode::BoxActionStyle::AddVolume)
     {
-        const auto cfgSourceNode = fetchHead();
-
         // Add Species and Insert nodes
         for (auto &[speciesCreator, population] : species)
         {
@@ -85,6 +83,8 @@ class TestGraph : public DissolveGraph
             EXPECT_TRUE(fetchHead()->setOption<Units::DensityUnits>("DensityUnits", rhoUnits));
             EXPECT_TRUE(addEdge({std::string(speciesNode.name()), "Species", insertNodeName, "Species"}));
             EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), "Configuration", insertNodeName, "Configuration"}));
+
+            cfgSourceNode = fetchHead();
         }
 
         return fetchHead();
@@ -102,7 +102,7 @@ class TestGraph : public DissolveGraph
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(species, rho, rhoUnits, InsertNode::BoxActionStyle::AddVolume);
+        return insertSpecies(fetchHead(), species, rho, rhoUnits, InsertNode::BoxActionStyle::AddVolume);
     }
 
     // Create basic configuration graph, returning the last node
@@ -118,7 +118,7 @@ class TestGraph : public DissolveGraph
         EXPECT_TRUE(addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return insertSpecies(species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits, InsertNode::BoxActionStyle::None);
+        return insertSpecies(fetchHead(), species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits, InsertNode::BoxActionStyle::None);
     }
     // Append an import coordinates node
     Node *appendImportCoordinates(CoordinateImportFileFormat fileFormat, bool supercell = false)
@@ -195,9 +195,10 @@ class TestGraph : public DissolveGraph
         // Set reference F(Q) data
         if (referenceData.hasFilename())
         {
-            EXPECT_TRUE(nextNode("Data1DImport", std::format("Reference-{}", name)));
-            EXPECT_TRUE(fetchHead()->setOption<std::string>("FilePath", std::string(referenceData.filename())));
-            EXPECT_TRUE(fetchHead()->setOption<Data1DImportFileFormat::Data1DImportFormat>(
+            auto data1DImportNode = createNode("Data1DImport", std::format("Reference-{}", name));
+            EXPECT_TRUE(data1DImportNode);
+            EXPECT_TRUE(data1DImportNode->setOption<std::string>("FilePath", std::string(referenceData.filename())));
+            EXPECT_TRUE(data1DImportNode->setOption<Data1DImportFileFormat::Data1DImportFormat>(
                 "ImportFormat", Data1DImportFileFormat::data1DImportFormat().enumerationByIndex(referenceData.formatIndex())));
             EXPECT_TRUE(addEdge({std::format("Reference-{}", name), "Data", name, "ReferenceData"}));
         }

--- a/tests/nodes/angle.cpp
+++ b/tests/nodes/angle.cpp
@@ -19,8 +19,8 @@ TEST(AngleNodeTest, Water)
     testGraph.createConfiguration("Box", {{createWater, 267}}, 0.1);
 
     // Create iterable graph containing an AtomicMCNode
-    auto iterator = dynamic_cast<IterableGraph *>(testGraph.createNode("Iterator", "Iterator"));
-    ASSERT_TRUE(iterator);
+    ASSERT_TRUE(testGraph.nextNode("Iterator", "Iterator"));
+    auto iterator = testGraph.head<IterableGraph>();
 
     // Create a dynamic input from the graph's existing Insert node
     EXPECT_TRUE(testGraph.addEdge({"Insert-Water", "Configuration", "Iterator", "Configuration"}));

--- a/tests/nodes/angle.cpp
+++ b/tests/nodes/angle.cpp
@@ -19,7 +19,7 @@ TEST(AngleNodeTest, Water)
     testGraph.createConfiguration("Box", {{createWater, 267}}, 0.1);
 
     // Create iterable graph containing an AtomicMCNode
-    ASSERT_TRUE(testGraph.nextNode("Iterator", "Iterator"));
+    ASSERT_TRUE(testGraph.appendNode("Iterator", "Iterator"));
     auto iterator = testGraph.head<IterableGraph>();
 
     // Create a dynamic input from the graph's existing Insert node

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -29,14 +29,14 @@ TEST(AtomShakeTest, Water)
     auto insertNode = testGraph.createConfiguration("Box", {{createWater, 1}}, 0.1);
 
     // Create iterable graph containing an AtomicMCNode
-    auto iterator = dynamic_cast<IterableGraph *>(testGraph.createNode("Iterator", "Iterator"));
+    ASSERT_TRUE(testGraph.nextNode("Iterator", "Iterator"));
+    auto iterator = testGraph.head<IterableGraph>();
     auto atomicMCNode = dynamic_cast<AtomicMCNode *>(iterator->createNode("AtomicMC", "AtomicMC"));
     ASSERT_TRUE(atomicMCNode->setOption<Number>("ShakesPerAtom", 10));
 
     // Create number node to modify temperature
-    auto temperatureValueNode = dynamic_cast<NumberNode *>(testGraph.createNode("Number", "Temperature"));
-    ASSERT_TRUE(temperatureValueNode);
-    ASSERT_TRUE(temperatureValueNode->setOption<Number>("X", 0));
+    ASSERT_TRUE(testGraph.nextNode("Number", "Temperature"));
+    ASSERT_TRUE(testGraph.fetchHead()->setOption<Number>("X", 0));
 
     // Set connections
     EXPECT_TRUE(testGraph.addEdge({"Insert-Water", "Configuration", "Iterator", "Configuration"}));

--- a/tests/nodes/atomicMC.cpp
+++ b/tests/nodes/atomicMC.cpp
@@ -29,13 +29,13 @@ TEST(AtomShakeTest, Water)
     auto insertNode = testGraph.createConfiguration("Box", {{createWater, 1}}, 0.1);
 
     // Create iterable graph containing an AtomicMCNode
-    ASSERT_TRUE(testGraph.nextNode("Iterator", "Iterator"));
+    ASSERT_TRUE(testGraph.appendNode("Iterator", "Iterator"));
     auto iterator = testGraph.head<IterableGraph>();
     auto atomicMCNode = dynamic_cast<AtomicMCNode *>(iterator->createNode("AtomicMC", "AtomicMC"));
     ASSERT_TRUE(atomicMCNode->setOption<Number>("ShakesPerAtom", 10));
 
     // Create number node to modify temperature
-    ASSERT_TRUE(testGraph.nextNode("Number", "Temperature"));
+    ASSERT_TRUE(testGraph.appendNode("Number", "Temperature"));
     ASSERT_TRUE(testGraph.fetchHead()->setOption<Number>("X", 0));
 
     // Set connections

--- a/tests/nodes/bragg.cpp
+++ b/tests/nodes/bragg.cpp
@@ -40,15 +40,15 @@ class BraggNodeTest : public ::testing::Test
         // Create species and configuration from MgO cif file
         auto root = testGraph_.dissolveGraph();
 
-        ASSERT_TRUE(testGraph_.nextNode("CIFLoader", "CIFLoader"));
+        ASSERT_TRUE(testGraph_.appendNode("CIFLoader", "CIFLoader"));
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<std::string>("FilePath", "cif/1000053.cif"));
 
-        ASSERT_TRUE(testGraph_.nextNode("CIFBondingOptions", "CIFBonds"));
+        ASSERT_TRUE(testGraph_.appendNode("CIFBondingOptions", "CIFBonds"));
         ASSERT_TRUE(root->addEdge({"CIFLoader", "CIFContext", "CIFBonds", "CIFContext"}));
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<bool>("PreventAllBonds", true));
 
         // Create a supercell that is 5 * unitcell
-        ASSERT_TRUE(testGraph_.nextNode("CIFMolecularSpecies", "Crystal"));
+        ASSERT_TRUE(testGraph_.appendNode("CIFMolecularSpecies", "Crystal"));
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<Vector3i>("SupercellRepeat", supercellRepeat_));
 
         ASSERT_TRUE(root->addEdge({"CIFBonds", "CIFContext", "Crystal", "CIFContext"}));
@@ -73,7 +73,7 @@ class BraggNodeTest : public ::testing::Test
         ASSERT_TRUE(neutronSQNode_);
 
         // Bragg node
-        ASSERT_TRUE(testGraph_.nextNode("Bragg", "Bragg01"));
+        ASSERT_TRUE(testGraph_.appendNode("Bragg", "Bragg01"));
         ASSERT_TRUE(root->addEdge({"Crystal", "SupercellConfiguration", "Bragg01", "Configuration"}));
         ASSERT_TRUE(root->addEdge({std::string(sqNode->name()), "UnweightedSQ", "Bragg01", "UnweightedSQ"}));
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<Number>("QMax", 20.0));

--- a/tests/nodes/bragg.cpp
+++ b/tests/nodes/bragg.cpp
@@ -40,29 +40,26 @@ class BraggNodeTest : public ::testing::Test
         // Create species and configuration from MgO cif file
         auto root = testGraph_.dissolveGraph();
 
-        auto cifLoaderNode = root->createNode("CIFLoader", "CIFLoader");
-        ASSERT_TRUE(cifLoaderNode->setOption<std::string>("FilePath", "cif/1000053.cif"));
+        ASSERT_TRUE(testGraph_.nextNode("CIFLoader", "CIFLoader"));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<std::string>("FilePath", "cif/1000053.cif"));
 
-        auto cifBondingNode = root->createNode("CIFBondingOptions", "CIFBonds");
+        ASSERT_TRUE(testGraph_.nextNode("CIFBondingOptions", "CIFBonds"));
         ASSERT_TRUE(root->addEdge({"CIFLoader", "CIFContext", "CIFBonds", "CIFContext"}));
-        ASSERT_TRUE(cifBondingNode->setOption<bool>("PreventAllBonds", true));
-
-        cifConfigurationNode_ = static_cast<CIFMolecularSpeciesNode *>(root->createNode("CIFMolecularSpecies", "Crystal"));
+        ASSERT_TRUE(fetchHead()->setOption<bool>("PreventAllBonds", true));
 
         // Create a supercell that is 5 * unitcell
-        ASSERT_TRUE(cifConfigurationNode_->setOption<Vector3i>("SupercellRepeat", supercellRepeat_));
+        ASSERT_TRUE(testGraph_.nextNode("CIFMolecularSpecies", "Crystal"));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Vector3i>("SupercellRepeat", supercellRepeat_));
 
         ASSERT_TRUE(root->addEdge({"CIFBonds", "CIFContext", "Crystal", "CIFContext"}));
 
         // Import coordinates
-        auto cfgName = std::string(cifConfigurationNode_->name());
-        auto importCoordsNode = testGraph_.appendImportCoordinates(
-            cifConfigurationNode_,
+        ASSERT_TRUE(testGraph_.appendImportCoordinates(
             CoordinateImportFileFormat("epsr25/mgo500-555/mgo.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR),
-            true);
+            true));
 
         // Add correlation function nodes
-        auto &&[grNode, sqNode] = testGraph_.appendGRSQ(importCoordsNode, false, true);
+        auto &&[grNode, sqNode] = testGraph_.appendGRSQ(false, true);
         ASSERT_TRUE(grNode);
         ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.025));
         ASSERT_TRUE(sqNode);
@@ -76,16 +73,18 @@ class BraggNodeTest : public ::testing::Test
         ASSERT_TRUE(neutronSQNode_);
 
         // Bragg node
-        braggNode_ = static_cast<BraggNode *>(root->createNode("Bragg", "Bragg01"));
-        ASSERT_TRUE(braggNode_);
+        ASSERT_TRUE(testGraph_.nextNode("Bragg", "Bragg01"));
         ASSERT_TRUE(root->addEdge({"Crystal", "SupercellConfiguration", "Bragg01", "Configuration"}));
         ASSERT_TRUE(root->addEdge({std::string(sqNode->name()), "UnweightedSQ", "Bragg01", "UnweightedSQ"}));
-        ASSERT_TRUE(braggNode_->setOption<Number>("QMax", 20.0));
-        ASSERT_TRUE(braggNode_->setOption<Function1DWrapper>("BraggQBroadening",
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Number>("QMax", 20.0));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Function1DWrapper>("BraggQBroadening",
                                                              {Functions1D::Form::GaussianC2, {0.0235482, 0.0470964}}));
 
         // Set Bragg multiplicities
-        ASSERT_TRUE(braggNode_->setOption<Vector3i>("Multiplicity", braggMultiplicities));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Vector3i>("Multiplicity", braggMultiplicities));
+        
+        braggNode_ = testGraph_.head<BraggNode>();
+        ASSERT_TRUE(braggNode_);
     }
 
     static bool testReflections(const std::vector<BraggReflection> &braggReflections,

--- a/tests/nodes/bragg.cpp
+++ b/tests/nodes/bragg.cpp
@@ -45,7 +45,7 @@ class BraggNodeTest : public ::testing::Test
 
         ASSERT_TRUE(testGraph_.nextNode("CIFBondingOptions", "CIFBonds"));
         ASSERT_TRUE(root->addEdge({"CIFLoader", "CIFContext", "CIFBonds", "CIFContext"}));
-        ASSERT_TRUE(fetchHead()->setOption<bool>("PreventAllBonds", true));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<bool>("PreventAllBonds", true));
 
         // Create a supercell that is 5 * unitcell
         ASSERT_TRUE(testGraph_.nextNode("CIFMolecularSpecies", "Crystal"));
@@ -77,12 +77,12 @@ class BraggNodeTest : public ::testing::Test
         ASSERT_TRUE(root->addEdge({"Crystal", "SupercellConfiguration", "Bragg01", "Configuration"}));
         ASSERT_TRUE(root->addEdge({std::string(sqNode->name()), "UnweightedSQ", "Bragg01", "UnweightedSQ"}));
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<Number>("QMax", 20.0));
-        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Function1DWrapper>("BraggQBroadening",
-                                                             {Functions1D::Form::GaussianC2, {0.0235482, 0.0470964}}));
+        ASSERT_TRUE(testGraph_.fetchHead()->setOption<Function1DWrapper>(
+            "BraggQBroadening", {Functions1D::Form::GaussianC2, {0.0235482, 0.0470964}}));
 
         // Set Bragg multiplicities
         ASSERT_TRUE(testGraph_.fetchHead()->setOption<Vector3i>("Multiplicity", braggMultiplicities));
-        
+
         braggNode_ = testGraph_.head<BraggNode>();
         ASSERT_TRUE(braggNode_);
     }

--- a/tests/nodes/broadening.cpp
+++ b/tests/nodes/broadening.cpp
@@ -13,13 +13,12 @@ TEST(BroadeningTest, ArgonBroadening)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 10000}}, 0.0213);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode,
-        CoordinateImportFileFormat("epsr25/argon10000/argonbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 10000}}, 0.0213));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/argon10000/argonbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Append GR and SQ nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, true, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(true, true);
 
     // Set up neutron SQ
     auto neutronSQNode = testGraph.appendNeutronSQ(sqNode, "Yarnell", {{"Ar", "Ar36", 1.0}});

--- a/tests/nodes/cif.cpp
+++ b/tests/nodes/cif.cpp
@@ -30,13 +30,13 @@ class CIFNodeTest : public ::testing::Test
     void createGraph(std::string filename)
     {
         auto name = cifNameFromFile(filename);
-        auto loaderNode = testGraph_.createNode("CIFLoader", name);
-        loaderNode->setOption("FilePath", path_ + filename);
-        auto bondingNode = testGraph_.createNode("CIFBondingOptions", name + "//BondingOptions");
-        auto removeAtomicNode = testGraph_.createNode("CIFRemoveAtomic", name + "//RemoveAtomic");
-        auto removeWaterNode = testGraph_.createNode("CIFRemoveWater", name + "//RemoveWater");
-        auto structureCleanupNode = testGraph_.createNode("CIFStructureCleanup", name + "//StructureCleanup");
-        auto molecularSpeciesNode = testGraph_.createNode("CIFMolecularSpecies", name + "//MolecularSpecies");
+        EXPECT_TRUE(testGraph_.nextNode("CIFLoader", name));
+        testGraph_.fetchHead()->setOption("FilePath", path_ + filename);
+        EXPECT_TRUE(testGraph_.nextNode("CIFBondingOptions", name + "//BondingOptions"));
+        EXPECT_TRUE(testGraph_.nextNode("CIFRemoveAtomic", name + "//RemoveAtomic"));
+        EXPECT_TRUE(testGraph_.nextNode("CIFRemoveWater", name + "//RemoveWater"));
+        EXPECT_TRUE(testGraph_.nextNode("CIFStructureCleanup", name + "//StructureCleanup"));
+        EXPECT_TRUE(testGraph_.nextNode("CIFMolecularSpecies", name + "//MolecularSpecies"));
         testGraph_.addEdge({name, "CIFContext", name + "//BondingOptions", "CIFContext"});
         testGraph_.addEdge({name + "//BondingOptions", "CIFContext", name + "//RemoveAtomic", "CIFContext"});
         testGraph_.addEdge({name + "//RemoveAtomic", "CIFContext", name + "//RemoveWater", "CIFContext"});
@@ -240,26 +240,28 @@ TEST_F(CIFNodeTest, CuBTC)
     EmpiricalFormula::EmpiricalFormulaMap cellFormulaNH2 = cellFormulaH;
     cellFormulaNH2[Elements::N] = 6 * N;
     cellFormulaNH2[Elements::H] *= 2;
-    auto atomGroupA1 = testGraph_.createNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupA1");
-    atomGroupA1->setOption("Assembly", std::string("A"));
-    atomGroupA1->setOption("AtomGroup", std::string("1"));
-    atomGroupA1->setOption("SetActive", false);
-    auto atomGroupB2 = testGraph_.createNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupB2");
-    atomGroupB2->setOption("Assembly", std::string("B"));
-    atomGroupB2->setOption("AtomGroup", std::string("2"));
-    atomGroupB2->setOption("SetActive", true);
-    auto atomGroupC2 = testGraph_.createNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupC2");
-    atomGroupC2->setOption("Assembly", std::string("C"));
-    atomGroupC2->setOption("AtomGroup", std::string("2"));
-    atomGroupC2->setOption("SetActive", true);
+    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupA1"));
+    testGraph_.fetchHead()->setOption("Assembly", std::string("A"));
+    testGraph_.fetchHead()->setOption("AtomGroup", std::string("1"));
+    testGraph_.fetchHead()->setOption("SetActive", false);
+    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupB2"));
+    testGraph_.fetchHead()->setOption("Assembly", std::string("B"));
+    testGraph_.fetchHead()->setOption("AtomGroup", std::string("2"));
+    testGraph_.fetchHead()->setOption("SetActive", true);
+    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupC2"));
+    testGraph_.fetchHead()->setOption("Assembly", std::string("C"));
+    testGraph_.fetchHead()->setOption("AtomGroup", std::string("2"));
+    testGraph_.fetchHead()->setOption("SetActive", true);
     testGraph_.removeEdge(
         {cifNameFromFile(cif) + "//StructureCleanup", "CIFContext", std::string(molecularSpeciesNode->name()), "CIFContext"});
     testGraph_.addEdge(
-        {cifNameFromFile(cif) + "//StructureCleanup", "CIFContext", std::string(atomGroupA1->name()), "CIFContext"});
-    testGraph_.addEdge({std::string(atomGroupA1->name()), "CIFContext", std::string(atomGroupB2->name()), "CIFContext"});
-    testGraph_.addEdge({std::string(atomGroupB2->name()), "CIFContext", std::string(atomGroupC2->name()), "CIFContext"});
+        {cifNameFromFile(cif) + "//StructureCleanup", "CIFContext", cifNameFromFile(cif) + "//AtomGroupA1", "CIFContext"});
     testGraph_.addEdge(
-        {std::string(atomGroupC2->name()), "CIFContext", std::string(molecularSpeciesNode->name()), "CIFContext"});
+        {cifNameFromFile(cif) + "//AtomGroupA1", "CIFContext", cifNameFromFile(cif) + "//AtomGroupB2", "CIFContext"});
+    testGraph_.addEdge(
+        {cifNameFromFile(cif) + "//AtomGroupB2", "CIFContext", cifNameFromFile(cif) + "//AtomGroupC2", "CIFContext"});
+    testGraph_.addEdge(
+        {cifNameFromFile(cif) + "//AtomGroupC2", "CIFContext", std::string(molecularSpeciesNode->name()), "CIFContext"});
     testGraph_.setUpdateRequired();
     ASSERT_EQ(molecularSpeciesNode->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(

--- a/tests/nodes/cif.cpp
+++ b/tests/nodes/cif.cpp
@@ -30,13 +30,13 @@ class CIFNodeTest : public ::testing::Test
     void createGraph(std::string filename)
     {
         auto name = cifNameFromFile(filename);
-        EXPECT_TRUE(testGraph_.nextNode("CIFLoader", name));
+        EXPECT_TRUE(testGraph_.appendNode("CIFLoader", name));
         testGraph_.fetchHead()->setOption("FilePath", path_ + filename);
-        EXPECT_TRUE(testGraph_.nextNode("CIFBondingOptions", name + "//BondingOptions"));
-        EXPECT_TRUE(testGraph_.nextNode("CIFRemoveAtomic", name + "//RemoveAtomic"));
-        EXPECT_TRUE(testGraph_.nextNode("CIFRemoveWater", name + "//RemoveWater"));
-        EXPECT_TRUE(testGraph_.nextNode("CIFStructureCleanup", name + "//StructureCleanup"));
-        EXPECT_TRUE(testGraph_.nextNode("CIFMolecularSpecies", name + "//MolecularSpecies"));
+        EXPECT_TRUE(testGraph_.appendNode("CIFBondingOptions", name + "//BondingOptions"));
+        EXPECT_TRUE(testGraph_.appendNode("CIFRemoveAtomic", name + "//RemoveAtomic"));
+        EXPECT_TRUE(testGraph_.appendNode("CIFRemoveWater", name + "//RemoveWater"));
+        EXPECT_TRUE(testGraph_.appendNode("CIFStructureCleanup", name + "//StructureCleanup"));
+        EXPECT_TRUE(testGraph_.appendNode("CIFMolecularSpecies", name + "//MolecularSpecies"));
         testGraph_.addEdge({name, "CIFContext", name + "//BondingOptions", "CIFContext"});
         testGraph_.addEdge({name + "//BondingOptions", "CIFContext", name + "//RemoveAtomic", "CIFContext"});
         testGraph_.addEdge({name + "//RemoveAtomic", "CIFContext", name + "//RemoveWater", "CIFContext"});
@@ -240,15 +240,15 @@ TEST_F(CIFNodeTest, CuBTC)
     EmpiricalFormula::EmpiricalFormulaMap cellFormulaNH2 = cellFormulaH;
     cellFormulaNH2[Elements::N] = 6 * N;
     cellFormulaNH2[Elements::H] *= 2;
-    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupA1"));
+    EXPECT_TRUE(testGraph_.appendNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupA1"));
     testGraph_.fetchHead()->setOption("Assembly", std::string("A"));
     testGraph_.fetchHead()->setOption("AtomGroup", std::string("1"));
     testGraph_.fetchHead()->setOption("SetActive", false);
-    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupB2"));
+    EXPECT_TRUE(testGraph_.appendNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupB2"));
     testGraph_.fetchHead()->setOption("Assembly", std::string("B"));
     testGraph_.fetchHead()->setOption("AtomGroup", std::string("2"));
     testGraph_.fetchHead()->setOption("SetActive", true);
-    EXPECT_TRUE(testGraph_.nextNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupC2"));
+    EXPECT_TRUE(testGraph_.appendNode("SetCIFAtomGroupActivity", cifNameFromFile(cif) + "//AtomGroupC2"));
     testGraph_.fetchHead()->setOption("Assembly", std::string("C"));
     testGraph_.fetchHead()->setOption("AtomGroup", std::string("2"));
     testGraph_.fetchHead()->setOption("SetActive", true);

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -13,10 +13,10 @@ TEST(GRNodeTest, Methods)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 5000}}, 0.0213);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 5000}}, 0.0213));
 
     // Append GR and SQ nodes
-    auto sqNode = testGraph.appendGRSQ(lastNode, true, true);
+    auto sqNode = testGraph.appendGRSQ(true, true);
     auto arSpeciesNode = testGraph.findNode("Ar");
     ASSERT_TRUE(arSpeciesNode);
     auto grNode = testGraph.findNode("GR");
@@ -46,13 +46,12 @@ TEST(GRNodeTest, Water)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water1000-neutron/waterbox.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
 
@@ -91,13 +90,12 @@ TEST(GRNodeTest, WaterMethanol)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water300methanol600/watermeth.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, _] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, _] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
 
@@ -266,14 +264,13 @@ TEST(GRNodeTest, Benzene)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode =
-        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/benzene200-neutron/boxbenz.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(
+        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
 

--- a/tests/nodes/graphArgon.cpp
+++ b/tests/nodes/graphArgon.cpp
@@ -32,13 +32,12 @@ TEST(GraphArgonTest, AllCorrelations)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 1000}}, 0.0213);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("dissolve2/argon/Ar_bulk_step1000.xyz",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::XYZ));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{[] { return createAtomic(Elements::Ar); }, 1000}}, 0.0213));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "dissolve2/argon/Ar_bulk_step1000.xyz", CoordinateImportFileFormat::CoordinateImportFormat::XYZ)));
 
     // Append GR and SQ nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, true, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(true, true);
 
     // Set up neutron SQ
     auto neutronSQNode =

--- a/tests/nodes/neutronSQ.cpp
+++ b/tests/nodes/neutronSQ.cpp
@@ -13,13 +13,12 @@ TEST(NeutronSQNodeTest, Water)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water1000-neutron/waterbox.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);
@@ -60,13 +59,12 @@ TEST(NeutronSQNodeTest, WaterReferenceFT)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water1000-neutron/waterbox.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);
@@ -112,13 +110,12 @@ TEST(NeutronSQNodeTest, WaterMethanol)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water300methanol600/watermeth.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);
@@ -180,14 +177,13 @@ TEST(NeutronSQNodeTest, Benzene)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode =
-        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/benzene200-neutron/boxbenz.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(
+        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);

--- a/tests/nodes/siteRDF.cpp
+++ b/tests/nodes/siteRDF.cpp
@@ -34,7 +34,7 @@ class SiteRDFNodeTest : public ::testing::Test
         testGraph_.createConfiguration("Box", {{createWaterDLPoly, 267}}, 0.1);
 
         // Add iterator
-        EXPECT_TRUE(testGraph_.createNode("Iterator", "Iterator"));
+        EXPECT_TRUE(testGraph_.nextNode("Iterator", "Iterator"));
         iterator_ = testGraph_.head<IterableGraph>();
 
         // Grab the water species for convenience

--- a/tests/nodes/siteRDF.cpp
+++ b/tests/nodes/siteRDF.cpp
@@ -34,7 +34,7 @@ class SiteRDFNodeTest : public ::testing::Test
         testGraph_.createConfiguration("Box", {{createWaterDLPoly, 267}}, 0.1);
 
         // Add iterator
-        EXPECT_TRUE(testGraph_.nextNode("Iterator", "Iterator"));
+        EXPECT_TRUE(testGraph_.appendNode("Iterator", "Iterator"));
         iterator_ = testGraph_.head<IterableGraph>();
 
         // Grab the water species for convenience

--- a/tests/nodes/siteRDF.cpp
+++ b/tests/nodes/siteRDF.cpp
@@ -34,8 +34,8 @@ class SiteRDFNodeTest : public ::testing::Test
         testGraph_.createConfiguration("Box", {{createWaterDLPoly, 267}}, 0.1);
 
         // Add iterator
-        iterator_ = dynamic_cast<IterableGraph *>(testGraph_.createNode("Iterator", "Iterator"));
-        ASSERT_TRUE(iterator_);
+        EXPECT_TRUE(testGraph_.createNode("Iterator", "Iterator"));
+        iterator_ = testGraph_.head<IterableGraph>();
 
         // Grab the water species for convenience
         auto waterNode = testGraph_.findNode("Water");

--- a/tests/nodes/sq.cpp
+++ b/tests/nodes/sq.cpp
@@ -13,13 +13,12 @@ TEST(SQNodeTest, Water)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water1000-neutron/waterbox.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);
@@ -63,13 +62,12 @@ TEST(SQNodeTest, WaterMethanol)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water300methanol600/watermeth.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 300}, {createMethanol, 600}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);
@@ -242,14 +240,13 @@ TEST(SQNodeTest, Benzene)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode =
-        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/benzene200-neutron/boxbenz.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(
+        testGraph.createConfiguration("Box", {{createBenzene, 200}}, 0.876, Units::DensityUnits::GramsPerCentimetreCubedUnits));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);

--- a/tests/nodes/xRaySQ.cpp
+++ b/tests/nodes/xRaySQ.cpp
@@ -13,13 +13,12 @@ TEST(XRaySQNodeTest, WaterReferenceFT)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto lastNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    lastNode = testGraph.appendImportCoordinates(
-        lastNode, CoordinateImportFileFormat("epsr25/water1000-neutron/waterbox.ato",
-                                             CoordinateImportFileFormat::CoordinateImportFormat::EPSR));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
+        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
 
     // Add correlation function nodes
-    auto &&[grNode, sqNode] = testGraph.appendGRSQ(lastNode, false, true);
+    auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
     ASSERT_TRUE(grNode);
     ASSERT_TRUE(grNode->setOption<Number>("BinWidth", 0.03));
     ASSERT_TRUE(sqNode);

--- a/tests/pairPotentials/cutoffs.cpp
+++ b/tests/pairPotentials/cutoffs.cpp
@@ -15,11 +15,9 @@ TEST(PairPotentialCutoffTest, ShortRange)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto insertNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        insertNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -35,11 +33,11 @@ TEST(PairPotentialCutoffTest, ShortRange)
     ow->setCharge(0.0);
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
 
     // Check consistency between production and test forces at different cutoffs
     std::vector<Vector3> pairPotentialForces, geometryForces;
@@ -55,11 +53,9 @@ TEST(PairPotentialCutoffTest, Coulomb)
 {
     // Set up the test graph
     TestGraph testGraph;
-    auto insertNode = testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1);
-    auto importNode = testGraph.appendImportCoordinates(
-        insertNode,
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY));
-    ASSERT_TRUE(importNode);
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{createWater, 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendImportCoordinates(
+        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
 
     // Adjust pair potential properties
     PairPotential::setCoulombTruncationScheme(PairPotential::CoulombTruncationScheme::NoCoulombTruncation);
@@ -72,11 +68,11 @@ TEST(PairPotentialCutoffTest, Coulomb)
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
     // Run the graph from the Import node to set up the configuration
-    ASSERT_EQ(importNode->run(), NodeConstants::ProcessResult::Success);
-    ASSERT_EQ(importNode->versionIndex(), 0);
+    ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
+    ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
     // Get the configuration
-    auto cfg = importNode->getOutputValue<Configuration *>("Configuration");
+    auto cfg = testGraph.fetchHead()->getOutputValue<Configuration *>("Configuration");
 
     // Check consistency between production and test forces at different cutoffs
     std::vector<Vector3> pairPotentialForces, geometryForces;

--- a/tests/pairPotentials/cutoffs.cpp
+++ b/tests/pairPotentials/cutoffs.cpp
@@ -32,7 +32,7 @@ TEST(PairPotentialCutoffTest, ShortRange)
     hw->setCharge(0.0);
     ow->setCharge(0.0);
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 
@@ -67,7 +67,7 @@ TEST(PairPotentialCutoffTest, Coulomb)
     ASSERT_TRUE(ow);
     ow->interactionPotential().setFormAndParameters(ShortRangeFunctions::Form::LennardJones, "epsilon=0.0 sigma=0.0");
 
-    // Run the graph from the Import node to set up the configuration
+    // Run the graph from the head node to set up the configuration
     ASSERT_EQ(testGraph.fetchHead()->run(), NodeConstants::ProcessResult::Success);
     ASSERT_EQ(testGraph.fetchHead()->versionIndex(), 0);
 


### PR DESCRIPTION
The idea here is to allow `TestGraph` to keep track of the last node added to the graph (mostly useful when the nodes are being added in a broadly linear sequence), stored internally in `head_` allowing the developer to get either a `Node *` via a `fetchHead()` call, or a pointer to the desired node type via `head<NodeType>`. The latter is useful for compile time checking that the node is of the expected type.

<img width="1624" height="499" alt="nextnode" src="https://github.com/user-attachments/assets/4850a12e-86a2-4d63-89ec-b036417ec16e" />
