### PR TITLE
chore: Move Atom-related constants to separate include

### DIFF
--- a/src/classes/CMakeLists.txt
+++ b/src/classes/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(
   angleFunctions.h
   array3DIterator.h
   atom.h
+  atomConstants.h
   atomType.h
   bondFunctions.h
   box.h

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -28,10 +28,16 @@ void Atom::setZ(Elements::Element z) { Z_ = z; }
 Elements::Element Atom::Z() const { return Z_; }
 
 // Return presence of atom
-Atom::Presence Atom::presence() const { return Z_ == Elements::Phantom ? Presence::Phantom : Presence::Physical; }
+AtomConstants::Presence Atom::presence() const
+{
+    return Z_ == Elements::Phantom ? AtomConstants::Presence::Phantom : AtomConstants::Presence::Physical;
+}
 
 // Return whether the atom is of the presence specified
-bool Atom::isPresence(Presence presenceType) const { return presenceType == Presence::Any || presence() == presenceType; }
+bool Atom::isPresence(AtomConstants::Presence presenceType) const
+{
+    return presenceType == AtomConstants::Presence::Any || presence() == presenceType;
+}
 
 // Set atomic charge
 void Atom::setQ(double q) { q_ = q; }

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "classes/atomConstants.h"
 #include "classes/atomType.h"
 #include "math/vector3.h"
 
@@ -17,14 +18,6 @@ class Atom : public Serialisable<>
      * Properties
      */
     public:
-    // Presence
-    enum class Presence
-    {
-        Phantom = -1,
-        Physical,
-        Any
-    };
-
     protected:
     // Coordinates
     Vector3 r_;
@@ -35,7 +28,7 @@ class Atom : public Serialisable<>
     // Index in parent
     int index_{-1};
     // Atom type index in parent object
-    int atomTypeIndex_{AtomType::Ignore};
+    int atomTypeIndex_{AtomConstants::TypeIndex::Ignore};
 
     public:
     // Set basic properties
@@ -49,9 +42,9 @@ class Atom : public Serialisable<>
     // Return atomic element
     Elements::Element Z() const;
     // Return presence of atom
-    Presence presence() const;
+    AtomConstants::Presence presence() const;
     // Return whether the atom is of the presence specified
-    bool isPresence(Presence presence) const;
+    bool isPresence(AtomConstants::Presence presence) const;
     // Set atomic charge
     void setQ(double q);
     // Return atomic charge

--- a/src/classes/atomConstants.h
+++ b/src/classes/atomConstants.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+namespace AtomConstants
+{
+// Presence
+enum class Presence
+{
+    Phantom = -1,
+    Physical,
+    Any
+};
+// Enumeration for special type indices
+enum TypeIndex
+{
+    Ignore = -1
+};
+}; // namespace AtomConstants

--- a/src/classes/atomType.h
+++ b/src/classes/atomType.h
@@ -5,6 +5,7 @@
 
 #include "base/enumOptions.h"
 #include "base/serialiser.h"
+#include "classes/atomConstants.h"
 #include "classes/interactionPotential.h"
 #include "classes/shortRangeFunctions.h"
 #include "data/elements.h"
@@ -49,14 +50,9 @@ class AtomType : public Serialisable<>, public std::enable_shared_from_this<Atom
     // Atomic charge
     double charge_{0.0};
     // Index of this type in the master type index
-    int index_{-1};
+    int index_{AtomConstants::TypeIndex::Ignore};
 
     public:
-    // Enumeration for special type indices
-    enum SpecialTypeIndex
-    {
-        Ignore = -1
-    };
     // Return short-range interaction potential
     InteractionPotential<ShortRangeFunctions> &interactionPotential();
     const InteractionPotential<ShortRangeFunctions> &interactionPotential() const;

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -123,7 +123,7 @@ class Configuration : public Serialisable<const CoreData &>
     // Return nth Molecule
     std::shared_ptr<Molecule> molecule(int n);
     // Return the number of atoms in the configuration (or only those with the specified presence)
-    int nAtoms(SpeciesAtom::Presence withPresence = SpeciesAtom::Presence::Any) const;
+    int nAtoms(AtomConstants::Presence withPresence = AtomConstants::Presence::Any) const;
     // Return Atom array
     std::vector<ConfigurationAtom> &atoms();
     const std::vector<ConfigurationAtom> &atoms() const;

--- a/src/classes/configuration_contents.cpp
+++ b/src/classes/configuration_contents.cpp
@@ -112,7 +112,7 @@ std::optional<double> Configuration::atomicDensity() const
     if (nAtoms() == 0)
         return {};
 
-    return nAtoms(SpeciesAtom::Presence::Physical) / box_->volume();
+    return nAtoms(AtomConstants::Presence::Physical) / box_->volume();
 }
 
 // Return the chemical density (g/cm3) of the Configuration
@@ -250,9 +250,9 @@ const std::vector<std::shared_ptr<Molecule>> &Configuration::molecules() const {
 std::shared_ptr<Molecule> Configuration::molecule(int n) { return molecules_[n]; }
 
 // Return the number of atoms in the configuration (or only those with the specified presence)
-int Configuration::nAtoms(SpeciesAtom::Presence withPresence) const
+int Configuration::nAtoms(AtomConstants::Presence withPresence) const
 {
-    if (withPresence == SpeciesAtom::Presence::Any)
+    if (withPresence == AtomConstants::Presence::Any)
     {
         return atoms_.size();
     }
@@ -343,10 +343,10 @@ void Configuration::updateTypeIndexing()
     // Loop over atoms
     for (auto &atom : atoms_)
     {
-        if (atom.isPresence(Atom::Presence::Physical))
+        if (atom.isPresence(AtomConstants::Presence::Physical))
             atom.setAtomTypeIndex(typeMap[atom.speciesAtom()->atomType()]);
         else
-            atom.setAtomTypeIndex(AtomType::Ignore);
+            atom.setAtomTypeIndex(AtomConstants::TypeIndex::Ignore);
     }
 
     typeIndicesValid_ = true;

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -75,7 +75,7 @@ class Species : public Serialisable<>
     // Remove set of atom indices
     void removeAtoms(std::vector<int> indices);
     // Return the number of atoms in the species (or only those with the specified presence)
-    int nAtoms(SpeciesAtom::Presence withPresence = SpeciesAtom::Presence::Any) const;
+    int nAtoms(AtomConstants::Presence withPresence = AtomConstants::Presence::Any) const;
     // Renumber atoms so they are sequential in the list
     void renumberAtoms();
     // Return the nth atom in the Species

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -109,9 +109,9 @@ void Species::removeAtoms(std::vector<int> indices)
 }
 
 // Return the number of atoms in the species (or only those with the specified presence)
-int Species::nAtoms(SpeciesAtom::Presence withPresence) const
+int Species::nAtoms(AtomConstants::Presence withPresence) const
 {
-    return withPresence == SpeciesAtom::Presence::Any
+    return withPresence == AtomConstants::Presence::Any
                ? atoms_.size()
                : std::count_if(atoms_.begin(), atoms_.end(),
                                [withPresence](const auto &i) { return i.isPresence(withPresence); });
@@ -245,7 +245,7 @@ int Species::atomSelectionVersion() const { return atomSelectionVersion_; }
 double Species::mass() const
 {
     return std::accumulate(atoms_.begin(), atoms_.end(), 0.0, [](const auto acc, const auto &i)
-                           { return acc + (i.isPresence(SpeciesAtom::Presence::Physical) ? AtomicMass::mass(i.Z()) : 0.0); });
+                           { return acc + (i.isPresence(AtomConstants::Presence::Physical) ? AtomicMass::mass(i.Z()) : 0.0); });
 }
 
 // Add new atom type to atom types
@@ -287,7 +287,7 @@ KeyedVector<const AtomType *, int> Species::atomTypePopulations() const
 {
     KeyedVector<const AtomType *, int> result;
     for (const auto &i : atoms_)
-        if (i.atomType() && i.isPresence((SpeciesAtom::Presence::Physical)))
+        if (i.atomType() && i.isPresence((AtomConstants::Presence::Physical)))
             result[i.atomType()] += 1;
 
     return result;

--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -97,11 +97,12 @@ void Structure::removeAtoms(const std::vector<const StructureAtom *> &atomsToRem
 }
 
 // Return the number of atoms in the structure (or only those with the specified presence)
-int Structure::nAtoms(Atom::Presence withPresence) const
+int Structure::nAtoms(AtomConstants::Presence withPresence) const
 {
-    return withPresence == Atom::Presence::Any ? atoms_.size()
-                                               : std::count_if(atoms_.begin(), atoms_.end(), [withPresence](const auto &i)
-                                                               { return i->isPresence(withPresence); });
+    return withPresence == AtomConstants::Presence::Any
+               ? atoms_.size()
+               : std::count_if(atoms_.begin(), atoms_.end(),
+                               [withPresence](const auto &i) { return i->isPresence(withPresence); });
 }
 
 // Return atom at index

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -111,7 +111,7 @@ class Structure : public Serialisable<>
     // Remove a number of atoms
     void removeAtoms(const std::vector<const StructureAtom *> &atoms);
     // Return the number of atoms
-    int nAtoms(Atom::Presence withPresence = Atom::Presence::Any) const;
+    int nAtoms(AtomConstants::Presence withPresence = AtomConstants::Presence::Any) const;
     // Return atom at index
     StructureAtom *atomAt(int i);
     // Return atoms

--- a/src/generator/add.cpp
+++ b/src/generator/add.cpp
@@ -101,7 +101,7 @@ bool AddGeneratorNode::execute(const GeneratorContext &generatorContext)
                          box->axisAngles().x, box->axisAngles().y, box->axisAngles().z);
     }
     else
-        adjustBoxVolume(cfg, ipop, sp->nAtoms(SpeciesAtom::Presence::Physical), sp->mass());
+        adjustBoxVolume(cfg, ipop, sp->nAtoms(AtomConstants::Presence::Physical), sp->mass());
 
     // Get the positioningType_ type and rotation flag
     Messenger::print("[Add] Positioning type is '{}' and rotation is {}.\n",

--- a/src/generator/addOnSphere.cpp
+++ b/src/generator/addOnSphere.cpp
@@ -92,7 +92,7 @@ bool AddOnSphereGeneratorNode::execute(const GeneratorContext &generatorContext)
     const auto *box = cfg->box();
 
     // Set / adjust target box volume
-    adjustBoxVolume(cfg, ipop, sp->nAtoms(SpeciesAtom::Presence::Physical) + sp->nAtoms(SpeciesAtom::Presence::Physical),
+    adjustBoxVolume(cfg, ipop, sp->nAtoms(AtomConstants::Presence::Physical) + sp->nAtoms(AtomConstants::Presence::Physical),
                     sp->mass() + sp->mass());
 
     // Get the positioningType_ type and rotation flag

--- a/src/generator/addPair.cpp
+++ b/src/generator/addPair.cpp
@@ -81,7 +81,7 @@ bool AddPairGeneratorNode::execute(const GeneratorContext &generatorContext)
 
     // Set / adjust target box volume
     adjustBoxVolume(cfg, ipop,
-                    speciesA_->nAtoms(SpeciesAtom::Presence::Physical) + speciesB_->nAtoms(SpeciesAtom::Presence::Physical),
+                    speciesA_->nAtoms(AtomConstants::Presence::Physical) + speciesB_->nAtoms(AtomConstants::Presence::Physical),
                     speciesA_->mass() + speciesB_->mass());
 
     // Get the positioningType_ type and rotation flag

--- a/src/modules/bragg/functions.cpp
+++ b/src/modules/bragg/functions.cpp
@@ -42,7 +42,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, Configuration *cf
     // Grab some useful values
     const auto *box = cfg->box();
     auto nTypes = cfg->atomTypePopulations().size();
-    auto nAtoms = cfg->nAtoms(SpeciesAtom::Presence::Physical);
+    auto nAtoms = cfg->nAtoms(AtomConstants::Presence::Physical);
     auto &atoms = cfg->atoms();
 
     // Set up reciprocal axes and lengths - take those from the Box and scale based on the multiplicity
@@ -180,7 +180,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, Configuration *cf
     for (n = 0; n < nAtoms; ++n)
     {
         // Skip unphysical atoms
-        if (!atoms[n].isPresence(SpeciesAtom::Presence::Physical))
+        if (!atoms[n].isPresence(AtomConstants::Presence::Physical))
             continue;
 
         // Calculate reciprocal lattice atom coordinates
@@ -251,7 +251,7 @@ bool BraggModule::calculateBraggTerms(GenericList &moduleData, Configuration *cf
     for (n = 0; n < nAtoms; ++n)
     {
         // Skip unphysical atoms
-        if (!atoms[n].isPresence(SpeciesAtom::Presence::Physical))
+        if (!atoms[n].isPresence(AtomConstants::Presence::Physical))
             continue;
 
         // Grab localTypeIndex and array pointers for this atom

--- a/src/modules/gr/functions.cpp
+++ b/src/modules/gr/functions.cpp
@@ -72,7 +72,7 @@ bool GRModule::calculateGRSimple(Configuration *cfg, const double binWidth,
     // Loop over Atoms and construct arrays
     for (auto &atom : cfg->atoms())
     {
-        if (atom.atomTypeIndex() == AtomType::Ignore)
+        if (atom.atomTypeIndex() == AtomConstants::TypeIndex::Ignore)
             continue;
         r[atom.atomTypeIndex()][nr[atom.atomTypeIndex()]++] = atom.r();
     }
@@ -192,7 +192,7 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
         for (auto &i : atomsI)
         {
             auto typeI = i->atomTypeIndex();
-            if (typeI == AtomType::Ignore)
+            if (typeI == AtomConstants::TypeIndex::Ignore)
                 continue;
 
             auto &rI = i->r();
@@ -200,7 +200,7 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
             for (auto &j : atomsJ)
             {
                 auto typeJ = j->atomTypeIndex();
-                if (typeJ == AtomType::Ignore)
+                if (typeJ == AtomConstants::TypeIndex::Ignore)
                     continue;
 
                 auto &rJ = j->r();
@@ -239,7 +239,7 @@ bool GRModule::calculateGRCells(Configuration *cfg, const double rdfRange,
                           auto typeI = i->atomTypeIndex();
                           auto &j = atomsI[jdx];
                           auto typeJ = j->atomTypeIndex();
-                          if (typeI != AtomType::Ignore && typeJ != AtomType::Ignore)
+                          if (typeI != AtomConstants::TypeIndex::Ignore && typeJ != AtomConstants::TypeIndex::Ignore)
                           {
                               // No need to perform MIM since we're in the same cell
                               fullLUT[{typeI, typeJ}]->second.bin((i->r() - j->r()).magnitude());
@@ -413,11 +413,11 @@ bool GRModule::calculateGR(GenericList &processingData, Configuration *cfg, GRMo
                                         return;
 
                                     auto typeI = i->atomTypeIndex();
-                                    if (typeI == AtomType::Ignore)
+                                    if (typeI == AtomConstants::TypeIndex::Ignore)
                                         return;
 
                                     auto typeJ = j->atomTypeIndex();
-                                    if (typeJ == AtomType::Ignore)
+                                    if (typeJ == AtomConstants::TypeIndex::Ignore)
                                         return;
 
                                     boundLUT[{typeI, typeJ}]->second.bin(box->minimumDistance(i->r(), j->r()));

--- a/src/nodes/bragg.cpp
+++ b/src/nodes/bragg.cpp
@@ -245,7 +245,7 @@ bool BraggNode::calculateBraggTerms()
     // Grab some useful values
     const auto *box = targetConfiguration_->box();
     auto nTypes = targetConfiguration_->atomTypePopulations().size();
-    auto nAtoms = targetConfiguration_->nAtoms(SpeciesAtom::Presence::Physical);
+    auto nAtoms = targetConfiguration_->nAtoms(AtomConstants::Presence::Physical);
     auto &atoms = targetConfiguration_->atoms();
 
     // Set up reciprocal axes and lengths - take those from the Box and scale based on the multiplicity
@@ -383,7 +383,7 @@ bool BraggNode::calculateBraggTerms()
     for (n = 0; n < nAtoms; ++n)
     {
         // Skip unphysical atoms
-        if (!atoms[n].isPresence(SpeciesAtom::Presence::Physical))
+        if (!atoms[n].isPresence(AtomConstants::Presence::Physical))
             continue;
 
         // Calculate reciprocal lattice atom coordinates
@@ -454,7 +454,7 @@ bool BraggNode::calculateBraggTerms()
     for (n = 0; n < nAtoms; ++n)
     {
         // Skip unphysical atoms
-        if (!atoms[n].isPresence(SpeciesAtom::Presence::Physical))
+        if (!atoms[n].isPresence(AtomConstants::Presence::Physical))
             continue;
 
         // Grab localTypeIndex and array pointers for this atom

--- a/src/nodes/gr/helpers.cpp
+++ b/src/nodes/gr/helpers.cpp
@@ -67,7 +67,7 @@ bool GRNode::calculateGRSimple(const Array2D<typename std::map<std::string, Hist
     for (auto &atom : targetConfiguration_->atoms())
     {
         m = atom.atomTypeIndex();
-        if (m == AtomType::Ignore)
+        if (m == AtomConstants::TypeIndex::Ignore)
             continue;
         r[m][nr[m]++] = atom.r();
     }
@@ -189,7 +189,7 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
         for (auto &i : atomsI)
         {
             auto typeI = i->atomTypeIndex();
-            if (typeI == AtomType::Ignore)
+            if (typeI == AtomConstants::TypeIndex::Ignore)
                 continue;
 
             auto &rI = i->r();
@@ -197,7 +197,7 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
             for (auto &j : atomsJ)
             {
                 auto typeJ = j->atomTypeIndex();
-                if (typeJ == AtomType::Ignore)
+                if (typeJ == AtomConstants::TypeIndex::Ignore)
                     continue;
 
                 auto &rJ = j->r();
@@ -234,7 +234,7 @@ bool GRNode::calculateGRCells(double grRange, const Array2D<typename std::map<st
                           auto typeI = i->atomTypeIndex();
                           auto &j = atomsI[jdx];
                           auto typeJ = j->atomTypeIndex();
-                          if (typeI != AtomType::Ignore && typeJ != AtomType::Ignore)
+                          if (typeI != AtomConstants::TypeIndex::Ignore && typeJ != AtomConstants::TypeIndex::Ignore)
                           {
                               // No need to perform MIM since we're in the same cell
                               fullLUT[{typeI, typeJ}]->second.bin((i->r() - j->r()).magnitude());
@@ -357,11 +357,11 @@ bool GRNode::calculateRawGR(const double grRange, bool &alreadyUpToDate)
                                         return;
 
                                     auto typeI = atomI->atomTypeIndex();
-                                    if (typeI == AtomType::Ignore)
+                                    if (typeI == AtomConstants::TypeIndex::Ignore)
                                         return;
 
                                     auto typeJ = atomJ->atomTypeIndex();
-                                    if (typeJ == AtomType::Ignore)
+                                    if (typeJ == AtomConstants::TypeIndex::Ignore)
                                         return;
 
                                     boundLUT[{typeI, typeJ}]->second.bin(box->minimumDistance(atomI->r(), atomJ->r()));

--- a/src/nodes/insert.cpp
+++ b/src/nodes/insert.cpp
@@ -62,7 +62,7 @@ std::tuple<int, int, double> InsertNode::getPopulationTotals(int population, con
     for (auto n = 0; n < population; ++n)
     {
         const auto *molSp = molecules.localMolecule(n).species();
-        nPhysicalToBeAdded += molSp->nAtoms(SpeciesAtom::Presence::Physical);
+        nPhysicalToBeAdded += molSp->nAtoms(AtomConstants::Presence::Physical);
         nTotalAtomsToBeAdded += molSp->nAtoms();
         massToBeAdded += molSp->mass();
     }

--- a/tests/workflows/phantomAtoms.cpp
+++ b/tests/workflows/phantomAtoms.cpp
@@ -27,7 +27,7 @@ TEST(PhantomAtomsTest, Basic)
 
     // Basic species checks
     EXPECT_EQ(species.nAtoms(), 5);
-    EXPECT_EQ(species.nAtoms(SpeciesAtom::Presence::Phantom), 4);
+    EXPECT_EQ(species.nAtoms(AtomConstants::Presence::Phantom), 4);
     EXPECT_DOUBLE_EQ(species.mass(), AtomicMass::mass(Elements::Ar));
 
     // Get the configuration
@@ -37,10 +37,10 @@ TEST(PhantomAtomsTest, Basic)
     // Basic configuration checks
     EXPECT_EQ(cfg->nMolecules(), nMolecules);
     EXPECT_EQ(cfg->nAtoms(), nMolecules * species.nAtoms());
-    EXPECT_EQ(cfg->nAtoms(SpeciesAtom::Presence::Phantom), nMolecules * species.nAtoms(SpeciesAtom::Presence::Phantom));
+    EXPECT_EQ(cfg->nAtoms(AtomConstants::Presence::Phantom), nMolecules * species.nAtoms(AtomConstants::Presence::Phantom));
 
     // Check density - should correspond to number density of physical atoms only
-    EXPECT_NEAR(*cfg->atomicDensity(), (nMolecules * species.nAtoms(SpeciesAtom::Presence::Physical)) / cfg->box()->volume(),
+    EXPECT_NEAR(*cfg->atomicDensity(), (nMolecules * species.nAtoms(AtomConstants::Presence::Physical)) / cfg->box()->volume(),
                 1.0e-5);
 }
 


### PR DESCRIPTION
Ahead of templating the base `Atom` class, this PR moves all useful atom-related constants / enums to a separate include in order to save hiding them behind an (unknown) template parameter.

Ground work for #2436