### PR TITLE
refactor: Import structure nodes

### DIFF
--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -13,7 +13,7 @@ Structure &Structure::operator=(const Structure &source)
     clear();
 
     for (auto &atom : source.atoms_)
-        atoms_.emplace_back(std::unique_ptr<StructureAtom>())->set(atom->Z(), atom->r(), atom->q());
+        atoms_.emplace_back(std::make_unique<StructureAtom>())->set(atom->Z(), atom->r(), atom->q());
 
     for (auto &bond : source.bonds_)
         addBond(bond->i()->index(), bond->j()->index());

--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -6,6 +6,21 @@
 
 Structure::Structure() : box_(std::make_unique<SingleImageBox>()) {}
 
+Structure::Structure(const Structure &source) { *this = source; }
+
+Structure &Structure::operator=(const Structure &source)
+{
+    clear();
+
+    for (auto &atom : source.atoms_)
+        atoms_.emplace_back(std::unique_ptr<StructureAtom>())->set(atom->Z(), atom->r(), atom->q());
+
+    for (auto &bond : source.bonds_)
+        addBond(bond->i()->index(), bond->j()->index());
+
+    return *this;
+}
+
 // Clear Data
 void Structure::clear()
 {

--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -219,6 +219,27 @@ void Structure::createBox(const Vector3 lengths, const Vector3 angles, bool nonP
     box_ = nonPeriodic ? std::make_unique<NonPeriodicBox>() : Box::generate(lengths, angles);
 }
 
+// Create Box definition from axes matrix
+void Structure::createBox(const Matrix3 &axes)
+{
+    // Calculate cell lengths
+    Vector3 lengths(axes.columnMagnitude(0), axes.columnMagnitude(1), axes.columnMagnitude(2));
+
+    // Calculate cell angles
+    Vector3 vecx, vecy, vecz;
+    vecx = axes.columnAsVec3(0);
+    vecy = axes.columnAsVec3(1);
+    vecz = axes.columnAsVec3(2);
+    vecx.normalise();
+    vecy.normalise();
+    vecz.normalise();
+
+    Vector3 angles(acos(vecy.dp(vecz)), acos(vecx.dp(vecz)), acos(vecx.dp(vecy)));
+    angles.toDegrees();
+
+    box_ = Box::generate(lengths, angles);
+}
+
 /*
  * Serialisation
  */

--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -13,7 +13,10 @@ Structure &Structure::operator=(const Structure &source)
     clear();
 
     for (auto &atom : source.atoms_)
-        atoms_.emplace_back(std::make_unique<StructureAtom>())->set(atom->Z(), atom->r(), atom->q());
+    {
+        auto &i = atoms_.emplace_back(std::make_unique<StructureAtom>());
+        i->copy(*atom);
+    }
 
     for (auto &bond : source.bonds_)
         addBond(bond->i()->index(), bond->j()->index());
@@ -40,18 +43,27 @@ void Structure::renumberAtoms() const
         i->setIndex(count++);
 }
 
-// Add a new atom to the Species, returning its index
+// Add a new atom
 StructureAtom *Structure::addAtom(Elements::Element Z, Vector3 r, double q)
 {
     auto &i = atoms_.emplace_back(std::make_unique<StructureAtom>());
-    i->set(Z, r, q);
+    i->Atom::set(Z, r, q);
+
+    i->setIndex(atoms_.size() - 1);
+
+    return i.get();
+}
+StructureAtom *Structure::addAtom(const std::string &name, Vector3 r, double q)
+{
+    auto &i = atoms_.emplace_back(std::make_unique<StructureAtom>());
+    i->set(name, r, q);
 
     i->setIndex(atoms_.size() - 1);
 
     return i.get();
 }
 
-// Remove the specified atom from the species
+// Remove the specified atom
 void Structure::removeAtom(const StructureAtom *atom)
 {
     auto bonds = atom->bonds();
@@ -83,7 +95,7 @@ void Structure::removeAtoms(const std::vector<const StructureAtom *> &atomsToRem
     renumberAtoms();
 }
 
-// Return the number of atoms in the species (or only those with the specified presence)
+// Return the number of atoms in the structure (or only those with the specified presence)
 int Structure::nAtoms(Atom::Presence withPresence) const
 {
     return withPresence == Atom::Presence::Any ? atoms_.size()

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -15,10 +15,26 @@ class StructureBond;
 class StructureAtom : public Atom
 {
     private:
+    // Identifying name string
+    std::string name_;
     // Bonds to this atom
     std::vector<StructureBond *> bonds_;
 
     public:
+    // Copy the specified atom's data
+    void copy(const StructureAtom &other)
+    {
+        name_ = other.name_;
+        Z_ = other.Z_;
+        r_ = other.r_;
+        q_ = other.q_;
+    }
+    // Set with name, and assume no element for now
+    void set(const std::string &name, Vector3 r, double q = 0.0)
+    {
+        name_ = name;
+        Atom::set(Elements::Unknown, r, q);
+    }
     // Return bonds to this atom
     const std::vector<StructureBond *> &bonds() const { return bonds_; }
     // Add a bond to this atom
@@ -89,6 +105,7 @@ class Structure : public Serialisable<>
     public:
     // Add a new atom
     StructureAtom *addAtom(Elements::Element Z, Vector3 r, double q = 0.0);
+    StructureAtom *addAtom(const std::string &name, Vector3 r, double q = 0.0);
     // Remove the specified atom
     void removeAtom(const StructureAtom *atom);
     // Remove a number of atoms

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -36,6 +36,7 @@ class StructureBond : public Serialisable<>
         i_->addBond(this);
         j_->addBond(this);
     }
+    virtual ~StructureBond() = default;
 
     private:
     StructureAtom *i_{nullptr}, *j_{nullptr};

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -68,7 +68,7 @@ class Structure : public Serialisable<>
 {
     public:
     Structure();
-    ~Structure() = default;
+    virtual ~Structure() = default;
     // Clear Data
     void clear();
 

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -69,6 +69,8 @@ class Structure : public Serialisable<>
     public:
     Structure();
     virtual ~Structure() = default;
+    Structure(const Structure &source);
+    Structure &operator=(const Structure &source);
     // Clear Data
     void clear();
 

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -149,6 +149,8 @@ class Structure : public Serialisable<>
     void removeBox();
     // Create Box definition with specified lengths and angles
     void createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic = false);
+    // Create Box definition from axes matrix
+    void createBox(const Matrix3 &axes);
 
     /*
      * Serialisation

--- a/src/nodes/importDLPolyStructure.cpp
+++ b/src/nodes/importDLPolyStructure.cpp
@@ -52,8 +52,8 @@ NodeConstants::ProcessResult ImportDLPolyStructureNode::process()
     auto nAtoms = parser.hasArg(2) ? parser.argi(2) : 0;
     if (nAtoms == 0)
         message(" --> Expecting coordinates for an unknown number of atoms (DLPOLY keytrj={}, imcon={}) - will read "
-                         "until end of file.\n",
-                         nAtoms, keytrj, imcon);
+                "until end of file.\n",
+                nAtoms, keytrj, imcon);
     else
         message(" --> Expecting coordinates for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
 

--- a/src/nodes/importDLPolyStructure.cpp
+++ b/src/nodes/importDLPolyStructure.cpp
@@ -5,24 +5,87 @@
 
 ImportDLPolyStructureNode::ImportDLPolyStructureNode(Graph *parentGraph) : Node(parentGraph)
 {
-    // Inputs
-    addInput<Configuration *>("Configuration", "Configuration to which coordinates will be imported", configuration_);
-
     // Options
     addOption<std::string>("FilePath", "File path", filePath_);
-    addOption<CoordinateImportFileFormat::CoordinateImportFormat>("FileFormat", "File format", format_);
 
     // Outputs
-    addOutput<Configuration *>("Configuration", "Output configuration", configuration_);
+    addOutput<Structure>("Structure", "Imported structure", structure_);
 }
 
-std::string_view ImportDLPolyStructureNode::type() const { return "ImportCoordinates"; }
+std::string_view ImportDLPolyStructureNode::type() const { return "ImportDLPolyStructure"; }
 
-std::string_view ImportDLPolyStructureNode::summary() const { return "Import coordinates from a file."; }
+std::string_view ImportDLPolyStructureNode::summary() const { return "Import a DL_POLY CONFIG or REVCON file."; }
 
 NodeConstants::ProcessResult ImportDLPolyStructureNode::process()
 {
-    CoordinateImportFileFormat fileSource(filePath_, format_);
+    /*
+     * Import DL_POLY coordinates information through the specified line parser.
+     * We assume CONFIG or REVCON format:
+     *
+     * Line 1:    Title
+     * Line 2:    keytrj   imcon    natoms    []
+     * Line 3-5:  cell matrix (if imcon > 0)
+     * Line 6:    atomtype        id
+     * Line 7:    rx   ry   rz
+     * Line 8:    vx   vy   vz      if (keytrj > 0)
+     * Line 9:    fx   fy   fz	if (keytrj > 1)
+     *   ...
+     */
 
-    return fileSource.importData(configuration_) ? NodeConstants::ProcessResult::Success : NodeConstants::ProcessResult::Failed;
+    structure_.clear();
+
+    // Open file and check that we're OK to proceed importing from it
+    LineParser parser;
+    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+        return error("Couldn't open file '{}' for loading coordinates data.\n", filePath_);
+
+    // Skip title
+    if (parser.skipLines(1) != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+
+    // Import in keytrj, imcon, and number of atoms, and initialise arrays
+    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+
+    auto keytrj = parser.argi(0);
+    auto imcon = parser.argi(1);
+    auto nAtoms = parser.hasArg(2) ? parser.argi(2) : 0;
+    if (nAtoms == 0)
+        Messenger::print(" --> Expecting coordinates for an unknown number of atoms (DLPOLY keytrj={}, imcon={}) - will read "
+                         "until end of file.\n",
+                         nAtoms, keytrj, imcon);
+    else
+        Messenger::print(" --> Expecting coordinates for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
+
+    // Read cell information if given
+    if (imcon > 0)
+    {
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto m1 = parser.arg3d(0);
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto m2 = parser.arg3d(0);
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto m3 = parser.arg3d(0);
+        structure_.createBox(Matrix3(m1, m2, m3));
+    }
+
+    // Loop over atoms (either a specified number, or until we reach the end of the file
+    while (!parser.eofOrBlank())
+    {
+        // Skip atomname line, get the positions, then skip velocity and force lines if necessary
+        if (parser.skipLines(1) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        structure_.addAtom(Elements::Unknown, parser.arg3d(0));
+        if (parser.skipLines(keytrj) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        if ((nAtoms > 0) && (structure_.nAtoms() == nAtoms))
+            break;
+    }
+
+    return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/importDLPolyStructure.cpp
+++ b/src/nodes/importDLPolyStructure.cpp
@@ -51,11 +51,11 @@ NodeConstants::ProcessResult ImportDLPolyStructureNode::process()
     auto imcon = parser.argi(1);
     auto nAtoms = parser.hasArg(2) ? parser.argi(2) : 0;
     if (nAtoms == 0)
-        Messenger::print(" --> Expecting coordinates for an unknown number of atoms (DLPOLY keytrj={}, imcon={}) - will read "
+        message(" --> Expecting coordinates for an unknown number of atoms (DLPOLY keytrj={}, imcon={}) - will read "
                          "until end of file.\n",
                          nAtoms, keytrj, imcon);
     else
-        Messenger::print(" --> Expecting coordinates for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
+        message(" --> Expecting coordinates for {} atoms (DLPOLY keytrj={}, imcon={}).\n", nAtoms, keytrj, imcon);
 
     // Read cell information if given
     if (imcon > 0)

--- a/src/nodes/importDLPolyStructure.cpp
+++ b/src/nodes/importDLPolyStructure.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/importDLPolyStructure.h"
+
+ImportDLPolyStructureNode::ImportDLPolyStructureNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Inputs
+    addInput<Configuration *>("Configuration", "Configuration to which coordinates will be imported", configuration_);
+
+    // Options
+    addOption<std::string>("FilePath", "File path", filePath_);
+    addOption<CoordinateImportFileFormat::CoordinateImportFormat>("FileFormat", "File format", format_);
+
+    // Outputs
+    addOutput<Configuration *>("Configuration", "Output configuration", configuration_);
+}
+
+std::string_view ImportDLPolyStructureNode::type() const { return "ImportCoordinates"; }
+
+std::string_view ImportDLPolyStructureNode::summary() const { return "Import coordinates from a file."; }
+
+NodeConstants::ProcessResult ImportDLPolyStructureNode::process()
+{
+    CoordinateImportFileFormat fileSource(filePath_, format_);
+
+    return fileSource.importData(configuration_) ? NodeConstants::ProcessResult::Success : NodeConstants::ProcessResult::Failed;
+}

--- a/src/nodes/importDLPolyStructure.h
+++ b/src/nodes/importDLPolyStructure.h
@@ -3,8 +3,8 @@
 
 #pragma once
 
-#include "nodes/node.h"
 #include "classes/structure.h"
+#include "nodes/node.h"
 
 class ImportDLPolyStructureNode : public Node
 {

--- a/src/nodes/importDLPolyStructure.h
+++ b/src/nodes/importDLPolyStructure.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "nodes/node.h"
+#include "classes/structure.h"
+
+class ImportDLPolyStructureNode : public Node
+{
+    public:
+    ImportDLPolyStructureNode(Graph *parentGraph);
+    ~ImportDLPolyStructureNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // File path
+    std::string filePath_;
+    // Structure
+    Structure structure_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/src/nodes/importEPSRAtoStructure.cpp
+++ b/src/nodes/importEPSRAtoStructure.cpp
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/importEPSRAtoStructure.h"
+
+ImportEPSRAtoStructureNode::ImportEPSRAtoStructureNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Options
+    addOption<std::string>("FilePath", "File path", filePath_);
+
+    // Outputs
+    addOutput<Structure>("Structure", "Imported structure", structure_);
+}
+
+std::string_view ImportEPSRAtoStructureNode::type() const { return "ImportEPSRAtoStructure"; }
+
+std::string_view ImportEPSRAtoStructureNode::summary() const { return "Import an EPSR ato file."; }
+
+NodeConstants::ProcessResult ImportEPSRAtoStructureNode::process()
+{
+    structure_.clear();
+
+    // Open file and check that we're OK to proceed importing from it
+    LineParser parser;
+    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+        return error("Couldn't open file '{}' for loading EPSR ato data.\n", filePath_);
+
+    // File header:
+    // Either  1   : nmols, box length, temperature   (for cubic systems)
+    //    or   2   : nmols,   temperature             (for non-cubic systems)
+    // followed by : A, B, C
+    //             : phib, thetac, phic
+    if (parser.getArgsDelim() != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+    auto nMols = parser.argi(0);
+    if (parser.nArgs() == 3)
+    {
+        double boxSize = parser.argd(1);
+        Messenger::print("File has a cubic cell (side length {} Angstroms)", boxSize);
+        structure_.createBox({boxSize, boxSize, boxSize}, {90.0, 90.0, 90.0});
+    }
+    else
+    {
+        Messenger::print("File has a full cell specification");
+        Vector3 lengths, angles;
+        if (parser.getArgsDelim() != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        lengths = parser.arg3d(0);
+        if (parser.getArgsDelim() != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        angles = parser.arg3d(0);
+        structure_.createBox(lengths, angles);
+    }
+
+    // 2 : step sizes etc. **IGNORED**
+    if (parser.getArgsDelim() != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+
+    // Molecule/atom specifications are in the form:
+    // n  : natoms, comx, comy, comz, phix, phiy, phiz
+    // n+1: atom name 1
+    // n+2: x,y,z (offsets from com)
+    // n+3: nrestraints, res1, res2... (number of distance restraints, 5 per line)
+    // n+4: ...resN-1, resN
+    // n+5: nrot (number of defined molecular rotations)
+    // n+6: atom1, atom2 (bonds of rotation 'axis')
+    // n+7: list of headgroup atoms that are rotated
+    auto atomOffset = 0;
+    for (auto m = 0; m < nMols; m++)
+    {
+        Messenger::printVerbose("Importing molecule {} from EPSR ato file...\n", m + 1);
+
+        if (parser.getArgsDelim() != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto nAtoms = parser.argi(0);
+        auto com = parser.arg3d(1);
+
+        for (auto n = 0; n < nAtoms; n++)
+        {
+            // Atom name
+            if (parser.getArgsDelim() != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            auto name = parser.args(0);
+
+            // Atom coordinates (specified as offset from com)
+            if (parser.getArgsDelim() != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            auto delta = parser.arg3d(0);
+
+            // Add a new atom
+            structure_.addAtom(name, com + delta);
+
+            // Import in number of restraints line
+            if (parser.getArgsDelim() != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            auto nRestraints = parser.argi(0);
+            auto currentArg = 1;
+            while (nRestraints > 0)
+            {
+                // Look at next available argument - if none, import another line in
+                if (currentArg >= parser.nArgs())
+                {
+                    if (parser.getArgsDelim() != LineParser::Success)
+                        return NodeConstants::ProcessResult::Failed;
+                    currentArg = 0;
+                }
+                currentArg += 2;
+                --nRestraints;
+            }
+        }
+
+        // Discard molecular rotations and dihedrals
+        // There are 14 atoms per line - first line contains number of atoms followed by (up to) 13 indices
+        if (parser.getArgsDelim() != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto nRotations = parser.argi(0);
+        while (nRotations > 0)
+        {
+            // Import line to find out which type of definition this is...
+            if (parser.getArgsDelim() != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+
+            // Skip axis line
+            if (parser.skipLines(1) != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+
+            // If a DIHedral, we expect an integer which defines the number of constraints, and thus the number of
+            // lines to skip before the main
+            if (DissolveSys::sameString(parser.argsv(0), "DIH"))
+            {
+                if (parser.getArgsDelim() != LineParser::Success)
+                    return NodeConstants::ProcessResult::Failed;
+                if (parser.skipLines(parser.argi(0)) != LineParser::Success)
+                    return NodeConstants::ProcessResult::Failed;
+            }
+
+            // Finally, import in number of atoms affected by rotation and calculate next number of lines to discard
+            if (parser.getArgsDelim() != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            if (parser.skipLines(parser.argi(0) / 14) != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+
+            --nRotations;
+        }
+
+        atomOffset += nAtoms;
+    }
+
+    // Atomtype specifications follow, but we have the coordinates and so are done.
+    // TODO We could parse the atom type to element mappings and back-convert our elements
+
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/importEPSRAtoStructure.cpp
+++ b/src/nodes/importEPSRAtoStructure.cpp
@@ -36,12 +36,12 @@ NodeConstants::ProcessResult ImportEPSRAtoStructureNode::process()
     if (parser.nArgs() == 3)
     {
         double boxSize = parser.argd(1);
-        Messenger::print("File has a cubic cell (side length {} Angstroms)", boxSize);
+        message("File has a cubic cell (side length {} Angstroms)", boxSize);
         structure_.createBox({boxSize, boxSize, boxSize}, {90.0, 90.0, 90.0});
     }
     else
     {
-        Messenger::print("File has a full cell specification");
+        message("File has a full cell specification");
         Vector3 lengths, angles;
         if (parser.getArgsDelim() != LineParser::Success)
             return NodeConstants::ProcessResult::Failed;

--- a/src/nodes/importEPSRAtoStructure.h
+++ b/src/nodes/importEPSRAtoStructure.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/structure.h"
+#include "nodes/node.h"
+
+class ImportEPSRAtoStructureNode : public Node
+{
+    public:
+    ImportEPSRAtoStructureNode(Graph *parentGraph);
+    ~ImportEPSRAtoStructureNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // File path
+    std::string filePath_;
+    // Structure
+    Structure structure_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/src/nodes/importMoscitoStructure.cpp
+++ b/src/nodes/importMoscitoStructure.cpp
@@ -43,7 +43,7 @@ NodeConstants::ProcessResult ImportMoscitoStructureNode::process()
      * Units are:  distance = nm, velocities = nm ps-1, forces = kJ mol-1 nm-1
      */
 
-    Messenger::print(" --> Importing coordinates in Moscito (str) format...\n");
+    message(" --> Importing coordinates in Moscito (str) format...\n");
     // Read cell lengths
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return NodeConstants::ProcessResult::Failed;
@@ -53,7 +53,7 @@ NodeConstants::ProcessResult ImportMoscitoStructureNode::process()
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return NodeConstants::ProcessResult::Failed;
     auto nMolecules = parser.argi(0);
-    Messenger::print(" --> Structure file contains {} molecules.\n", nMolecules);
+    message(" --> Structure file contains {} molecules.\n", nMolecules);
 
     for (auto n = 0; n < nMolecules; ++n)
     {

--- a/src/nodes/importMoscitoStructure.cpp
+++ b/src/nodes/importMoscitoStructure.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/importMoscitoStructure.h"
+
+ImportMoscitoStructureNode::ImportMoscitoStructureNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Options
+    addOption<std::string>("FilePath", "File path", filePath_);
+
+    // Outputs
+    addOutput<Structure>("Structure", "Imported structure", structure_);
+}
+
+std::string_view ImportMoscitoStructureNode::type() const { return "ImportXYZStructure"; }
+
+std::string_view ImportMoscitoStructureNode::summary() const { return "Import a Moscito file."; }
+
+NodeConstants::ProcessResult ImportMoscitoStructureNode::process()
+{
+    structure_.clear();
+
+    // Open file and check that we're OK to proceed importing from it
+    LineParser parser;
+    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+        return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
+
+    /*
+     * Import Moscito coordinate information through the specified line parser.
+     * Structure file format is as follows (see http://139.30.122.11/MOSCITO/manual4.pdf):
+     *
+     * Line 1:    cx    cy    cz
+     * Line 2:    nmolecules
+     * Line 3:    empty / remark
+     * Line 4:    molecule label
+     * Line 5:    moltype  natoms  molindex
+     * Line 6:    atomlabel   typeindex
+     * Line 7:    rx   ry   rz
+     * Line 8:    vx   vy   vz
+     * Line 9:    fx   fy   fz
+     *   ...
+     *
+     * Units are:  distance = nm, velocities = nm ps-1, forces = kJ mol-1 nm-1
+     */
+
+    Messenger::print(" --> Importing coordinates in Moscito (str) format...\n");
+    // Read cell lengths
+    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+    structure_.createBox(parser.arg3d(0), {90.0, 90.0, 90.0});
+
+    // Read nmolecules
+    if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+    auto nMolecules = parser.argi(0);
+    Messenger::print(" --> Structure file contains {} molecules.\n", nMolecules);
+
+    for (auto n = 0; n < nMolecules; ++n)
+    {
+        // Read and discard remark and molecule label lines
+        if (parser.skipLines(2) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+
+        // Get number of atoms in this molecule (second integer)
+        if (parser.getArgsDelim(LineParser::KeepBlanks) != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        auto nAtoms = parser.argi(1);
+
+        // Read in atom coordinates
+        for (auto i = 0; i < nAtoms; ++i)
+        {
+            // Read atom label / index line
+            if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            auto name = parser.args(0);
+
+            // Read coordinates (in nm)
+            // Coordinates are in fixed format (15.8e) with *no spacing between values*
+            if (parser.readNextLine(LineParser::Defaults) != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+            std::string coords{parser.line()};
+            structure_.addAtom(name, {std::stof(coords.substr(0, 15)) * 10.0, std::stof(coords.substr(15, 15)) * 10.0,
+                                      std::stof(coords.substr(30)) * 10.0});
+
+            // Skip velocity and force lines
+            if (parser.skipLines(2) != LineParser::Success)
+                return NodeConstants::ProcessResult::Failed;
+        }
+    }
+
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/importMoscitoStructure.h
+++ b/src/nodes/importMoscitoStructure.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/structure.h"
+#include "nodes/node.h"
+
+class ImportMoscitoStructureNode : public Node
+{
+    public:
+    ImportMoscitoStructureNode(Graph *parentGraph);
+    ~ImportMoscitoStructureNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // File path
+    std::string filePath_;
+    // Structure
+    Structure structure_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/importXYZStructure.h"
+
+ImportXYZStructureNode::ImportXYZStructureNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Options
+    addOption<std::string>("FilePath", "File path", filePath_);
+
+    // Outputs
+    addOutput<Structure>("Structure", "Imported structure", structure_);
+}
+
+std::string_view ImportXYZStructureNode::type() const { return "ImportXYZStructure"; }
+
+std::string_view ImportXYZStructureNode::summary() const { return "Import an XYZ file."; }
+
+NodeConstants::ProcessResult ImportXYZStructureNode::process()
+{
+    structure_.clear();
+
+    // Open file and check that we're OK to proceed importing from it
+    LineParser parser;
+    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+        return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
+
+    // Read natoms
+    if (parser.getArgsDelim() != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+    auto nAtoms = parser.argi(0);
+
+    // Skip title
+    if (parser.skipLines(1) != LineParser::Success)
+        return NodeConstants::ProcessResult::Failed;
+
+    message("Expecting coordinates for {} atoms.\n", nAtoms);
+    for (auto n = 0; n < nAtoms; ++n)
+    {
+        if (parser.getArgsDelim() != LineParser::Success)
+            return NodeConstants::ProcessResult::Failed;
+        structure_.addAtom(Elements::element(parser.argsv(0)), parser.arg3d(1), parser.hasArg(4) ? parser.argd(4) : 0.0);
+    }
+
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/importXYZStructure.h
+++ b/src/nodes/importXYZStructure.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/structure.h"
+#include "nodes/node.h"
+
+class ImportXYZStructureNode : public Node
+{
+    public:
+    ImportXYZStructureNode(Graph *parentGraph);
+    ~ImportXYZStructureNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // File path
+    std::string filePath_;
+    // Structure
+    Structure structure_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -29,6 +29,7 @@
 #include "nodes/importConfigurationCoordinates.h"
 #include "nodes/importConfigurationTrajectory.h"
 #include "nodes/importDLPolyStructure.h"
+#include "nodes/importEPSRAtoStructure.h"
 #include "nodes/importXYZStructure.h"
 #include "nodes/insert.h"
 #include "nodes/integrator.h"
@@ -96,6 +97,7 @@ void NodeRegistry::instantiateNodeProducers()
                   {"ImportConfigurationCoordinates", makeDerivedNode<ImportConfigurationCoordinatesNode>()},
                   {"ImportConfigurationTrajectory", makeDerivedNode<ImportConfigurationTrajectoryNode>()},
                   {"ImportDLPolyStructure", makeDerivedNode<ImportDLPolyStructureNode>()},
+                  {"ImportEPSRAtoStructure", makeDerivedNode<ImportEPSRAtoStructureNode>()},
                   {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
                   {"Insert", makeDerivedNode<InsertNode>()},
                   {"Integrator", makeDerivedNode<Integrator1DNode>()},

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -29,6 +29,7 @@
 #include "nodes/importConfigurationCoordinates.h"
 #include "nodes/importConfigurationTrajectory.h"
 #include "nodes/importDLPolyStructure.h"
+#include "nodes/importXYZStructure.h"
 #include "nodes/insert.h"
 #include "nodes/integrator.h"
 #include "nodes/intraAngle.h"
@@ -95,6 +96,7 @@ void NodeRegistry::instantiateNodeProducers()
                   {"ImportConfigurationCoordinates", makeDerivedNode<ImportConfigurationCoordinatesNode>()},
                   {"ImportConfigurationTrajectory", makeDerivedNode<ImportConfigurationTrajectoryNode>()},
                   {"ImportDLPolyStructure", makeDerivedNode<ImportDLPolyStructureNode>()},
+                  {"ImportXYZStructure", makeDerivedNode<ImportXYZStructureNode>()},
                   {"Insert", makeDerivedNode<InsertNode>()},
                   {"Integrator", makeDerivedNode<Integrator1DNode>()},
                   {"IntraAngle", makeDerivedNode<IntraAngleNode>()},

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -40,6 +40,7 @@
 #include "nodes/numberNode.h"
 #include "nodes/setCIFAtomGroupActivity.h"
 #include "nodes/setCell.h"
+#include "nodes/setCoordinates.h"
 #include "nodes/siteRDF.h"
 #include "nodes/species.h"
 #include "nodes/sq/sq.h"
@@ -102,8 +103,9 @@ void NodeRegistry::instantiateNodeProducers()
                   {"MD", makeDerivedNode<MDNode>()},
                   {"Multiply", makeDerivedNode<MultiplyNode>()},
                   {"NeutronSQ", makeDerivedNode<NeutronSQNode>()},
-                  {"SetCell", makeDerivedNode<SetCellNode>()},
                   {"Number", makeDerivedNode<NumberNode>()},
+                  {"SetCell", makeDerivedNode<SetCellNode>()},
+                  {"SetCoordinates", makeDerivedNode<SetCoordinatesNode>()},
                   {"SiteRDF", makeDerivedNode<SiteRDFNode>()},
                   {"SQ", makeDerivedNode<SQNode>()},
                   {"Species", makeDerivedNode<SpeciesNode>()},

--- a/src/nodes/registry.cpp
+++ b/src/nodes/registry.cpp
@@ -28,6 +28,7 @@
 #include "nodes/gr/gr.h"
 #include "nodes/importConfigurationCoordinates.h"
 #include "nodes/importConfigurationTrajectory.h"
+#include "nodes/importDLPolyStructure.h"
 #include "nodes/insert.h"
 #include "nodes/integrator.h"
 #include "nodes/intraAngle.h"
@@ -92,6 +93,7 @@ void NodeRegistry::instantiateNodeProducers()
                   {"GR", makeDerivedNode<GRNode>()},
                   {"ImportConfigurationCoordinates", makeDerivedNode<ImportConfigurationCoordinatesNode>()},
                   {"ImportConfigurationTrajectory", makeDerivedNode<ImportConfigurationTrajectoryNode>()},
+                  {"ImportDLPolyStructure", makeDerivedNode<ImportDLPolyStructureNode>()},
                   {"Insert", makeDerivedNode<InsertNode>()},
                   {"Integrator", makeDerivedNode<Integrator1DNode>()},
                   {"IntraAngle", makeDerivedNode<IntraAngleNode>()},

--- a/src/nodes/setCoordinates.cpp
+++ b/src/nodes/setCoordinates.cpp
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "nodes/setCoordinates.h"
+
+SetCoordinatesNode::SetCoordinatesNode(Graph *parentGraph) : Node(parentGraph)
+{
+    // Inputs
+    addInput<Configuration *>("Configuration", "Configuration to modify", configuration_);
+    addInput("Structure", "Structure to apply", structure_);
+
+    // Outputs
+    addOutput<Configuration *>("Configuration", "Output configuration", configuration_);
+}
+
+std::string_view SetCoordinatesNode::type() const { return "SetCoordinates"; }
+
+std::string_view SetCoordinatesNode::summary() const { return "Set coordinates of a configuration from a source structure."; }
+
+NodeConstants::ProcessResult SetCoordinatesNode::process()
+{
+    // Check sizes
+    if (configuration_->nAtoms() != structure_.nAtoms())
+        return error("Mismatch between sizes of configuration and source structure data ({} vs {} atoms).\n",
+                     configuration_->nAtoms(), structure_.nAtoms());
+
+    // Copy atom positions
+    for (auto &&[cfgAtom, structureAtom] : zip(configuration_->atoms(), structure_.atoms()))
+        cfgAtom.setR(structureAtom->r());
+
+    return NodeConstants::ProcessResult::Success;
+}

--- a/src/nodes/setCoordinates.h
+++ b/src/nodes/setCoordinates.h
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "classes/structure.h"
+#include "nodes/node.h"
+
+// Forward Declarations
+class Configuration;
+
+class SetCoordinatesNode : public Node
+{
+    public:
+    SetCoordinatesNode(Graph *parentGraph);
+    ~SetCoordinatesNode() override = default;
+
+    /*
+     * Definition
+     */
+    public:
+    std::string_view type() const override;
+    std::string_view summary() const override;
+
+    /*
+     * Data
+     */
+    private:
+    // Target configuration
+    Configuration *configuration_;
+    // Structure to apply
+    Structure structure_;
+
+    /*
+     * Processing
+     */
+    private:
+    // Run main processing
+    NodeConstants::ProcessResult process() override;
+};

--- a/tests/classes/cells.cpp
+++ b/tests/classes/cells.cpp
@@ -18,8 +18,7 @@ TEST(CellsTest, Basic)
     TestGraph testGraph;
     ASSERT_TRUE(testGraph.createConfiguration("Box", {{"Ar", 1}, {"species/water-dlpoly.toml", 267}}, 0.1,
                                               Units::DensityUnits::AtomsPerAngstromUnits));
-    ASSERT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "dlpoly/solvated_atom/solvated-argon-rcut5.CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    ASSERT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/solvated_atom/solvated-argon-rcut5.CONFIG"));
 
     // Set all charge and short-range interaction potentials to zero
     auto arSpeciesNode = dynamic_cast<SpeciesNode *>(testGraph.findNode("Ar"));

--- a/tests/classes/cells3.cpp
+++ b/tests/classes/cells3.cpp
@@ -28,8 +28,7 @@ class CellsEnergyTest : public ::testing::Test
     {
         EXPECT_TRUE(
             testGraph_.createConfiguration("Box", {{"Ar|epsilon=0.774040 sigma=3.445996", nMolecules}}, lengths, angles));
-        EXPECT_TRUE(testGraph_.appendImportCoordinates(
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+        EXPECT_TRUE(testGraph_.appendSetCoordinates("ImportDLPolyStructure", referenceCoordinates));
 
         // Run the graph from the head node to set up the configuration
         EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);

--- a/tests/classes/cells4.cpp
+++ b/tests/classes/cells4.cpp
@@ -28,8 +28,7 @@ class CellsMIMTest : public ::testing::Test
     {
         EXPECT_TRUE(
             testGraph_.createConfiguration("Box", {{"Ar|epsilon=0.774040 sigma=3.445996", nMolecules}}, lengths, angles));
-        EXPECT_TRUE(testGraph_.appendImportCoordinates(
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+        EXPECT_TRUE(testGraph_.appendSetCoordinates("ImportDLPolyStructure", referenceCoordinates));
 
         // Run the graph from the head node to set up the configuration
         EXPECT_EQ(testGraph_.fetchHead()->run(), NodeConstants::ProcessResult::Success);

--- a/tests/ff/benzene.cpp
+++ b/tests/ff/benzene.cpp
@@ -19,8 +19,7 @@ class BenzeneForcefieldTest : public ::testing::Test
                                                        {"species/benzene.toml", 181},
                                                    },
                                                    {29.925089931, 29.925089931, 29.925089931}));
-        ASSERT_TRUE(testGraph_.appendImportCoordinates(
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+        ASSERT_TRUE(testGraph_.appendSetCoordinates("ImportDLPolyStructure", referenceCoordinates));
 
         // Adjust pair potential properties
         PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);

--- a/tests/ff/hexane.cpp
+++ b/tests/ff/hexane.cpp
@@ -12,7 +12,7 @@ namespace UnitTest
 class HexaneForcefieldTest : public ::testing::Test
 {
     public:
-    void setUp(int nMols, std::string_view referenceCoordinates)
+    void setUp(int nMols, const std::string &referenceCoordinates)
     {
         ASSERT_TRUE(testGraph_.createConfiguration("Box",
                                                    {

--- a/tests/ff/hexane.cpp
+++ b/tests/ff/hexane.cpp
@@ -19,8 +19,7 @@ class HexaneForcefieldTest : public ::testing::Test
                                                        {"species/hexane.toml", nMols},
                                                    },
                                                    {30.769064857500, 46.153597286200, 30.769064857500}));
-        ASSERT_TRUE(testGraph_.appendImportCoordinates(
-            CoordinateImportFileFormat(referenceCoordinates, CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+        ASSERT_TRUE(testGraph_.appendSetCoordinates("ImportDLPolyStructure", referenceCoordinates));
 
         // Adjust pair potential properties
         PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);

--- a/tests/ff/water-1000.cpp
+++ b/tests/ff/water-1000.cpp
@@ -15,8 +15,7 @@ TEST(Water1000EnergyTest, Full)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -47,8 +46,7 @@ TEST(Water1000ForceTest, Full)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "dlpoly/water1000/full.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/full.REVCON"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -81,8 +79,7 @@ TEST(Water1000EnergyTest, ShortRangeOnly)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -118,8 +115,7 @@ TEST(Water1000ForceTest, ShortRangeOnly)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/vdw.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/vdw.REVCON"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -157,8 +153,7 @@ TEST(Water1000EnergyTest, ShiftedCoulombOnly)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -191,8 +186,7 @@ TEST(Water1000ForceTest, CoulombOnly)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setCoulombTruncationScheme(PairPotential::CoulombTruncationScheme::NoCoulombTruncation);
@@ -234,8 +228,7 @@ TEST(Water1000ForceTest, ShiftedCoulombOnly)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setRange(15.0, 1.0e-4);
@@ -270,8 +263,7 @@ TEST(Water1000EnergyTest, Override)
     // Set up the test graph
     TestGraph testGraph;
     ASSERT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    ASSERT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    ASSERT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -310,8 +302,7 @@ TEST(Water1000ForceTest, Overrides)
     // Set up the test graph
     TestGraph testGraph;
     ASSERT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    ASSERT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/vdw.REVCON", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    ASSERT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/vdw.REVCON"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -14,8 +14,8 @@
 #include "nodes/importConfigurationCoordinates.h"
 #include "nodes/insert.h"
 #include "nodes/neutronSQ/neutronSQ.h"
-#include "nodes/species.h"
 #include "nodes/setCoordinates.h"
+#include "nodes/species.h"
 #include "nodes/sq/sq.h"
 #include "nodes/xRaySQ/xRaySQ.h"
 #include <gtest/gtest.h>

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -170,34 +170,20 @@ class TestGraph : public DissolveGraph
         return createAndInsertSpecies(fetchHead(), species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
                                       InsertNode::BoxActionStyle::None);
     }
-    // Append an import coordinates node
-    Node *appendImportCoordinates(CoordinateImportFileFormat fileFormat, bool supercell = false)
-    {
-        const auto cfgSourceNode = fetchHead();
-
-        EXPECT_TRUE(appendNode("ImportConfigurationCoordinates"));
-        EXPECT_TRUE(fetchHead()->setOption<std::string>("FilePath", std::string(fileFormat.filename())));
-        EXPECT_TRUE(fetchHead()->setOption<CoordinateImportFileFormat::CoordinateImportFormat>(
-            "FileFormat",
-            CoordinateImportFileFormat::coordinateImportFileFormat().enumerationByIndex(fileFormat.formatIndex())));
-        EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), supercell ? "SupercellConfiguration" : "Configuration",
-                             "ImportConfigurationCoordinates", "Configuration"}));
-
-        return head<ImportConfigurationCoordinatesNode>();
-    }
     // Append a set coordinates node with a structure import input
-    Node *appendSetCoordinates(std::string_view importNodeType, std::string_view filePath)
+    Node *appendSetCoordinates(std::string_view importNodeType, std::string filePath,
+                               std::string sourceOutpuName = "Configuration")
     {
         const auto cfgSourceNode = fetchHead();
 
         EXPECT_TRUE(appendNode("SetCoordinates"));
         auto structureNode = createNode(importNodeType);
         EXPECT_TRUE(structureNode);
-        EXPECT_TRUE(structureNode->setOption<std::string>("FilePath", std::string(filePath)));
+        EXPECT_TRUE(structureNode->setOption<std::string>("FilePath", filePath));
 
         EXPECT_TRUE(addEdge({std::string(structureNode->name()), "Structure", "SetCoordinates", "Structure"}));
 
-        EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), "Configuration", "SetCoordinates", "Configuration"}));
+        EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), sourceOutpuName, "SetCoordinates", "Configuration"}));
 
         return head<SetCoordinatesNode>();
     }

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -15,6 +15,7 @@
 #include "nodes/insert.h"
 #include "nodes/neutronSQ/neutronSQ.h"
 #include "nodes/species.h"
+#include "nodes/setCoordinates.h"
 #include "nodes/sq/sq.h"
 #include "nodes/xRaySQ/xRaySQ.h"
 #include <gtest/gtest.h>
@@ -183,6 +184,22 @@ class TestGraph : public DissolveGraph
                              "ImportConfigurationCoordinates", "Configuration"}));
 
         return head<ImportConfigurationCoordinatesNode>();
+    }
+    // Append a set coordinates node with a structure import input
+    Node *appendSetCoordinates(std::string_view importNodeType, std::string filePath)
+    {
+        const auto cfgSourceNode = fetchHead();
+
+        EXPECT_TRUE(appendNode("SetCoordinates"));
+        auto structureNode = createNode(importNodeType);
+        EXPECT_TRUE(structureNode);
+        EXPECT_TRUE(structureNode->setOption<std::string>("FilePath", filePath));
+
+        EXPECT_TRUE(addEdge({std::string(structureNode->name()), "Structure", "SetCoordinates", "Structure"}));
+
+        EXPECT_TRUE(addEdge({std::string(cfgSourceNode->name()), "Configuration", "SetCoordinates", "Configuration"}));
+
+        return head<SetCoordinatesNode>();
     }
     // Append GR and SQ nodes
     std::pair<GRNode *, SQNode *> appendGRSQ(bool noAveraging = false, bool noIntraBroadening = false)

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -186,14 +186,14 @@ class TestGraph : public DissolveGraph
         return head<ImportConfigurationCoordinatesNode>();
     }
     // Append a set coordinates node with a structure import input
-    Node *appendSetCoordinates(std::string_view importNodeType, std::string filePath)
+    Node *appendSetCoordinates(std::string_view importNodeType, std::string_view filePath)
     {
         const auto cfgSourceNode = fetchHead();
 
         EXPECT_TRUE(appendNode("SetCoordinates"));
         auto structureNode = createNode(importNodeType);
         EXPECT_TRUE(structureNode);
-        EXPECT_TRUE(structureNode->setOption<std::string>("FilePath", filePath));
+        EXPECT_TRUE(structureNode->setOption<std::string>("FilePath", std::string(filePath)));
 
         EXPECT_TRUE(addEdge({std::string(structureNode->name()), "Structure", "SetCoordinates", "Structure"}));
 

--- a/tests/nodes/bragg.cpp
+++ b/tests/nodes/bragg.cpp
@@ -54,9 +54,8 @@ class BraggNodeTest : public ::testing::Test
         ASSERT_TRUE(root->addEdge({"CIFBonds", "CIFContext", "Crystal", "CIFContext"}));
 
         // Import coordinates
-        ASSERT_TRUE(testGraph_.appendImportCoordinates(
-            CoordinateImportFileFormat("epsr25/mgo500-555/mgo.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR),
-            true));
+        ASSERT_TRUE(
+            testGraph_.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/mgo500-555/mgo.ato", "SupercellConfiguration"));
 
         // Add correlation function nodes
         auto &&[grNode, sqNode] = testGraph_.appendGRSQ(false, true);

--- a/tests/nodes/broadening.cpp
+++ b/tests/nodes/broadening.cpp
@@ -14,8 +14,7 @@ TEST(BroadeningTest, ArgonBroadening)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"Ar", 10000}}, 0.0213));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/argon10000/argonbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/argon10000/argonbox.ato"));
 
     // Append GR and SQ nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(true, true);

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -90,7 +90,7 @@ TEST(GRNodeTest, WaterMethanol)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 300}, {"species/methanol.toml", 600}}, 0.1));
-    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure","epsr25/water300methanol600/watermeth.ato"));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water300methanol600/watermeth.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, _] = testGraph.appendGRSQ(false, true);

--- a/tests/nodes/gr.cpp
+++ b/tests/nodes/gr.cpp
@@ -47,8 +47,7 @@ TEST(GRNodeTest, Water)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water1000-neutron/waterbox.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -91,8 +90,7 @@ TEST(GRNodeTest, WaterMethanol)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 300}, {"species/methanol.toml", 600}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure","epsr25/water300methanol600/watermeth.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, _] = testGraph.appendGRSQ(false, true);
@@ -266,8 +264,7 @@ TEST(GRNodeTest, Benzene)
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/benzene.toml", 200}}, 0.876,
                                               Units::DensityUnits::GramsPerCentimetreCubedUnits));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/benzene200-neutron/boxbenz.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);

--- a/tests/nodes/graphArgon.cpp
+++ b/tests/nodes/graphArgon.cpp
@@ -33,8 +33,7 @@ TEST(GraphArgonTest, AllCorrelations)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"Ar", 1000}}, 0.0213));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "dissolve2/argon/Ar_bulk_step1000.xyz", CoordinateImportFileFormat::CoordinateImportFormat::XYZ)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportXYZStructure", "dissolve2/argon/Ar_bulk_step1000.xyz"));
 
     // Append GR and SQ nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(true, true);

--- a/tests/nodes/neutronSQ.cpp
+++ b/tests/nodes/neutronSQ.cpp
@@ -14,8 +14,7 @@ TEST(NeutronSQNodeTest, Water)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water1000-neutron/waterbox.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -60,8 +59,7 @@ TEST(NeutronSQNodeTest, WaterReferenceFT)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water1000-neutron/waterbox.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -111,8 +109,7 @@ TEST(NeutronSQNodeTest, WaterMethanol)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 300}, {"species/methanol.toml", 600}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water300methanol600/watermeth.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -179,8 +176,7 @@ TEST(NeutronSQNodeTest, Benzene)
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/benzene.toml", 200}}, 0.876,
                                               Units::DensityUnits::GramsPerCentimetreCubedUnits));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/benzene200-neutron/boxbenz.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);

--- a/tests/nodes/sq.cpp
+++ b/tests/nodes/sq.cpp
@@ -14,8 +14,7 @@ TEST(SQNodeTest, Water)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water1000-neutron/waterbox.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -63,8 +62,7 @@ TEST(SQNodeTest, WaterMethanol)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 300}, {"species/methanol.toml", 600}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water300methanol600/watermeth.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water300methanol600/watermeth.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);
@@ -242,8 +240,7 @@ TEST(SQNodeTest, Benzene)
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/benzene.toml", 200}}, 0.876,
                                               Units::DensityUnits::GramsPerCentimetreCubedUnits));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/benzene200-neutron/boxbenz.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/benzene200-neutron/boxbenz.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);

--- a/tests/nodes/xRaySQ.cpp
+++ b/tests/nodes/xRaySQ.cpp
@@ -14,8 +14,7 @@ TEST(XRaySQNodeTest, WaterReferenceFT)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(CoordinateImportFileFormat(
-        "epsr25/water1000-neutron/waterbox.ato", CoordinateImportFileFormat::CoordinateImportFormat::EPSR)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportEPSRAtoStructure", "epsr25/water1000-neutron/waterbox.ato"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);

--- a/tests/pairPotentials/cutoffs.cpp
+++ b/tests/pairPotentials/cutoffs.cpp
@@ -16,8 +16,7 @@ TEST(PairPotentialCutoffTest, ShortRange)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);
@@ -54,8 +53,7 @@ TEST(PairPotentialCutoffTest, Coulomb)
     // Set up the test graph
     TestGraph testGraph;
     EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    EXPECT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setCoulombTruncationScheme(PairPotential::CoulombTruncationScheme::NoCoulombTruncation);

--- a/tests/pairPotentials/overrides.cpp
+++ b/tests/pairPotentials/overrides.cpp
@@ -14,8 +14,7 @@ TEST(PairPotentialOverridesTest, Water)
     // Set up the test graph
     TestGraph testGraph;
     ASSERT_TRUE(testGraph.createConfiguration("Box", {{"species/water.toml", 1000}}, 0.1));
-    ASSERT_TRUE(testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("dlpoly/water1000/CONFIG", CoordinateImportFileFormat::CoordinateImportFormat::DLPOLY)));
+    ASSERT_TRUE(testGraph.appendSetCoordinates("ImportDLPolyStructure", "dlpoly/water1000/CONFIG"));
 
     // Adjust pair potential properties
     PairPotential::setShortRangeTruncationScheme(PairPotential::ShortRangeTruncationScheme::NoShortRangeTruncation);

--- a/tests/workflows/phantomAtoms.cpp
+++ b/tests/workflows/phantomAtoms.cpp
@@ -48,9 +48,8 @@ TEST(PhantomAtomsTest, Water)
 {
     // Set up the test graph
     TestGraph testGraph;
-    testGraph.createConfiguration("Box", {{"species/water-with-lps.toml", 1000}}, 0.1);
-    testGraph.appendImportCoordinates(
-        CoordinateImportFileFormat("xyz/water1000-phantom.xyz", CoordinateImportFileFormat::CoordinateImportFormat::XYZ));
+    EXPECT_TRUE(testGraph.createConfiguration("Box", {{"species/water-with-lps.toml", 1000}}, 0.1));
+    EXPECT_TRUE(testGraph.appendSetCoordinates("ImportXYZStructure", "xyz/water1000-phantom.xyz"));
 
     // Add correlation function nodes
     auto &&[grNode, sqNode] = testGraph.appendGRSQ(false, true);


### PR DESCRIPTION
This PR effectively moves all code from `CoordinateImportFileFormat` into individual nodes which output a `Structure` object. All of the new unit tests are updated accordingly.

The old `CoordinateImportFileFormat` is _not_ removed as it is still depended on by `TrajectoryImportFileFormat` (to be converted in a follow-up PR).