### PR TITLE
refactor: Use DoubleKeyedMap in PotentialSet

### DIFF
--- a/src/classes/potentialSet.cpp
+++ b/src/classes/potentialSet.cpp
@@ -21,9 +21,9 @@ void PotentialSet::reset()
 // Set new fingerprint
 void PotentialSet::setFingerprint(std::string_view fingerprint) { fingerprint_ = fingerprint; }
 
-// Return full map of potentials specified
-std::map<std::string, PotentialSet::PotentialData> &PotentialSet::potentialMap() { return potentials_; }
-const std::map<std::string, PotentialSet::PotentialData> &PotentialSet::potentialMap() const { return potentials_; }
+// Return full set of potentials
+DoubleKeyedMap<Data1D> &PotentialSet::potentials() { return potentials_; }
+const DoubleKeyedMap<Data1D> &PotentialSet::potentials() const { return potentials_; }
 
 /*
  * Operators
@@ -31,28 +31,30 @@ const std::map<std::string, PotentialSet::PotentialData> &PotentialSet::potentia
 
 PotentialSet &PotentialSet::operator+=(const double delta)
 {
-    for (auto &[key, pot] : potentials_)
-        pot.potential += delta;
+    for (auto &pot : std::views::values(potentials_))
+        pot += delta;
     return (*this);
 }
 
 PotentialSet &PotentialSet::operator+=(const PotentialSet &source)
 {
-    for (auto &[key, pot] : source.potentialMap())
-    {
-        auto it = potentials_.find(key);
-        if (it != potentials_.end())
-            it->second.potential += pot.potential;
-        else
-            potentials_[key] = pot;
-    }
+    for (auto &[key, pot] : source.potentials_)
+        potentials_.map()[key] += pot;
+
     return (*this);
+}
+
+PotentialSet PotentialSet::operator*(double factor) const
+{
+    auto result = *this;
+    result *= factor;
+    return result;
 }
 
 PotentialSet &PotentialSet::operator*=(const double factor)
 {
-    for (auto &[key, pot] : potentials_)
-        pot.potential *= factor;
+    for (auto &pot : std::views::values(potentials_))
+        pot *= factor;
     return (*this);
 }
 
@@ -60,47 +62,13 @@ PotentialSet &PotentialSet::operator*=(const double factor)
  * Serialisation
  */
 
-// Read data through specified LineParser
-bool PotentialSet::deserialise(LineParser &parser, const CoreData &coreData)
+// Express as a serialisable value
+void PotentialSet::serialise(std::string tag, SerialisedValue &target) const
 {
-    if (parser.readNextLine(LineParser::Defaults, fingerprint_) != LineParser::Success)
-        return false;
+    auto &result = target[tag];
 
-    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-        return false;
-    auto size = parser.argli(0);
-    for (auto n = 0; n < size; ++n)
-    {
-        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
-            return false;
-        PotentialData value;
-        auto key = parser.args(0);
-        value.count = parser.argi(1);
-        value.at1 = coreData.findAtomType(parser.args(2)).get();
-        value.at2 = coreData.findAtomType(parser.args(3)).get();
-
-        if (!value.potential.deserialise(parser))
-            return false;
-
-        potentials_[key] = value;
-    }
-
-    return true;
+    potentials_.serialise("potentials", result);
 }
 
-// Write data through specified LineParser
-bool PotentialSet::serialise(LineParser &parser) const
-{
-    if (!parser.writeLineF("{}\n", fingerprint_))
-        return false;
-    if (!parser.writeLineF("{}\n", potentials_.size()))
-        return false;
-    for (auto &[key, value] : potentials_)
-    {
-        if (!parser.writeLineF("{} {} {} {}\n", key, value.count, value.at1->name(), value.at2->name()))
-            return false;
-        if (!value.potential.serialise(parser))
-            return false;
-    }
-    return true;
-}
+// Read values from a serialisable value
+void PotentialSet::deserialise(SerialisedValue node) { potentials_.deserialise(node["potentials"]); }

--- a/src/classes/potentialSet.h
+++ b/src/classes/potentialSet.h
@@ -4,13 +4,13 @@
 #pragma once
 
 #include "math/data1D.h"
-#include "modules/epsrManager/epsrManager.h"
+#include "templates/doubleKeyedMap.h"
 
 // Forward Declarations
 class AtomType;
 
 // Set of Potentials
-class PotentialSet
+class PotentialSet : public Serialisable<>
 {
     public:
     PotentialSet();
@@ -22,14 +22,8 @@ class PotentialSet
     private:
     // Fingerprint for these potentials
     std::string fingerprint_;
-    struct PotentialData
-    {
-        Data1D potential;
-        double count{0};
-        const AtomType *at1, *at2;
-    };
-    // Map of named potentials to data
-    std::map<std::string, PotentialData> potentials_;
+    // Map of potentials
+    DoubleKeyedMap<Data1D> potentials_;
 
     public:
     // Reset Potentials
@@ -38,24 +32,25 @@ class PotentialSet
     void setFingerprint(std::string_view fingerprint);
     // Return fingerprint of potentials
     std::string_view fingerprint() const;
-    // Return full map of potentials specified
-    std::map<std::string, PotentialData> &potentialMap();
-    const std::map<std::string, PotentialData> &potentialMap() const;
+    // Return full set of potentials
+    DoubleKeyedMap<Data1D> &potentials();
+    const DoubleKeyedMap<Data1D> &potentials() const;
 
     /*
      * Operators
      */
     public:
-    PotentialSet &operator+=(const double delta);
+    PotentialSet &operator+=(double delta);
     PotentialSet &operator+=(const PotentialSet &source);
-    PotentialSet &operator*=(const double factor);
+    PotentialSet operator*(double factor) const;
+    PotentialSet &operator*=(double factor);
 
     /*
      * Serialisation
      */
     public:
-    // Read data through specified LineParser
-    bool deserialise(LineParser &parser, const CoreData &coreData);
-    // Write data through specified LineParser
-    bool serialise(LineParser &parser) const;
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override;
+    // Read values from a serialisable value
+    void deserialise(SerialisedValue node);
 };

--- a/src/items/deserialisers.cpp
+++ b/src/items/deserialisers.cpp
@@ -180,7 +180,6 @@ GenericItemDeserialiser::GenericItemDeserialiser()
     registerDeserialiser<IntegerHistogram1D>(simpleDeserialise<IntegerHistogram1D>);
     registerDeserialiser<PartialSet>(simpleDeserialiseCore<PartialSet>);
     registerDeserialiser<PartialSetAccumulator>(simpleDeserialise<PartialSetAccumulator>);
-    registerDeserialiser<PotentialSet>(simpleDeserialiseCore<PotentialSet>);
     registerDeserialiser<SampledData1D>(simpleDeserialise<SampledData1D>);
     registerDeserialiser<SampledDouble>(simpleDeserialise<SampledDouble>);
     registerDeserialiser<SampledVector>(simpleDeserialise<SampledVector>);

--- a/src/items/serialisers.cpp
+++ b/src/items/serialisers.cpp
@@ -119,7 +119,6 @@ GenericItemSerialiser::GenericItemSerialiser()
     registerSerialiser<IntegerHistogram1D>(simpleSerialise<IntegerHistogram1D>);
     registerSerialiser<PartialSet>(simpleSerialise<PartialSet>);
     registerSerialiser<PartialSetAccumulator>(simpleSerialise<PartialSetAccumulator>);
-    registerSerialiser<PotentialSet>(simpleSerialise<PotentialSet>);
     registerSerialiser<SampledData1D>(simpleSerialise<SampledData1D>);
     registerSerialiser<SampledDouble>(simpleSerialise<SampledDouble>);
     registerSerialiser<SampledVector>(simpleSerialise<SampledVector>);

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -23,6 +23,8 @@ template <class T> class History : public Serialisable<>
     std::function<T()> initialiser_{};
 
     public:
+    // Clear all data in the history
+    void clear() { history_.clear(); }
     // Push data into the history and return current average
     T push(const T &data, int averagingLength)
     {

--- a/src/modules/epsrManager/epsrManager.h
+++ b/src/modules/epsrManager/epsrManager.h
@@ -7,9 +7,8 @@
 #include "classes/scatteringMatrix.h"
 #include "generator/generator.h"
 #include "math/averaging.h"
-#include "module/groups.h"
+#include "math/history.h"
 #include "module/module.h"
-#include <tuple>
 
 // EPSR Manager Module
 class EPSRManagerModule : public Module
@@ -21,14 +20,13 @@ class EPSRManagerModule : public Module
     /*
      * Definition
      */
-
     private:
     // Target Module containing data to refine against
     std::vector<Module *> target_;
     // Frequency at which to apply generated perturbations to interatomic potentials
     std::optional<int> modifyPotential_{1};
-    // Vector storing atom pairs and associated potentials
-    std::vector<std::tuple<const AtomType *, const AtomType *, Data1D>> potentials_;
+    // History of potentials
+    History<PotentialSet> potentials_;
     // Potential scalings
     std::string potentialScalings_;
     // Number of historical potentials sets to combine into final potentials

--- a/src/modules/epsrManager/process.cpp
+++ b/src/modules/epsrManager/process.cpp
@@ -34,6 +34,7 @@ Module::ExecutionResult EPSRManagerModule::process(Dissolve &dissolve)
 
     // Loop over target data and form summed / averaged potentials
     PotentialSet newPotentials;
+    DoubleKeyedMap<double> counts;
     for (auto *module : target_)
     {
         auto *epsrModule = dynamic_cast<EPSRModule *>(module);
@@ -41,26 +42,24 @@ Module::ExecutionResult EPSRManagerModule::process(Dissolve &dissolve)
 
         for (auto &&[at1, at2, potential] : eps)
         {
-            auto key = EPSRManagerModule::pairKey(at1, at2);
-            auto keyIt = newPotentials.potentialMap().find(key);
-            if (keyIt == newPotentials.potentialMap().end())
-                newPotentials.potentialMap()[key] = {potential, 1, at1, at2};
-            else
-            {
-                Interpolator::addInterpolated(potential, newPotentials.potentialMap()[key].potential, 1.0);
-                ++newPotentials.potentialMap()[key].count;
-            }
+            newPotentials.potentials()[{at1->name(), at2->name()}] += potential;
+            counts[{at1->name(), at2->name()}] += 1.0;
         }
     }
-    for (auto &&[key, epData] : newPotentials.potentialMap())
-        epData.potential /= newPotentials.potentialMap()[key].count;
+
+    // Normalise potentials to counts
+    for (auto &&[key, potential] : newPotentials.potentials())
+        potential /= counts[key];
 
     // Does a PotentialSet already exist for this Configuration?
     auto originalPotentialsObject = moduleData.realiseIf<PotentialSet>("PotentialSet", name_, GenericItem::InRestartFileFlag);
+
     // Set restart equal to changes
     originalPotentialsObject.first = newPotentials;
+
     // Reference to the current potentials
     auto &currentPotentials = moduleData.realise<PotentialSet>("PotentialSet", name_, GenericItem::InRestartFileFlag);
+
     // Average the Potentials
     if (averagingLength_)
         Averaging::average<PotentialSet>(dissolve.processingModuleData(), "PotentialSet", name(), averagingLength_.value(),
@@ -84,16 +83,16 @@ Module::ExecutionResult EPSRManagerModule::process(Dissolve &dissolve)
 
         Messenger::print("Apply scaling factor of {} to potential(s) {}-{}...\n", scaleFactor, typeA, typeB);
         auto count = 0;
-        for (auto &&[key, epData] : currentPotentials.potentialMap())
+        for (auto &&[key, potential] : currentPotentials.potentials())
         {
+            auto parts = currentPotentials.potentials().keyPair(key);
+
             // Is this potential a match
-            if ((DissolveSys::sameWildString(typeA, epData.at1->name()) &&
-                 DissolveSys::sameWildString(typeB, epData.at2->name())) ||
-                (DissolveSys::sameWildString(typeB, epData.at1->name()) &&
-                 DissolveSys::sameWildString(typeA, epData.at2->name())))
+            if ((DissolveSys::sameWildString(typeA, parts.first) && DissolveSys::sameWildString(typeB, parts.second)) ||
+                (DissolveSys::sameWildString(typeB, parts.first) && DissolveSys::sameWildString(typeA, parts.second)))
             {
-                Messenger::print(" ... matched and scaled potential {}-{}\n", epData.at1->name(), epData.at2->name());
-                epData.potential *= scaleFactor;
+                Messenger::print(" ... matched and scaled potential {}-{}\n", parts.first, parts.second);
+                potential *= scaleFactor;
                 ++count;
             }
         }
@@ -101,13 +100,14 @@ Module::ExecutionResult EPSRManagerModule::process(Dissolve &dissolve)
     }
 
     // Adjust global potentials
-    for (auto &&[key, epData] : currentPotentials.potentialMap())
-    {
-        // Grab pointer to the relevant pair potential (if it exists)
-        auto *pp = dissolve.pairPotential(epData.at1, epData.at2);
-        if (pp)
-            pp->setAdditionalPotential(epData.potential);
-    }
+    // TODO DISSOLVE2
+    // for (auto &&[key, epData] : currentPotentials.potentials())
+    // {
+    //     // Grab pointer to the relevant pair potential (if it exists)
+    //     auto *pp = dissolve.pairPotential(epData.at1, epData.at2);
+    //     if (pp)
+    //         pp->setAdditionalPotential(epData.potential);
+    // }
 
     return ExecutionResult::Success;
 }

--- a/tests/classes/potentialSet.cpp
+++ b/tests/classes/potentialSet.cpp
@@ -4,6 +4,7 @@
 #include "classes/potentialSet.h"
 #include "classes/atomType.h"
 #include "math/data1D.h"
+#include "math/history.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 
@@ -15,14 +16,14 @@ TEST(PotentialSetTest, SimpleAddition)
     Data1D x;
     const auto value = 2.0;
     x.addPoint(1, value);
-    pots.potentialMap()["A-A"].potential = x;
-    pots.potentialMap()["A-B"].potential = x;
-    pots.potentialMap()["A-C"].potential = x;
+    pots.potentials()["A-A"] = x;
+    pots.potentials()["A-B"] = x;
+    pots.potentials()["A-C"] = x;
 
     pots += pots;
-    EXPECT_EQ(4.0, pots.potentialMap()["A-A"].potential.value(0));
-    EXPECT_EQ(4.0, pots.potentialMap()["A-B"].potential.value(0));
-    EXPECT_EQ(4.0, pots.potentialMap()["A-C"].potential.value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-A"].value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-B"].value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-C"].value(0));
 }
 
 TEST(PotentialSetTest, Multiplication)
@@ -31,14 +32,14 @@ TEST(PotentialSetTest, Multiplication)
     Data1D x;
     const auto value = 3.0;
     x.addPoint(1, value);
-    pots.potentialMap()["A-A"].potential = x;
-    pots.potentialMap()["A-B"].potential = x;
-    pots.potentialMap()["A-C"].potential = x;
+    pots.potentials()["A-A"] = x;
+    pots.potentials()["A-B"] = x;
+    pots.potentials()["A-C"] = x;
 
     pots *= 2;
-    EXPECT_EQ(6.0, pots.potentialMap()["A-A"].potential.value(0));
-    EXPECT_EQ(6.0, pots.potentialMap()["A-B"].potential.value(0));
-    EXPECT_EQ(6.0, pots.potentialMap()["A-C"].potential.value(0));
+    EXPECT_EQ(6.0, pots.potentials()["A-A"].value(0));
+    EXPECT_EQ(6.0, pots.potentials()["A-B"].value(0));
+    EXPECT_EQ(6.0, pots.potentials()["A-C"].value(0));
 }
 
 TEST(PotentialSetTest, ComplexAddition)
@@ -48,152 +49,66 @@ TEST(PotentialSetTest, ComplexAddition)
     Data1D x;
     const auto value = 2.0;
     x.addPoint(1, value);
-    pots.potentialMap()["A-A"].potential = x;
-    pots.potentialMap()["A-B"].potential = x;
-    pots.potentialMap()["A-C"].potential = x;
+    pots.potentials()["A-A"] = x;
+    pots.potentials()["A-B"] = x;
+    pots.potentials()["A-C"] = x;
 
-    pots2.potentialMap()["A-A"].potential = x;
-    pots2.potentialMap()["A-B"].potential = x;
-    pots2.potentialMap()["A-C"].potential = x;
-    pots2.potentialMap()["A-D"].potential = x;
+    pots2.potentials()["A-A"] = x;
+    pots2.potentials()["A-B"] = x;
+    pots2.potentials()["A-C"] = x;
+    pots2.potentials()["A-D"] = x;
 
     pots += pots2;
-    EXPECT_EQ(4.0, pots.potentialMap()["A-A"].potential.value(0));
-    EXPECT_EQ(4.0, pots.potentialMap()["A-B"].potential.value(0));
-    EXPECT_EQ(4.0, pots.potentialMap()["A-C"].potential.value(0));
-    EXPECT_EQ(2.0, pots.potentialMap()["A-D"].potential.value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-A"].value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-B"].value(0));
+    EXPECT_EQ(4.0, pots.potentials()["A-C"].value(0));
+    EXPECT_EQ(2.0, pots.potentials()["A-D"].value(0));
 }
 
 TEST(PotentialSetTest, Averaging)
 {
-    GenericList moduleData;
-    auto originalPotentialsObject =
-        moduleData.realiseIf<PotentialSet>("PotentialSet", "module", GenericItem::InRestartFileFlag);
-
-    std::string filename{std::format("{}.restart.txt", ::testing::UnitTest::GetInstance()->current_test_info()->name())};
-    // Open the file
-    LineParser parser;
-    ASSERT_TRUE(parser.openOutput(filename));
-
     Data1D x;
     Data1D y;
     const auto value = 2.0;
     const auto value2 = 4.0;
     const auto averagingLength = 10;
 
-    AtomType A("A"), B("B"), C("C"), D("D");
-
     x.addPoint(1, value);
     y.addPoint(1, value2);
 
+    History<PotentialSet> history;
     for (auto n = 0; n <= 2 * averagingLength; n++)
     {
         PotentialSet pots;
-        pots.potentialMap()["A-A"].at1 = &A;
-        pots.potentialMap()["A-A"].at2 = &A;
-        pots.potentialMap()["A-A"].potential = x;
 
-        pots.potentialMap()["A-B"].at1 = &A;
-        pots.potentialMap()["A-B"].at2 = &B;
-        pots.potentialMap()["A-B"].potential = x;
+        pots.potentials()["A-A"] = x;
+        pots.potentials()["A-B"] = x;
+        pots.potentials()["A-C"] = y;
+        pots.potentials()["A-D"] = y;
 
-        pots.potentialMap()["A-C"].at1 = &A;
-        pots.potentialMap()["A-C"].at2 = &C;
-        pots.potentialMap()["A-C"].potential = y;
+        auto averagedPots = history.push(pots, averagingLength);
 
-        pots.potentialMap()["A-D"].at1 = &A;
-        pots.potentialMap()["A-D"].at2 = &D;
-        pots.potentialMap()["A-D"].potential = y;
-
-        originalPotentialsObject.first = pots;
-        Averaging::average<PotentialSet>(moduleData, "PotentialSet", "module", averagingLength,
-                                         Averaging::AveragingScheme::LinearAveraging);
-
-        EXPECT_EQ(&A, pots.potentialMap()["A-A"].at1);
-        EXPECT_EQ(&A, pots.potentialMap()["A-A"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-B"].at1);
-        EXPECT_EQ(&B, pots.potentialMap()["A-B"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-C"].at1);
-        EXPECT_EQ(&C, pots.potentialMap()["A-C"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-D"].at1);
-        EXPECT_EQ(&D, pots.potentialMap()["A-D"].at2);
-
-        EXPECT_EQ(2.0, pots.potentialMap()["A-A"].potential.value(0));
-        EXPECT_EQ(2.0, pots.potentialMap()["A-A"].potential.value(0));
-        EXPECT_EQ(2.0, pots.potentialMap()["A-B"].potential.value(0));
-        EXPECT_EQ(4.0, pots.potentialMap()["A-C"].potential.value(0));
-        EXPECT_EQ(4.0, pots.potentialMap()["A-D"].potential.value(0));
-
-        pots.serialise(parser);
-    }
-}
-
-TEST(PotentialSetTest, Averaging2)
-{
-    GenericList moduleData;
-    auto originalPotentialsObject =
-        moduleData.realiseIf<PotentialSet>("PotentialSet", "module", GenericItem::InRestartFileFlag);
-
-    std::string filename{std::format("{}.restart.txt", ::testing::UnitTest::GetInstance()->current_test_info()->name())};
-
-    // Open the file
-    LineParser parser;
-    if (!parser.openOutput(filename))
-    {
-        parser.closeFiles();
+        EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
+        EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
+        EXPECT_EQ(2.0, averagedPots.potentials()["A-B"].value(0));
+        EXPECT_EQ(4.0, averagedPots.potentials()["A-C"].value(0));
+        EXPECT_EQ(4.0, averagedPots.potentials()["A-D"].value(0));
     }
 
-    Data1D x;
-    Data1D y;
-    const auto value = 2.0;
-    const auto value2 = 4.0;
-    const auto averagingLength = 10;
+    // Round-trip the data via TOML
+    SerialisedValue toml;
+    history.serialise("history", toml);
+    history.clear();
 
-    AtomType A("A"), B("B"), C("C"), D("D");
+    history.deserialise(toml["history"]);
 
-    x.addPoint(1, value);
-    y.addPoint(1, value2);
+    auto averagedPots = history.average();
 
-    for (auto n = 0; n <= 2 * averagingLength; n++)
-    {
-        PotentialSet pots;
-        pots.potentialMap()["A-A"].at1 = &A;
-        pots.potentialMap()["A-A"].at2 = &A;
-        pots.potentialMap()["A-A"].potential = x;
-
-        pots.potentialMap()["A-B"].at1 = &A;
-        pots.potentialMap()["A-B"].at2 = &B;
-        pots.potentialMap()["A-B"].potential = x;
-
-        pots.potentialMap()["A-C"].at1 = &A;
-        pots.potentialMap()["A-C"].at2 = &C;
-        pots.potentialMap()["A-C"].potential = y;
-
-        pots.potentialMap()["A-D"].at1 = &A;
-        pots.potentialMap()["A-D"].at2 = &D;
-        pots.potentialMap()["A-D"].potential = y;
-
-        originalPotentialsObject.first = pots;
-        Averaging::average<PotentialSet>(moduleData, "PotentialSet", "module", averagingLength,
-                                         Averaging::AveragingScheme::LinearAveraging);
-
-        EXPECT_EQ(&A, pots.potentialMap()["A-A"].at1);
-        EXPECT_EQ(&A, pots.potentialMap()["A-A"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-B"].at1);
-        EXPECT_EQ(&B, pots.potentialMap()["A-B"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-C"].at1);
-        EXPECT_EQ(&C, pots.potentialMap()["A-C"].at2);
-        EXPECT_EQ(&A, pots.potentialMap()["A-D"].at1);
-        EXPECT_EQ(&D, pots.potentialMap()["A-D"].at2);
-
-        EXPECT_EQ(2.0, pots.potentialMap()["A-A"].potential.value(0));
-        EXPECT_EQ(2.0, pots.potentialMap()["A-A"].potential.value(0));
-        EXPECT_EQ(2.0, pots.potentialMap()["A-B"].potential.value(0));
-        EXPECT_EQ(4.0, pots.potentialMap()["A-C"].potential.value(0));
-        EXPECT_EQ(4.0, pots.potentialMap()["A-D"].potential.value(0));
-
-        pots.serialise(parser);
-    }
+    EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
+    EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
+    EXPECT_EQ(2.0, averagedPots.potentials()["A-B"].value(0));
+    EXPECT_EQ(4.0, averagedPots.potentials()["A-C"].value(0));
+    EXPECT_EQ(4.0, averagedPots.potentials()["A-D"].value(0));
 }
 
 } // namespace UnitTest

--- a/tests/classes/potentialSet.cpp
+++ b/tests/classes/potentialSet.cpp
@@ -16,14 +16,14 @@ TEST(PotentialSetTest, SimpleAddition)
     Data1D x;
     const auto value = 2.0;
     x.addPoint(1, value);
-    pots.potentials()["A-A"] = x;
-    pots.potentials()["A-B"] = x;
-    pots.potentials()["A-C"] = x;
+    pots.potentials()["A//A"] = x;
+    pots.potentials()["A//B"] = x;
+    pots.potentials()["A//C"] = x;
 
     pots += pots;
-    EXPECT_EQ(4.0, pots.potentials()["A-A"].value(0));
-    EXPECT_EQ(4.0, pots.potentials()["A-B"].value(0));
-    EXPECT_EQ(4.0, pots.potentials()["A-C"].value(0));
+    EXPECT_DOUBLE_EQ(4.0, pots.potentials()["A//A"].value(0));
+    EXPECT_DOUBLE_EQ(4.0, pots.potentials()["A//B"].value(0));
+    EXPECT_DOUBLE_EQ(4.0, pots.potentials()["A//C"].value(0));
 }
 
 TEST(PotentialSetTest, Multiplication)
@@ -32,14 +32,14 @@ TEST(PotentialSetTest, Multiplication)
     Data1D x;
     const auto value = 3.0;
     x.addPoint(1, value);
-    pots.potentials()["A-A"] = x;
-    pots.potentials()["A-B"] = x;
-    pots.potentials()["A-C"] = x;
+    pots.potentials()["A//A"] = x;
+    pots.potentials()["A//B"] = x;
+    pots.potentials()["A//C"] = x;
 
     pots *= 2;
-    EXPECT_EQ(6.0, pots.potentials()["A-A"].value(0));
-    EXPECT_EQ(6.0, pots.potentials()["A-B"].value(0));
-    EXPECT_EQ(6.0, pots.potentials()["A-C"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//A"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//B"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//C"].value(0));
 }
 
 TEST(PotentialSetTest, ComplexAddition)
@@ -49,20 +49,20 @@ TEST(PotentialSetTest, ComplexAddition)
     Data1D x;
     const auto value = 2.0;
     x.addPoint(1, value);
-    pots.potentials()["A-A"] = x;
-    pots.potentials()["A-B"] = x;
-    pots.potentials()["A-C"] = x;
+    pots.potentials()["A//A"] = x;
+    pots.potentials()["A//B"] = x;
+    pots.potentials()["A//C"] = x;
 
-    pots2.potentials()["A-A"] = x;
-    pots2.potentials()["A-B"] = x;
-    pots2.potentials()["A-C"] = x;
-    pots2.potentials()["A-D"] = x;
+    pots2.potentials()["A//A"] = x;
+    pots2.potentials()["A//B"] = x;
+    pots2.potentials()["A//C"] = x;
+    pots2.potentials()["A//D"] = x;
 
     pots += pots2;
-    EXPECT_EQ(4.0, pots.potentials()["A-A"].value(0));
-    EXPECT_EQ(4.0, pots.potentials()["A-B"].value(0));
-    EXPECT_EQ(4.0, pots.potentials()["A-C"].value(0));
-    EXPECT_EQ(2.0, pots.potentials()["A-D"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//A"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//B"].value(0));
+    EXPECT_DOUBLE_EQ(value * 2, pots.potentials()["A//C"].value(0));
+    EXPECT_DOUBLE_EQ(value, pots.potentials()["A//D"].value(0));
 }
 
 TEST(PotentialSetTest, Averaging)
@@ -81,18 +81,17 @@ TEST(PotentialSetTest, Averaging)
     {
         PotentialSet pots;
 
-        pots.potentials()["A-A"] = x;
-        pots.potentials()["A-B"] = x;
-        pots.potentials()["A-C"] = y;
-        pots.potentials()["A-D"] = y;
+        pots.potentials()["A//A"] = x;
+        pots.potentials()["A//B"] = x;
+        pots.potentials()["A//C"] = y;
+        pots.potentials()["A//D"] = y;
 
         auto averagedPots = history.push(pots, averagingLength);
 
-        EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
-        EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
-        EXPECT_EQ(2.0, averagedPots.potentials()["A-B"].value(0));
-        EXPECT_EQ(4.0, averagedPots.potentials()["A-C"].value(0));
-        EXPECT_EQ(4.0, averagedPots.potentials()["A-D"].value(0));
+        EXPECT_DOUBLE_EQ(value, averagedPots.potentials()["A//A"].value(0));
+        EXPECT_DOUBLE_EQ(value, averagedPots.potentials()["A//B"].value(0));
+        EXPECT_DOUBLE_EQ(value2, averagedPots.potentials()["A//C"].value(0));
+        EXPECT_DOUBLE_EQ(value2, averagedPots.potentials()["A//D"].value(0));
     }
 
     // Round-trip the data via TOML
@@ -104,11 +103,10 @@ TEST(PotentialSetTest, Averaging)
 
     auto averagedPots = history.average();
 
-    EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
-    EXPECT_EQ(2.0, averagedPots.potentials()["A-A"].value(0));
-    EXPECT_EQ(2.0, averagedPots.potentials()["A-B"].value(0));
-    EXPECT_EQ(4.0, averagedPots.potentials()["A-C"].value(0));
-    EXPECT_EQ(4.0, averagedPots.potentials()["A-D"].value(0));
+    EXPECT_DOUBLE_EQ(value, averagedPots.potentials()["A//A"].value(0));
+    EXPECT_DOUBLE_EQ(value, averagedPots.potentials()["A//B"].value(0));
+    EXPECT_DOUBLE_EQ(value2, averagedPots.potentials()["A//C"].value(0));
+    EXPECT_DOUBLE_EQ(value2, averagedPots.potentials()["A//D"].value(0));
 }
 
 } // namespace UnitTest


### PR DESCRIPTION
This PR removes the dependency of raw `AtomType` pointers from `PotentialSet` and replaces them with a `DoubleKeyedMap` in line with other classes.  The changes break the `EPSRManagerModule` but that particular refactor depends on our chosen route with `EPSRModule`.

Closes #2407.