### PR TITLE
fix: Add Number to menu of nodes

### DIFF
--- a/src/gui/qml/nodeGraph/GraphView.qml
+++ b/src/gui/qml/nodeGraph/GraphView.qml
@@ -52,6 +52,11 @@ Pane {
                     onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Multiply", "New Node")
                 }
                 MenuItem {
+                    text: "Number"
+
+                    onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Number", "New Number")
+                }
+                MenuItem {
                     text: "Subtract"
 
                     onClicked: graphRoot.rootModel.emplace_back(Math.round(ctxMenuCatcher.mouseX), Math.round(ctxMenuCatcher.mouseY), "Subtract", "New Node")

--- a/src/gui/qml/nodeGraph/ParameterDelegate.qml
+++ b/src/gui/qml/nodeGraph/ParameterDelegate.qml
@@ -27,6 +27,9 @@ DelegateChooser {
             Layout.alignment: Qt.AlignRight
             Layout.column: 2
             Layout.row: index
+            editable: true
+            from: -1000000
+            to: 1000000
             value: param
 
             onValueModified: param = value


### PR DESCRIPTION
I noticed while preparing screenshots for the RSE program board that the menu to add nodes to the GUI did not include the (rather critical) Number node.  I have added that node to the menu.

Additionally, the default QML spinbox only has a range from 0 to 1 and is not text editable by default.  I've changed the corresponding QML for a greater range and to allow direct edits.  We may have a discussion in the longer term about how to handle the range.