### PR TITLE
chore: Remove SpeciesAtom::selected_ member and associated stuff from Species

### DIFF
--- a/src/classes/coreData.cpp
+++ b/src/classes/coreData.cpp
@@ -154,8 +154,8 @@ Species *CoreData::copySpecies(const Species *species)
     {
         // Create the Atom in our new Species
         auto id = newSpecies->addAtom(i.Z(), i.r(), i.q());
-        if (i.isSelected())
-            newSpecies->selectAtom(id);
+        // if (i.isSelected())
+        // newSpecies->selectAtom(id);
 
         // Find and assign the atom type
         newSpecies->atom(id).setAtomType(newSpecies->findAtomType(i.atomType()->name()));

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -57,8 +57,6 @@ class Species : public Serialisable<>
     private:
     // List of atoms in the Species
     std::vector<SpeciesAtom> atoms_;
-    // Version of the atom selection
-    VersionCounter atomSelectionVersion_;
     // Atom types for the species
     std::vector<std::shared_ptr<AtomType>> atomTypes_;
 
@@ -86,26 +84,10 @@ class Species : public Serialisable<>
     std::vector<SpeciesAtom> &atoms();
     // Transmute specified atom
     void transmuteAtom(int index, Elements::Element newZ);
-    // Clear current atom selection
-    void clearAtomSelection();
-    // Add atom to selection
-    void selectAtom(int index);
-    // Remove atom from selection
-    void deselectAtom(int index);
-    // Toggle selection state of specified atom
-    void toggleAtomSelection(int index);
     // Return the fragment (vector of indices) containing the specified atom, optionally ignoring paths along the bond(s)
     // provided
     std::vector<int> fragment(int startIndex, OptionalReferenceWrapper<SpeciesBond> exclude = std::nullopt,
                               OptionalReferenceWrapper<SpeciesBond> excludeToo = std::nullopt) const;
-    // Return current atom selection for modification
-    const std::vector<SpeciesAtom *> modifiableSelectedAtoms();
-    // Return current atom selection
-    const std::vector<const SpeciesAtom *> selectedAtoms() const;
-    // Return whether the current selection comprises atoms of a single element
-    bool isSelectionSingleElement() const;
-    // Return version of the atom selection
-    int atomSelectionVersion() const;
     // Return total atomic mass of Species
     double mass() const;
     // Add new atom type to atom types

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -150,13 +150,6 @@ bool SpeciesAngle::matches(const SpeciesAtom *i, const SpeciesAtom *j, const Spe
     return (j_ == j) && ((i_ == i && k_ == k) || (i_ == k && k_ == i));
 }
 
-// Return whether all atoms in the interaction are currently selected
-bool SpeciesAngle::isSelected() const
-{
-    assert(i_ && j_ && k_);
-    return (i_->isSelected() && j_->isSelected() && k_->isSelected());
-}
-
 // Detach from current atoms
 void SpeciesAngle::detach()
 {

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -62,8 +62,6 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     int index(int n) const;
     // Return whether SpeciesAtom match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k) const;
-    // Return whether all atoms in the interaction are currently selected
-    bool isSelected() const;
 
     /*
      * Interaction Parameters

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -28,7 +28,6 @@ void SpeciesAtom::move(SpeciesAtom &source)
     r_ = source.r_;
     q_ = source.q_;
     atomType_ = source.atomType_;
-    selected_ = source.selected_;
     index_ = source.index_;
 
     bonds_ = std::move(source.bonds_);
@@ -51,7 +50,6 @@ void SpeciesAtom::move(SpeciesAtom &source)
     source.r_ = {};
     source.q_ = 0.0;
     source.atomType_ = nullptr;
-    source.selected_ = false;
     source.index_ = -1;
     source.bonds_.clear();
     source.angles_.clear();
@@ -85,12 +83,6 @@ const AtomType *SpeciesAtom::atomType() const { return atomType_; }
 
 // Return 'user' index (1->N)
 int SpeciesAtom::userIndex() const { return index_ + 1; }
-
-// Set whether the atom is currently selected
-void SpeciesAtom::setSelected(bool selected) { selected_ = selected; }
-
-// Return whether the atom is currently selected
-bool SpeciesAtom::isSelected() const { return selected_; }
 
 /*
  * Bond Information

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -41,8 +41,6 @@ class SpeciesAtom : public Atom
     Species *parent_{nullptr};
     // Assigned AtomType
     const AtomType *atomType_{nullptr};
-    // Whether the atom is currently selected
-    bool selected_{false};
 
     public:
     // Return parent Species
@@ -53,10 +51,6 @@ class SpeciesAtom : public Atom
     const AtomType *atomType() const;
     // Return 'user' index (1->N)
     int userIndex() const;
-    // Set whether the atom is currently selected
-    void setSelected(bool selected);
-    // Return whether the atom is currently selected
-    bool isSelected() const;
 
     /*
      * Intramolecular Information

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -139,13 +139,6 @@ bool SpeciesBond::matches(const SpeciesAtom *i, const SpeciesAtom *j) const
     return (i_ == i && j_ == j) || (i_ == j && j_ == i);
 }
 
-// Return whether all atoms in the interaction are currently selected
-bool SpeciesBond::isSelected() const
-{
-    assert(i_ && j_);
-    return (i_->isSelected() && j_->isSelected());
-}
-
 // Detach from current atoms
 void SpeciesBond::detach()
 {

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -56,8 +56,6 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j) const;
-    // Return whether all atoms in the interaction are currently selected
-    bool isSelected() const;
     // Detach from current atoms
     void detach();
 

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -195,13 +195,6 @@ bool SpeciesImproper::matches(const SpeciesAtom *i, const SpeciesAtom *j, const 
     return false;
 }
 
-// Return whether all atoms in the interaction are currently selected
-bool SpeciesImproper::isSelected() const
-{
-    assert(i_ && j_ && k_ && l_);
-    return (i_->isSelected() && j_->isSelected() && k_->isSelected() && l_->isSelected());
-}
-
 /*
  * Interaction Parameters
  */

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -70,9 +70,6 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
-    // Return whether all atoms in the interaction are currently selected
-    bool isSelected() const;
-
     /*
      * Interaction Parameters
      */

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -181,13 +181,6 @@ bool SpeciesTorsion::matches(const SpeciesAtom *i, const SpeciesAtom *j, const S
     return (i_ == i && j_ == j && k_ == k && l_ == l) || (i_ == l && j_ == k && k_ == j && l_ == i);
 }
 
-// Return whether all atoms in the interaction are currently selected
-bool SpeciesTorsion::isSelected() const
-{
-    assert(i_ && j_ && k_ && l_);
-    return (i_->isSelected() && j_->isSelected() && k_->isSelected() && l_->isSelected());
-}
-
 /*
  * Interaction Parameters
  */

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -68,8 +68,6 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
-    // Return whether all atoms in the interaction are currently selected
-    bool isSelected() const;
 
     /*
      * Interaction Parameters

--- a/src/classes/species_atomic.cpp
+++ b/src/classes/species_atomic.cpp
@@ -158,48 +158,6 @@ void Species::transmuteAtom(int index, Elements::Element newZ)
     i.setZ(newZ);
 }
 
-// Clear current Atom selection
-void Species::clearAtomSelection()
-{
-    for (auto &i : atoms_)
-        i.setSelected(false);
-
-    ++atomSelectionVersion_;
-}
-
-// Add Atom to selection
-void Species::selectAtom(int index)
-{
-    auto &i = atoms_[index];
-    if (!i.isSelected())
-    {
-        i.setSelected(true);
-
-        ++atomSelectionVersion_;
-    }
-}
-
-// Remove atom from selection
-void Species::deselectAtom(int index)
-{
-    auto &i = atoms_[index];
-    if (i.isSelected())
-    {
-        i.setSelected(false);
-
-        ++atomSelectionVersion_;
-    }
-}
-
-// Toggle selection state of specified atom
-void Species::toggleAtomSelection(int index)
-{
-    if (atoms_[index].isSelected())
-        deselectAtom(index);
-    else
-        selectAtom(index);
-}
-
 // Return the fragment containing the specified atom, optionally ignoring paths along the bond(s) provided
 std::vector<int> Species::fragment(int startIndex, OptionalReferenceWrapper<SpeciesBond> exclude,
                                    OptionalReferenceWrapper<SpeciesBond> excludeToo) const
@@ -208,38 +166,6 @@ std::vector<int> Species::fragment(int startIndex, OptionalReferenceWrapper<Spec
     getIndicesRecursive(indices, startIndex, exclude, excludeToo);
     return indices;
 }
-
-// Return current atom selection for modification
-const std::vector<SpeciesAtom *> Species::modifiableSelectedAtoms()
-{
-    std::vector<SpeciesAtom *> selectedAtoms;
-    for (auto &i : atoms_)
-        if (i.isSelected())
-            selectedAtoms.emplace_back(&i);
-
-    return selectedAtoms;
-}
-const std::vector<const SpeciesAtom *> Species::selectedAtoms() const
-{
-    std::vector<const SpeciesAtom *> selectedAtoms;
-    for (auto &i : atoms_)
-        if (i.isSelected())
-            selectedAtoms.emplace_back(&i);
-
-    return selectedAtoms;
-}
-
-// Return whether the current selection comprises atoms of a single element
-bool Species::isSelectionSingleElement() const
-{
-    auto selection = selectedAtoms();
-    if (selection.empty())
-        return false;
-    return std::all_of(selection.begin(), selection.end(), [&](const auto *i) { return i->Z() == selection.front()->Z(); });
-}
-
-// Return version of the atom selection
-int Species::atomSelectionVersion() const { return atomSelectionVersion_; }
 
 // Return total atomic mass of Species
 double Species::mass() const

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -473,7 +473,6 @@ void Species::finaliseGeometry()
             bond.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'i', excluding the Bond as a path
-        clearAtomSelection();
         selection = fragment(bond.j()->index(), bond);
         bond.setAttachedAtoms(1, selection);
     }
@@ -509,7 +508,6 @@ void Species::finaliseGeometry()
             angle.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
-        clearAtomSelection();
         selection = fragment(angle.k()->index(), *ji, jk);
 
         // Remove Atom 'j' from the list if it's there
@@ -549,7 +547,6 @@ void Species::finaliseGeometry()
             torsion.setAttachedAtoms(0, selection);
 
         // Select all Atoms attached to Atom 'k', excluding the Bond jk as a path
-        clearAtomSelection();
         selection = fragment(torsion.k()->index(), *jk);
 
         // Remove Atom 'k' from the list

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -298,8 +298,9 @@ std::vector<int> Forcefield::assignAtomTypes(Species *sp, AtomTypeAssignmentStra
             continue;
 
         // -- Don't assign a type unless the atom is selected (strategy == Forcefield::TypeSelection)
-        if ((strategy == Forcefield::TypeSelection) && (!i.isSelected()))
-            continue;
+        // if ((strategy == Forcefield::TypeSelection) && (!i.isSelected()))
+        // continue;
+        // TODO DISSOLVE2
 
         if (!assignAtomType(i, setSpeciesAtomCharges))
         {
@@ -446,8 +447,8 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
     // Assign bond terms
     for (auto &bond : sp->bonds())
     {
-        if (selectionOnly && (!bond.isSelected()))
-            continue;
+        // if (selectionOnly && (!bond.isSelected()))
+        // continue;
 
         if (!assignBondTermParameters(sp, bond, determineTypes))
             return false;
@@ -456,8 +457,8 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
     // Generate angle parameters
     for (auto &angle : sp->angles())
     {
-        if (selectionOnly && (!angle.isSelected()))
-            continue;
+        // if (selectionOnly && (!angle.isSelected()))
+        // continue;
 
         if (!assignAngleTermParameters(sp, angle, determineTypes))
             return false;
@@ -466,8 +467,8 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
     // Generate torsion parameters
     for (auto &torsion : sp->torsions())
     {
-        if (selectionOnly && (!torsion.isSelected()))
-            continue;
+        // if (selectionOnly && (!torsion.isSelected()))
+        // continue;
 
         if (!assignTorsionTermParameters(sp, torsion, determineTypes))
             return false;
@@ -485,8 +486,8 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
             if (i.nBonds() != 3)
                 continue;
 
-            if (selectionOnly && (!i.isSelected()))
-                continue;
+            // if (selectionOnly && (!i.isSelected()))
+            // continue;
 
             // Loop over combinations of bonds to the central atom
             for (auto indexJ = 0; indexJ < i.nBonds() - 2; ++indexJ)
@@ -494,24 +495,24 @@ bool Forcefield::assignIntramolecular(Species *sp, int flags) const
                 // Get SpeciesAtom 'j'
                 auto *j = i.bond(indexJ).partner(&i);
 
-                if (selectionOnly && (!j->isSelected()))
-                    continue;
+                // if (selectionOnly && (!j->isSelected()))
+                continue;
 
                 for (auto indexK = indexJ + 1; indexK < i.nBonds() - 1; ++indexK)
                 {
                     // Get SpeciesAtom 'k'
                     auto *k = i.bond(indexK).partner(&i);
 
-                    if (selectionOnly && (!k->isSelected()))
-                        continue;
+                    // if (selectionOnly && (!k->isSelected()))
+                    // continue;
 
                     for (auto indexL = indexK + 1; indexL < i.nBonds(); ++indexL)
                     {
                         // Get SpeciesAtom 'l'
                         auto *l = i.bond(indexL).partner(&i);
 
-                        if (selectionOnly && (!l->isSelected()))
-                            continue;
+                        // if (selectionOnly && (!l->isSelected()))
+                        // continue;
 
                         // Try to assign / generate an improper term (which may legitimately not exist)
                         if (!assignImproperTermParameters(improperTerm, &i, j, k, l, determineTypes))

--- a/src/gui/models/addForcefieldDialogModel.cpp
+++ b/src/gui/models/addForcefieldDialogModel.cpp
@@ -59,8 +59,9 @@ void AddForcefieldDialogModel::next()
             originalAtomTypeNames_.clear();
 
             // Set selection status
-            for (auto &&[targetI, modifiedI] : zip(species_->atoms(), modifiedSpecies_->atoms()))
-                modifiedI.setSelected(targetI.isSelected());
+            // for (auto &&[targetI, modifiedI] : zip(species_->atoms(), modifiedSpecies_->atoms()))
+            // modifiedI.setSelected(targetI.isSelected());
+            // TODO DISSOLVE2
 
             Q_EMIT assignErrors({});
             // Determine atom types
@@ -142,12 +143,7 @@ void AddForcefieldDialogModel::setSpecies(Species *sp)
 }
 
 // Does the species have selected atoms
-bool AddForcefieldDialogModel::speciesHasSelection() const
-{
-    if (!species_)
-        return false;
-    return !species_->selectedAtoms().empty();
-}
+bool AddForcefieldDialogModel::speciesHasSelection() const { return false; }
 
 // The forcefield model
 const QAbstractItemModel *AddForcefieldDialogModel::forcefields() const { return &ffSort_; }
@@ -217,8 +213,8 @@ void AddForcefieldDialogModel::finalise()
     {
 
         // Selection only?
-        if (typesSelectionOnly && (!original.isSelected()))
-            continue;
+        // if (typesSelectionOnly && (!original.isSelected()))
+        // continue;
 
         // Copy AtomType TODO DISSOLVE2
         // dissolve_->coreData().copyAtomType(modified, original);
@@ -241,8 +237,8 @@ void AddForcefieldDialogModel::finalise()
         for (auto &originalBond : species_->bonds())
         {
             // Selection only?
-            if (intraSelectionOnly && (!originalBond.isSelected()))
-                continue;
+            // if (intraSelectionOnly && (!originalBond.isSelected()))
+            // continue;
 
             // dissolve_->coreData().copySpeciesBond(*modifiedBond, originalBond);
             // TODO DISSOLVE2
@@ -254,8 +250,8 @@ void AddForcefieldDialogModel::finalise()
         for (auto &originalAngle : species_->angles())
         {
             // Selection only?
-            if (intraSelectionOnly && (!originalAngle.isSelected()))
-                continue;
+            // if (intraSelectionOnly && (!originalAngle.isSelected()))
+            // continue;
 
             // dissolve_->coreData().copySpeciesAngle(*modifiedAngle, originalAngle);
             // TODO DISSOLVE2
@@ -266,8 +262,8 @@ void AddForcefieldDialogModel::finalise()
         for (auto &originalTorsion : species_->torsions())
         {
             // Selection only?
-            if (intraSelectionOnly && (!originalTorsion.isSelected()))
-                continue;
+            // if (intraSelectionOnly && (!originalTorsion.isSelected()))
+            // continue;
 
             // dissolve_->coreData().copySpeciesTorsion(*modifiedTorsion, originalTorsion);
             // TODO DISSOLVE2
@@ -278,8 +274,8 @@ void AddForcefieldDialogModel::finalise()
         for (auto &modifiedImproper : modifiedSpecies_->impropers())
         {
             // Selection only?
-            if (intraSelectionOnly && (!modifiedImproper.isSelected()))
-                continue;
+            // if (intraSelectionOnly && (!modifiedImproper.isSelected()))
+            // continue;
 
             // Find / create the improper in the target species
             auto optImproper = species_->getImproper(modifiedImproper.indexI(), modifiedImproper.indexJ(),

--- a/src/gui/render/renderableSpecies.cpp
+++ b/src/gui/render/renderableSpecies.cpp
@@ -190,8 +190,8 @@ void RenderableSpecies::recreatePrimitives(const View &view, const ColourDefinit
             speciesAssembly_.add(atomPrimitive_, A, ElementColours::colour(i.Z()));
 
             // Is the atom selected?
-            if (i.isSelected())
-                selectionAssembly_.add(selectedAtomPrimitive_, A, colourBlack);
+            // if (i.isSelected())
+            // selectionAssembly_.add(selectedAtomPrimitive_, A, colourBlack);
         }
 
         // Draw bonds
@@ -240,8 +240,8 @@ const void RenderableSpecies::sendToGL(const double pixelScaling)
 // Recreate selection Primitive
 void RenderableSpecies::recreateSelectionPrimitive()
 {
-    if (selectionPrimitiveVersion_ == source_->atomSelectionVersion())
-        return;
+    // if (selectionPrimitiveVersion_ == source_->atomSelectionVersion())
+    // return;
 
     // Clear existing data
     selectionAssembly_.clear();
@@ -260,8 +260,8 @@ void RenderableSpecies::recreateSelectionPrimitive()
         for (const auto &i : source_->atoms())
         {
             // If not selected, continue
-            if (!i.isSelected())
-                continue;
+            // if (!i.isSelected())
+            // continue;
 
             // Get element colour
             auto &colour = ElementColours::colour(i.Z());
@@ -299,8 +299,8 @@ void RenderableSpecies::recreateSelectionPrimitive()
 
         for (auto &i : source_->atoms())
         {
-            if (!i.isSelected())
-                continue;
+            // if (!i.isSelected())
+            // continue;
 
             A.setIdentity();
             A.setTranslation(i.r());
@@ -310,7 +310,7 @@ void RenderableSpecies::recreateSelectionPrimitive()
         }
     }
 
-    selectionPrimitiveVersion_ = source_->atomSelectionVersion();
+    // selectionPrimitiveVersion_ = source_->atomSelectionVersion();
 }
 
 // Clear interaction Primitive


### PR DESCRIPTION
This PR removes the `selected_` member from the `SpeciesAtom` class as well as the mechanism for detecting whether a particular intramolecular term was selected (this was a very rarely-used feature of the old AddForcefieldWidget).  When we wish to reimplement selecting atoms on a `Structure` or `Species` within the GUI, this should be handled in a class outside of the `Structure` / `Species` itself.

Ground work for #2436