### PR TITLE
refactor: Remove atom selection stuff

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -154,8 +154,6 @@ Species *CoreData::copySpecies(const Species *species)
     {
         // Create the Atom in our new Species
         auto id = newSpecies->addAtom(i.Z(), i.r(), i.q());
-        if (i.isSelected())
-            newSpecies->selectAtom(id);
 
         // Find and assign the atom type
         newSpecies->atom(id).setAtomType(newSpecies->findAtomType(i.atomType()->name()));

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -57,8 +57,6 @@ class Species : public Serialisable<>
     private:
     // List of atoms in the Species
     std::vector<SpeciesAtom> atoms_;
-    // Version of the atom selection
-    VersionCounter atomSelectionVersion_;
     // Atom types for the species
     std::vector<std::shared_ptr<AtomType>> atomTypes_;
 
@@ -86,26 +84,10 @@ class Species : public Serialisable<>
     std::vector<SpeciesAtom> &atoms();
     // Transmute specified atom
     void transmuteAtom(int index, Elements::Element newZ);
-    // Clear current atom selection
-    void clearAtomSelection();
-    // Add atom to selection
-    void selectAtom(int index);
-    // Remove atom from selection
-    void deselectAtom(int index);
-    // Toggle selection state of specified atom
-    void toggleAtomSelection(int index);
     // Return the fragment (vector of indices) containing the specified atom, optionally ignoring paths along the bond(s)
     // provided
     std::vector<int> fragment(int startIndex, OptionalReferenceWrapper<SpeciesBond> exclude = std::nullopt,
                               OptionalReferenceWrapper<SpeciesBond> excludeToo = std::nullopt) const;
-    // Return current atom selection for modification
-    const std::vector<SpeciesAtom *> modifiableSelectedAtoms();
-    // Return current atom selection
-    const std::vector<const SpeciesAtom *> selectedAtoms() const;
-    // Return whether the current selection comprises atoms of a single element
-    bool isSelectionSingleElement() const;
-    // Return version of the atom selection
-    int atomSelectionVersion() const;
     // Return total atomic mass of Species
     double mass() const;
     // Add new atom type to atom types

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -6,8 +6,6 @@
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
 #include "classes/atom.h"
-#include "data/elements.h"
-#include "math/vector3.h"
 #include "templates/optionalRef.h"
 #include <vector>
 

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -158,48 +158,6 @@ void Species::transmuteAtom(int index, Elements::Element newZ)
     i.setZ(newZ);
 }
 
-// Clear current Atom selection
-void Species::clearAtomSelection()
-{
-    for (auto &i : atoms_)
-        i.setSelected(false);
-
-    ++atomSelectionVersion_;
-}
-
-// Add Atom to selection
-void Species::selectAtom(int index)
-{
-    auto &i = atoms_[index];
-    if (!i.isSelected())
-    {
-        i.setSelected(true);
-
-        ++atomSelectionVersion_;
-    }
-}
-
-// Remove atom from selection
-void Species::deselectAtom(int index)
-{
-    auto &i = atoms_[index];
-    if (i.isSelected())
-    {
-        i.setSelected(false);
-
-        ++atomSelectionVersion_;
-    }
-}
-
-// Toggle selection state of specified atom
-void Species::toggleAtomSelection(int index)
-{
-    if (atoms_[index].isSelected())
-        deselectAtom(index);
-    else
-        selectAtom(index);
-}
-
 // Return the fragment containing the specified atom, optionally ignoring paths along the bond(s) provided
 std::vector<int> Species::fragment(int startIndex, OptionalReferenceWrapper<SpeciesBond> exclude,
                                    OptionalReferenceWrapper<SpeciesBond> excludeToo) const
@@ -208,38 +166,6 @@ std::vector<int> Species::fragment(int startIndex, OptionalReferenceWrapper<Spec
     getIndicesRecursive(indices, startIndex, exclude, excludeToo);
     return indices;
 }
-
-// Return current atom selection for modification
-const std::vector<SpeciesAtom *> Species::modifiableSelectedAtoms()
-{
-    std::vector<SpeciesAtom *> selectedAtoms;
-    for (auto &i : atoms_)
-        if (i.isSelected())
-            selectedAtoms.emplace_back(&i);
-
-    return selectedAtoms;
-}
-const std::vector<const SpeciesAtom *> Species::selectedAtoms() const
-{
-    std::vector<const SpeciesAtom *> selectedAtoms;
-    for (auto &i : atoms_)
-        if (i.isSelected())
-            selectedAtoms.emplace_back(&i);
-
-    return selectedAtoms;
-}
-
-// Return whether the current selection comprises atoms of a single element
-bool Species::isSelectionSingleElement() const
-{
-    auto selection = selectedAtoms();
-    if (selection.empty())
-        return false;
-    return std::all_of(selection.begin(), selection.end(), [&](const auto *i) { return i->Z() == selection.front()->Z(); });
-}
-
-// Return version of the atom selection
-int Species::atomSelectionVersion() const { return atomSelectionVersion_; }
 
 // Return total atomic mass of Species
 double Species::mass() const

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -472,7 +472,6 @@ void Species::generateAttachedAtomLists()
             bond.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'i', excluding the Bond as a path
-        clearAtomSelection();
         selection = fragment(bond.j()->index(), bond);
         bond.setAttachedAtoms(1, selection);
     }
@@ -508,7 +507,6 @@ void Species::generateAttachedAtomLists()
             angle.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
-        clearAtomSelection();
         selection = fragment(angle.k()->index(), *ji, jk);
 
         // Remove Atom 'j' from the list if it's there
@@ -548,7 +546,6 @@ void Species::generateAttachedAtomLists()
             torsion.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
-        clearAtomSelection();
         selection = fragment(torsion.k()->index(), *jk);
 
         // Remove Atom 'k' from the list

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -146,7 +146,9 @@ bool AddForcefieldDialogModel::speciesHasSelection() const
 {
     if (!species_)
         return false;
-    return !species_->selectedAtoms().empty();
+    // return !species_->selectedAtoms().empty();
+    // TODO DISSOLVE2
+    return false;
 }
 
 // The forcefield model

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -240,8 +240,9 @@ const void RenderableSpecies::sendToGL(const double pixelScaling)
 // Recreate selection Primitive
 void RenderableSpecies::recreateSelectionPrimitive()
 {
-    if (selectionPrimitiveVersion_ == source_->atomSelectionVersion())
-        return;
+    // if (selectionPrimitiveVersion_ == source_->atomSelectionVersion())
+    // return;
+    // TODO DISSOLVE2
 
     // Clear existing data
     selectionAssembly_.clear();
@@ -310,7 +311,8 @@ void RenderableSpecies::recreateSelectionPrimitive()
         }
     }
 
-    selectionPrimitiveVersion_ = source_->atomSelectionVersion();
+    // TODO DISSOLVE2
+    // selectionPrimitiveVersion_ = source_->atomSelectionVersion();
 }
 
 // Clear interaction Primitive

--- a/src/io/import/cif.cpp
+++ b/src/io/import/cif.cpp
@@ -555,7 +555,6 @@ bool CIFHandler::createCleanedUnitCell()
                 // Select all atoms that are part of the same moiety?
                 if (removeNETAByFragment_)
                 {
-                    cleanedUnitCellSpecies_.clearAtomSelection();
                     auto selection = cleanedUnitCellSpecies_.fragment(i.index());
                     std::copy(selection.begin(), selection.end(), std::back_inserter(indicesToRemove));
                 }


### PR DESCRIPTION
Removes atom selection stuff from `Species` - this should be handled externally to the class where it needs to be (e.g. selecting atoms in the GUI for sites etc.)