### PR TITLE
chore: Remove unused BondType

### DIFF
--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -152,38 +152,6 @@ void SpeciesBond::detach()
 }
 
 /*
- * Bond Type
- */
-
-// Bond type keywords
-std::string_view BondTypeKeywords[] = {"Single", "Double", "Triple", "Quadruple", "Aromatic"};
-double BondTypeOrders[] = {1.0, 2.0, 3.0, 4.0, 1.5};
-
-// Convert bond type string to functional form
-SpeciesBond::BondType SpeciesBond::bondType(std::string_view s)
-{
-    for (auto n = 0; n < SpeciesBond::nBondTypes; ++n)
-        if (DissolveSys::sameString(s, BondTypeKeywords[n]))
-            return (SpeciesBond::BondType)n;
-    return SpeciesBond::nBondTypes;
-}
-
-// Return bond type functional form text
-std::string_view SpeciesBond::bondType(SpeciesBond::BondType bt) { return BondTypeKeywords[bt]; }
-
-// Return bond order for specified bond type
-double SpeciesBond::bondOrder(SpeciesBond::BondType bt) { return BondTypeOrders[bt]; }
-
-// Set bond type
-void SpeciesBond::setBondType(BondType type) { bondType_ = type; }
-
-// Return bond type
-SpeciesBond::BondType SpeciesBond::bondType() const { return bondType_; }
-
-// Return bond order for current bond type
-double SpeciesBond::bondOrder() const { return SpeciesBond::bondOrder(bondType_); }
-
-/*
  * Interaction Parameters
  */
 

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -28,7 +28,6 @@ SpeciesBond::SpeciesBond(SpeciesBond &&source) noexcept : SpeciesIntra(source)
 
     // Copy data
     assign(source.i_, source.j_);
-    bondType_ = source.bondType_;
     interactionPotential_ = source.interactionPotential_;
     commonTerm_ = source.commonTerm_;
 
@@ -41,7 +40,6 @@ SpeciesBond &SpeciesBond::operator=(const SpeciesBond &source)
 {
     // Copy data
     assign(source.i_, source.j_);
-    bondType_ = source.bondType_;
     interactionPotential_ = source.interactionPotential_;
     commonTerm_ = source.commonTerm_;
     SpeciesIntra::operator=(source);
@@ -57,7 +55,6 @@ SpeciesBond &SpeciesBond::operator=(SpeciesBond &&source) noexcept
 
     // Copy data
     assign(source.i_, source.j_);
-    bondType_ = source.bondType_;
     interactionPotential_ = source.interactionPotential_;
     commonTerm_ = source.commonTerm_;
     SpeciesIntra::operator=(source);

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -60,39 +60,6 @@ class SpeciesBond : public SpeciesIntra<SpeciesBond, BondFunctions>
     void detach();
 
     /*
-     * Bond Type
-     */
-    public:
-    // Bond Type enum
-    enum BondType
-    {
-        SingleBond,
-        DoubleBond,
-        TripleBond,
-        QuadrupleBond,
-        AromaticBond,
-        nBondTypes
-    };
-    // Convert bond type string to functional form
-    static BondType bondType(std::string_view s);
-    // Return bond type functional form text
-    static std::string_view bondType(BondType bt);
-    // Return bond order for specified bond type
-    static double bondOrder(BondType bt);
-
-    private:
-    // Bond type
-    BondType bondType_{SpeciesBond::SingleBond};
-
-    public:
-    // Set bond type
-    void setBondType(BondType type);
-    // Return bond type
-    BondType bondType() const;
-    // Return bond order for current bond type
-    double bondOrder() const;
-
-    /*
      * Interaction Parameters
      */
     public:

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -60,7 +60,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
     BondFunctions::Form bf;
     AngleFunctions::Form af;
     TorsionFunctions::Form tf;
-    SpeciesBond::BondType bt;
     Vector3 boxAngles(90.0, 90.0, 90.0);
     std::optional<Vector3> boxLengths;
     auto elec14Scaling = 0.5, vdw14Scaling = 0.5;
@@ -253,16 +252,6 @@ bool Species::read(LineParser &parser, CoreData &coreData)
                     errorsEncountered = true;
                     break;
                 }
-
-                // Get the bond type
-                bt = SpeciesBond::bondType(parser.argsv(3));
-                if (bt == SpeciesBond::nBondTypes)
-                {
-                    Messenger::error("Unrecognised bond type '{}'.\n", parser.argsv(3));
-                    errorsEncountered = true;
-                    break;
-                }
-                b->get().setBondType(bt);
                 break;
             case (Species::SpeciesKeyword::BoxAngles):
                 boxAngles = parser.arg3d(1);
@@ -769,7 +758,6 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             return false;
 
     // Bonds
-    std::vector<const SpeciesBond *> bondTypes[SpeciesBond::nBondTypes];
     if (!bonds_.empty())
     {
         if (!parser.writeLineF("\n{}# Bonds\n", newPrefix))
@@ -790,31 +778,7 @@ bool Species::write(LineParser &parser, std::string_view prefix)
                                         BondFunctions::forms().keyword(bond.interactionForm()),
                                         bond.interactionPotential().parametersAsString()))
                 return false;
-
-            // Add the bond to the reference vector based on its indicated bond type (unless it is a SingleBond,
-            // which we will ignore as this is the default)
-            if (bond.bondType() != SpeciesBond::SingleBond)
-                bondTypes[bond.bondType()].push_back(&bond);
         }
-
-        // Any bond type information to write?
-        auto bondTypeHeaderWritten = false;
-        for (auto bt = 1; bt < SpeciesBond::nBondTypes; ++bt)
-            if (!bondTypes[bt].empty())
-            {
-                // Write header if it hasn't been written already
-                if (!bondTypeHeaderWritten)
-                {
-                    if (!parser.writeLineF("\n{}# Bond Types\n", newPrefix))
-                        return false;
-                    bondTypeHeaderWritten = true;
-                }
-                for (const auto *bond : bondTypes[bt])
-                    if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {}\n", newPrefix,
-                                           keywords().keyword(Species::SpeciesKeyword::BondType), bond->indexI() + 1,
-                                           bond->indexJ() + 1, SpeciesBond::bondType((SpeciesBond::BondType)bt)))
-                        return false;
-            }
     }
 
     // Angles

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -9,13 +9,11 @@
 #include <utility>
 
 NETAConnectionNode::NETAConnectionNode(NETADefinition *parent, std::vector<Elements::Element> targetElements,
-                                       std::vector<std::reference_wrapper<const ForcefieldAtomType>> targetAtomTypes,
-                                       SpeciesBond::BondType bt)
+                                       std::vector<std::reference_wrapper<const ForcefieldAtomType>> targetAtomTypes)
     : NETANode(parent, NETANode::NodeType::Connection)
 {
     allowedElements_ = std::move(targetElements);
     allowedAtomTypes_ = std::move(targetAtomTypes);
-    bondType_ = bt;
 
     // Modifiers
     repeatCount_ = 1;

--- a/src/neta/connection.h
+++ b/src/neta/connection.h
@@ -18,8 +18,7 @@ class NETAConnectionNode : public NETANode
 {
     public:
     NETAConnectionNode(NETADefinition *parent, std::vector<Elements::Element> targetElements = {},
-                       std::vector<std::reference_wrapper<const ForcefieldAtomType>> targetAtomTypes = {},
-                       SpeciesBond::BondType bt = SpeciesBond::nBondTypes);
+                       std::vector<std::reference_wrapper<const ForcefieldAtomType>> targetAtomTypes = {});
     ~NETAConnectionNode() override = default;
 
     /*
@@ -30,8 +29,6 @@ class NETAConnectionNode : public NETANode
     std::vector<Elements::Element> allowedElements_;
     // Array of ForcefieldAtomTypes that the current context atom may be
     std::vector<std::reference_wrapper<const ForcefieldAtomType>> allowedAtomTypes_;
-    // Type of required connection
-    SpeciesBond::BondType bondType_;
 
     public:
     // Add element target to node


### PR DESCRIPTION
A quick PR to remove the `BondType` enum and member usages, since it was never used in practice anywhere in the code!

Ground work for #2436 