### PR TITLE
refactor: Add Species::createAtomic()

### DIFF
--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -331,19 +331,3 @@ void Species::deserialise(const SerialisedValue &node)
 
     finaliseGeometry();
 }
-
-// Load from specified TOML file
-void Species::load(std::string_view tomlFile)
-{
-    clear();
-
-    SerialisedValue contents = toml::parse(std::string(tomlFile));
-    if (contents.contains("species"))
-    {
-        deserialise(contents["species"]);
-        auto name = contents["species"]["name"].as_string();
-        setName(name.str);
-    }
-
-    finaliseGeometry();
-}

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -378,6 +378,16 @@ class Species : public Serialisable<>
     void centreAtOrigin();
 
     /*
+     * Creation
+     */
+    public:
+    // Create atomic species
+    void createAtomic(Elements::Element Z,
+                      InteractionPotential<ShortRangeFunctions> potential = {ShortRangeFunctions::Form::Undefined, ""});
+    // Load from specified TOML file
+    void load(std::string_view tomlFile);
+
+    /*
      * Serialisation
      */
     public:
@@ -419,6 +429,4 @@ class Species : public Serialisable<>
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node);
-    // Load from specified TOML file
-    void load(std::string_view tomlFile);
 };

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -44,3 +44,41 @@ void Species::centreAtOrigin()
     for (auto &i : atoms_)
         i -= centre;
 }
+
+/*
+ * Creation
+ */
+
+// Create atomic species
+void Species::createAtomic(Elements::Element Z, InteractionPotential<ShortRangeFunctions> potential)
+{
+    clear();
+
+    // Set up atom type
+    auto atomType = addAtomType(Z, Elements::symbol(Z));
+    atomType->interactionPotential().setFormAndParameters(potential.form(), potential.parameters());
+    addAtom(Z, {}, 0.0, atomType);
+
+    // Create isotopologues
+    for (auto isotope : Sears91::isotopes(Z))
+    {
+        auto iso = addIsotopologue(std::format("{}{}", Elements::symbol(Z), Sears91::A(isotope)));
+        iso->setAtomTypeIsotope(atomType, isotope);
+    }
+}
+
+// Load from specified TOML file
+void Species::load(std::string_view tomlFile)
+{
+    clear();
+
+    SerialisedValue contents = toml::parse(std::string(tomlFile));
+    if (contents.contains("species"))
+    {
+        deserialise(contents["species"]);
+        auto name = contents["species"]["name"].as_string();
+        setName(name.str);
+    }
+
+    finaliseGeometry();
+}

--- a/tests/classes/cells2.cpp
+++ b/tests/classes/cells2.cpp
@@ -19,7 +19,7 @@ class CellsPBCTest : public ::testing::Test
 
         // Set up pseudo-species
         probe_.setName("Probe");
-        probe_.addAtom(Elements::H, {0.0, 0.0, 0.0}, 0.0, probe_.addAtomType(Elements::H, "Probe"));
+        probe_.createAtomic(Elements::H);
     }
 
     protected:

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -114,18 +114,7 @@ class TestGraph : public DissolveGraph
         auto speciesNodePtr = speciesNodeUniquePtr.get();
         auto species = &speciesNodePtr->species();
         species->setName(Elements::symbol(element));
-
-        // Set up atom types
-        auto atomType = species->addAtomType(element, Elements::symbol(element));
-        atomType->interactionPotential().setFormAndParameters(potential.form(), potential.parameters());
-        species->addAtom(element, {}, 0.0, atomType);
-
-        // Create isotopologues
-        for (auto isotope : Sears91::isotopes(element))
-        {
-            auto iso = species->addIsotopologue(std::format("{}{}", Elements::symbol(element), Sears91::A(isotope)));
-            iso->setAtomTypeIsotope(atomType, isotope);
-        }
+        species->createAtomic(element, potential);
 
         return speciesNodeUniquePtr;
     }


### PR DESCRIPTION
This PR adds a simple function to `Species` to create an atomic species, and uses it in a couple of places in the code.

Ground work for #2436