### PR TITLE
refactor: DoubleKeyedMap::clear() should not decide mirrored status.

### DIFF
--- a/src/classes/histogramSet.cpp
+++ b/src/classes/histogramSet.cpp
@@ -17,9 +17,9 @@ void HistogramSet::initialise(const std::vector<const AtomType *> &types, double
 {
     atomTypes_ = types;
 
-    fullHistograms_.clear(triangular_);
-    boundHistograms_.clear(triangular_);
-    unboundHistograms_.clear(triangular_);
+    fullHistograms_ = DoubleKeyedMap<Histogram1D>(triangular_);
+    boundHistograms_ = DoubleKeyedMap<Histogram1D>(triangular_);
+    unboundHistograms_ = DoubleKeyedMap<Histogram1D>(triangular_);
 
     dissolve::for_each_pair(
         ParallelPolicies::seq, atomTypes_,

--- a/src/classes/neutronWeights.cpp
+++ b/src/classes/neutronWeights.cpp
@@ -69,10 +69,10 @@ void NeutronWeights::calculateWeightingMatrices(const std::map<const Species *, 
 {
     // Create weights matrices and calculate average scattering lengths
     // Note: Multiplier of 0.1 on b terms converts from units of fm (1e-11 m) to barn (1e-12 m)
-    concentrationProducts_.clear(true);
-    boundCoherentProducts_.clear(true);
-    weights_.clear(true);
-    intramolecularWeights_.clear(true);
+    concentrationProducts_.clear();
+    boundCoherentProducts_.clear();
+    weights_.clear();
+    intramolecularWeights_.clear();
     boundCoherentAverageOfSquares_ = 0.0;
     boundCoherentSquareOfAverage_ = 0.0;
     double ci, cj, bi, bj;

--- a/src/classes/neutronWeights.h
+++ b/src/classes/neutronWeights.h
@@ -34,13 +34,13 @@ class NeutronWeights
     // Isotope mix
     IsotopeMix isotopeMix_;
     // Concentration product matrix (ci * cj)
-    DoubleKeyedMap<double> concentrationProducts_;
+    DoubleKeyedMap<double> concentrationProducts_{true};
     // Bound coherent product matrix (bi * bj)
-    DoubleKeyedMap<double> boundCoherentProducts_;
+    DoubleKeyedMap<double> boundCoherentProducts_{true};
     // Full scattering weights
-    DoubleKeyedMap<double> weights_;
+    DoubleKeyedMap<double> weights_{true};
     // Intramolecular scattering weights
-    DoubleKeyedMap<double> intramolecularWeights_;
+    DoubleKeyedMap<double> intramolecularWeights_{true};
     // Bound coherent average squared scattering (<b>**2)
     double boundCoherentSquareOfAverage_;
     // Bound coherent squared average scattering (<b**2>)

--- a/src/classes/partialSet.cpp
+++ b/src/classes/partialSet.cpp
@@ -23,9 +23,9 @@ void PartialSet::initialise(const KeyedVector<const Species *, int> &speciesPopu
 
     triangular_ = triangular;
 
-    partials_.clear(triangular_);
-    boundPartials_.clear(triangular_);
-    unboundPartials_.clear(triangular_);
+    partials_ = DoubleKeyedMap<Data1D>(triangular_);
+    boundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
+    unboundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
 
     // Create data for partials and set tags
     dissolve::for_each_pair(
@@ -58,9 +58,9 @@ void PartialSet::initialise(const KeyedVector<const Species *, double> &realSpec
 
     triangular_ = triangular;
 
-    partials_.clear(triangular_);
-    boundPartials_.clear(triangular_);
-    unboundPartials_.clear(triangular_);
+    partials_ = DoubleKeyedMap<Data1D>(triangular_);
+    boundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
+    unboundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
 
     // Create data for partials and set tags
     dissolve::for_each_pair(
@@ -90,9 +90,9 @@ void PartialSet::initialise(const PartialSet &partialSet)
     triangular_ = partialSet.triangular_;
     rho_ = partialSet.rho_;
 
-    partials_.clear(triangular_);
-    boundPartials_.clear(triangular_);
-    unboundPartials_.clear(triangular_);
+    partials_ = DoubleKeyedMap<Data1D>(triangular_);
+    boundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
+    unboundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
 
     // Template data from source PartialSet and set tags
     dissolve::for_each_pair(
@@ -491,9 +491,9 @@ bool PartialSet::deserialise(LineParser &parser, const CoreData &coreData)
     }
 
     // Clear partials
-    partials_.clear(triangular_);
-    boundPartials_.clear(triangular_);
-    unboundPartials_.clear(triangular_);
+    partials_ = DoubleKeyedMap<Data1D>(triangular_);
+    boundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
+    unboundPartials_ = DoubleKeyedMap<Data1D>(triangular_);
 
     if (parser.getArgsDelim(LineParser::Defaults) != LineParser::Success)
         return false;

--- a/src/classes/partialSetAccumulator.cpp
+++ b/src/classes/partialSetAccumulator.cpp
@@ -12,9 +12,9 @@ void PartialSetAccumulator::operator+=(const PartialSet &source)
     // If this is the first accumulation, initialise our maps with the "mirrored" state of the source
     if (nAccumulated_ == 0)
     {
-        partials_.clear(source.partials().mirroredAreEquivalent());
-        boundPartials_.clear(source.boundPartials().mirroredAreEquivalent());
-        unboundPartials_.clear(source.unboundPartials().mirroredAreEquivalent());
+        partials_ = DoubleKeyedMap<SampledData1D>(source.partials().mirroredAreEquivalent());
+        boundPartials_ = DoubleKeyedMap<SampledData1D>(source.boundPartials().mirroredAreEquivalent());
+        unboundPartials_ = DoubleKeyedMap<SampledData1D>(source.unboundPartials().mirroredAreEquivalent());
     }
 
     // Full partials
@@ -144,9 +144,9 @@ bool PartialSetAccumulator::deserialise(LineParser &parser)
     auto mirroredEquivalent = parser.argb(2);
 
     // Clear data
-    partials_.clear(mirroredEquivalent);
-    boundPartials_.clear(mirroredEquivalent);
-    unboundPartials_.clear(mirroredEquivalent);
+    partials_ = DoubleKeyedMap<SampledData1D>(mirroredEquivalent);
+    boundPartials_ = DoubleKeyedMap<SampledData1D>(mirroredEquivalent);
+    unboundPartials_ = DoubleKeyedMap<SampledData1D>(mirroredEquivalent);
 
     if (nAccumulated_ == 0)
         return true;

--- a/src/classes/xRayWeights.cpp
+++ b/src/classes/xRayWeights.cpp
@@ -46,8 +46,8 @@ bool XRayWeights::setUp(const std::map<const Species *, double> &speciesPopulati
 
     // Set up weights matrices
     auto nTypes = typeFractions_.size();
-    concentrationProducts_.clear(true);
-    preFactors_.clear(true);
+    concentrationProducts_.clear();
+    preFactors_.clear();
 
     // Determine atomic concentration products and full pre-factor
     dissolve::for_each_pair(ParallelPolicies::seq, typeFractions_,

--- a/src/classes/xRayWeights.h
+++ b/src/classes/xRayWeights.h
@@ -27,9 +27,9 @@ class XRayWeights
     // Form factor data for atom types
     std::map<const AtomType *, std::reference_wrapper<const FormFactorData>> formFactorData_;
     // Concentration product matrix (ci * cj)
-    DoubleKeyedMap<double> concentrationProducts_;
+    DoubleKeyedMap<double> concentrationProducts_{true};
     // Pre-factors matrix (ci * cj * [2-dij])
-    DoubleKeyedMap<double> preFactors_;
+    DoubleKeyedMap<double> preFactors_{true};
 
     public:
     // Set-up from supplied species populations and form factors

--- a/src/modules/epsr/functions.cpp
+++ b/src/modules/epsr/functions.cpp
@@ -29,7 +29,7 @@ void EPSRModule::updateDeltaSQ(GenericList &processingData,
 
     // Realise the DeltaSQ array
     auto deltaSQ = processingData.realise<DoubleKeyedMap<Data1D>>("DeltaSQ", name_, GenericItem::ItemFlag::NoFlags);
-    deltaSQ.clear(true);
+    deltaSQ = DoubleKeyedMap<Data1D>(true);
 
     for (auto &[key, calcSQ] : calculatedSQ)
     {

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -214,7 +214,7 @@ Module::ExecutionResult EPSRModule::process(Dissolve &dissolve)
 
     // Create storage for our summed UnweightedSQ
     auto &calculatedUnweightedSQ = moduleData.realise<DoubleKeyedMap<Data1D>>("UnweightedSQ", name_);
-    calculatedUnweightedSQ.clear(true);
+    calculatedUnweightedSQ = DoubleKeyedMap<Data1D>(true);
     dissolve::for_each_pair(
         ParallelPolicies::par, atomTypes, [&](int indexI, auto atI, int indexJ, auto atJ)
         { calculatedUnweightedSQ[{atI->name(), atJ->name()}].setTag(std::format("{}-{}", atI->name(), atJ->name())); });

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -61,11 +61,7 @@ template <typename ValueClass> class DoubleKeyedMap : public Serialisable<>
 
     public:
     // Clear data
-    void clear(bool mirrored = false)
-    {
-        data_.clear();
-        mirroredAreEquivalent_ = mirrored;
-    }
+    void clear() { data_.clear(); }
     // Return whether the mirrored key pairs A-B and B-A are equivalent
     bool mirroredAreEquivalent() const { return mirroredAreEquivalent_; }
     // Set / overwrite key

--- a/tests/data/species/ppScaleFactorTest.toml
+++ b/tests/data/species/ppScaleFactorTest.toml
@@ -1,0 +1,88 @@
+
+[species]
+name = "Unnamed"
+
+[species.atomTypes]
+
+[species.atomTypes.C1]
+z = "C"
+charge = -0.1
+form = "LJ"
+
+[species.atomTypes.C1.parameters]
+epsilon = 1.0
+sigma = 3.0
+
+[species.atomTypes.C2]
+z = "C"
+charge = 0.1
+form = "LJ"
+
+[species.atomTypes.C2.parameters]
+epsilon = 1.0
+sigma = 3.0
+
+
+[[species.atoms]]
+index = 1
+z = "C"
+r = [
+-1.39,
+0.0,
+0.0,
+]
+q = -0.2
+type = "C1"
+[[species.atoms]]
+index = 2
+z = "C"
+r = [
+-0.695,
+1.20378,
+0.0,
+]
+q = 0.2
+type = "C2"
+[[species.atoms]]
+index = 3
+z = "C"
+r = [
+0.695,
+1.20378,
+0.0,
+]
+q = 0.2
+type = "C2"
+[[species.atoms]]
+index = 4
+z = "C"
+r = [
+1.39,
+0.0,
+0.0,
+]
+q = -0.2
+type = "C1"
+
+[[species.bonds]]
+form = "None"
+i = 1
+j = 2
+[[species.bonds]]
+form = "None"
+i = 2
+j = 3
+[[species.bonds]]
+form = "None"
+i = 3
+j = 4
+
+[[species.torsions]]
+form = "None"
+i = 1
+j = 2
+k = 3
+l = 4
+q14 = 0.5
+v14 = 0.5
+


### PR DESCRIPTION
The `clear()` function in `DoubleKeyedMap` took an argument `bool mirrored` which determined whether the newly-cleared maps would be key-symmetric.  However, this could override the choice made on construction of the object, leading to undesired behaviour (particularly since the argument had a default value).

Here we remove that issue and simplify the clear operation.

Works towards #2436