### PR TITLE
refactor: Common Atom Class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ justfile
 *.state
 
 # Test files
+**cmake_test_discovery*
 *.gr
 *.sq
 *.rewrite

--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(
   classes
   angleFunctions.cpp
   array3DIterator.cpp
+  atom.cpp
   atomType.cpp
   bondFunctions.cpp
   box.cpp
@@ -78,6 +79,7 @@ add_library(
   xRayWeights.cpp
   angleFunctions.h
   array3DIterator.h
+  atom.h
   atomType.h
   bondFunctions.h
   box.h

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -23,6 +23,12 @@ Elements::Element Atom::Z() const { return Z_; }
 double &Atom::q() { return q_; };
 double Atom::q() const { return q_; }
 
+// Return index (0->[N-1])
+int Atom::index() const { return index_; };
+
+// Set index
+void Atom::setIndex(int index) { index_ = index; }
+
 // Set index of associated atom type in parent object
 void Atom::setAtomTypeIndex(int id) { atomTypeIndex_ = id; }
 

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "classes/atom.h"
+
+// Return coordinates
+Vector3 &Atom::r() { return r_; }
+const Vector3 &Atom::r() const { return r_; }

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -14,9 +14,6 @@ void Atom::set(Elements::Element Z, const Vector3 &r, double q)
 // Set coordinates
 void Atom::setR(const Vector3 &r) { r_ = r; }
 
-// Adjust coordinates
-void Atom::adjustR(const Vector3 &delta) { r_ += delta; }
-
 // Return coordinates
 const Vector3 &Atom::r() const { return r_; }
 
@@ -43,3 +40,11 @@ void Atom::setAtomTypeIndex(int id) { atomTypeIndex_ = id; }
 
 // Return associated atom type index
 int Atom::atomTypeIndex() const { return atomTypeIndex_; }
+
+/*
+ * Coordinate Manipulation Operators
+ */
+
+void Atom::operator+=(const Vector3 &delta) { r_ += delta; }
+
+void Atom::operator-=(const Vector3 &delta) { r_ -= delta; }

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -3,9 +3,25 @@
 
 #include "classes/atom.h"
 
+// Set basic properties
+void Atom::set(Elements::Element Z, const Vector3 &r, double q)
+{
+    r_ = r;
+    Z_ = Z;
+    q_ = q;
+}
+
 // Return coordinates
 Vector3 &Atom::r() { return r_; }
 const Vector3 &Atom::r() const { return r_; }
+
+// Return atomic element
+Elements::Element &Atom::Z() { return Z_; }
+Elements::Element Atom::Z() const { return Z_; }
+
+// Return atomic charge
+double &Atom::q() { return q_; };
+double Atom::q() const { return q_; }
 
 // Set index of associated atom type in parent object
 void Atom::setAtomTypeIndex(int id) { atomTypeIndex_ = id; }

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -6,3 +6,9 @@
 // Return coordinates
 Vector3 &Atom::r() { return r_; }
 const Vector3 &Atom::r() const { return r_; }
+
+// Set index of associated atom type in parent object
+void Atom::setAtomTypeIndex(int id) { atomTypeIndex_ = id; }
+
+// Return associated atom type index
+int Atom::atomTypeIndex() const { return atomTypeIndex_; }

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -11,16 +11,25 @@ void Atom::set(Elements::Element Z, const Vector3 &r, double q)
     q_ = q;
 }
 
+// Set coordinates
+void Atom::setR(const Vector3 &r) { r_ = r; }
+
+// Adjust coordinates
+void Atom::adjustR(const Vector3 &delta) { r_ += delta; }
+
 // Return coordinates
-Vector3 &Atom::r() { return r_; }
 const Vector3 &Atom::r() const { return r_; }
 
+// Set atomic element
+void Atom::setZ(Elements::Element z) { Z_ = z; }
+
 // Return atomic element
-Elements::Element &Atom::Z() { return Z_; }
 Elements::Element Atom::Z() const { return Z_; }
 
+// Set atomic charge
+void Atom::setQ(double q) { q_ = q; }
+
 // Return atomic charge
-double &Atom::q() { return q_; };
 double Atom::q() const { return q_; }
 
 // Return index (0->[N-1])

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -9,6 +9,10 @@
 // Basic Atom
 class Atom
 {
+    public:
+    Atom() = default;
+    virtual ~Atom() = default;
+
     /*
      * Properties
      */

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -31,19 +31,24 @@ class Atom
     public:
     // Set basic properties
     virtual void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
+    // Set coordinates
+    void setR(const Vector3 &r);
+    // Adjust coordinates
+    void adjustR(const Vector3 &delta);
     // Return coordinates
-    Vector3 &r();
     const Vector3 &r() const;
+    // Set atomic element
+    void setZ(Elements::Element z);
     // Return atomic element
-    Elements::Element &Z();
     Elements::Element Z() const;
+    // Set atomic charge
+    void setQ(double q);
     // Return atomic charge
-    double &q();
     double q() const;
-    // Return index
-    int index() const;
     // Set index
     void setIndex(int index);
+    // Return index
+    int index() const;
     // Set index of associated atom type in parent object
     void setAtomTypeIndex(int id);
     // Return associated atom type index

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -15,13 +15,25 @@ class Atom
     private:
     // Coordinates
     Vector3 r_;
+    // Atomic element
+    Elements::Element Z_{Elements::Unknown};
+    // Charge
+    double q_{0.0};
     // Atom type index in parent object
     int atomTypeIndex_{AtomType::Ignore};
 
     public:
+    // Set basic properties
+    void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
     // Return coordinates
     Vector3 &r();
     const Vector3 &r() const;
+    // Return atomic element
+    Elements::Element &Z();
+    Elements::Element Z() const;
+    // Return atomic charge
+    double &q();
+    double q() const;
     // Set index of associated atom type in parent object
     void setAtomTypeIndex(int id);
     // Return associated atom type index

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -34,7 +34,7 @@ class Atom
     // Set coordinates
     void setR(const Vector3 &r);
     // Adjust coordinates
-    void adjustR(const Vector3 &delta);
+    void operator+=(const Vector3 &delta);
     // Return coordinates
     const Vector3 &r() const;
     // Set atomic element

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "classes/atomType.h"
 #include "math/vector3.h"
 
 // Basic Atom
@@ -14,9 +15,15 @@ class Atom
     private:
     // Coordinates
     Vector3 r_;
+    // Atom type index in parent object
+    int atomTypeIndex_{AtomType::Ignore};
 
     public:
     // Return coordinates
     Vector3 &r();
     const Vector3 &r() const;
+    // Set index of associated atom type in parent object
+    void setAtomTypeIndex(int id);
+    // Return associated atom type index
+    int atomTypeIndex() const;
 };

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -23,6 +23,8 @@ class Atom
     Elements::Element Z_{Elements::Unknown};
     // Charge
     double q_{0.0};
+    // Index in parent
+    int index_{-1};
     // Atom type index in parent object
     int atomTypeIndex_{AtomType::Ignore};
 
@@ -38,6 +40,10 @@ class Atom
     // Return atomic charge
     double &q();
     double q() const;
+    // Return index
+    int index() const;
+    // Set index
+    void setIndex(int index);
     // Set index of associated atom type in parent object
     void setAtomTypeIndex(int id);
     // Return associated atom type index

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "math/vector3.h"
+
+// Basic Atom
+class Atom
+{
+    /*
+     * Properties
+     */
+    private:
+    // Coordinates
+    Vector3 r_;
+
+    public:
+    // Return coordinates
+    Vector3 &r();
+    const Vector3 &r() const;
+};

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -33,8 +33,6 @@ class Atom
     virtual void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
     // Set coordinates
     void setR(const Vector3 &r);
-    // Adjust coordinates
-    void operator+=(const Vector3 &delta);
     // Return coordinates
     const Vector3 &r() const;
     // Set atomic element
@@ -53,4 +51,11 @@ class Atom
     void setAtomTypeIndex(int id);
     // Return associated atom type index
     int atomTypeIndex() const;
+
+    /*
+     * Coordinate Manipulation Operators
+     */
+    public:
+    void operator+=(const Vector3 &delta);
+    void operator-=(const Vector3 &delta);
 };

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -12,7 +12,7 @@ class Atom
     /*
      * Properties
      */
-    private:
+    protected:
     // Coordinates
     Vector3 r_;
     // Atomic element
@@ -24,7 +24,7 @@ class Atom
 
     public:
     // Set basic properties
-    void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
+    virtual void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
     // Return coordinates
     Vector3 &r();
     const Vector3 &r() const;

--- a/src/classes/changeData.cpp
+++ b/src/classes/changeData.cpp
@@ -42,7 +42,7 @@ void ChangeData::updatePosition()
 void ChangeData::revertPosition()
 {
     // Set stored position
-    atom_->r() = r_;
+    atom_->setR(r_);
 
     // If the cell changed with the move, revert that too
     if (cell_ != atom_->cell())

--- a/src/classes/changeData.cpp
+++ b/src/classes/changeData.cpp
@@ -42,7 +42,7 @@ void ChangeData::updatePosition()
 void ChangeData::revertPosition()
 {
     // Set stored position
-    atom_->setCoordinates(r_);
+    atom_->r() = r_;
 
     // If the cell changed with the move, revert that too
     if (cell_ != atom_->cell())

--- a/src/classes/configurationAtom.cpp
+++ b/src/classes/configurationAtom.cpp
@@ -7,12 +7,6 @@
 #include "classes/speciesAtom.h"
 #include <utility>
 
-// Set AtomType index in parent Configuration
-void ConfigurationAtom::setConfigurationTypeIndex(int id) { configurationTypeIndex_ = id; }
-
-// Return AtomType index in parent Configuration
-int ConfigurationAtom::configurationTypeIndex() const { return configurationTypeIndex_; }
-
 // Return global index of the atom
 int ConfigurationAtom::globalIndex() const
 {

--- a/src/classes/configurationAtom.cpp
+++ b/src/classes/configurationAtom.cpp
@@ -7,24 +7,6 @@
 #include "classes/speciesAtom.h"
 #include <utility>
 
-// Set coordinates
-void ConfigurationAtom::set(const Vector3 r) { r_ = r; }
-
-// Set coordinates
-void ConfigurationAtom::set(double rx, double ry, double rz) { r_.set(rx, ry, rz); }
-
-// Return coordinates
-const Vector3 &ConfigurationAtom::r() const { return r_; }
-
-// Return x-coordinate
-double ConfigurationAtom::x() const { return r_.x; }
-
-// Return y-coordinate
-double ConfigurationAtom::y() const { return r_.y; }
-
-// Return z-coordinate
-double ConfigurationAtom::z() const { return r_.z; }
-
 // Set AtomType index in parent Configuration
 void ConfigurationAtom::setConfigurationTypeIndex(int id) { configurationTypeIndex_ = id; }
 
@@ -62,22 +44,6 @@ void ConfigurationAtom::setCell(Cell *cell) { cell_ = cell; }
 
 // Return cell in which the atom exists
 Cell *ConfigurationAtom::cell() const { return cell_; }
-
-/*
- * Coordinate Manipulation
- */
-
-// Set coordinates
-void ConfigurationAtom::setCoordinates(const Vector3 &newr) { r_ = newr; }
-
-// Set coordinates
-void ConfigurationAtom::setCoordinates(double dx, double dy, double dz) { setCoordinates(Vector3(dx, dy, dz)); }
-
-// Translate coordinates
-void ConfigurationAtom::translateCoordinates(const Vector3 &delta) { setCoordinates(r_ + delta); }
-
-// Translate coordinates
-void ConfigurationAtom::translateCoordinates(double dx, double dy, double dz) { setCoordinates(r_ + Vector3(dx, dy, dz)); }
 
 /*
  * Intramolecular Information

--- a/src/classes/configurationAtom.h
+++ b/src/classes/configurationAtom.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "classes/atom.h"
 #include "classes/speciesAtom.h"
 #include "kernels/potentials/base.h"
 #include "math/vector3.h"
@@ -14,30 +15,16 @@ class Cell;
 class Molecule;
 
 // Configuration Atom
-class ConfigurationAtom
+class ConfigurationAtom : public Atom
 {
     /*
      * Properties
      */
     private:
-    // Coordinates
-    Vector3 r_;
     // Assigned AtomType index, local to Configuration (for partial indexing etc.)
     int configurationTypeIndex_{-1};
 
     public:
-    // Set coordinates
-    void set(const Vector3 r);
-    // Set coordinates
-    void set(double rx, double ry, double rz);
-    // Return coordinates
-    const Vector3 &r() const;
-    // Return x-coordinate
-    double x() const;
-    // Return y-coordinate
-    double y() const;
-    // Return z-coordinate
-    double z() const;
     // Set AtomType index in parent Configuration
     void setConfigurationTypeIndex(int id);
     // Return AtomType index in parent Configuration
@@ -71,19 +58,6 @@ class ConfigurationAtom
     void setCell(Cell *cell);
     // Return cell in which the atom exists
     Cell *cell() const;
-
-    /*
-     * Coordinate Manipulation
-     */
-    public:
-    // Set coordinates
-    void setCoordinates(const Vector3 &newr);
-    // Set coordinates
-    void setCoordinates(double dx, double dy, double dz);
-    // Translate coordinates
-    void translateCoordinates(const Vector3 &delta);
-    // Translate coordinates
-    void translateCoordinates(double dx, double dy, double dz);
 
     /*
      * Intramolecular Information

--- a/src/classes/configurationAtom.h
+++ b/src/classes/configurationAtom.h
@@ -6,7 +6,6 @@
 #include "classes/atom.h"
 #include "classes/speciesAtom.h"
 #include "kernels/potentials/base.h"
-#include "math/vector3.h"
 #include <memory>
 #include <vector>
 
@@ -20,15 +19,7 @@ class ConfigurationAtom : public Atom
     /*
      * Properties
      */
-    private:
-    // Assigned AtomType index, local to Configuration (for partial indexing etc.)
-    int configurationTypeIndex_{-1};
-
     public:
-    // Set AtomType index in parent Configuration
-    void setConfigurationTypeIndex(int id);
-    // Return AtomType index in parent Configuration
-    int configurationTypeIndex() const;
     // Return global index of the atom
     int globalIndex() const;
 

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -27,10 +27,6 @@ ConfigurationAtom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const s
     // Set the position
     newAtom.r() = r;
 
-    // Set configuration type index for pair potential lookup
-    // TODO This can be removed once the Dissolve1 unit tests have been ported over to Dissolve2
-    newAtom.setConfigurationTypeIndex(sourceAtom->atomType()->index());
-
     return newAtom;
 }
 
@@ -348,9 +344,9 @@ void Configuration::updateTypeIndexing()
     for (auto &atom : atoms_)
     {
         if (atom.speciesAtom()->isPresence(SpeciesAtom::Presence::Physical))
-            atom.setConfigurationTypeIndex(typeMap[atom.speciesAtom()->atomType()]);
+            atom.setAtomTypeIndex(typeMap[atom.speciesAtom()->atomType()]);
         else
-            atom.setConfigurationTypeIndex(AtomType::Ignore);
+            atom.setAtomTypeIndex(AtomType::Ignore);
     }
 
     typeIndicesValid_ = true;

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -25,7 +25,7 @@ ConfigurationAtom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const s
     molecule->addAtom(&newAtom);
 
     // Set the position
-    newAtom.r() = r;
+    newAtom.setR(r);
 
     return newAtom;
 }
@@ -297,7 +297,7 @@ void Configuration::scaleContents(Vector3 scaleFactors)
                 box()->toFractional(r);
                 r.multiply(scaleFactors);
                 box()->toReal(r);
-                i->r() = r;
+                i->setR(r);
             }
         }
         else

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -25,7 +25,7 @@ ConfigurationAtom &Configuration::addAtom(const SpeciesAtom *sourceAtom, const s
     molecule->addAtom(&newAtom);
 
     // Set the position
-    newAtom.setCoordinates(r);
+    newAtom.r() = r;
 
     // Set configuration type index for pair potential lookup
     // TODO This can be removed once the Dissolve1 unit tests have been ported over to Dissolve2
@@ -301,7 +301,7 @@ void Configuration::scaleContents(Vector3 scaleFactors)
                 box()->toFractional(r);
                 r.multiply(scaleFactors);
                 box()->toReal(r);
-                i->setCoordinates(r);
+                i->r() = r;
             }
         }
         else

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -58,7 +58,7 @@ bool Configuration::serialise(LineParser &parser) const
         return false;
     for (const auto &i : atoms_)
     {
-        if (!parser.writeLineF("{} {} {} {}\n", i.molecule()->arrayIndex(), i.x(), i.y(), i.z()))
+        if (!parser.writeLineF("{} {} {} {}\n", i.molecule()->arrayIndex(), i.r().x, i.r().y, i.r().z))
             return false;
     }
 
@@ -154,7 +154,7 @@ bool Configuration::deserialise(LineParser &parser, const CoreData &coreData, bo
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
 
-        atom(n).setCoordinates(parser.arg3d(1));
+        atom(n).r() = parser.arg3d(1);
     }
 
     // Scale box and cells according to the applied size factor

--- a/src/classes/configuration_io.cpp
+++ b/src/classes/configuration_io.cpp
@@ -154,7 +154,7 @@ bool Configuration::deserialise(LineParser &parser, const CoreData &coreData, bo
         if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
             return false;
 
-        atom(n).r() = parser.arg3d(1);
+        atom(n).setR(parser.arg3d(1));
     }
 
     // Scale box and cells according to the applied size factor

--- a/src/classes/configuration_upkeep.cpp
+++ b/src/classes/configuration_upkeep.cpp
@@ -40,7 +40,7 @@ void Configuration::updateAtomLocations(bool clearExistingLocations)
 void Configuration::updateAtomLocation(ConfigurationAtom *i)
 {
     // Fold Atom coordinates into Box
-    i->r() = box_->fold(i->r());
+    i->setR(box_->fold(i->r()));
 
     // Determine new Cell position
     auto *cell = cells_.cell(i->r());

--- a/src/classes/configuration_upkeep.cpp
+++ b/src/classes/configuration_upkeep.cpp
@@ -40,7 +40,7 @@ void Configuration::updateAtomLocations(bool clearExistingLocations)
 void Configuration::updateAtomLocation(ConfigurationAtom *i)
 {
     // Fold Atom coordinates into Box
-    i->setCoordinates(box_->fold(i->r()));
+    i->r() = box_->fold(i->r());
 
     // Determine new Cell position
     auto *cell = cells_.cell(i->r());

--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -153,7 +153,7 @@ Species *CoreData::copySpecies(const Species *species)
     for (auto &i : species->atoms())
     {
         // Create the Atom in our new Species
-        auto id = newSpecies->addAtom(i.Z(), i.r(), i.charge());
+        auto id = newSpecies->addAtom(i.Z(), i.r(), i.q());
         if (i.isSelected())
             newSpecies->selectAtom(id);
 

--- a/src/classes/localMolecule.cpp
+++ b/src/classes/localMolecule.cpp
@@ -10,7 +10,7 @@ LocalMolecule::LocalMolecule(const Species *copyFrom)
     setSpecies(copyFrom);
     for (auto &&[local, i] : zip(localAtoms_, copyFrom->atoms()))
     {
-        local.r() = i.r();
+        local.setR(i.r());
     }
 }
 

--- a/src/classes/localMolecule.cpp
+++ b/src/classes/localMolecule.cpp
@@ -10,7 +10,7 @@ LocalMolecule::LocalMolecule(const Species *copyFrom)
     setSpecies(copyFrom);
     for (auto &&[local, i] : zip(localAtoms_, copyFrom->atoms()))
     {
-        local.setCoordinates(i.r());
+        local.r() = i.r();
     }
 }
 

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -235,12 +235,12 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 void Molecule::translate(const Vector3 &delta)
 {
     for (auto n = 0; n < nAtoms(); ++n)
-        atom(n)->adjustR(delta);
+        *atom(n) += delta;
 }
 
 // Translate specified atoms by the delta specified
 void Molecule::translate(const Vector3 &delta, const std::vector<int> &targetAtoms)
 {
     for (const auto i : targetAtoms)
-        atom(i)->adjustR(delta);
+        *atom(i) += delta;
 }

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -137,7 +137,7 @@ Vector3 Molecule::unFold(const Box *box)
     traverseLocal(box,
                   [&cog](ConfigurationAtom *j, Vector3 rJ)
                   {
-                      j->setCoordinates(rJ);
+                      j->r() = rJ;
                       cog += rJ;
                   });
     return cog / nAtoms();
@@ -154,7 +154,7 @@ void Molecule::setCentreOfGeometry(const Box *box, const Vector3 &newCentre)
     for (auto n = 0; n < nAtoms(); ++n)
     {
         newR = box->minimumVector(atom(n)->r(), cog) + newCentre;
-        atom(n)->setCoordinates(newR);
+        atom(n)->r() = newR;
     }
 }
 
@@ -202,7 +202,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix)
 
     // Apply transform
     for (auto &i : atoms())
-        i->setCoordinates(transformationMatrix * (i->r() - cog) + cog);
+        i->r() = transformationMatrix * (i->r() - cog) + cog;
 }
 
 // Transform molecule with supplied matrix about specified origin
@@ -213,7 +213,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 
     // Apply transform
     for (auto &i : atoms())
-        i->setCoordinates(transformationMatrix * (i->r() - origin) + origin);
+        i->r() = transformationMatrix * (i->r() - origin) + origin;
 }
 
 // Transform selected atoms with supplied matrix, around specified origin
@@ -227,7 +227,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
     {
         i = atom(index);
         newR = transformationMatrix * box->minimumVector(origin, i->r()) + origin;
-        i->setCoordinates(newR);
+        i->r() = newR;
     }
 }
 
@@ -235,12 +235,12 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 void Molecule::translate(const Vector3 &delta)
 {
     for (auto n = 0; n < nAtoms(); ++n)
-        atom(n)->translateCoordinates(delta);
+        atom(n)->r() += delta;
 }
 
 // Translate specified atoms by the delta specified
 void Molecule::translate(const Vector3 &delta, const std::vector<int> &targetAtoms)
 {
     for (const auto i : targetAtoms)
-        atom(i)->translateCoordinates(delta);
+        atom(i)->r() += delta;
 }

--- a/src/classes/molecule.cpp
+++ b/src/classes/molecule.cpp
@@ -137,7 +137,7 @@ Vector3 Molecule::unFold(const Box *box)
     traverseLocal(box,
                   [&cog](ConfigurationAtom *j, Vector3 rJ)
                   {
-                      j->r() = rJ;
+                      j->setR(rJ);
                       cog += rJ;
                   });
     return cog / nAtoms();
@@ -154,7 +154,7 @@ void Molecule::setCentreOfGeometry(const Box *box, const Vector3 &newCentre)
     for (auto n = 0; n < nAtoms(); ++n)
     {
         newR = box->minimumVector(atom(n)->r(), cog) + newCentre;
-        atom(n)->r() = newR;
+        atom(n)->setR(newR);
     }
 }
 
@@ -202,7 +202,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix)
 
     // Apply transform
     for (auto &i : atoms())
-        i->r() = transformationMatrix * (i->r() - cog) + cog;
+        i->setR(transformationMatrix * (i->r() - cog) + cog);
 }
 
 // Transform molecule with supplied matrix about specified origin
@@ -213,7 +213,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 
     // Apply transform
     for (auto &i : atoms())
-        i->r() = transformationMatrix * (i->r() - origin) + origin;
+        i->setR(transformationMatrix * (i->r() - origin) + origin);
 }
 
 // Transform selected atoms with supplied matrix, around specified origin
@@ -227,7 +227,7 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
     {
         i = atom(index);
         newR = transformationMatrix * box->minimumVector(origin, i->r()) + origin;
-        i->r() = newR;
+        i->setR(newR);
     }
 }
 
@@ -235,12 +235,12 @@ void Molecule::transform(const Box *box, const Matrix3 &transformationMatrix, co
 void Molecule::translate(const Vector3 &delta)
 {
     for (auto n = 0; n < nAtoms(); ++n)
-        atom(n)->r() += delta;
+        atom(n)->adjustR(delta);
 }
 
 // Translate specified atoms by the delta specified
 void Molecule::translate(const Vector3 &delta, const std::vector<int> &targetAtoms)
 {
     for (const auto i : targetAtoms)
-        atom(i)->r() += delta;
+        atom(i)->adjustR(delta);
 }

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -53,7 +53,7 @@ double PotentialMap::energy(const ConfigurationAtom &i, const ConfigurationAtom 
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return pp->energy(r) + (PairPotential::includeCoulombPotential()
                                 ? 0
-                                : pp->analyticCoulombEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r));
+                                : pp->analyticCoulombEnergy(i.speciesAtom()->q() * j.speciesAtom()->q(), r));
 }
 
 // Return energy between Atoms at distance specified, scaling electrostatic and short-range components
@@ -69,7 +69,7 @@ double PotentialMap::energy(const ConfigurationAtom &i, const ConfigurationAtom 
     return PairPotential::includeCoulombPotential()
                ? pp->energy(r, elecScale, srScale)
                : pp->energy(r) * srScale +
-                     pp->analyticCoulombEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r) * elecScale;
+                     pp->analyticCoulombEnergy(i.speciesAtom()->q() * j.speciesAtom()->q(), r) * elecScale;
 }
 
 // Return energy between SpeciesAtoms at distance specified
@@ -82,7 +82,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
     // interpolated potential
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return pp->energy(r) +
-           (PairPotential::includeCoulombPotential() ? 0 : pp->analyticCoulombEnergy(i->charge() * j->charge(), r));
+           (PairPotential::includeCoulombPotential() ? 0 : pp->analyticCoulombEnergy(i->q() * j->q(), r));
 }
 
 // Return energy between SpeciesAtoms at distance specified, scaling electrostatic and short-range components
@@ -96,7 +96,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return PairPotential::includeCoulombPotential()
                ? pp->energy(r, elecScale, srScale)
-               : pp->energy(r) * srScale + pp->analyticCoulombEnergy(i->charge() * j->charge(), r) * elecScale;
+               : pp->energy(r) * srScale + pp->analyticCoulombEnergy(i->q() * j->q(), r) * elecScale;
 }
 
 // Return analytic energy between Atom types at distance specified
@@ -109,7 +109,7 @@ double PotentialMap::analyticEnergy(const ConfigurationAtom &i, const Configurat
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, 1.0, 1.0)
-               : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
+               : pp->analyticEnergy(i.speciesAtom()->q() * j.speciesAtom()->q(), r, 1.0, 1.0);
 }
 
 // Return analytic energy between Atom types at distance specified, scaling electrostatic and short-range components
@@ -123,7 +123,7 @@ double PotentialMap::analyticEnergy(const ConfigurationAtom &i, const Configurat
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, elecScale, srScale)
-               : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);
+               : pp->analyticEnergy(i.speciesAtom()->q() * j.speciesAtom()->q(), r, elecScale, srScale);
 }
 
 // Return force between Atoms at distance specified
@@ -134,7 +134,7 @@ double PotentialMap::force(const ConfigurationAtom &i, const ConfigurationAtom &
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r)
-               : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r);
+               : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r);
 }
 
 // Return force between Atoms at distance specified, scaling electrostatic and short-range components
@@ -147,7 +147,7 @@ double PotentialMap::force(const ConfigurationAtom &i, const ConfigurationAtom &
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
                : pp->force(r) * srScale +
-                     pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r) * elecScale;
+                     pp->analyticCoulombForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r) * elecScale;
 }
 
 // Return force between SpeciesAtoms at distance specified
@@ -160,7 +160,7 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r)
     // interpolated potential
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return PairPotential::includeCoulombPotential() ? pp->force(r)
-                                                    : pp->force(r) + pp->analyticCoulombForce(i->charge() * j->charge(), r);
+                                                    : pp->force(r) + pp->analyticCoulombForce(i->q() * j->q(), r);
 }
 
 // Return force between SpeciesAtoms at distance specified, scaling electrostatic and short-range components
@@ -174,7 +174,7 @@ double PotentialMap::force(const SpeciesAtom *i, const SpeciesAtom *j, double r,
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
-               : pp->force(r) * srScale + pp->analyticCoulombForce(i->charge() * j->charge(), r) * elecScale;
+               : pp->force(r) * srScale + pp->analyticCoulombForce(i->q() * j->q(), r) * elecScale;
 }
 
 // Return analytic force between Atom types at distance specified
@@ -188,7 +188,7 @@ double PotentialMap::analyticForce(const ConfigurationAtom &i, const Configurati
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, 1.0, 1.0)
-               : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
+               : pp->analyticForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r, 1.0, 1.0);
 }
 
 // Return analytic force between Atom types at distance specified, scaling electrostatic and short-range components
@@ -203,5 +203,5 @@ double PotentialMap::analyticForce(const ConfigurationAtom &i, const Configurati
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, elecScale, srScale)
-               : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);
+               : pp->analyticForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r, elecScale, srScale);
 }

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -50,7 +50,7 @@ double PotentialMap::energy(const ConfigurationAtom &i, const ConfigurationAtom 
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return pp->energy(r) + (PairPotential::includeCoulombPotential()
                                 ? 0
                                 : pp->analyticCoulombEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r));
@@ -65,7 +65,7 @@ double PotentialMap::energy(const ConfigurationAtom &i, const ConfigurationAtom 
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->energy(r, elecScale, srScale)
                : pp->energy(r) * srScale +
@@ -106,7 +106,7 @@ double PotentialMap::analyticEnergy(const ConfigurationAtom &i, const Configurat
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, 1.0, 1.0)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -120,7 +120,7 @@ double PotentialMap::analyticEnergy(const ConfigurationAtom &i, const Configurat
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being local to the atom
     // types
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticEnergy(r, elecScale, srScale)
                : pp->analyticEnergy(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);
@@ -131,7 +131,7 @@ double PotentialMap::force(const ConfigurationAtom &i, const ConfigurationAtom &
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r)
                : pp->force(r) + pp->analyticCoulombForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r);
@@ -143,7 +143,7 @@ double PotentialMap::force(const ConfigurationAtom &i, const ConfigurationAtom &
 {
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
                : pp->force(r) * srScale +
@@ -185,7 +185,7 @@ double PotentialMap::analyticForce(const ConfigurationAtom &i, const Configurati
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, 1.0, 1.0)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, 1.0, 1.0);
@@ -200,7 +200,7 @@ double PotentialMap::analyticForce(const ConfigurationAtom &i, const Configurati
 
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
-    auto *pp = potentialMatrix_[{i.configurationTypeIndex(), j.configurationTypeIndex()}];
+    auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->analyticForce(r, elecScale, srScale)
                : pp->analyticForce(i.speciesAtom()->charge() * j.speciesAtom()->charge(), r, elecScale, srScale);

--- a/src/classes/potentialMap.cpp
+++ b/src/classes/potentialMap.cpp
@@ -81,8 +81,7 @@ double PotentialMap::energy(const SpeciesAtom *i, const SpeciesAtom *j, double r
     // Check to see whether Coulomb terms should be calculated from atomic charges, rather than them being included in the
     // interpolated potential
     auto *pp = potentialMatrix_[{i->atomType()->index(), j->atomType()->index()}];
-    return pp->energy(r) +
-           (PairPotential::includeCoulombPotential() ? 0 : pp->analyticCoulombEnergy(i->q() * j->q(), r));
+    return pp->energy(r) + (PairPotential::includeCoulombPotential() ? 0 : pp->analyticCoulombEnergy(i->q() * j->q(), r));
 }
 
 // Return energy between SpeciesAtoms at distance specified, scaling electrostatic and short-range components
@@ -146,8 +145,7 @@ double PotentialMap::force(const ConfigurationAtom &i, const ConfigurationAtom &
     auto *pp = potentialMatrix_[{i.atomTypeIndex(), j.atomTypeIndex()}];
     return PairPotential::includeCoulombPotential()
                ? pp->force(r, elecScale, srScale)
-               : pp->force(r) * srScale +
-                     pp->analyticCoulombForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r) * elecScale;
+               : pp->force(r) * srScale + pp->analyticCoulombForce(i.speciesAtom()->q() * j.speciesAtom()->q(), r) * elecScale;
 }
 
 // Return force between SpeciesAtoms at distance specified

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -39,7 +39,7 @@ void Species::copyBasic(const Species *source, bool copyAtomTypes)
     name_ = source->name_;
 
     for (auto &i : source->atoms_)
-        addAtom(i.Z(), i.r(), i.charge(), copyAtomTypes ? i.atomType() : nullptr);
+        addAtom(i.Z(), i.r(), i.q(), copyAtomTypes ? i.atomType() : nullptr);
 
     for (auto &bond : source->bonds_)
         addBond(bond.indexI(), bond.indexJ());
@@ -151,7 +151,7 @@ void Species::print() const
         auto &i = atom(n);
         Messenger::print("    {:4d}  {:3}  {:4} ({:2d})  {:12.4e}  {:12.4e}  {:12.4e}  {:12.4e}\n", n + 1,
                          Elements::symbol(i.Z()), (i.atomType() ? i.atomType()->name() : "??"),
-                         (i.atomType() ? i.atomType()->index() : -1), i.r().x, i.r().y, i.r().z, i.charge());
+                         (i.atomType() ? i.atomType()->index() : -1), i.r().x, i.r().y, i.r().z, i.q());
     }
 
     if (nBonds() > 0)

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -84,8 +84,6 @@ class Species : public Serialisable<>
     // Return a reference to the vector of atoms
     const std::vector<SpeciesAtom> &atoms() const;
     std::vector<SpeciesAtom> &atoms();
-    // Set coordinates of specified atom (by index and individual coordinates)
-    void setAtomCoordinates(int id, double x, double y, double z);
     // Transmute specified atom
     void transmuteAtom(int index, Elements::Element newZ);
     // Clear current atom selection

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -102,12 +102,6 @@ void SpeciesAtom::setAtomType(const AtomType *at)
 // Return SpeciesAtomType of SpeciesAtom
 const AtomType *SpeciesAtom::atomType() const { return atomType_; }
 
-// Set index (0->[N-1])
-void SpeciesAtom::setIndex(int id) { index_ = id; }
-
-// Return index (0->[N-1])
-int SpeciesAtom::index() const { return index_; }
-
 // Return 'user' index (1->N)
 int SpeciesAtom::userIndex() const { return index_ + 1; }
 

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -66,9 +66,7 @@ void SpeciesAtom::move(SpeciesAtom &source)
 
 void SpeciesAtom::set(Elements::Element Z, const Vector3 &r, double q)
 {
-    Z_ = Z;
-    r_ = r;
-    q_ = q;
+    Atom::set(Z, r, q);
 
     presence_ = Z_ == Elements::Phantom ? Presence::Phantom : Presence::Physical;
 }

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -76,6 +76,9 @@ void SpeciesAtom::set(Elements::Element Z, const Vector3 &r, double q)
 // Return parent Species
 Species *SpeciesAtom::parent() const { return parent_; }
 
+// Return presence of atom
+SpeciesAtom::Presence SpeciesAtom::presence() const { return presence_; }
+
 // Return whether the atom is of the presence specified
 bool SpeciesAtom::isPresence(SpeciesAtom::Presence presence) const
 {
@@ -113,9 +116,6 @@ void SpeciesAtom::setSelected(bool selected) { selected_ = selected; }
 
 // Return whether the atom is currently selected
 bool SpeciesAtom::isSelected() const { return selected_; }
-
-// Return presence of atom
-SpeciesAtom::Presence SpeciesAtom::presence() const { return presence_; }
 
 /*
  * Bond Information

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -26,7 +26,7 @@ void SpeciesAtom::move(SpeciesAtom &source)
     parent_ = source.parent_;
     Z_ = source.Z_;
     r_ = source.r_;
-    charge_ = source.charge_;
+    q_ = source.q_;
     atomType_ = source.atomType_;
     selected_ = source.selected_;
     index_ = source.index_;
@@ -50,7 +50,7 @@ void SpeciesAtom::move(SpeciesAtom &source)
     // Tidy old data
     source.Z_ = Elements::Unknown;
     source.r_ = {};
-    source.charge_ = 0.0;
+    source.q_ = 0.0;
     source.atomType_ = nullptr;
     source.selected_ = false;
     source.index_ = -1;
@@ -64,40 +64,23 @@ void SpeciesAtom::move(SpeciesAtom &source)
  * Properties
  */
 
-// Return parent Species
-Species *SpeciesAtom::parent() const { return parent_; }
-
-// Set basic properties
-void SpeciesAtom::set(Elements::Element Z, double rx, double ry, double rz, double q) { set(Z, {rx, ry, rz}, q); }
 void SpeciesAtom::set(Elements::Element Z, const Vector3 &r, double q)
 {
     Z_ = Z;
     r_ = r;
-    charge_ = q;
+    q_ = q;
 
     presence_ = Z_ == Elements::Phantom ? Presence::Phantom : Presence::Physical;
 }
 
-// Set atomic element
-void SpeciesAtom::setZ(Elements::Element Z) { Z_ = Z; }
-
-// Return atomic element
-Elements::Element SpeciesAtom::Z() const { return Z_; }
+// Return parent Species
+Species *SpeciesAtom::parent() const { return parent_; }
 
 // Return whether the atom is of the presence specified
 bool SpeciesAtom::isPresence(SpeciesAtom::Presence presence) const
 {
     return presence == SpeciesAtom::Presence::Any || presence_ == presence;
 }
-
-// Return coordinates
-const Vector3 &SpeciesAtom::r() const { return r_; }
-
-// Set charge of SpeciesAtom
-void SpeciesAtom::setCharge(double charge) { charge_ = charge; }
-
-// Return charge of SpeciesAtom
-double SpeciesAtom::charge() const { return charge_; }
 
 // Set AtomType of SpeciesAtom
 void SpeciesAtom::setAtomType(const AtomType *at)
@@ -299,28 +282,6 @@ SpeciesAtom::ScaledInteractionDefinition SpeciesAtom::scaling(const SpeciesAtom 
         return it->second;
     return {SpeciesAtom::ScaledInteraction::NotScaled, 1.0, 1.0};
 }
-
-/*
- * Coordinate Manipulation
- */
-
-// Set coordinate
-void SpeciesAtom::setCoordinate(int index, double value) { r_.set(index, value); }
-
-// Set coordinates
-void SpeciesAtom::setCoordinates(double x, double y, double z)
-{
-    r_.x = x;
-    r_.y = y;
-    r_.z = z;
-}
-
-// Set coordinates (from Vec3)
-void SpeciesAtom::setCoordinates(const Vector3 &newr) { r_ = newr; }
-
-// Translate coordinates of atom
-void SpeciesAtom::translateCoordinates(const Vector3 &delta) { r_ += delta; }
-
 /*
  * Atom Environment Helpers
  */
@@ -492,7 +453,7 @@ int SpeciesAtom::guessOxidationState(const SpeciesAtom *i)
 // Express as a serialisable value
 void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"charge", charge_}};
+    target[tag] = {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"q", q_}};
     if (atomType_)
         target[tag]["type"] = atomType_->name().data();
 }
@@ -500,7 +461,7 @@ void SpeciesAtom::deserialise(const SerialisedValue &node)
 {
     index_ = toml::find<int>(node, "index") - 1;
 
-    set(toml::find<Elements::Element>(node, "z"), toml::find<Vector3>(node, "r"), toml::find_or<double>(node, "charge", 0));
+    set(toml::find<Elements::Element>(node, "z"), toml::find<Vector3>(node, "r"), toml::find_or<double>(node, "q", 0));
 
     Serialisable::optionalOn(node, "type",
                              [&](const auto innerNode)

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -5,11 +5,10 @@
 
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
+#include "classes/atom.h"
 #include "data/elements.h"
 #include "math/vector3.h"
 #include "templates/optionalRef.h"
-#include <map>
-#include <memory>
 #include <vector>
 
 // Forward Declarations
@@ -21,7 +20,7 @@ class SpeciesImproper;
 class SpeciesTorsion;
 
 // SpeciesAtom Definition
-class SpeciesAtom : public Serialisable<>
+class SpeciesAtom : public Atom, Serialisable<>
 {
     public:
     SpeciesAtom(Species *parent);
@@ -50,12 +49,6 @@ class SpeciesAtom : public Serialisable<>
     private:
     // Parent Species
     Species *parent_{nullptr};
-    // Atomic element
-    Elements::Element Z_{Elements::Unknown};
-    // Coordinates
-    Vector3 r_{0.0, 0.0, 0.0};
-    // Charge (if contained in file)
-    double charge_{0.0};
     // Assigned AtomType
     const AtomType *atomType_{nullptr};
     // Index in Species
@@ -68,21 +61,8 @@ class SpeciesAtom : public Serialisable<>
     public:
     // Return parent Species
     Species *parent() const;
-    // Set basic properties
-    void set(Elements::Element Z, double rx, double ry, double rz, double q = 0.0);
-    void set(Elements::Element Z, const Vector3 &r, double q = 0.0);
-    // Set atomic element
-    void setZ(Elements::Element Z);
-    // Return atomic element
-    Elements::Element Z() const;
     // Return whether the atom is of the presence specified
     bool isPresence(SpeciesAtom::Presence presence) const;
-    // Return coordinates (read-only)
-    const Vector3 &r() const;
-    // Set charge of Atom
-    void setCharge(double charge);
-    // Return charge of Atom
-    double charge() const;
     // Set AtomType of Atom
     void setAtomType(const AtomType *at);
     // Return AtomType of Atom

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -63,6 +63,8 @@ class SpeciesAtom : public Atom, Serialisable<>
     void set(Elements::Element Z, const Vector3 &r, double q = 0.0) override;
     // Return parent Species
     Species *parent() const;
+    // Return presence of atom
+    Presence presence() const;
     // Return whether the atom is of the presence specified
     bool isPresence(SpeciesAtom::Presence presence) const;
     // Set AtomType of Atom
@@ -79,8 +81,6 @@ class SpeciesAtom : public Atom, Serialisable<>
     void setSelected(bool selected);
     // Return whether the atom is currently selected
     bool isSelected() const;
-    // Return presence of atom
-    Presence presence() const;
 
     /*
      * Intramolecular Information

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -59,6 +59,8 @@ class SpeciesAtom : public Atom, Serialisable<>
     Presence presence_{Presence::Physical};
 
     public:
+    // Set basic properties
+    void set(Elements::Element Z, const Vector3 &r, double q = 0.0) override;
     // Return parent Species
     Species *parent() const;
     // Return whether the atom is of the presence specified
@@ -152,19 +154,6 @@ class SpeciesAtom : public Atom, Serialisable<>
     void setScaledInteractions();
     // Return scaling type and factors (electrostatic, van der Waals) to employ with specified Atom
     ScaledInteractionDefinition scaling(const SpeciesAtom *j) const;
-
-    /*
-     * Coordinate Manipulation
-     */
-    public:
-    // Set coordinate
-    void setCoordinate(int index, double value);
-    // Set coordinates
-    void setCoordinates(double x, double y, double z);
-    // Set coordinates (from Vec3)
-    void setCoordinates(const Vector3 &newr);
-    // Translate coordinates
-    void translateCoordinates(const Vector3 &delta);
 
     /*
      * Atom Environment Helpers

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -50,8 +50,6 @@ class SpeciesAtom : public Atom, Serialisable<>
     Species *parent_{nullptr};
     // Assigned AtomType
     const AtomType *atomType_{nullptr};
-    // Index in Species
-    int index_{-1};
     // Whether the atom is currently selected
     bool selected_{false};
     // Presence of atom
@@ -70,10 +68,6 @@ class SpeciesAtom : public Atom, Serialisable<>
     void setAtomType(const AtomType *at);
     // Return AtomType of Atom
     const AtomType *atomType() const;
-    // Set index (0->[N-1])
-    void setIndex(int id);
-    // Return index (0->[N-1])
-    int index() const;
     // Return 'user' index (1->N)
     int userIndex() const;
     // Set whether the atom is currently selected

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -24,7 +24,6 @@ class SpeciesAtom : public Atom, Serialisable<>
 {
     public:
     SpeciesAtom(Species *parent);
-    ~SpeciesAtom() = default;
     SpeciesAtom(SpeciesAtom &source) = delete;
     SpeciesAtom(SpeciesAtom &&source) noexcept;
     SpeciesAtom &operator=(const SpeciesAtom &source) = delete;

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -338,5 +338,5 @@ double Species::totalCharge(bool useAtomTypes) const
 void Species::randomiseCoordinates(double maxDisplacement)
 {
     for (auto &i : atoms_)
-        i.adjustR(Vector3::randomUnit() * maxDisplacement);
+        i += Vector3::randomUnit() * maxDisplacement;
 }

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -33,6 +33,7 @@ int Species::addAtom(Elements::Element Z, Vector3 r, double q, const AtomType *a
 {
     auto &i = atoms_.emplace_back(this);
     i.set(Z, r, q);
+
     i.setIndex(atoms_.size() - 1);
     i.setAtomType(atomType);
 
@@ -143,9 +144,6 @@ const SpeciesAtom &Species::atom(int n) const
 const std::vector<SpeciesAtom> &Species::atoms() const { return atoms_; }
 std::vector<SpeciesAtom> &Species::atoms() { return atoms_; }
 
-// Set coordinates of specified atom (by index and individual coordinates)
-void Species::setAtomCoordinates(int id, double x, double y, double z) { atom(id).setCoordinates(x, y, z); }
-
 // Transmute specified SpeciesAtom
 void Species::transmuteAtom(int index, Elements::Element newZ)
 {
@@ -157,7 +155,7 @@ void Species::transmuteAtom(int index, Elements::Element newZ)
 
     // Remove any existing AtomType assignment
     i.setAtomType(nullptr);
-    i.setZ(newZ);
+    i.Z() = newZ;
 }
 
 // Clear current Atom selection
@@ -333,13 +331,12 @@ double Species::totalCharge(bool useAtomTypes) const
         return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i)
                                { return acc + (i.atomType() ? i.atomType()->charge() : 0.0); });
     else
-        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0,
-                               [](const auto acc, const auto &i) { return acc + i.charge(); });
+        return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i) { return acc + i.q(); });
 }
 
 // Apply random noise to atoms
 void Species::randomiseCoordinates(double maxDisplacement)
 {
     for (auto &i : atoms_)
-        i.translateCoordinates(Vector3::randomUnit() * maxDisplacement);
+        i.r() += Vector3::randomUnit() * maxDisplacement;
 }

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -32,7 +32,7 @@ void Species::getIndicesRecursive(std::vector<int> &indices, int index, Optional
 int Species::addAtom(Elements::Element Z, Vector3 r, double q, const AtomType *atomType)
 {
     auto &i = atoms_.emplace_back(this);
-    i.set(Z, r.x, r.y, r.z, q);
+    i.set(Z, r, q);
     i.setIndex(atoms_.size() - 1);
     i.setAtomType(atomType);
 

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -155,7 +155,7 @@ void Species::transmuteAtom(int index, Elements::Element newZ)
 
     // Remove any existing AtomType assignment
     i.setAtomType(nullptr);
-    i.Z() = newZ;
+    i.setZ(newZ);
 }
 
 // Clear current Atom selection
@@ -338,5 +338,5 @@ double Species::totalCharge(bool useAtomTypes) const
 void Species::randomiseCoordinates(double maxDisplacement)
 {
     for (auto &i : atoms_)
-        i.r() += Vector3::randomUnit() * maxDisplacement;
+        i.adjustR(Vector3::randomUnit() * maxDisplacement);
 }

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -279,7 +279,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     errorsEncountered = true;
                 }
                 auto &i = atom(index);
-                i.q() = parser.argd(2);
+                i.setQ(parser.argd(2));
                 break;
             }
             case (Species::SpeciesKeyword::EndSpecies):
@@ -291,7 +291,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
 
                     // Fold atoms
                     for (auto &i : atoms_)
-                        i.r() = box_->fold(i.r());
+                        i.setR(box_->fold(i.r()));
                 }
                 updateIsotopologues();
                 Messenger::print("Found end of Species '{}'.\n", name());

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -279,7 +279,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     errorsEncountered = true;
                 }
                 auto &i = atom(index);
-                i.setCharge(parser.argd(2));
+                i.q() = parser.argd(2);
                 break;
             }
             case (Species::SpeciesKeyword::EndSpecies):
@@ -291,7 +291,7 @@ bool Species::read(LineParser &parser, CoreData &coreData)
 
                     // Fold atoms
                     for (auto &i : atoms_)
-                        i.setCoordinates(box_->fold(i.r()));
+                        i.r() = box_->fold(i.r());
                 }
                 updateIsotopologues();
                 Messenger::print("Found end of Species '{}'.\n", name());
@@ -733,7 +733,7 @@ bool Species::write(LineParser &parser, std::string_view prefix)
     {
         if (!parser.writeLineF("{}{}  {:3d}  {:3}  {:12.6e}  {:12.6e}  {:12.6e}  '{}'  {:12.6e}\n", newPrefix,
                                keywords().keyword(Species::SpeciesKeyword::Atom), ++count, Elements::symbol(i.Z()), i.r().x,
-                               i.r().y, i.r().z, i.atomType() == nullptr ? "None" : i.atomType()->name(), i.charge()))
+                               i.r().y, i.r().z, i.atomType() == nullptr ? "None" : i.atomType()->name(), i.q()))
             return false;
     }
 

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -30,7 +30,7 @@ void Species::setCentre(const Box *box, const Vector3 newCentre)
         for (auto &i : atoms_)
         {
             newR = box->minimumVector(i.r(), cog) + newCentre;
-            i.setCoordinates(newR);
+            i.r() = newR;
         }
 }
 
@@ -42,5 +42,5 @@ void Species::centreAtOrigin()
         centre += i.r();
     centre /= atoms_.size();
     for (auto &i : atoms_)
-        i.translateCoordinates(-centre);
+        i.r() -= centre;
 }

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -30,7 +30,7 @@ void Species::setCentre(const Box *box, const Vector3 newCentre)
         for (auto &i : atoms_)
         {
             newR = box->minimumVector(i.r(), cog) + newCentre;
-            i.r() = newR;
+            i.setR(newR);
         }
 }
 
@@ -42,5 +42,5 @@ void Species::centreAtOrigin()
         centre += i.r();
     centre /= atoms_.size();
     for (auto &i : atoms_)
-        i.r() -= centre;
+        i.adjustR(-centre);
 }

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -42,5 +42,5 @@ void Species::centreAtOrigin()
         centre += i.r();
     centre /= atoms_.size();
     for (auto &i : atoms_)
-        i.adjustR(-centre);
+        i -= centre;
 }

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -342,7 +342,7 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, b
 
     // Set the charge on the SpeciesAtom if requested
     if (setSpeciesAtomCharges)
-        i.setCharge(ffa.charge());
+        i.q() = ffa.charge();
 }
 
 // Assign / generate bond term parameters

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -342,7 +342,7 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, b
 
     // Set the charge on the SpeciesAtom if requested
     if (setSpeciesAtomCharges)
-        i.q() = ffa.charge();
+        i.setQ(ffa.charge());
 }
 
 // Assign / generate bond term parameters

--- a/src/generator/rotateFragment.cpp
+++ b/src/generator/rotateFragment.cpp
@@ -77,7 +77,7 @@ bool RotateFragmentGeneratorNode::execute(const GeneratorContext &generatorConte
     for (auto index : parent->instances()[parentIndex].allIndices())
     {
         auto atom = molecule->atom(index);
-        atom->set(rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin());
+        atom->r() = rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin();
     }
 
     return true;

--- a/src/generator/rotateFragment.cpp
+++ b/src/generator/rotateFragment.cpp
@@ -77,7 +77,7 @@ bool RotateFragmentGeneratorNode::execute(const GeneratorContext &generatorConte
     for (auto index : parent->instances()[parentIndex].allIndices())
     {
         auto atom = molecule->atom(index);
-        atom->r() = rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin();
+        atom->setR(rotationMatrix.transform(box->minimumVector(site.origin(), atom->r())) + site.origin());
     }
 
     return true;

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -231,7 +231,7 @@ void AddForcefieldDialogModel::finalise()
         // }
 
         // Copy charge on species atom
-        original.setCharge(modified.charge());
+        original.q() = modified.q();
     }
 
     // Copy intramolecular terms

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -231,7 +231,7 @@ void AddForcefieldDialogModel::finalise()
         // }
 
         // Copy charge on species atom
-        original.q() = modified.q();
+        original.setQ(modified.q());
     }
 
     // Copy intramolecular terms

--- a/src/gui/models/modifyChargesModel.cpp
+++ b/src/gui/models/modifyChargesModel.cpp
@@ -46,11 +46,11 @@ bool ModifyChargesModel::scale(Species *species, bool showDialogOnError = true)
 
         auto sum = 0.0;
         for (auto &atom : species->atoms())
-            sum += atom.charge();
+            sum += atom.q();
         scaleFactor = scaleTarget / sum;
     }
     for (auto &atom : species->atoms())
-        atom.setCharge(atom.charge() * scaleFactor);
+        atom.q() = atom.q() * scaleFactor;
 
     return true;
 }
@@ -61,12 +61,12 @@ void ModifyChargesModel::smooth(Species *species)
     auto sum = species->totalCharge(false), shiftVal = 0.0;
     shiftVal = (sum - targetSum) / species->nAtoms();
     for (auto &atom : species->atoms())
-        atom.setCharge(atom.charge() - shiftVal);
+        atom.q() = atom.q() - shiftVal;
 }
 
 void ModifyChargesModel::reduceSignificantFigures(Species *species)
 {
     auto significantFigures = sigFigValue();
     for (auto &atom : species->atoms())
-        atom.setCharge(std::round(atom.charge() * std::pow(10, significantFigures)) / std::pow(10, significantFigures));
+        atom.q() = std::round(atom.q() * std::pow(10, significantFigures)) / std::pow(10, significantFigures);
 }

--- a/src/gui/models/modifyChargesModel.cpp
+++ b/src/gui/models/modifyChargesModel.cpp
@@ -50,7 +50,7 @@ bool ModifyChargesModel::scale(Species *species, bool showDialogOnError = true)
         scaleFactor = scaleTarget / sum;
     }
     for (auto &atom : species->atoms())
-        atom.q() = atom.q() * scaleFactor;
+        atom.setQ(atom.q() * scaleFactor);
 
     return true;
 }
@@ -61,12 +61,12 @@ void ModifyChargesModel::smooth(Species *species)
     auto sum = species->totalCharge(false), shiftVal = 0.0;
     shiftVal = (sum - targetSum) / species->nAtoms();
     for (auto &atom : species->atoms())
-        atom.q() = atom.q() - shiftVal;
+        atom.setQ(atom.q() - shiftVal);
 }
 
 void ModifyChargesModel::reduceSignificantFigures(Species *species)
 {
     auto significantFigures = sigFigValue();
     for (auto &atom : species->atoms())
-        atom.q() = std::round(atom.q() * std::pow(10, significantFigures)) / std::pow(10, significantFigures);
+        atom.setQ(std::round(atom.q() * std::pow(10, significantFigures)) / std::pow(10, significantFigures));
 }

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -57,7 +57,7 @@ QVariant SpeciesAtomModel::data(const QModelIndex &index, int role) const
         case 4:
             return item.r().get(index.column() - 2);
         case 5:
-            return item.charge();
+            return item.q();
         default:
             return {};
     }
@@ -132,7 +132,7 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
         }
         break;
         case 5:
-            item.setCharge(value.toDouble());
+            item.q() = value.toDouble();
             break;
     }
     Q_EMIT dataChanged(index, index);

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -128,11 +128,11 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
         {
             auto newR = item.r();
             newR.set(index.column() - 2, value.toDouble());
-            item.r() = newR;
+            item.setR(newR);
         }
         break;
         case 5:
-            item.q() = value.toDouble();
+            item.setQ(value.toDouble());
             break;
     }
     Q_EMIT dataChanged(index, index);

--- a/src/gui/models/speciesAtomModel.cpp
+++ b/src/gui/models/speciesAtomModel.cpp
@@ -128,7 +128,7 @@ bool SpeciesAtomModel::setData(const QModelIndex &index, const QVariant &value, 
         {
             auto newR = item.r();
             newR.set(index.column() - 2, value.toDouble());
-            item.setCoordinates(newR);
+            item.r() = newR;
         }
         break;
         case 5:

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -368,8 +368,8 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(SpeciesAtom *fromAtom, 
 
     // Temporary SpeciesAtom
     static SpeciesAtom j(nullptr);
-    j.setZ(toElement);
-    j.setCoordinates(toPoint);
+    j.Z() = toElement;
+    j.r() = toPoint;
 
     // Render based on the current drawing style
     if (displayStyle_ == LinesStyle)
@@ -417,10 +417,10 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(Vector3 fromPoint, Elem
 
     // Temporary SpeciesAtoms
     static SpeciesAtom i(nullptr), j(nullptr);
-    i.setZ(fromElement);
-    i.setCoordinates(fromPoint);
-    j.setZ(toElement);
-    j.setCoordinates(toPoint);
+    i.Z() = fromElement;
+    i.r() = fromPoint;
+    j.Z() = toElement;
+    j.r() = toPoint;
 
     // Render based on the current drawing style
     if (displayStyle_ == LinesStyle)

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -368,8 +368,8 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(SpeciesAtom *fromAtom, 
 
     // Temporary SpeciesAtom
     static SpeciesAtom j(nullptr);
-    j.Z() = toElement;
-    j.r() = toPoint;
+    j.setZ(toElement);
+    j.setR(toPoint);
 
     // Render based on the current drawing style
     if (displayStyle_ == LinesStyle)
@@ -417,10 +417,10 @@ void RenderableSpecies::recreateDrawInteractionPrimitive(Vector3 fromPoint, Elem
 
     // Temporary SpeciesAtoms
     static SpeciesAtom i(nullptr), j(nullptr);
-    i.Z() = fromElement;
-    i.r() = fromPoint;
-    j.Z() = toElement;
-    j.r() = toPoint;
+    i.setZ(fromElement);
+    i.setR(fromPoint);
+    j.setZ(toElement);
+    j.setR(toPoint);
 
     // Render based on the current drawing style
     if (displayStyle_ == LinesStyle)

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -623,7 +623,7 @@ bool CIFHandler::detectMolecules()
         LocalMolecule tempMol(sp);
         tempMol.unFold(cleanedUnitCellSpecies_.box());
         for (auto &&[molAtom, spAtom] : zip(tempMol.localAtoms(), sp->atoms()))
-            spAtom.setCoordinates(molAtom.r());
+            spAtom.r() = molAtom.r();
 
         // Give the species a name
         sp->setName(EmpiricalFormula::formula(sp->atoms(), [&](const auto &at) { return at.Z(); }));
@@ -1171,7 +1171,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         // This represents our full instance coordinates we will be storing (but not their final order)
         instanceMolecule.unFold(unitCellSpecies_.box());
         for (auto &&[molAtom, spAtom] : zip(instanceMolecule.localAtoms(), instanceSpecies.atoms()))
-            spAtom.setCoordinates(molAtom.r());
+            spAtom.r() = molAtom.r();
 
         /*
          * Now, we have a root match atom on the current instance and a vector of possible matching sites on the reference

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -623,7 +623,7 @@ bool CIFHandler::detectMolecules()
         LocalMolecule tempMol(sp);
         tempMol.unFold(cleanedUnitCellSpecies_.box());
         for (auto &&[molAtom, spAtom] : zip(tempMol.localAtoms(), sp->atoms()))
-            spAtom.r() = molAtom.r();
+            spAtom.setR(molAtom.r());
 
         // Give the species a name
         sp->setName(EmpiricalFormula::formula(sp->atoms(), [&](const auto &at) { return at.Z(); }));
@@ -748,7 +748,7 @@ bool CIFHandler::createSupercell()
                             mol.setSpecies(sp);
 
                             for (auto &&[coreAtom, instanceAtom] : zip(instance.localAtoms(), mol.localAtoms()))
-                                instanceAtom.r() = coreAtom.r() + tVec;
+                                instanceAtom.setR(coreAtom.r() + tVec);
                         }
                     }
                 }
@@ -762,7 +762,7 @@ bool CIFHandler::createSupercell()
             {
                 auto mol = supercellConfiguration_.addMolecule(sp);
                 for (auto &&[molAtom, instanceAtom] : zip(mol->atoms(), instance.localAtoms()))
-                    molAtom->r() = instanceAtom.r();
+                    molAtom->setR(instanceAtom.r());
             }
         }
 
@@ -1162,7 +1162,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         auto count = 0;
         for (auto &&[matchedAtom, instanceMolAtom] : zip(matchedUnitCellAtoms, instanceMolecule.localAtoms()))
         {
-            instanceMolAtom.r() = matchedAtom->r();
+            instanceMolAtom.setR(matchedAtom->r());
             atomMask[matchedAtom->index()] = true;
         }
         auto &instanceMoleculeRootAtom = instanceMolecule.localAtoms()[rootAtomLocalIndex];
@@ -1171,7 +1171,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         // This represents our full instance coordinates we will be storing (but not their final order)
         instanceMolecule.unFold(unitCellSpecies_.box());
         for (auto &&[molAtom, spAtom] : zip(instanceMolecule.localAtoms(), instanceSpecies.atoms()))
-            spAtom.r() = molAtom.r();
+            spAtom.setR(molAtom.r());
 
         /*
          * Now, we have a root match atom on the current instance and a vector of possible matching sites on the reference
@@ -1211,7 +1211,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         instance.setSpecies(referenceSpecies);
         for (const auto &[refSpeciesAtom, instanceSpeciesAtom] : matchMap)
         {
-            instance.localAtom(refSpeciesAtom->index()).r() = instanceSpeciesAtom->r();
+            instance.localAtom(refSpeciesAtom->index()).setR(instanceSpeciesAtom->r());
         }
 
         // Find the next available atom

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -748,7 +748,7 @@ bool CIFHandler::createSupercell()
                             mol.setSpecies(sp);
 
                             for (auto &&[coreAtom, instanceAtom] : zip(instance.localAtoms(), mol.localAtoms()))
-                                instanceAtom.setCoordinates(coreAtom.r() + tVec);
+                                instanceAtom.r() = coreAtom.r() + tVec;
                         }
                     }
                 }
@@ -762,7 +762,7 @@ bool CIFHandler::createSupercell()
             {
                 auto mol = supercellConfiguration_.addMolecule(sp);
                 for (auto &&[molAtom, instanceAtom] : zip(mol->atoms(), instance.localAtoms()))
-                    molAtom->setCoordinates(instanceAtom.r());
+                    molAtom->r() = instanceAtom.r();
             }
         }
 
@@ -1162,7 +1162,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         auto count = 0;
         for (auto &&[matchedAtom, instanceMolAtom] : zip(matchedUnitCellAtoms, instanceMolecule.localAtoms()))
         {
-            instanceMolAtom.setCoordinates(matchedAtom->r());
+            instanceMolAtom.r() = matchedAtom->r();
             atomMask[matchedAtom->index()] = true;
         }
         auto &instanceMoleculeRootAtom = instanceMolecule.localAtoms()[rootAtomLocalIndex];
@@ -1211,7 +1211,7 @@ std::vector<LocalMolecule> CIFHandler::getSpeciesInstances(const Species *refere
         instance.setSpecies(referenceSpecies);
         for (const auto &[refSpeciesAtom, instanceSpeciesAtom] : matchMap)
         {
-            instance.localAtom(refSpeciesAtom->index()).setCoordinates(instanceSpeciesAtom->r());
+            instance.localAtom(refSpeciesAtom->index()).r() = instanceSpeciesAtom->r();
         }
 
         // Find the next available atom

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -124,7 +124,7 @@ bool CoordinateImportFileFormat::importData(LineParser &parser, Configuration *c
 
     // All good, so copy atom coordinates over into our array
     for (auto &&[i, ri] : zip(cfg->atoms(), r))
-        i.setCoordinates(ri);
+        i.r() = ri;
 
     return true;
 }

--- a/src/io/import/coordinates.cpp
+++ b/src/io/import/coordinates.cpp
@@ -124,7 +124,7 @@ bool CoordinateImportFileFormat::importData(LineParser &parser, Configuration *c
 
     // All good, so copy atom coordinates over into our array
     for (auto &&[i, ri] : zip(cfg->atoms(), r))
-        i.r() = ri;
+        i.setR(ri);
 
     return true;
 }

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -52,7 +52,7 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
                 // All good, so copy atom coordinates over into our array
                 for (auto &&[i, ri] : zip(cfg->atoms(), r))
                 {
-                    i.setCoordinates(ri);
+                    i.r() = ri;
                 }
             }
             break;

--- a/src/io/import/trajectory.cpp
+++ b/src/io/import/trajectory.cpp
@@ -52,7 +52,7 @@ bool TrajectoryImportFileFormat::importData(LineParser &parser, Configuration *c
                 // All good, so copy atom coordinates over into our array
                 for (auto &&[i, ri] : zip(cfg->atoms(), r))
                 {
-                    i.r() = ri;
+                    i.setR(ri);
                 }
             }
             break;

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -75,7 +75,7 @@ Module::ExecutionResult AtomShakeModule::process(Dissolve &dissolve)
                                DissolveMath::randomPlusMinusOne() * stepSize_);
 
                     // Translate Atom and update its Cell position
-                    i->translateCoordinates(rDelta);
+                    i->r() += rDelta;
                     targetConfiguration_->updateAtomLocation(i);
 
                     // Calculate new energy

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -75,7 +75,7 @@ Module::ExecutionResult AtomShakeModule::process(Dissolve &dissolve)
                                DissolveMath::randomPlusMinusOne() * stepSize_);
 
                     // Translate Atom and update its Cell position
-                    i->adjustR(rDelta);
+                    *i += rDelta;
                     targetConfiguration_->updateAtomLocation(i);
 
                     // Calculate new energy

--- a/src/modules/atomShake/process.cpp
+++ b/src/modules/atomShake/process.cpp
@@ -75,7 +75,7 @@ Module::ExecutionResult AtomShakeModule::process(Dissolve &dissolve)
                                DissolveMath::randomPlusMinusOne() * stepSize_);
 
                     // Translate Atom and update its Cell position
-                    i->r() += rDelta;
+                    i->adjustR(rDelta);
                     targetConfiguration_->updateAtomLocation(i);
 
                     // Calculate new energy

--- a/src/modules/avgMol/functions.cpp
+++ b/src/modules/avgMol/functions.cpp
@@ -43,7 +43,7 @@ void AvgMolModule::updateArrays(GenericList &moduleData)
 void AvgMolModule::updateSpecies(const SampledVector &x, const SampledVector &y, const SampledVector &z)
 {
     for (auto &&[i, rx, ry, rz] : zip(averageSpecies_.atoms(), x.values(), y.values(), z.values()))
-        i.r() = {rx, ry, rz};
+        i.setR({rx, ry, rz});
 }
 
 /*

--- a/src/modules/avgMol/functions.cpp
+++ b/src/modules/avgMol/functions.cpp
@@ -43,7 +43,7 @@ void AvgMolModule::updateArrays(GenericList &moduleData)
 void AvgMolModule::updateSpecies(const SampledVector &x, const SampledVector &y, const SampledVector &z)
 {
     for (auto &&[i, rx, ry, rz] : zip(averageSpecies_.atoms(), x.values(), y.values(), z.values()))
-        i.setCoordinates({rx, ry, rz});
+        i.r() = {rx, ry, rz};
 }
 
 /*

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -255,7 +255,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, Configuration *cf
             continue;
 
         // Grab localTypeIndex and array pointers for this atom
-        localTypeIndex = atoms[n].configurationTypeIndex();
+        localTypeIndex = atoms[n].atomTypeIndex();
 
         cosTermsH = braggAtomVectorXCos.pointerAt(n, 0);
         cosTermsK = braggAtomVectorYCos.pointerAt(n, 0);

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -202,7 +202,7 @@ Module::ExecutionResult ClusteringModule::process(Dissolve &dissolve)
                     if (360.0 - angle < angle)
                         angle = 360.0 - angle;
 
-                    if (minAngleDev_ <= angle <= maxAngleDev_)
+                    if (angle >= minAngleDev_ && angle <= maxAngleDev_)
                         keep = true;
                 }
                 // Add to the temp map symmetrically. Not paying attention to site indexes but I suppose this method tags donors
@@ -445,7 +445,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
                 auto mol = clusterConfig_.addMolecule(site->parent()->parent());
                 for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
                 {
-                    molAtom->setCoordinates(sourceAtom->r());
+                    molAtom->r() = sourceAtom->r();
                     clusterConfig_.updateAtomLocation(molAtom);
                 }
             }
@@ -461,7 +461,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
                     auto mol = clusterConfig_.addMolecule(site->parent()->parent());
                     for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
                     {
-                        molAtom->setCoordinates(sourceAtom->r());
+                        molAtom->r() = sourceAtom->r();
                         clusterConfig_.updateAtomLocation(molAtom);
                     }
                 }
@@ -475,7 +475,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
             auto mol = clusterConfig_.addMolecule(site->parent()->parent());
             for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
             {
-                molAtom->setCoordinates(sourceAtom->r());
+                molAtom->r() = sourceAtom->r();
                 clusterConfig_.updateAtomLocation(molAtom);
             }
         }

--- a/src/modules/clustering/process.cpp
+++ b/src/modules/clustering/process.cpp
@@ -445,7 +445,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
                 auto mol = clusterConfig_.addMolecule(site->parent()->parent());
                 for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
                 {
-                    molAtom->r() = sourceAtom->r();
+                    molAtom->setR(sourceAtom->r());
                     clusterConfig_.updateAtomLocation(molAtom);
                 }
             }
@@ -461,7 +461,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
                     auto mol = clusterConfig_.addMolecule(site->parent()->parent());
                     for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
                     {
-                        molAtom->r() = sourceAtom->r();
+                        molAtom->setR(sourceAtom->r());
                         clusterConfig_.updateAtomLocation(molAtom);
                     }
                 }
@@ -475,7 +475,7 @@ void ClusteringModule::generateClustersConfig(Dissolve &dissolve, int displaySiz
             auto mol = clusterConfig_.addMolecule(site->parent()->parent());
             for (auto &&[molAtom, sourceAtom] : zip(mol->atoms(), site->molecule()->atoms()))
             {
-                molAtom->r() = sourceAtom->r();
+                molAtom->setR(sourceAtom->r());
                 clusterConfig_.updateAtomLocation(molAtom);
             }
         }

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -36,7 +36,7 @@ bool GRModule::calculateGRTestSerial(Configuration *cfg,
                             [&, box](auto i, auto &atomI, auto j, auto &atomJ)
                             {
                                 if (i != j)
-                                    fullLUT[{atomI.configurationTypeIndex(), atomJ.configurationTypeIndex()}]->second.bin(
+                                    fullLUT[{atomI.atomTypeIndex(), atomJ.atomTypeIndex()}]->second.bin(
                                         box->minimumDistance(atomI.r(), atomJ.r()));
                             });
 
@@ -72,9 +72,9 @@ bool GRModule::calculateGRSimple(Configuration *cfg, const double binWidth,
     // Loop over Atoms and construct arrays
     for (auto &atom : cfg->atoms())
     {
-        if (atom.configurationTypeIndex() == AtomType::Ignore)
+        if (atom.atomTypeIndex() == AtomType::Ignore)
             continue;
-        r[atom.configurationTypeIndex()][nr[atom.configurationTypeIndex()]++] = atom.r();
+        r[atom.atomTypeIndex()][nr[atom.atomTypeIndex()]++] = atom.r();
     }
 
     Messenger::printVerbose("Ready..\n");
@@ -191,7 +191,7 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
         // quicker than working out if we need to given the absence of a 2D look-up array
         for (auto &i : atomsI)
         {
-            auto typeI = i->configurationTypeIndex();
+            auto typeI = i->atomTypeIndex();
             if (typeI == AtomType::Ignore)
                 continue;
 
@@ -199,7 +199,7 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
 
             for (auto &j : atomsJ)
             {
-                auto typeJ = j->configurationTypeIndex();
+                auto typeJ = j->atomTypeIndex();
                 if (typeJ == AtomType::Ignore)
                     continue;
 
@@ -236,9 +236,9 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
                               return;
 
                           auto &i = atomsI[idx];
-                          auto typeI = i->configurationTypeIndex();
+                          auto typeI = i->atomTypeIndex();
                           auto &j = atomsI[jdx];
-                          auto typeJ = j->configurationTypeIndex();
+                          auto typeJ = j->atomTypeIndex();
                           if (typeI != AtomType::Ignore && typeJ != AtomType::Ignore)
                           {
                               // No need to perform MIM since we're in the same cell
@@ -412,11 +412,11 @@ bool GRModule::calculateGR(GenericList &processingData, Configuration *cfg, GRMo
                                     if (index == jndex)
                                         return;
 
-                                    auto typeI = i->configurationTypeIndex();
+                                    auto typeI = i->atomTypeIndex();
                                     if (typeI == AtomType::Ignore)
                                         return;
 
-                                    auto typeJ = j->configurationTypeIndex();
+                                    auto typeJ = j->atomTypeIndex();
                                     if (typeJ == AtomType::Ignore)
                                         return;
 

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -240,7 +240,7 @@ Module::ExecutionResult MDModule::process(Dissolve &dissolve)
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.translateCoordinates(v * dT + a * 0.5 * deltaTSq);
+            i.r() += v * dT + a * 0.5 * deltaTSq;
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -240,7 +240,7 @@ Module::ExecutionResult MDModule::process(Dissolve &dissolve)
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.r() += v * dT + a * 0.5 * deltaTSq;
+            i.adjustR(v * dT + a * 0.5 * deltaTSq);
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/src/modules/md/process.cpp
+++ b/src/modules/md/process.cpp
@@ -240,7 +240,7 @@ Module::ExecutionResult MDModule::process(Dissolve &dissolve)
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.adjustR(v * dT + a * 0.5 * deltaTSq);
+            i += v * dT + a * 0.5 * deltaTSq;
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -56,7 +56,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                 auto moveInitialPos = i->r();
 
                 // Translate Atom randomly according to the stepsize and update its Cell position
-                i->r() += Vector3::randomUnit() * stepSize;
+                i->adjustR(Vector3::randomUnit() * stepSize);
                 targetConfiguration_->updateAtomLocation(i);
 
                 // Calculate new energy
@@ -79,7 +79,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                 else
                 {
                     // Move not accepted - revert to initial position
-                    i->r() = moveInitialPos;
+                    i->setR(moveInitialPos);
                     targetConfiguration_->updateAtomLocation(i);
                 }
                 ++nAttempts;

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -56,7 +56,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                 auto moveInitialPos = i->r();
 
                 // Translate Atom randomly according to the stepsize and update its Cell position
-                i->translateCoordinates(Vector3::randomUnit() * stepSize);
+                i->r() += Vector3::randomUnit() * stepSize;
                 targetConfiguration_->updateAtomLocation(i);
 
                 // Calculate new energy
@@ -79,7 +79,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                 else
                 {
                     // Move not accepted - revert to initial position
-                    i->setCoordinates(moveInitialPos);
+                    i->r() = moveInitialPos;
                     targetConfiguration_->updateAtomLocation(i);
                 }
                 ++nAttempts;

--- a/src/nodes/atomicMC/process.cpp
+++ b/src/nodes/atomicMC/process.cpp
@@ -56,7 +56,7 @@ NodeConstants::ProcessResult AtomicMCNode::process()
                 auto moveInitialPos = i->r();
 
                 // Translate Atom randomly according to the stepsize and update its Cell position
-                i->adjustR(Vector3::randomUnit() * stepSize);
+                *i += Vector3::randomUnit() * stepSize;
                 targetConfiguration_->updateAtomLocation(i);
 
                 // Calculate new energy

--- a/src/nodes/bragg.cpp
+++ b/src/nodes/bragg.cpp
@@ -458,7 +458,7 @@ bool BraggNode::calculateBraggTerms()
             continue;
 
         // Grab localTypeIndex and array pointers for this atom
-        localTypeIndex = atoms[n].configurationTypeIndex();
+        localTypeIndex = atoms[n].atomTypeIndex();
 
         cosTermsH = braggAtomVectorXCos.pointerAt(n, 0);
         cosTermsK = braggAtomVectorYCos.pointerAt(n, 0);

--- a/src/nodes/gr/helpers.cpp
+++ b/src/nodes/gr/helpers.cpp
@@ -31,7 +31,7 @@ bool GRNode::calculateGRTestSerial(const Array2D<typename std::map<std::string, 
                             [&, box](auto indexI, auto &atomI, auto indexJ, auto &atomJ)
                             {
                                 if (indexI != indexJ)
-                                    fullLUT[{atomI.configurationTypeIndex(), atomJ.configurationTypeIndex()}]->second.bin(
+                                    fullLUT[{atomI.atomTypeIndex(), atomJ.atomTypeIndex()}]->second.bin(
                                         box->minimumDistance(atomI.r(), atomJ.r()));
                             });
 
@@ -66,7 +66,7 @@ bool GRNode::calculateGRSimple(const Array2D<typename std::map<std::string, Hist
     // Loop over Atoms and construct arrays
     for (auto &atom : targetConfiguration_->atoms())
     {
-        m = atom.configurationTypeIndex();
+        m = atom.atomTypeIndex();
         if (m == AtomType::Ignore)
             continue;
         r[m][nr[m]++] = atom.r();
@@ -188,7 +188,7 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
         // quicker than working out if we need to given the absence of a 2D look-up array
         for (auto &i : atomsI)
         {
-            auto typeI = i->configurationTypeIndex();
+            auto typeI = i->atomTypeIndex();
             if (typeI == AtomType::Ignore)
                 continue;
 
@@ -196,7 +196,7 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
 
             for (auto &j : atomsJ)
             {
-                auto typeJ = j->configurationTypeIndex();
+                auto typeJ = j->atomTypeIndex();
                 if (typeJ == AtomType::Ignore)
                     continue;
 
@@ -231,9 +231,9 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
                           if (idx == jdx)
                               return;
                           auto &i = atomsI[idx];
-                          auto typeI = i->configurationTypeIndex();
+                          auto typeI = i->atomTypeIndex();
                           auto &j = atomsI[jdx];
-                          auto typeJ = j->configurationTypeIndex();
+                          auto typeJ = j->atomTypeIndex();
                           if (typeI != AtomType::Ignore && typeJ != AtomType::Ignore)
                           {
                               // No need to perform MIM since we're in the same cell
@@ -356,11 +356,11 @@ bool GRNode::calculateRawGR(const double grRange, bool &alreadyUpToDate)
                                     if (indexI == indexJ)
                                         return;
 
-                                    auto typeI = atomI->configurationTypeIndex();
+                                    auto typeI = atomI->atomTypeIndex();
                                     if (typeI == AtomType::Ignore)
                                         return;
 
-                                    auto typeJ = atomJ->configurationTypeIndex();
+                                    auto typeJ = atomJ->atomTypeIndex();
                                     if (typeJ == AtomType::Ignore)
                                         return;
 

--- a/src/nodes/md.cpp
+++ b/src/nodes/md.cpp
@@ -345,7 +345,7 @@ NodeConstants::ProcessResult MDNode::process()
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.r() += v * dT + a * 0.5 * deltaTSq;
+            i.adjustR(v * dT + a * 0.5 * deltaTSq);
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/src/nodes/md.cpp
+++ b/src/nodes/md.cpp
@@ -345,7 +345,7 @@ NodeConstants::ProcessResult MDNode::process()
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.translateCoordinates(v * dT + a * 0.5 * deltaTSq);
+            i.r() += v * dT + a * 0.5 * deltaTSq;
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/src/nodes/md.cpp
+++ b/src/nodes/md.cpp
@@ -345,7 +345,7 @@ NodeConstants::ProcessResult MDNode::process()
         for (auto &&[i, v, a] : zip(atoms, velocities, accelerations))
         {
             // Propagate positions (by whole step)...
-            i.adjustR(v * dT + a * 0.5 * deltaTSq);
+            i += v * dT + a * 0.5 * deltaTSq;
 
             // ...velocities (by half step)...
             v += a * 0.5 * dT;

--- a/tests/classes/cells2.cpp
+++ b/tests/classes/cells2.cpp
@@ -34,7 +34,7 @@ class CellsPBCTest : public ::testing::Test
 
         // Add a molecule at the origin
         auto central = configuration_.addMolecule(&probe_);
-        central->atom(0)->setCoordinates(origin);
+        central->atom(0)->r() = origin;
 
         // Add surrounding molecules on a sphere with radius equal to the inscribed sphere radius
         const auto r = configuration_.box()->inscribedSphereRadius();
@@ -43,8 +43,7 @@ class CellsPBCTest : public ::testing::Test
             auto theta = DissolveMath::random() * M_PI;
             auto phi = DissolveMath::random() * 2.0 * M_PI;
             auto mol = configuration_.addMolecule(&probe_);
-            mol->atom(0)->setCoordinates(Vector3(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)) +
-                                         origin);
+            mol->atom(0)->r() = Vector3(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)) + origin;
         }
 
         configuration_.updateObjectRelationships();

--- a/tests/classes/cells2.cpp
+++ b/tests/classes/cells2.cpp
@@ -34,7 +34,7 @@ class CellsPBCTest : public ::testing::Test
 
         // Add a molecule at the origin
         auto central = configuration_.addMolecule(&probe_);
-        central->atom(0)->r() = origin;
+        central->atom(0)->setR(origin);
 
         // Add surrounding molecules on a sphere with radius equal to the inscribed sphere radius
         const auto r = configuration_.box()->inscribedSphereRadius();
@@ -43,7 +43,7 @@ class CellsPBCTest : public ::testing::Test
             auto theta = DissolveMath::random() * M_PI;
             auto phi = DissolveMath::random() * 2.0 * M_PI;
             auto mol = configuration_.addMolecule(&probe_);
-            mol->atom(0)->r() = Vector3(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)) + origin;
+            mol->atom(0)->setR(Vector3(r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)) + origin);
         }
 
         configuration_.updateObjectRelationships();

--- a/tests/gui/modifyCharges.cpp
+++ b/tests/gui/modifyCharges.cpp
@@ -46,7 +46,7 @@ TEST_F(ModifyChargesModelTest, Scale)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.q() = 1.0;
+        atom.setQ(1.0);
 
     // Test "Scale"
     model.setScaleType(ModifyChargesModel::Scale);
@@ -94,7 +94,7 @@ TEST_F(ModifyChargesModelTest, Smooth)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.q() = 1.0;
+        atom.setQ(1.0);
 
     // Target smooth value to 20
     model.updateSmoothValue(20.0);
@@ -130,7 +130,7 @@ TEST_F(ModifyChargesModelTest, ReduceSigFig)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.q() = 1.235;
+        atom.setQ(1.235);
 
     model.reduceSignificantFigures(species);
 

--- a/tests/gui/modifyCharges.cpp
+++ b/tests/gui/modifyCharges.cpp
@@ -46,7 +46,7 @@ TEST_F(ModifyChargesModelTest, Scale)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.setCharge(1.0);
+        atom.q() = 1.0;
 
     // Test "Scale"
     model.setScaleType(ModifyChargesModel::Scale);
@@ -54,7 +54,7 @@ TEST_F(ModifyChargesModelTest, Scale)
 
     auto success = model.scale(species, NO_DISPLAY);
     for (auto &atom : species->atoms())
-        ASSERT_EQ(atom.charge(), 2);
+        ASSERT_EQ(atom.q(), 2);
 
     // Test "ScaleTo" (returns false if input is zero, else we test the sum of the charges)
     model.setScaleType(ModifyChargesModel::ScaleTo);
@@ -67,7 +67,7 @@ TEST_F(ModifyChargesModelTest, Scale)
     success = model.scale(species, NO_DISPLAY);
     auto sum = 0.0;
     for (auto &atom : species->atoms())
-        sum += atom.charge();
+        sum += atom.q();
     ASSERT_EQ(sum, 10);
 }
 
@@ -94,7 +94,7 @@ TEST_F(ModifyChargesModelTest, Smooth)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.setCharge(1.0);
+        atom.q() = 1.0;
 
     // Target smooth value to 20
     model.updateSmoothValue(20.0);
@@ -102,7 +102,7 @@ TEST_F(ModifyChargesModelTest, Smooth)
 
     auto sum = 0.0;
     for (auto &atom : species->atoms())
-        sum += atom.charge();
+        sum += atom.q();
 
     ASSERT_EQ(sum, 20.0);
 }
@@ -130,12 +130,12 @@ TEST_F(ModifyChargesModelTest, ReduceSigFig)
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        atom.setCharge(1.235);
+        atom.q() = 1.235;
 
     model.reduceSignificantFigures(species);
 
     // Set charges equal for simplicity
     for (auto &atom : species->atoms())
-        ASSERT_EQ(atom.charge(), 1.24);
+        ASSERT_EQ(atom.q(), 1.24);
 }
 } // namespace UnitTest

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -37,7 +37,7 @@ class PairPotentialsScaleFactorsTest : public ::testing::Test
         molecule_.setSpecies(&species_);
         for (auto &&[molAtom, spAtom] : zip(molecule_.localAtoms(), species_.atoms()))
         {
-            molAtom.r() = spAtom.r();
+            molAtom.setR(spAtom.r());
             molAtom.setAtomTypeIndex(spAtom.atomType()->index());
         }
 

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -162,7 +162,7 @@ TEST_F(PairPotentialsScaleFactorsTest, SpeciesEnergyWithSpeciesCharges)
     auto &i = species_.atom(0);
     auto &j = species_.atom(3);
 
-    testScalings(&i, &j, (j.r() - i.r()).magnitude(), i.charge() * j.charge());
+    testScalings(&i, &j, (j.r() - i.r()).magnitude(), i.q() * j.q());
 }
 
 TEST_F(PairPotentialsScaleFactorsTest, MoleculeEnergyWithAtomTypeCharges)
@@ -183,8 +183,8 @@ TEST_F(PairPotentialsScaleFactorsTest, MoleculeEnergyWithSpeciesCharges)
     auto &i = molecule_.localAtoms()[0];
     auto &j = molecule_.localAtoms()[3];
 
-    testScalings(i, j, (j.r() - i.r()).magnitude(), species_.atom(0).charge() * species_.atom(3).charge());
-    testAnalyticScalings(i, j, (j.r() - i.r()).magnitude(), species_.atom(0).charge() * species_.atom(3).charge());
+    testScalings(i, j, (j.r() - i.r()).magnitude(), species_.atom(0).q() * species_.atom(3).q());
+    testAnalyticScalings(i, j, (j.r() - i.r()).magnitude(), species_.atom(0).q() * species_.atom(3).q());
 }
 
 } // namespace UnitTest

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -38,7 +38,7 @@ class PairPotentialsScaleFactorsTest : public ::testing::Test
         for (auto &&[molAtom, spAtom] : zip(molecule_.localAtoms(), species_.atoms()))
         {
             molAtom.r() = spAtom.r();
-            molAtom.setConfigurationTypeIndex(spAtom.atomType()->index());
+            molAtom.setAtomTypeIndex(spAtom.atomType()->index());
         }
 
         // Set up the function wrapper

--- a/tests/pairPotentials/scaleFactors.cpp
+++ b/tests/pairPotentials/scaleFactors.cpp
@@ -37,7 +37,7 @@ class PairPotentialsScaleFactorsTest : public ::testing::Test
         molecule_.setSpecies(&species_);
         for (auto &&[molAtom, spAtom] : zip(molecule_.localAtoms(), species_.atoms()))
         {
-            molAtom.setCoordinates(spAtom.r());
+            molAtom.r() = spAtom.r();
             molAtom.setConfigurationTypeIndex(spAtom.atomType()->index());
         }
 


### PR DESCRIPTION
This PR reintroduces `Atom` as a base class for `ConfigurationAtom` and `SpeciesAtom`.  There are likely to be comments on function / member variable namings I'm sure!  Every simulator refers to position as `r` and charge as `q` so I think we should retain these, but they don't translate to beautiful setter names (e.g. `setR()`). In the name of consistency, though...

One thing not tackled in this PR for reasons of size was getting rid of the horrible `Configuration::globalIndex()` function - this is a new issue #2418.