### PR TITLE
chore: More CoreData work after species-atomtypes

### DIFF
--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -209,13 +209,13 @@ void Species::print() const
  */
 
 // Apply terms from specified Forcefield
-bool Species::applyForcefieldTerms(std::shared_ptr<Forcefield> ff, CoreData &coreData)
+bool Species::applyForcefieldTerms(std::shared_ptr<Forcefield> ff)
 {
     if (!ff)
         return Messenger::error("No forcefield supplied!\n");
 
     // Assign atom types to the species
-    if (!ff->assignAtomTypes(this, coreData, Forcefield::TypeAll, false).empty())
+    if (!ff->assignAtomTypes(this, Forcefield::TypeAll, false).empty())
         return false;
 
     // Assign intramolecular terms

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -314,7 +314,7 @@ class Species : public Serialisable<>
      */
     public:
     // Apply terms from specified Forcefield
-    bool applyForcefieldTerms(std::shared_ptr<Forcefield> ff, CoreData &coreData);
+    bool applyForcefieldTerms(std::shared_ptr<Forcefield> ff);
     // Clear forcefield terms
     void clearForcefieldTerms(bool nullifyAtomTypes = true);
 

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -271,21 +271,20 @@ Forcefield::getAtomTypes(const std::vector<const SpeciesAtom *> &atoms, bool det
 }
 
 // Assign suitable AtomType to the supplied atom
-bool Forcefield::assignAtomType(SpeciesAtom &i, CoreData &coreData, bool setSpeciesAtomCharges) const
+bool Forcefield::assignAtomType(SpeciesAtom &i, bool setSpeciesAtomCharges) const
 {
     auto optRef = determineAtomType(i);
     if (!optRef)
         return false;
     const ForcefieldAtomType &assignedType = *optRef;
 
-    assignAtomType(assignedType, i, coreData, setSpeciesAtomCharges);
+    assignAtomType(assignedType, i, setSpeciesAtomCharges);
 
     return true;
 }
 
 // Assign suitable atom types to the supplied Species, returning the number of failures
-std::vector<int> Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy,
-                                             bool setSpeciesAtomCharges) const
+std::vector<int> Forcefield::assignAtomTypes(Species *sp, AtomTypeAssignmentStrategy strategy, bool setSpeciesAtomCharges) const
 {
     Messenger::print("Assigning atomtypes to species '{}' from forcefield '{}'...\n", sp->name(), name());
 
@@ -302,7 +301,7 @@ std::vector<int> Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, At
         if ((strategy == Forcefield::TypeSelection) && (!i.isSelected()))
             continue;
 
-        if (!assignAtomType(i, coreData, setSpeciesAtomCharges))
+        if (!assignAtomType(i, setSpeciesAtomCharges))
         {
             Messenger::error("No matching forcefield type for atom {} ({}).\n", i.userIndex(), Elements::symbol(i.Z()));
             failedElements.push_back(i.userIndex());
@@ -317,8 +316,7 @@ std::vector<int> Forcefield::assignAtomTypes(Species *sp, CoreData &coreData, At
 }
 
 // Assign specific AtomType to the supplied atom
-void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, CoreData &coreData,
-                                bool setSpeciesAtomCharges) const
+void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, bool setSpeciesAtomCharges) const
 {
 
     // Check if an AtomType of the same name already exists - if it does, just use that one

--- a/src/data/ff/ff.h
+++ b/src/data/ff/ff.h
@@ -22,7 +22,6 @@
 #include <vector>
 
 // Forward Declarations
-class CoreData;
 class Species;
 class SpeciesAtom;
 
@@ -157,7 +156,7 @@ class Forcefield
 
     protected:
     // Assign suitable AtomType to the supplied atom
-    bool assignAtomType(SpeciesAtom &i, CoreData &coreData, bool setSpeciesAtomCharges) const;
+    bool assignAtomType(SpeciesAtom &i, bool setSpeciesAtomCharges) const;
     // Assign / generate bond term parameters
     virtual bool assignBondTermParameters(const Species *parent, SpeciesBond &bond, bool determineTypes) const;
     // Assign / generate angle term parameters
@@ -186,10 +185,9 @@ class Forcefield
     };
     // Assign suitable AtomTypes to the supplied Species, returning the number of failures
     // Returns any elements that were unassigned
-    std::vector<int> assignAtomTypes(Species *sp, CoreData &coreData, AtomTypeAssignmentStrategy strategy,
-                                     bool setSpeciesAtomCharges) const;
+    std::vector<int> assignAtomTypes(Species *sp, AtomTypeAssignmentStrategy strategy, bool setSpeciesAtomCharges) const;
     // Assign specific AtomType to the supplied atom
-    void assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, CoreData &coreData, bool setSpeciesAtomCharges) const;
+    void assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, bool setSpeciesAtomCharges) const;
     // Assign intramolecular parameters to the supplied Species
     bool assignIntramolecular(Species *sp, int flags = Forcefield::GenerateImpropersFlag) const;
 

--- a/src/gui/addForcefieldTermsDialog.cpp
+++ b/src/gui/addForcefieldTermsDialog.cpp
@@ -15,9 +15,8 @@ AddForcefieldTermsDialog::AddForcefieldTermsDialog(QWidget *parent, Dissolve &di
     // QIcon::setThemeName("personal");
 
     auto *view = new QQuickWidget(QUrl("qrc:/dialogs/qml/AddForcefieldTermsDialog.qml"), this);
-    AtomTypeModel atModel(dissolve.coreData());
-
-    atModel.setData(dissolve.coreData().atomTypes());
+    AtomTypeModel atModel;
+    atModel.setData(sp->atomTypes());
 
     view->rootContext()->setContextProperty("atModel", QVariant::fromValue(&atModel));
     view->setMinimumSize(300, 300);

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -124,7 +124,8 @@ void AddForcefieldDialogModel::next()
 //
 // // Set model and signals for the master terms tree
 // atomTypes_.setQueryFunction([this](const auto type)
-//     commons_->setBondQueryFunction([this](std::string_view name, Species *sp) { return sp->getCommonBond(name).has_value(); });
+//     commons_->setBondQueryFunction([this](std::string_view name, Species *sp) { return sp->getCommonBond(name).has_value();
+//     });
 // commons_->setAngleQueryFunction([this](std::string_view name, Species *sp)
 //                                 { return sp->getCommonAngle(name).has_value(); });
 // commons_->setTorsionQueryFunction([this](std::string_view name, Species *sp)

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -14,8 +14,6 @@ AddForcefieldDialogModel::AddForcefieldDialogModel() : ffSort_(this)
     ffSort_.setSourceModel(ffModel_.get());
 }
 
-AddForcefieldDialogModel::~AddForcefieldDialogModel() { temporaryDissolve_->clear(); }
-
 // The current page in the wizard
 AddForcefieldDialogModel::Page AddForcefieldDialogModel::index() { return index_; }
 
@@ -56,7 +54,7 @@ void AddForcefieldDialogModel::next()
             // Must have a valid forcefield
             if (!ff_)
                 return;
-            modifiedSpecies_ = temporaryDissolve_->coreData().addSpecies();
+            modifiedSpecies_ = std::make_shared<Species>();
             modifiedSpecies_->copyBasic(species_);
             originalAtomTypeNames_.clear();
 
@@ -70,18 +68,17 @@ void AddForcefieldDialogModel::next()
             {
                 case Radio::All:
                     modifiedSpecies_->clearAtomTypes();
-                    temporaryDissolve_->coreData().clearAtomTypes();
 
-                    assignErrs = ff_->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeAll,
-                                                      !keepSpeciesAtomChargesCheck_);
+                    assignErrs =
+                        ff_->assignAtomTypes(modifiedSpecies_.get(), Forcefield::TypeAll, !keepSpeciesAtomChargesCheck_);
                     break;
                 case Radio::Selected:
-                    assignErrs = ff_->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeSelection,
-                                                      !keepSpeciesAtomChargesCheck_);
+                    assignErrs =
+                        ff_->assignAtomTypes(modifiedSpecies_.get(), Forcefield::TypeSelection, !keepSpeciesAtomChargesCheck_);
                     break;
                 case Radio::Empty:
-                    assignErrs = ff_->assignAtomTypes(modifiedSpecies_, temporaryCoreData_, Forcefield::TypeMissing,
-                                                      !keepSpeciesAtomChargesCheck_);
+                    assignErrs =
+                        ff_->assignAtomTypes(modifiedSpecies_.get(), Forcefield::TypeMissing, !keepSpeciesAtomChargesCheck_);
                 default:
                     break;
             }
@@ -92,10 +89,10 @@ void AddForcefieldDialogModel::next()
                 return;
             }
 
-            for (auto &at : temporaryDissolve_->coreData().atomTypes())
+            for (auto &at : modifiedSpecies_->atomTypes())
                 originalAtomTypeNames_.emplace_back(std::string(at->name()));
 
-            atomTypes_.setData(temporaryCoreData_.atomTypes());
+            atomTypes_.setData(modifiedSpecies_->atomTypes());
             Q_EMIT atomTypesIndicatorChanged();
 
             // checkAtomTypeConflicts();
@@ -118,26 +115,23 @@ void AddForcefieldDialogModel::next()
     indexChanged();
 }
 
-// Supply the main Dissolve instance
-void AddForcefieldDialogModel::setDissolve(Dissolve &dissolve)
-{
-    dissolve_ = &dissolve;
-
-    temporaryDissolve_ = std::make_unique<Dissolve>(temporaryCoreData_);
-    // commons_ = std::make_unique<MasterTermTreeModel>(temporaryCoreData_);
-    // TODO DISSOLVE2
-
-    // Set model and signals for the common terms tree
-    atomTypes_.setQueryFunction([this](const auto type)
-                                { return dissolve_->coreData().findAtomType(type->name()) != nullptr; });
-    commons_->setBondQueryFunction([this](std::string_view name, Species *sp) { return sp->getCommonBond(name).has_value(); });
-    commons_->setAngleQueryFunction([this](std::string_view name, Species *sp)
-                                    { return sp->getCommonAngle(name).has_value(); });
-    commons_->setTorsionQueryFunction([this](std::string_view name, Species *sp)
-                                      { return sp->getCommonTorsion(name).has_value(); });
-    commons_->setImproperQueryFunction([this](std::string_view name, Species *sp)
-                                       { return sp->getCommonImproper(name).has_value(); });
-}
+// void AddForcefieldDialogModel::setDissolve(Dissolve &dissolve)
+// {
+// TODO DISSOLVE2
+// dissolve_ = &dissolve;
+//
+// masters_ = std::make_unique<MasterTermTreeModel>(temporaryCoreData_);
+//
+// // Set model and signals for the master terms tree
+// atomTypes_.setQueryFunction([this](const auto type)
+//     commons_->setBondQueryFunction([this](std::string_view name, Species *sp) { return sp->getCommonBond(name).has_value(); });
+// commons_->setAngleQueryFunction([this](std::string_view name, Species *sp)
+//                                 { return sp->getCommonAngle(name).has_value(); });
+// commons_->setTorsionQueryFunction([this](std::string_view name, Species *sp)
+//                                   { return sp->getCommonTorsion(name).has_value(); });
+// commons_->setImproperQueryFunction([this](std::string_view name, Species *sp)
+//                                    { return sp->getCommonImproper(name).has_value(); });
+// }
 
 // Supply the species to operate on
 void AddForcefieldDialogModel::setSpecies(Species *sp)
@@ -166,13 +160,6 @@ bool AddForcefieldDialogModel::progressionAllowed() const
     if (index_ == Page::SelectForcefieldPage)
         return ff_ != nullptr;
     return true;
-}
-
-// Determine whether we have any naming conflicts
-int AddForcefieldDialogModel::atomTypesIndicator() const
-{
-    return std::count_if(temporaryCoreData_.atomTypes().begin(), temporaryCoreData_.atomTypes().end(),
-                         [&](const auto &atomType) { return dissolve_->coreData().findAtomType(atomType->name()); });
 }
 
 // Whether we are at the final page of the wizard
@@ -433,11 +420,12 @@ void AddForcefieldDialogModel::assignIntramolecularTerms(const Forcefield *ff)
             flags += Forcefield::SelectionOnlyFlag;
 
         // Try to assign terms across the species
-        if (!ff->assignIntramolecular(modifiedSpecies_, flags))
+        if (!ff->assignIntramolecular(modifiedSpecies_.get(), flags))
             return;
 
-        // Reduce to common terms?
-        if (!noMasterTerms_)
-            modifiedSpecies_->reduceToCommonTerms(temporaryCoreData_, intramolecularRadio_ == Radio::Selected);
+        // Reduce to master terms?
+        // TODO DISSOLVE2
+        // if (!noMasterTerms_)
+        // modifiedSpecies_->reduceToCommonTerms(temporaryCoreData_, intramolecularRadio_ == Radio::Selected);
     }
 }

--- a/src/gui/models/addForcefieldDialogModel.h
+++ b/src/gui/models/addForcefieldDialogModel.h
@@ -31,7 +31,7 @@ class AddForcefieldDialogModel : public QObject
     // The Master Improper Model
     Q_PROPERTY(const CommonImproperModel *impropers READ impropers NOTIFY commonsChanged)
     // The number of atom types conflicts
-    Q_PROPERTY(int atomTypesIndicator READ atomTypesIndicator NOTIFY atomTypesIndicatorChanged);
+    // Q_PROPERTY(int atomTypesIndicator READ atomTypesIndicator NOTIFY atomTypesIndicatorChanged);
     // Whether it is safe to move to the next page
     Q_PROPERTY(bool progressionAllowed READ progressionAllowed NOTIFY progressionAllowedChanged);
     Q_PROPERTY(bool keepSpeciesAtomChargesCheck MEMBER keepSpeciesAtomChargesCheck_)
@@ -94,13 +94,9 @@ class AddForcefieldDialogModel : public QObject
     // The chosen forcefield
     Forcefield *ff_ = nullptr;
     std::unique_ptr<MasterTermTreeModel> commons_ = nullptr;
-    // Temporary Dissolve reference for creating / importing layers
-    std::unique_ptr<Dissolve> temporaryDissolve_;
-    // Temporary core data for applying Forcefield terms
-    CoreData temporaryCoreData_;
     // The destination for the forcefield
     Species *species_ = nullptr;
-    Species *modifiedSpecies_ = nullptr;
+    std::shared_ptr<Species> modifiedSpecies_;
     // Original atom type names assigned to species
     std::vector<std::string> originalAtomTypeNames_;
     // The Atom Type Model
@@ -124,7 +120,7 @@ class AddForcefieldDialogModel : public QObject
     public:
     // Instantiate the model
     AddForcefieldDialogModel();
-    ~AddForcefieldDialogModel();
+    ~AddForcefieldDialogModel() = default;
     // The current page in the wizard
     Page index();
     // Progress in the wizard
@@ -147,7 +143,6 @@ class AddForcefieldDialogModel : public QObject
     Forcefield *ff() const;
     // Update the chosen forcefield
     void setFf(Forcefield *f);
-    int atomTypesIndicator() const;
     // Does the species have selected atoms
     bool speciesHasSelection() const;
     // Can the user safely pass to the next stage?
@@ -160,8 +155,6 @@ class AddForcefieldDialogModel : public QObject
     // Add a prefix to the name of a common term
     Q_INVOKABLE void addMasterPrefix(int type, int index, QString prefix);
 
-    // Supply the main Dissolve instance
-    void setDissolve(Dissolve &Dissolve);
     // Supply the species to operate on
     void setSpecies(Species *species);
     // Apply the forcefield

--- a/src/gui/models/atomTypeModel.cpp
+++ b/src/gui/models/atomTypeModel.cpp
@@ -7,8 +7,6 @@
 #include "classes/coreData.h"
 #include "templates/algorithms.h"
 
-AtomTypeModel::AtomTypeModel(const CoreData &coreData) : coreData_(coreData) {}
-
 void AtomTypeModel::reset()
 {
     beginResetModel();
@@ -16,12 +14,8 @@ void AtomTypeModel::reset()
 }
 
 // Set source AtomType data
-void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
-                            OptionalReferenceWrapper<const CoreData> coreData)
+void AtomTypeModel::setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes)
 {
-    if (coreData)
-        coreData_ = coreData;
-
     beginResetModel();
     atomTypes_ = atomTypes;
     endResetModel();
@@ -144,13 +138,10 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
         switch (index.column())
         {
             case (AtomTypeModelData::Name):
-                // Ensure uniqueness of name if we have a reference CoreData
-                if (coreData_)
-                    atomType->setName(DissolveSys::uniqueName(value.toString().toStdString(), coreData_->get().atomTypes(),
-                                                              [&atomType](const auto &at)
-                                                              { return atomType == at ? "" : at->name(); }));
-                else
-                    atomType->setName(value.toString().toStdString());
+                // Ensure uniqueness of name
+                atomType->setName(DissolveSys::uniqueName(value.toString().toStdString(), atomTypes_->get(),
+                                                          [&atomType](const auto &at)
+                                                          { return atomType == at ? "" : at->name(); }));
                 break;
             case (AtomTypeModelData::Element):
                 return false;
@@ -183,11 +174,9 @@ bool AtomTypeModel::setData(const QModelIndex &index, const QVariant &value, int
 
 Qt::ItemFlags AtomTypeModel::flags(const QModelIndex &index) const
 {
-    Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+    Qt::ItemFlags flags = Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsEditable;
     if (index.column() == AtomTypeModelData::Name)
     {
-        if (coreData_)
-            flags |= Qt::ItemIsEditable;
         if (checkedItems_)
             flags |= Qt::ItemIsUserCheckable;
     }

--- a/src/gui/models/atomTypeModel.h
+++ b/src/gui/models/atomTypeModel.h
@@ -45,11 +45,6 @@ class AtomTypeModel : public QAbstractListModel
 
     public:
     AtomTypeModel() = default;
-    explicit AtomTypeModel(const CoreData &coreData);
-
-    private:
-    // Optional CoreData reference
-    OptionalReferenceWrapper<const CoreData> coreData_;
 
     private:
     ModelUpdater modelUpdater;
@@ -64,8 +59,7 @@ class AtomTypeModel : public QAbstractListModel
 
     public:
     // Set source AtomType data
-    void setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes,
-                 OptionalReferenceWrapper<const CoreData> coreData = std::nullopt);
+    void setData(const std::vector<std::shared_ptr<AtomType>> &atomTypes);
     // Set function to return QIcon for item
     void setQueryFunction(std::function<bool(const std::shared_ptr<AtomType> &atomType)> func);
     // Set vector containing checked items

--- a/src/gui/models/dissolveModel.cpp
+++ b/src/gui/models/dissolveModel.cpp
@@ -20,9 +20,8 @@ Dissolve &DissolveModel::dissolve()
 void DissolveModel::setDissolve(Dissolve &dissolve)
 {
     dissolve_ = &dissolve;
-    atomTypes_.setData(dissolve_->coreData().atomTypes());
+
     // commons_ = std::make_unique<MasterTermTreeModel>(dissolve_->coreData());
-    // TODO DISSOLVE2
     configurationModel_.setData(dissolve_->coreData().configurations());
     moduleLayersModel_.setData(dissolve_->coreData().processingLayers(), &dissolve_->coreData());
     Q_EMIT modelsUpdated();
@@ -31,7 +30,6 @@ void DissolveModel::setDissolve(Dissolve &dissolve)
 // Update models
 void DissolveModel::update()
 {
-    atomTypes_.reset();
     if (commons_)
     {
         commons_->bondModel_.reset();
@@ -43,12 +41,6 @@ void DissolveModel::update()
     moduleLayersModel_.reset();
     Q_EMIT modelsUpdated();
 }
-
-// The Atom Type Model
-AtomTypeModel *DissolveModel::atomTypesModel() { return &atomTypes_; }
-
-// The number of atom types
-int DissolveModel::nAtomTypes() { return atomTypes_.rowCount(); }
 
 // The Master Bond Model
 const CommonBondModel *DissolveModel::commonBondsModel() const

--- a/src/gui/models/dissolveModel.h
+++ b/src/gui/models/dissolveModel.h
@@ -16,8 +16,6 @@
 class DissolveModel : public QObject
 {
     Q_OBJECT
-    // The Atom Type Model
-    Q_PROPERTY(AtomTypeModel *atomTypesModel READ atomTypesModel NOTIFY atomTypesChanged)
     // The Master Bond Model
     Q_PROPERTY(const CommonBondModel *commonBondsModel READ commonBondsModel NOTIFY commonsChanged)
     // The Master Angle Model
@@ -36,8 +34,6 @@ class DissolveModel : public QObject
     Q_PROPERTY(Graph *graph READ graph NOTIFY modelsUpdated)
 
     private:
-    // The Atom Type Model
-    AtomTypeModel atomTypes_;
     // Master terms model
     std::unique_ptr<MasterTermTreeModel> commons_ = nullptr;
     ConfigurationModel configurationModel_;
@@ -54,8 +50,6 @@ class DissolveModel : public QObject
     Q_SIGNALS:
     // The models might've been updated
     void modelsUpdated();
-    // The Atom Types model has been replaced
-    void atomTypesChanged();
     // The Master terms models have been replaced
     void commonsChanged();
 
@@ -74,10 +68,6 @@ class DissolveModel : public QObject
     DissolveModel() = default;
     ~DissolveModel() = default;
 
-    // The Atom Type Model
-    AtomTypeModel *atomTypesModel();
-    // The number of atom types
-    int nAtomTypes();
     // The Master Bond Model
     const CommonBondModel *commonBondsModel() const;
     // The number of common bonds

--- a/src/gui/models/ffSortFilterModel.cpp
+++ b/src/gui/models/ffSortFilterModel.cpp
@@ -23,19 +23,22 @@ bool ForcefieldSortFilterModel::filterAcceptsRow(int sourceRow, const QModelInde
     if (!ff)
         return false;
 
-    CoreData temporaryCoreData;
-    Dissolve temporaryDissolve(temporaryCoreData);
+    // CoreData temporaryCoreData;
+    // Dissolve temporaryDissolve(temporaryCoreData);
+    //
+    // Species *modifiedSpecies_ = temporaryDissolve.coreData().addSpecies();
+    // modifiedSpecies_->copyBasic(species_);
+    // // // originalAtomTypeNames_.clear();
+    //
+    // // modifiedSpecies_->clearAtomTypes();
+    // // temporaryDissolve.clearAtomTypes();
+    //
+    // ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData, Forcefield::TypeAll, true);
+    // Messenger::unMute();
+    // return temporaryDissolve.coreData().atomTypes().size() > 0;
+    // TODO DISSOLVE2
 
-    Species *modifiedSpecies_ = temporaryDissolve.coreData().addSpecies();
-    modifiedSpecies_->copyBasic(species_);
-    // // originalAtomTypeNames_.clear();
-
-    // modifiedSpecies_->clearAtomTypes();
-    // temporaryDissolve.clearAtomTypes();
-
-    ff->assignAtomTypes(modifiedSpecies_, temporaryCoreData, Forcefield::TypeAll, true);
-    Messenger::unMute();
-    return temporaryDissolve.coreData().atomTypes().size() > 0;
+    return true;
 }
 
 void ForcefieldSortFilterModel::setSpecies(const Species *species)

--- a/src/gui/qml/ForceFieldAtomTypes.qml
+++ b/src/gui/qml/ForceFieldAtomTypes.qml
@@ -87,7 +87,7 @@ Item {
         anchors.left: parent.left
         anchors.top: indicator.top
         fillMode: Image.PreserveAspectFit
-        source: control.dialogModel.atomTypesIndicator == 0 ? "qrc:/general/icons/true.svg" : "qrc:/general/icons/warn.svg"
+        // source: control.dialogModel.atomTypesIndicator == 0 ? "qrc:/general/icons/true.svg" : "qrc:/general/icons/warn.svg"
     }
     D.Text {
         id: indicator
@@ -95,7 +95,7 @@ Item {
         anchors.bottom: parent.bottom
         anchors.left: indicatorImage.right
         anchors.right: parent.right
-        text: control.dialogModel.atomTypesIndicator == 0 ? "There are no naming conflicts with the assigned atom types" : (control.dialogModel.atomTypesIndicator + " assigned atom types conflict with existing types")
+        // text: control.dialogModel.atomTypesIndicator == 0 ? "There are no naming conflicts with the assigned atom types" : (control.dialogModel.atomTypesIndicator + " assigned atom types conflict with existing types")
         wrapMode: Text.Wrap
     }
     Connections {

--- a/src/modules/epsr/epsr.h
+++ b/src/modules/epsr/epsr.h
@@ -120,13 +120,12 @@ class EPSRModule : public Module
 
     public:
     // Create / retrieve arrays for storage of empirical potential coefficients
-    Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
-                                                        std::optional<int> ncoeffp = std::nullopt);
+    Array2D<std::vector<double>> &potentialCoefficients(GenericList &moduleData, std::optional<int> ncoeffp = std::nullopt);
     // Generate empirical potentials from current coefficients
     bool generateEmpiricalPotentials(Dissolve &dissolve, const std::vector<const AtomType *> &atomTypes, double rho,
                                      std::optional<int> ncoeffp, double rminpt, double rmaxpt, double sigma1, double sigma2);
     // Generate and return single empirical potential function
-    Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int nAtomTypes, int i, int j, int n);
+    Data1D generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n);
     // Calculate absolute energy of empirical potentials
     double absEnergyEP(GenericList &moduleData, const std::vector<const AtomType *> &atomTypes);
     // Truncate the supplied data

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -42,11 +42,12 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData,
 }
 
 // Create / retrieve arrays for storage of empirical potential coefficients
-Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &moduleData, const int nAtomTypes,
-                                                                std::optional<int> ncoeffp)
+Array2D<std::vector<double>> &EPSRModule::potentialCoefficients(GenericList &moduleData, std::optional<int> ncoeffp)
 {
     auto &coefficients =
         moduleData.realise<Array2D<std::vector<double>>>("PotentialCoefficients", name_, GenericItem::InRestartFileFlag);
+
+    const auto nAtomTypes = targetConfiguration_->atomTypeVector().size();
 
     auto arrayNCoeffP = (coefficients.nRows() && coefficients.nColumns() ? coefficients[{0, 0}].size() : 0);
     if ((coefficients.nRows() != nAtomTypes) || (coefficients.nColumns() != nAtomTypes) ||
@@ -70,8 +71,7 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, const std::vect
                                              double sigma1, double sigma2)
 {
     // Get coefficients array
-    Array2D<std::vector<double>> &coefficients =
-        potentialCoefficients(dissolve.processingModuleData(), atomTypes.size(), ncoeffp);
+    Array2D<std::vector<double>> &coefficients = potentialCoefficients(dissolve.processingModuleData(), ncoeffp);
 
     dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                             [&](int i, auto at1, int j, auto at2)
@@ -124,10 +124,12 @@ bool EPSRModule::generateEmpiricalPotentials(Dissolve &dissolve, const std::vect
 }
 
 // Generate and return single empirical potential function
-Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int nAtomTypes, int i, int j, int n)
+Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int i, int j, int n)
 {
     // EPSR constants
     const auto mcoeff = 200;
+    const auto nAtomTypes = targetConfiguration_->atomTypeVector().size();
+    std::cout << std::format("EPSRMODULE::generateEmpiricalPotentialFunction() - natomtypes = {}\n", nAtomTypes);
 
     // Calculate some values if they were not provided
     auto rmaxpt = rMaxPT_ ? rMaxPT_.value() : PairPotential::range();
@@ -135,7 +137,7 @@ Data1D EPSRModule::generateEmpiricalPotentialFunction(Dissolve &dissolve, int nA
     nCoeffP_ = nCoeffP_ <= 0 ? std::min(int(10.0 * rmaxpt + 0.0001), mcoeff) : nCoeffP_;
 
     // Get coefficients array
-    auto &coefficients = potentialCoefficients(dissolve.processingModuleData(), nAtomTypes);
+    auto &coefficients = potentialCoefficients(dissolve.processingModuleData());
     auto &potCoeff = coefficients[{i, j}];
 
     // Regenerate empirical potential from the stored coefficients
@@ -173,7 +175,7 @@ double EPSRModule::absEnergyEP(GenericList &moduleData, const std::vector<const 
      */
 
     // Get coefficients array
-    auto &coefficients = potentialCoefficients(moduleData, atomTypes.size());
+    auto &coefficients = potentialCoefficients(moduleData);
     if (coefficients.empty())
         return 0.0;
 

--- a/src/modules/epsr/io.cpp
+++ b/src/modules/epsr/io.cpp
@@ -119,10 +119,13 @@ bool EPSRModule::readPCof(Dissolve &dissolve, std::string_view filename)
             break;
     }
 
+    // Get atom types from configuration
+    auto atomTypes = targetConfiguration_->atomTypeVector();
+
     // Retrieve and zero the current potential coefficients file
     auto &potentialCoefficients = dissolve.processingModuleData().realise<Array2D<std::vector<double>>>(
         "PotentialCoefficients", name_, GenericItem::InRestartFileFlag);
-    potentialCoefficients.initialise(dissolve.coreData().nAtomTypes(), dissolve.coreData().nAtomTypes(), true);
+    potentialCoefficients.initialise(atomTypes.size(), atomTypes.size(), true);
     for (auto &n : potentialCoefficients)
     {
         n.clear();
@@ -142,13 +145,19 @@ bool EPSRModule::readPCof(Dissolve &dissolve, std::string_view filename)
             return Messenger::error("Failed to read pair potential atom types from pcof file.\n");
 
         // Find the atom types to which these coefficients relate
-        auto at1 = dissolve.coreData().findAtomType(parser.argsv(0));
-        if (!at1)
+        auto at1It = std::ranges::find_if(atomTypes, [&](const auto *atomType)
+                                          { return DissolveSys::sameString(parser.argsv(0), atomType->name()); });
+        ;
+        if (at1It == atomTypes.end())
             return Messenger::error("Unrecognised AtomType '{}' referenced in pcof file.\n", parser.argsv(0));
-        auto at2 = dissolve.coreData().findAtomType(parser.argsv(1));
-        if (!at2)
+        auto at2It = std::ranges::find_if(atomTypes, [&](const auto *atomType)
+                                          { return DissolveSys::sameString(parser.argsv(1), atomType->name()); });
+        ;
+        if (at2It == atomTypes.end())
             return Messenger::error("Unrecognised AtomType '{}' referenced in pcof file.\n", parser.argsv(1));
 
+        auto at1 = *at1It;
+        auto at2 = *at2It;
         Messenger::print("Found {}-{} potential...\n", at1->name(), at2->name());
 
         // Next line contains ??? and ??? TODO

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -663,7 +663,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     if (modifyPotential_ && (runCount % *modifyPotential_ == 0))
     {
         // Sum fluctuation coefficients in to the potential coefficients
-        auto &coefficients = potentialCoefficients(moduleData, nAtomTypes, ncoeffp);
+        auto &coefficients = potentialCoefficients(moduleData, ncoeffp);
         dissolve::for_each_pair(ParallelPolicies::seq, atomTypes,
                                 [&](int i, auto at1, int j, auto at2)
                                 {
@@ -749,7 +749,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
     }
     if (savePotentialCoefficients_)
     {
-        auto &coefficients = potentialCoefficients(moduleData, nAtomTypes, ncoeffp);
+        auto &coefficients = potentialCoefficients(moduleData, ncoeffp);
 
         if (!for_each_pair_early(atomTypes,
                                  [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool>

--- a/tests/ff/assignment-Kulmala2010.cpp
+++ b/tests/ff/assignment-Kulmala2010.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(Kulmala2010AssignmentTest, Hydronium)
 {
     Species species("Hydronium");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/hydronium.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 3);
     ASSERT_EQ(species.nAngles(), 3);
@@ -31,12 +30,11 @@ TEST(Kulmala2010AssignmentTest, Hydronium)
 TEST(Kulmala2010AssignmentTest, Ammonia)
 {
     Species species("Ammonia");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/ammonia.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 3);
     ASSERT_EQ(species.nAngles(), 3);
@@ -51,12 +49,11 @@ TEST(Kulmala2010AssignmentTest, Ammonia)
 TEST(Kulmala2010AssignmentTest, Ammonium)
 {
     Species species("Ammonium");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/ammonium.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 4);
     ASSERT_EQ(species.nAngles(), 6);
@@ -71,12 +68,11 @@ TEST(Kulmala2010AssignmentTest, Ammonium)
 TEST(Kulmala2010AssignmentTest, Dimethylammonium)
 {
     Species species("Dimethylammonium");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/dimethylammonium.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 10);
     ASSERT_EQ(species.nAngles(), 18);
@@ -108,12 +104,11 @@ TEST(Kulmala2010AssignmentTest, Dimethylammonium)
 TEST(Kulmala2010AssignmentTest, H2SO4)
 {
     Species species("H2SO4");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/h2so4.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 6);
     ASSERT_EQ(species.nAngles(), 8);
@@ -133,12 +128,11 @@ TEST(Kulmala2010AssignmentTest, H2SO4)
 TEST(Kulmala2010AssignmentTest, HSO4Minus)
 {
     Species species("HSO4-");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/hso4minus.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Kulmala2010")));
 
     ASSERT_EQ(species.nBonds(), 5);
     ASSERT_EQ(species.nAngles(), 7);

--- a/tests/ff/assignment-Ludwig-py5.cpp
+++ b/tests/ff/assignment-Ludwig-py5.cpp
@@ -12,12 +12,11 @@ namespace UnitTest
 TEST(LudwigPy5AssignmentTest, Py5)
 {
     Species species("Py5");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/py5.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Ludwig/Py5"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("Ludwig/Py5")));
 
     ASSERT_EQ(species.nBonds(), 27);
     ASSERT_EQ(species.nAngles(), 48);

--- a/tests/ff/assignment-OPLSAA2005-alcohols.cpp
+++ b/tests/ff/assignment-OPLSAA2005-alcohols.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(OPLSAA2005AlcoholsAssignmentTest, Methanol)
 {
     Species species("Methanol");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/methanol.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alcohols"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alcohols")));
 
     ASSERT_EQ(species.nBonds(), 5);
     ASSERT_EQ(species.nAngles(), 7);

--- a/tests/ff/assignment-OPLSAA2005-alkanes.cpp
+++ b/tests/ff/assignment-OPLSAA2005-alkanes.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(OPLSAA2005AlkanesAssignmentTest, Heptane)
 {
     Species species("Heptane");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/heptane.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alkanes"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alkanes")));
 
     ASSERT_EQ(species.nBonds(), 16);
     ASSERT_EQ(species.nAngles(), 30);
@@ -53,12 +52,11 @@ TEST(OPLSAA2005AlkanesAssignmentTest, Heptane)
 TEST(OPLSAA2005AlkanesAssignmentTest, Cycloheptane)
 {
     Species species("Cycloheptane");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/cycloheptane.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alkanes"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Alkanes")));
 
     ASSERT_EQ(species.nBonds(), 21);
     ASSERT_EQ(species.nAngles(), 42);

--- a/tests/ff/assignment-OPLSAA2005-aromatics.cpp
+++ b/tests/ff/assignment-OPLSAA2005-aromatics.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(OPLSAA2005AromaticsAssignmentTest, Benzene)
 {
     Species species("Benzene");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/benzene.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Aromatics"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Aromatics")));
 
     ASSERT_EQ(species.nBonds(), 12);
     ASSERT_EQ(species.nAngles(), 18);
@@ -36,12 +35,11 @@ TEST(OPLSAA2005AromaticsAssignmentTest, Benzene)
 TEST(OPLSAA2005AromaticsAssignmentTest, Naphthalene)
 {
     Species species("Naphthalene");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/naphthalene.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Aromatics"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("OPLSAA2005/Aromatics")));
 
     ASSERT_EQ(species.nBonds(), 19);
     ASSERT_EQ(species.nAngles(), 30);

--- a/tests/ff/assignment-PCL2019-anions.cpp
+++ b/tests/ff/assignment-PCL2019-anions.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(PCL2019AnionsAssignmentTest, beti)
 {
     Species species("Hydronium");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/beti.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 20);
     ASSERT_EQ(species.nAngles(), 37);
@@ -33,12 +32,11 @@ TEST(PCL2019AnionsAssignmentTest, beti)
 TEST(PCL2019AnionsAssignmentTest, BF4)
 {
     Species species("BF4");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/bf4.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 4);
     ASSERT_EQ(species.nAngles(), 6);
@@ -52,12 +50,11 @@ TEST(PCL2019AnionsAssignmentTest, BF4)
 TEST(PCL2019AnionsAssignmentTest, c1SO3)
 {
     Species species("C1SO3");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c1so3.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 7);
     ASSERT_EQ(species.nAngles(), 12);
@@ -72,12 +69,11 @@ TEST(PCL2019AnionsAssignmentTest, c1SO3)
 TEST(PCL2019AnionsAssignmentTest, c1SO4)
 {
     Species species("C1SO4");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c1so4.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 8);
     ASSERT_EQ(species.nAngles(), 13);
@@ -92,12 +88,11 @@ TEST(PCL2019AnionsAssignmentTest, c1SO4)
 TEST(PCL2019AnionsAssignmentTest, c2SO3)
 {
     Species species("C2SO3");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2so3.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 10);
     ASSERT_EQ(species.nAngles(), 18);
@@ -121,12 +116,11 @@ TEST(PCL2019AnionsAssignmentTest, c2SO3)
 TEST(PCL2019AnionsAssignmentTest, c2SO4)
 {
     Species species("C2SO4");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2so4.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 11);
     ASSERT_EQ(species.nAngles(), 19);
@@ -151,12 +145,11 @@ TEST(PCL2019AnionsAssignmentTest, c2SO4)
 TEST(PCL2019AnionsAssignmentTest, c4fc1fsi)
 {
     Species species("C4FC1FSI");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4fc1fsi.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 23);
     ASSERT_EQ(species.nAngles(), 43);
@@ -173,12 +166,11 @@ TEST(PCL2019AnionsAssignmentTest, c4fc1fsi)
 TEST(PCL2019AnionsAssignmentTest, CCN3)
 {
     Species species("CCN3");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/ccn3.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 6);
     ASSERT_EQ(species.nAngles(), 6);
@@ -192,12 +184,11 @@ TEST(PCL2019AnionsAssignmentTest, CCN3)
 TEST(PCL2019AnionsAssignmentTest, dca)
 {
     Species species("DCA");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/dca.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 4);
     ASSERT_EQ(species.nAngles(), 3);
@@ -211,12 +202,11 @@ TEST(PCL2019AnionsAssignmentTest, dca)
 TEST(PCL2019AnionsAssignmentTest, fsi)
 {
     Species species("FSI");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/fsi.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 8);
     ASSERT_EQ(species.nAngles(), 13);
@@ -231,12 +221,11 @@ TEST(PCL2019AnionsAssignmentTest, fsi)
 TEST(PCL2019AnionsAssignmentTest, ntf2)
 {
     Species species("NTf2");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/ntf2.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 14);
     ASSERT_EQ(species.nAngles(), 25);
@@ -264,12 +253,11 @@ TEST(PCL2019AnionsAssignmentTest, ntf2)
 TEST(PCL2019AnionsAssignmentTest, oac)
 {
     Species species("OAc");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/oac.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 6);
     ASSERT_EQ(species.nAngles(), 9);
@@ -283,12 +271,11 @@ TEST(PCL2019AnionsAssignmentTest, oac)
 TEST(PCL2019AnionsAssignmentTest, otf)
 {
     Species species("OTf");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/otf.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 7);
     ASSERT_EQ(species.nAngles(), 12);
@@ -303,12 +290,11 @@ TEST(PCL2019AnionsAssignmentTest, otf)
 TEST(PCL2019AnionsAssignmentTest, PF6)
 {
     Species species("PF6");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/pf6.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 6);
     ASSERT_EQ(species.nAngles(), 15);
@@ -322,12 +308,11 @@ TEST(PCL2019AnionsAssignmentTest, PF6)
 TEST(PCL2019AnionsAssignmentTest, SCN)
 {
     Species species("SCN");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/scn.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 2);
     ASSERT_EQ(species.nAngles(), 1);
@@ -341,12 +326,11 @@ TEST(PCL2019AnionsAssignmentTest, SCN)
 TEST(PCL2019AnionsAssignmentTest, tfa)
 {
     Species species("TFA");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/tfa.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 6);
     ASSERT_EQ(species.nAngles(), 9);
@@ -361,12 +345,11 @@ TEST(PCL2019AnionsAssignmentTest, tfa)
 TEST(PCL2019AnionsAssignmentTest, tso)
 {
     Species species("TSO");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/tso.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Anions")));
 
     ASSERT_EQ(species.nBonds(), 18);
     ASSERT_EQ(species.nAngles(), 30);

--- a/tests/ff/assignment-PCL2019-cations.cpp
+++ b/tests/ff/assignment-PCL2019-cations.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(PCL2019CationsAssignmentTest, benzc1im)
 {
     Species species("benzc1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/benzc1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 27);
     ASSERT_EQ(species.nAngles(), 45);
@@ -34,12 +33,11 @@ TEST(PCL2019CationsAssignmentTest, benzc1im)
 TEST(PCL2019CationsAssignmentTest, c12c1im)
 {
     Species species("c12c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c12c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 49);
     ASSERT_EQ(species.nAngles(), 93);
@@ -59,12 +57,11 @@ TEST(PCL2019CationsAssignmentTest, c12c1im)
 TEST(PCL2019CationsAssignmentTest, c1c1im)
 {
     Species species("c1c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c1c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 16);
     ASSERT_EQ(species.nAngles(), 27);
@@ -93,12 +90,11 @@ TEST(PCL2019CationsAssignmentTest, c1c1im)
 TEST(PCL2019CationsAssignmentTest, c1c1pyrr)
 {
     Species species("c1c1pyrr");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c1c1pyrr.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 21);
     ASSERT_EQ(species.nAngles(), 42);
@@ -115,12 +111,11 @@ TEST(PCL2019CationsAssignmentTest, c1c1pyrr)
 TEST(PCL2019CationsAssignmentTest, c2c1c1im)
 {
     Species species("c2c1c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2c1c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 22);
     ASSERT_EQ(species.nAngles(), 39);
@@ -137,12 +132,11 @@ TEST(PCL2019CationsAssignmentTest, c2c1c1im)
 TEST(PCL2019CationsAssignmentTest, c2c1im)
 {
     Species species("c2c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 19);
     ASSERT_EQ(species.nAngles(), 33);
@@ -174,12 +168,11 @@ TEST(PCL2019CationsAssignmentTest, c2c1im)
 TEST(PCL2019CationsAssignmentTest, c2im)
 {
     Species species("c2im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 16);
     ASSERT_EQ(species.nAngles(), 27);
@@ -208,12 +201,11 @@ TEST(PCL2019CationsAssignmentTest, c2im)
 TEST(PCL2019CationsAssignmentTest, c2OHc1im)
 {
     Species species("c2OHc1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2ohc1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 20);
     ASSERT_EQ(species.nAngles(), 34);
@@ -230,12 +222,11 @@ TEST(PCL2019CationsAssignmentTest, c2OHc1im)
 TEST(PCL2019CationsAssignmentTest, c2py)
 {
     Species species("c2py");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c2py.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 18);
     ASSERT_EQ(species.nAngles(), 30);
@@ -266,12 +257,11 @@ TEST(PCL2019CationsAssignmentTest, c2py)
 TEST(PCL2019CationsAssignmentTest, c3c1im)
 {
     Species species("c3c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c3c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 22);
     ASSERT_EQ(species.nAngles(), 39);
@@ -288,12 +278,11 @@ TEST(PCL2019CationsAssignmentTest, c3c1im)
 TEST(PCL2019CationsAssignmentTest, c3c1pyrr)
 {
     Species species("c3c1pyrr");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c3c1pyrr.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 27);
     ASSERT_EQ(species.nAngles(), 54);
@@ -310,12 +299,11 @@ TEST(PCL2019CationsAssignmentTest, c3c1pyrr)
 TEST(PCL2019CationsAssignmentTest, c4c1c1im)
 {
     Species species("c4c1c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4c1c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 28);
     ASSERT_EQ(species.nAngles(), 51);
@@ -333,12 +321,11 @@ TEST(PCL2019CationsAssignmentTest, c4c1c1im)
 TEST(PCL2019CationsAssignmentTest, c4c1im)
 {
     Species species("c4c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 25);
     ASSERT_EQ(species.nAngles(), 45);
@@ -355,12 +342,11 @@ TEST(PCL2019CationsAssignmentTest, c4c1im)
 TEST(PCL2019CationsAssignmentTest, c4c1pyrr)
 {
     Species species("c4c1pyrr");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4c1pyrr.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 30);
     ASSERT_EQ(species.nAngles(), 60);
@@ -378,12 +364,11 @@ TEST(PCL2019CationsAssignmentTest, c4c1pyrr)
 TEST(PCL2019CationsAssignmentTest, c4c4im)
 {
     Species species("c4c4im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4c4im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 34);
     ASSERT_EQ(species.nAngles(), 63);
@@ -401,12 +386,11 @@ TEST(PCL2019CationsAssignmentTest, c4c4im)
 TEST(PCL2019CationsAssignmentTest, c4pyri)
 {
     Species species("c4pyri");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c4pyri.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 24);
     ASSERT_EQ(species.nAngles(), 42);
@@ -423,12 +407,11 @@ TEST(PCL2019CationsAssignmentTest, c4pyri)
 TEST(PCL2019CationsAssignmentTest, c6c1im)
 {
     Species species("c6c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c6c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 31);
     ASSERT_EQ(species.nAngles(), 57);
@@ -446,12 +429,11 @@ TEST(PCL2019CationsAssignmentTest, c6c1im)
 TEST(PCL2019CationsAssignmentTest, c8c1im)
 {
     Species species("c8c1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c8c1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 37);
     ASSERT_EQ(species.nAngles(), 69);
@@ -470,12 +452,11 @@ TEST(PCL2019CationsAssignmentTest, c8c1im)
 TEST(PCL2019CationsAssignmentTest, c8fc1im)
 {
     Species species("c8fc1im");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c8fc1im.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 37);
     ASSERT_EQ(species.nAngles(), 69);
@@ -494,12 +475,11 @@ TEST(PCL2019CationsAssignmentTest, c8fc1im)
 TEST(PCL2019CationsAssignmentTest, c8isoqui)
 {
     Species species("c8isoqui");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/c8isoqui.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 43);
     ASSERT_EQ(species.nAngles(), 78);
@@ -519,12 +499,11 @@ TEST(PCL2019CationsAssignmentTest, c8isoqui)
 TEST(PCL2019CationsAssignmentTest, cholinium)
 {
     Species species("cholinium");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/cholinium.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 20);
     ASSERT_EQ(species.nAngles(), 37);
@@ -541,12 +520,11 @@ TEST(PCL2019CationsAssignmentTest, cholinium)
 TEST(PCL2019CationsAssignmentTest, gua)
 {
     Species species("Gua");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/gua.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 9);
     ASSERT_EQ(species.nAngles(), 12);
@@ -562,12 +540,11 @@ TEST(PCL2019CationsAssignmentTest, gua)
 TEST(PCL2019CationsAssignmentTest, N1110)
 {
     Species species("N1110");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n1110.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 13);
     ASSERT_EQ(species.nAngles(), 24);
@@ -594,12 +571,11 @@ TEST(PCL2019CationsAssignmentTest, N1110)
 TEST(PCL2019CationsAssignmentTest, N1111)
 {
     Species species("N1111");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n1111.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 16);
     ASSERT_EQ(species.nAngles(), 30);
@@ -629,12 +605,11 @@ TEST(PCL2019CationsAssignmentTest, N1111)
 TEST(PCL2019CationsAssignmentTest, N2220)
 {
     Species species("N2220");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n2220.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 22);
     ASSERT_EQ(species.nAngles(), 42);
@@ -651,12 +626,11 @@ TEST(PCL2019CationsAssignmentTest, N2220)
 TEST(PCL2019CationsAssignmentTest, N2222)
 {
     Species species("N2222");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n2222.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 28);
     ASSERT_EQ(species.nAngles(), 54);
@@ -674,12 +648,11 @@ TEST(PCL2019CationsAssignmentTest, N2222)
 TEST(PCL2019CationsAssignmentTest, N4444)
 {
     Species species("N4444");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n4444.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 52);
     ASSERT_EQ(species.nAngles(), 102);
@@ -699,12 +672,11 @@ TEST(PCL2019CationsAssignmentTest, N4444)
 TEST(PCL2019CationsAssignmentTest, P66614)
 {
     Species species("P66614");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/p66614.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("PCL2019/Cations")));
 
     ASSERT_EQ(species.nBonds(), 100);
     ASSERT_EQ(species.nAngles(), 198);

--- a/tests/ff/assignment-SPCFw.cpp
+++ b/tests/ff/assignment-SPCFw.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(SPCFwAssignmentTest, Water)
 {
     Species species("Water");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/water.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms(1.2);
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("SPC/Fw"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("SPC/Fw")));
 
     ASSERT_EQ(species.nBonds(), 2);
     ASSERT_EQ(species.nAngles(), 1);

--- a/tests/ff/assignment-UFF-nmethylformamide.cpp
+++ b/tests/ff/assignment-UFF-nmethylformamide.cpp
@@ -11,12 +11,11 @@ namespace UnitTest
 TEST(UFFNMethylFormamideAssignmentTest, NMethylFormamide)
 {
     Species species("NMethylFormamide");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/n-methylformamide.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("UFF"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("UFF")));
 
     ASSERT_EQ(species.nBonds(), 8);
     ASSERT_EQ(species.nAngles(), 12);

--- a/tests/ff/assignment-UFF4MOF-mof5.cpp
+++ b/tests/ff/assignment-UFF4MOF-mof5.cpp
@@ -11,13 +11,12 @@ namespace UnitTest
 TEST(UFF4MOFMOF5AssignmentTest, MOF5)
 {
     Species species("MOF5");
-    CoreData removeMeCoreData_;
     DissolveSystemTest systemTest;
     SpeciesImportFileFormat importer("xyz/mof5.xyz");
     ASSERT_TRUE(importer.importData(&species));
     species.createBox({25.8320, 25.8320, 25.8320}, {90, 90, 90});
     species.recalculateIntermolecularTerms();
-    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("UFF4MOF"), removeMeCoreData_));
+    ASSERT_TRUE(species.applyForcefieldTerms(ForcefieldLibrary::forcefield("UFF4MOF")));
 
     ASSERT_EQ(species.nBonds(), 512);
     ASSERT_EQ(species.nAngles(), 912);

--- a/tests/modules/epsr.cpp
+++ b/tests/modules/epsr.cpp
@@ -96,8 +96,7 @@ TEST_F(EPSRModuleTest, Water3NInpA)
 
     // Absolute magnitudes of EP
     auto *epsrModule = systemTest.getModule<EPSRModule>("EPSR01");
-    auto &coefficients =
-        epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData(), systemTest.coreData().nAtomTypes());
+    auto &coefficients = epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData());
     ASSERT_FALSE(coefficients.empty());
     std::vector<std::tuple<int, int, double>> expectedEPMagnitudes = {{0, 0, 0.2475}, {0, 1, 0.3722}, {1, 1, 0.4567}};
     for (auto &&[i, j, epMag] : expectedEPMagnitudes)
@@ -188,8 +187,7 @@ TEST_F(EPSRModuleTest, Benzene)
 
     // Absolute magnitudes of EP
     auto *epsrModule = systemTest.getModule<EPSRModule>("EPSR01");
-    auto &coefficients =
-        epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData(), systemTest.coreData().nAtomTypes());
+    auto &coefficients = epsrModule->potentialCoefficients(systemTest.dissolve().processingModuleData());
     ASSERT_FALSE(coefficients.empty());
     std::vector<std::tuple<int, int, double>> expectedEPMagnitudes = {{0, 0, 0.4023}, {0, 1, 0.1966}, {1, 1, 0.2491}};
     for (auto &&[i, j, epMag] : expectedEPMagnitudes)


### PR DESCRIPTION
This PR removes a bunch of other `CoreData` uses highlighted after #2349.