### PR TITLE
refactor: Tidy up species intra serialisation

### DIFF
--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -70,16 +70,18 @@ template <typename... Contexts> class Serialisable
 
     // Perform an action on a child node in a table if the node exists.
     // This cuts out quite a bit of boilerplate.
-    template <typename Lambda> static void optionalOn(const SerialisedValue &node, std::string name, Lambda action)
+    template <typename Lambda> static bool optionalOn(const SerialisedValue &node, std::string name, Lambda action)
     {
         if (node.contains(name))
         {
             auto child = toml::find(node, name);
             if (!node.is_uninitialized())
                 action(child);
+            return true;
         }
-    }
 
+        return false;
+    }
     // A helper function to add elements of a vector to a node under the named heading
     template <serialisablePointer T>
     static void fromVectorToTable(const std::vector<T> &vector, std::string name, SerialisedValue &node)

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -312,5 +312,5 @@ void SpeciesAngle::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void SpeciesAngle::deserialise(const SerialisedValue &node)
 {
-    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonAngle(form); });
+    SpeciesIntra<SpeciesAngle, AngleFunctions>::deserialise(node, [&](auto &form) { return parent_->getCommonAngle(form); });
 }

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -293,6 +293,10 @@ double SpeciesAngle::force(double theta) const
                          AngleFunctions::forms().keyword(angleForm));
 }
 
+/*
+ * Serialisation
+ */
+
 // Express as a serialisable value
 void SpeciesAngle::serialise(std::string tag, SerialisedValue &target) const
 {
@@ -305,8 +309,8 @@ void SpeciesAngle::serialise(std::string tag, SerialisedValue &target) const
     if (k_ != nullptr)
         angle["k"] = k_->userIndex();
 }
-// This method populates the object's members with values read from an 'angle' TOML node
+// Read values from a serialisable value
 void SpeciesAngle::deserialise(const SerialisedValue &node)
 {
-    deserialiseForm(node, [&](auto &form) { return parent_->getCommonAngle(form); });
+    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonAngle(form); });
 }

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -74,6 +74,10 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     // Return force multiplier for specified angle theta (in radians)
     double force(double theta) const;
 
+    /*
+     * Serialisation
+     */
+    public:
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -333,5 +333,5 @@ void SpeciesBond::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void SpeciesBond::deserialise(const SerialisedValue &node)
 {
-    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonBond(form); });
+    SpeciesIntra<SpeciesBond, BondFunctions>::deserialise(node, [&](auto &form) { return parent_->getCommonBond(form); });
 }

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -315,6 +315,10 @@ double SpeciesBond::force(double distance) const
                          BondFunctions::forms().keyword(bondForm));
 }
 
+/*
+ * Serialisation
+ */
+
 // Express as a serialisable value
 void SpeciesBond::serialise(std::string tag, SerialisedValue &target) const
 {
@@ -326,8 +330,8 @@ void SpeciesBond::serialise(std::string tag, SerialisedValue &target) const
         bond["j"] = j_->userIndex();
 }
 
-// This method populates the object's members with values read from a 'bond' TOML node
+// Read values from a serialisable value
 void SpeciesBond::deserialise(const SerialisedValue &node)
 {
-    deserialiseForm(node, [&](auto &form) { return parent_->getCommonBond(form); });
+    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonBond(form); });
 }

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -103,6 +103,10 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     // Return force multiplier for specified distance
     double force(double distance) const;
 
+    /*
+     * Serialisation
+     */
+    public:
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -240,5 +240,6 @@ void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void SpeciesImproper::deserialise(const SerialisedValue &node)
 {
-    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonImproper(form); });
+    SpeciesIntra<SpeciesImproper, TorsionFunctions>::deserialise(node,
+                                                                 [&](auto &form) { return parent_->getCommonImproper(form); });
 }

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -218,6 +218,10 @@ double SpeciesImproper::force(double phi) const
     return SpeciesTorsion::force(phi, interactionForm(), interactionParameters());
 }
 
+/*
+ * Serialisation
+ */
+
 // Express as a serialisable value
 void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
 {
@@ -233,8 +237,8 @@ void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
         improper["l"] = l_->userIndex();
 }
 
-// This method populates the object's members with values read from an 'improper' TOML node
+// Read values from a serialisable value
 void SpeciesImproper::deserialise(const SerialisedValue &node)
 {
-    deserialiseForm(node, [&](auto &form) { return parent_->getCommonImproper(form); });
+    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonImproper(form); });
 }

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -82,6 +82,10 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     // Return force multiplier for specified angle phi (in radians)
     double force(double phi) const;
 
+    /*
+     * Serialisation
+     */
+    public:
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -157,10 +157,62 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     // Set identifying name (if a common term)
     virtual void setName(std::string_view name) { throw(std::runtime_error("Can't set the name of a base SpeciesIntra.\n")); }
     // Return identifying name (if a common term)
-    virtual std::string_view name() const { return ""; };
-    // Load parameters from serialisable value
-    void deserialiseParameters(const SerialisedValue &node)
+    virtual std::string_view name() const { return ""; }
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
+        auto &result = target[tag];
+
+        if (commonTerm_)
+            result["common"] = std::format("{}", commonTerm_->name());
+        else
+        {
+            result["form"] = Functions::forms().keyword(interactionForm());
+
+            auto values = interactionPotential().parameters();
+            if (!values.empty())
+            {
+                SerialisedValue parametersNode;
+                std::vector<std::string> parameters = Functions::parameters(interactionForm());
+                if (parameters.empty())
+                    parametersNode = values;
+                else
+                    for (auto parameterIndex = 0; parameterIndex < values.size(); ++parameterIndex)
+                        parametersNode[parameters[parameterIndex]] = values[parameterIndex];
+                result["parameters"] = parametersNode;
+            }
+        }
+    }
+    // Read values from a serialisable value
+    template <typename Lambda> void deserialise(const SerialisedValue &node, Lambda lambda)
+    {
+        // Common tag - used by individual species terms (not the common terms themselves) to specify a reference
+        if (!Serialisable::optionalOn(node, "common",
+                                      [this, &lambda](const SerialisedValue &node)
+                                      {
+                                          std::string form = node.as_string();
+                                          auto common = lambda(form);
+                                          if (!common)
+                                              throw std::runtime_error("Common Term not found.");
+                                          setCommonTerm(&common->get());
+                                      }))
+            deserialise(node);
+    }
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override
+    {
+        Serialisable::optionalOn(node, "form",
+                                 [this](const SerialisedValue &node)
+                                 {
+                                     std::string form = node.as_string();
+                                     setInteractionForm(Functions::forms().enumeration(form));
+                                 });
+
         Serialisable::optionalOn(node, "parameters",
                                  [this](const auto node)
                                  {
@@ -182,60 +234,5 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
                                      }
                                      setInteractionFormAndParameters(interactionForm(), values);
                                  });
-    }
-    // Load form from serialisable value
-    template <typename Lambda> void deserialiseForm(const SerialisedValue &node, Lambda lambda)
-    {
-        Serialisable::optionalOn(node, "form",
-                                 [this, &lambda](const SerialisedValue node)
-                                 {
-                                     std::string form = node.as_string();
-                                     if (form.find("@") == 0)
-                                     {
-                                         auto common = lambda(form);
-                                         if (!common)
-                                             throw std::runtime_error("Common Term not found.");
-                                         setCommonTerm(&common->get());
-                                     }
-                                     else
-                                         setInteractionForm(Functions::forms().enumeration(form));
-                                 });
-        deserialiseParameters(node);
-    }
-
-    // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node) override
-    {
-        Serialisable::optionalOn(node, "form",
-                                 [this](const auto node)
-                                 {
-                                     std::string form = node.as_string();
-                                     setInteractionForm(Functions::forms().enumeration(form));
-                                 });
-        deserialiseParameters(node);
-    }
-
-    // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const override
-    {
-        auto &result = target[tag];
-
-        if (commonTerm_ != nullptr)
-            result["form"] = std::format("@{}", commonTerm_->name());
-        else
-            result["form"] = Functions::forms().keyword(interactionForm());
-
-        auto values = interactionPotential().parameters();
-        if (!values.empty())
-        {
-            SerialisedValue parametersNode;
-            std::vector<std::string> parameters = Functions::parameters(interactionForm());
-            if (parameters.empty())
-                parametersNode = values;
-            else
-                for (auto parameterIndex = 0; parameterIndex < values.size(); ++parameterIndex)
-                    parametersNode[parameters[parameterIndex]] = values[parameterIndex];
-            result["parameters"] = parametersNode;
-        }
     }
 };

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -191,7 +191,8 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
     // Read values from a serialisable value
     template <typename Lambda> void deserialise(const SerialisedValue &node, Lambda lambda)
     {
-        // Common tag - used by individual species terms (not the common terms themselves) to specify a reference
+        // Common tag - used by individual species terms (not the common terms themselves) to specify a reference to a common
+        // term. If it doesn't exist, serialise form and parameters as normal.
         if (!Serialisable::optionalOn(node, "common",
                                       [this, &lambda](const SerialisedValue &node)
                                       {
@@ -201,7 +202,7 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
                                               throw std::runtime_error("Common Term not found.");
                                           setCommonTerm(&common->get());
                                       }))
-            deserialise(node);
+            SpeciesIntra::deserialise(node);
     }
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override
@@ -212,7 +213,6 @@ template <class Intra, class Functions> class SpeciesIntra : public Serialisable
                                      std::string form = node.as_string();
                                      setInteractionForm(Functions::forms().enumeration(form));
                                  });
-
         Serialisable::optionalOn(node, "parameters",
                                  [this](const auto node)
                                  {

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -517,10 +517,11 @@ double SpeciesTorsion::force(double phi, TorsionFunctions::Form form, const std:
 }
 
 // Return force multiplier for specified angle phi (in radians)
-double SpeciesTorsion::force(double phi) const
-{
-    return SpeciesTorsion::force(phi, interactionForm(), interactionParameters());
-}
+double SpeciesTorsion::force(double phi) const { return force(phi, interactionForm(), interactionParameters()); }
+
+/*
+ * Serialisation
+ */
 
 // Express as a serialisable value
 void SpeciesTorsion::serialise(std::string tag, SerialisedValue &target) const
@@ -540,10 +541,10 @@ void SpeciesTorsion::serialise(std::string tag, SerialisedValue &target) const
     torsion["v14"] = vdw14Scaling_;
 }
 
-// This method populates the object's members with values read from a 'torsion' TOML node
+// Read values from a serialisable value
 void SpeciesTorsion::deserialise(const SerialisedValue &node)
 {
-    deserialiseForm(node, [&](auto &form) { return parent_->getCommonTorsion(form); });
+    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonTorsion(form); });
 
     electrostatic14Scaling_ = toml::find_or<double>(node, "q14", 0.5);
 

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -544,7 +544,8 @@ void SpeciesTorsion::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void SpeciesTorsion::deserialise(const SerialisedValue &node)
 {
-    SpeciesIntra::deserialise(node, [&](auto &form) { return parent_->getCommonTorsion(form); });
+    SpeciesIntra<SpeciesTorsion, TorsionFunctions>::deserialise(node,
+                                                                [&](auto &form) { return parent_->getCommonTorsion(form); });
 
     electrostatic14Scaling_ = toml::find_or<double>(node, "q14", 0.5);
 

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -98,6 +98,10 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     // Return force multiplier for specified angle phi (in radians)
     double force(double phi) const;
 
+    /*
+     * Serialisation
+     */
+    public:
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -176,7 +176,7 @@ void Dissolve::serialise(std::string tag, SerialisedValue &target) const
     Serialisable::fromVectorToTable(coreData_.processingLayers(), "layers", root);
 }
 
-// This method populates the object's members with values read from a 'pairPotentials' TOML node
+// Read pair potentials from a serialisable value
 void Dissolve::deserialisePairPotentials(const SerialisedValue &node)
 {
     PairPotential::setRange(toml::find_or<double>(node, "range", 15.0), toml::find_or<double>(node, "delta", 0.005));


### PR DESCRIPTION
On the journey towards adding TOML-based species for our unit tests, this PR tidies up and simplifies the (de)serialisation for species intramolecular terms, particularly common terms.