### PR TITLE
fix:Array3D iterator bug

### DIFF
--- a/src/classes/array3DIterator.cpp
+++ b/src/classes/array3DIterator.cpp
@@ -3,7 +3,6 @@
 
 #include "classes/array3DIterator.h"
 #include <cmath>
-#include <iostream>
 
 Array3DIterator::Array3DIterator() {}
 
@@ -25,11 +24,11 @@ int Array3DIterator::toIndex() const { return x_ + sizeX_ * y_ + sizeX_ * sizeY_
 
 bool Array3DIterator::operator<(const Array3DIterator &other) const
 {
-    if (x_ != other.x_)
-        return x_ < other.x_;
+    if (z_ != other.z_)
+        return z_ < other.z_;
     if (y_ != other.y_)
         return y_ < other.y_;
-    return z_ < other.z_;
+    return x_ < other.x_;
 }
 bool Array3DIterator::operator==(const Array3DIterator &other) const
 {


### PR DESCRIPTION
I tracked down the source of my Array3D issues.  It is a legitimate bug, but it only gets triggered when performing a parallel iteration.  Even then, it depends on how TBB decides to split the work.  On most machines, TBB splits into a few different threads on the array's Z-axis, so the bug isn't triggered.  On my machine, for whatever reason, TBB decided to split into a thousand different threads that didn't even respect the Y-axis boundaries, so it created the weird conditions where the bug could be triggered.

The good news is that my testing mostly shows that this is a crash-to-desktop style bug, not a silently-produce-wrong-data bug, so I am probably the only person who ever experienced it.