### PR TITLE
refactor: NETA for all

### DIFF
--- a/src/classes/speciesRing.cpp
+++ b/src/classes/speciesRing.cpp
@@ -6,7 +6,7 @@
 #include "classes/speciesBond.h"
 #include "data/elements.h"
 
-SpeciesRing::SpeciesRing(const std::vector<const BaseAtom *> &atoms) : atoms_(atoms) {};
+SpeciesRing::SpeciesRing(const std::vector<const AtomBase *> &atoms) : atoms_(atoms) {};
 
 bool SpeciesRing::operator==(const SpeciesRing &other) const
 {
@@ -42,13 +42,13 @@ bool SpeciesRing::operator==(const SpeciesRing &other) const
  */
 
 // Set atoms in ring
-void SpeciesRing::setAtoms(const std::vector<const BaseAtom *> &atoms) { atoms_ = atoms; }
+void SpeciesRing::setAtoms(const std::vector<const AtomBase *> &atoms) { atoms_ = atoms; }
 
 // Return nth atom in ring
-const BaseAtom *SpeciesRing::atom(int n) const { return atoms_.at(n); }
+const AtomBase *SpeciesRing::atom(int n) const { return atoms_.at(n); }
 
 // Return array of atoms in ring
-const std::vector<const BaseAtom *> &SpeciesRing::atoms() const { return atoms_; }
+const std::vector<const AtomBase *> &SpeciesRing::atoms() const { return atoms_; }
 
 // Return size of ring (number of atoms in array)
 int SpeciesRing::size() const { return atoms_.size(); }

--- a/src/classes/speciesRing.cpp
+++ b/src/classes/speciesRing.cpp
@@ -6,7 +6,7 @@
 #include "classes/speciesBond.h"
 #include "data/elements.h"
 
-SpeciesRing::SpeciesRing(const std::vector<const SpeciesAtom *> &atoms) : atoms_(atoms) {};
+SpeciesRing::SpeciesRing(const std::vector<const BaseAtom *> &atoms) : atoms_(atoms) {};
 
 bool SpeciesRing::operator==(const SpeciesRing &other) const
 {
@@ -42,13 +42,13 @@ bool SpeciesRing::operator==(const SpeciesRing &other) const
  */
 
 // Set atoms in ring
-void SpeciesRing::setAtoms(const std::vector<const SpeciesAtom *> &atoms) { atoms_ = atoms; }
+void SpeciesRing::setAtoms(const std::vector<const BaseAtom *> &atoms) { atoms_ = atoms; }
 
 // Return nth atom in ring
-const SpeciesAtom *SpeciesRing::atom(int n) const { return atoms_.at(n); }
+const BaseAtom *SpeciesRing::atom(int n) const { return atoms_.at(n); }
 
 // Return array of atoms in ring
-const std::vector<const SpeciesAtom *> &SpeciesRing::atoms() const { return atoms_; }
+const std::vector<const BaseAtom *> &SpeciesRing::atoms() const { return atoms_; }
 
 // Return size of ring (number of atoms in array)
 int SpeciesRing::size() const { return atoms_.size(); }

--- a/src/classes/speciesRing.h
+++ b/src/classes/speciesRing.h
@@ -6,13 +6,13 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class BaseAtom;
 
 // SpeciesRing Definition
 class SpeciesRing
 {
     public:
-    SpeciesRing(const std::vector<const SpeciesAtom *> &atoms = {});
+    SpeciesRing(const std::vector<const BaseAtom *> &atoms = {});
     ~SpeciesRing() = default;
     bool operator==(const SpeciesRing &other) const;
 
@@ -21,15 +21,15 @@ class SpeciesRing
      */
     private:
     // Array of atoms in the ring, in the order in which they appear
-    std::vector<const SpeciesAtom *> atoms_;
+    std::vector<const BaseAtom *> atoms_;
 
     public:
     // Set atoms in ring
-    void setAtoms(const std::vector<const SpeciesAtom *> &atoms);
+    void setAtoms(const std::vector<const BaseAtom *> &atoms);
     // Return nth atom in ring
-    const SpeciesAtom *atom(int n) const;
+    const BaseAtom *atom(int n) const;
     // Return array of atoms in ring
-    const std::vector<const SpeciesAtom *> &atoms() const;
+    const std::vector<const BaseAtom *> &atoms() const;
     // Return size of ring (number of atoms in array)
     int size() const;
     // Print ring information

--- a/src/classes/speciesRing.h
+++ b/src/classes/speciesRing.h
@@ -6,13 +6,13 @@
 #include <vector>
 
 // Forward Declarations
-class BaseAtom;
+class AtomBase;
 
 // SpeciesRing Definition
 class SpeciesRing
 {
     public:
-    SpeciesRing(const std::vector<const BaseAtom *> &atoms = {});
+    SpeciesRing(const std::vector<const AtomBase *> &atoms = {});
     ~SpeciesRing() = default;
     bool operator==(const SpeciesRing &other) const;
 
@@ -21,15 +21,15 @@ class SpeciesRing
      */
     private:
     // Array of atoms in the ring, in the order in which they appear
-    std::vector<const BaseAtom *> atoms_;
+    std::vector<const AtomBase *> atoms_;
 
     public:
     // Set atoms in ring
-    void setAtoms(const std::vector<const BaseAtom *> &atoms);
+    void setAtoms(const std::vector<const AtomBase *> &atoms);
     // Return nth atom in ring
-    const BaseAtom *atom(int n) const;
+    const AtomBase *atom(int n) const;
     // Return array of atoms in ring
-    const std::vector<const BaseAtom *> &atoms() const;
+    const std::vector<const AtomBase *> &atoms() const;
     // Return size of ring (number of atoms in array)
     int size() const;
     // Print ring information

--- a/src/neta/NETAVisitor.cpp
+++ b/src/neta/NETAVisitor.cpp
@@ -154,10 +154,10 @@ antlrcpp::Any NETAVisitor::visitGeometryNode(NETAParser::GeometryNodeContext *co
         throw(NETAExceptions::NETASyntaxException(std::format("'{}' is not a valid comparison operator (for this context).\n",
                                                               context->EqualityOperator()->getText())));
     NETANode::ComparisonOperator op = NETANode::comparisonOperators().enumeration(context->EqualityOperator()->getText());
-    if (!SpeciesAtom::geometries().isValid(context->geometry->getText()))
+    if (!BaseAtom::geometries().isValid(context->geometry->getText()))
         throw(NETAExceptions::NETASyntaxException(
             std::format("'{}' is not a valid geometry type.\n", context->geometry->getText())));
-    SpeciesAtom::AtomGeometry geom = SpeciesAtom::geometries().enumeration(context->geometry->getText());
+    BaseAtom::AtomGeometry geom = BaseAtom::geometries().enumeration(context->geometry->getText());
 
     geometryNode->set(op, geom);
 

--- a/src/neta/NETAVisitor.cpp
+++ b/src/neta/NETAVisitor.cpp
@@ -154,10 +154,10 @@ antlrcpp::Any NETAVisitor::visitGeometryNode(NETAParser::GeometryNodeContext *co
         throw(NETAExceptions::NETASyntaxException(std::format("'{}' is not a valid comparison operator (for this context).\n",
                                                               context->EqualityOperator()->getText())));
     NETANode::ComparisonOperator op = NETANode::comparisonOperators().enumeration(context->EqualityOperator()->getText());
-    if (!BaseAtom::geometries().isValid(context->geometry->getText()))
+    if (!AtomBase::geometries().isValid(context->geometry->getText()))
         throw(NETAExceptions::NETASyntaxException(
             std::format("'{}' is not a valid geometry type.\n", context->geometry->getText())));
-    BaseAtom::AtomGeometry geom = BaseAtom::geometries().enumeration(context->geometry->getText());
+    AtomBase::AtomGeometry geom = AtomBase::geometries().enumeration(context->geometry->getText());
 
     geometryNode->set(op, geom);
 

--- a/src/neta/bondCount.cpp
+++ b/src/neta/bondCount.cpp
@@ -25,7 +25,7 @@ void NETABondCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETABondCountNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETABondCountNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;

--- a/src/neta/bondCount.cpp
+++ b/src/neta/bondCount.cpp
@@ -25,10 +25,10 @@ void NETABondCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETABondCountNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETABondCountNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;
 
-    return compareValues(i->bonds().size(), operator_, *value_) ? 1 : NETANode::NoMatch;
+    return compareValues(i->nBonds(), operator_, *value_) ? 1 : NETANode::NoMatch;
 }

--- a/src/neta/bondCount.h
+++ b/src/neta/bondCount.h
@@ -34,5 +34,5 @@ class NETABondCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/bondCount.h
+++ b/src/neta/bondCount.h
@@ -34,5 +34,5 @@ class NETABondCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/character.cpp
+++ b/src/neta/character.cpp
@@ -41,7 +41,7 @@ bool NETACharacterNode::addFFTypeTarget(const ForcefieldAtomType &ffType)
  */
 
 // Evaluate the node and return its score
-int NETACharacterNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETACharacterNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     // Check element
     if (std::find(allowedElements_.begin(), allowedElements_.end(), i->Z()) != allowedElements_.end() && !reverseLogic_)

--- a/src/neta/character.cpp
+++ b/src/neta/character.cpp
@@ -41,7 +41,7 @@ bool NETACharacterNode::addFFTypeTarget(const ForcefieldAtomType &ffType)
  */
 
 // Evaluate the node and return its score
-int NETACharacterNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETACharacterNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     // Check element
     if (std::find(allowedElements_.begin(), allowedElements_.end(), i->Z()) != allowedElements_.end() && !reverseLogic_)

--- a/src/neta/character.h
+++ b/src/neta/character.h
@@ -40,5 +40,5 @@ class NETACharacterNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/character.h
+++ b/src/neta/character.h
@@ -40,5 +40,5 @@ class NETACharacterNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -114,10 +114,10 @@ bool NETAConnectionNode::setFlag(std::string_view flag, bool state)
  */
 
 // Evaluate the node and return its score
-int NETAConnectionNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETAConnectionNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     // Get directly connected atoms about 'i', excluding any that have already been matched
-    std::map<const SpeciesAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
+    std::map<const BaseAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
     for (const auto *bond : i->bonds())
     {
         const auto *partner = bond->partner(i);

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -114,10 +114,10 @@ bool NETAConnectionNode::setFlag(std::string_view flag, bool state)
  */
 
 // Evaluate the node and return its score
-int NETAConnectionNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETAConnectionNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     // Get directly connected atoms about 'i', excluding any that have already been matched
-    std::map<const BaseAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
+    std::map<const AtomBase *, std::pair<int, NETAMatchedGroup>> neighbours;
     auto connectedAtoms = i->connectedAtoms();
     for (const auto *neighbour : connectedAtoms)
     {

--- a/src/neta/connection.cpp
+++ b/src/neta/connection.cpp
@@ -118,13 +118,12 @@ int NETAConnectionNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) co
 {
     // Get directly connected atoms about 'i', excluding any that have already been matched
     std::map<const BaseAtom *, std::pair<int, NETAMatchedGroup>> neighbours;
-    for (const auto *bond : i->bonds())
+    auto connectedAtoms = i->connectedAtoms();
+    for (const auto *neighbour : connectedAtoms)
     {
-        const auto *partner = bond->partner(i);
-
         // Search for this atom in the current match path
-        if (!matchPath.contains(partner) || (allowRootMatch_ && matchPath.isRoot(partner)))
-            neighbours.emplace(partner, std::pair<int, NETAMatchedGroup>(NETANode::NoMatch, matchPath));
+        if (!matchPath.contains(neighbour) || (allowRootMatch_ && matchPath.isRoot(neighbour)))
+            neighbours.emplace(neighbour, std::pair<int, NETAMatchedGroup>(NETANode::NoMatch, matchPath));
     }
 
     // Loop over neighbour atoms

--- a/src/neta/connection.h
+++ b/src/neta/connection.h
@@ -83,5 +83,5 @@ class NETAConnectionNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/connection.h
+++ b/src/neta/connection.h
@@ -83,5 +83,5 @@ class NETAConnectionNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/geometry.cpp
+++ b/src/neta/geometry.cpp
@@ -26,7 +26,7 @@ void NETAGeometryNode::set(ComparisonOperator op, SpeciesAtom::AtomGeometry geom
  */
 
 // Evaluate the node and return its score
-int NETAGeometryNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETAGeometryNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     auto result = i->isGeometry(geometry_);
 

--- a/src/neta/geometry.cpp
+++ b/src/neta/geometry.cpp
@@ -5,7 +5,7 @@
 #include "classes/speciesAtom.h"
 
 NETAGeometryNode::NETAGeometryNode(NETADefinition *parent)
-    : NETANode(parent, NETANode::NodeType::Geometry), geometry_(SpeciesAtom::AtomGeometry::Unknown),
+    : NETANode(parent, NETANode::NodeType::Geometry), geometry_(BaseAtom::AtomGeometry::Unknown),
       operator_(NETANode::ComparisonOperator::EqualTo)
 {
 }
@@ -15,7 +15,7 @@ NETAGeometryNode::NETAGeometryNode(NETADefinition *parent)
  */
 
 // Set bond count requirements
-void NETAGeometryNode::set(ComparisonOperator op, SpeciesAtom::AtomGeometry geometry)
+void NETAGeometryNode::set(ComparisonOperator op, BaseAtom::AtomGeometry geometry)
 {
     geometry_ = geometry;
     operator_ = op;
@@ -26,7 +26,7 @@ void NETAGeometryNode::set(ComparisonOperator op, SpeciesAtom::AtomGeometry geom
  */
 
 // Evaluate the node and return its score
-int NETAGeometryNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETAGeometryNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     auto result = i->isGeometry(geometry_);
 

--- a/src/neta/geometry.cpp
+++ b/src/neta/geometry.cpp
@@ -5,7 +5,7 @@
 #include "classes/speciesAtom.h"
 
 NETAGeometryNode::NETAGeometryNode(NETADefinition *parent)
-    : NETANode(parent, NETANode::NodeType::Geometry), geometry_(BaseAtom::AtomGeometry::Unknown),
+    : NETANode(parent, NETANode::NodeType::Geometry), geometry_(SpeciesAtom::AtomGeometry::Unknown),
       operator_(NETANode::ComparisonOperator::EqualTo)
 {
 }
@@ -15,7 +15,7 @@ NETAGeometryNode::NETAGeometryNode(NETADefinition *parent)
  */
 
 // Set bond count requirements
-void NETAGeometryNode::set(ComparisonOperator op, BaseAtom::AtomGeometry geometry)
+void NETAGeometryNode::set(ComparisonOperator op, SpeciesAtom::AtomGeometry geometry)
 {
     geometry_ = geometry;
     operator_ = op;

--- a/src/neta/geometry.h
+++ b/src/neta/geometry.h
@@ -34,5 +34,5 @@ class NETAGeometryNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/geometry.h
+++ b/src/neta/geometry.h
@@ -34,5 +34,5 @@ class NETAGeometryNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/hydrogenCount.cpp
+++ b/src/neta/hydrogenCount.cpp
@@ -32,8 +32,8 @@ int NETAHydrogenCountNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath)
         return NETANode::NoMatch;
 
     // Count number of hydrogens attached to this atom
-    auto nH = std::count_if(i->bonds().begin(), i->bonds().end(),
-                            [i](const auto *bond) { return bond->partner(i)->Z() == Elements::H; });
+    auto connectedAtoms = i->connectedAtoms();
+    auto nH = std::ranges::count_if(connectedAtoms, [i](const auto *neighbour) { return neighbour->Z() == Elements::H; });
 
     return compareValues(nH, operator_, *value_) ? 1 : NETANode::NoMatch;
 }

--- a/src/neta/hydrogenCount.cpp
+++ b/src/neta/hydrogenCount.cpp
@@ -26,7 +26,7 @@ void NETAHydrogenCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETAHydrogenCountNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETAHydrogenCountNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;

--- a/src/neta/hydrogenCount.cpp
+++ b/src/neta/hydrogenCount.cpp
@@ -26,7 +26,7 @@ void NETAHydrogenCountNode::set(ComparisonOperator op, int value)
  */
 
 // Evaluate the node and return its score
-int NETAHydrogenCountNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETAHydrogenCountNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     if (!value_)
         return NETANode::NoMatch;

--- a/src/neta/hydrogenCount.h
+++ b/src/neta/hydrogenCount.h
@@ -34,5 +34,5 @@ class NETAHydrogenCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/hydrogenCount.h
+++ b/src/neta/hydrogenCount.h
@@ -34,5 +34,5 @@ class NETAHydrogenCountNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/matchedGroup.cpp
+++ b/src/neta/matchedGroup.cpp
@@ -6,30 +6,30 @@
 #include "classes/speciesBond.h"
 #include <algorithm>
 
-NETAMatchedGroup::NETAMatchedGroup(const BaseAtom *root) : root_(root) {}
+NETAMatchedGroup::NETAMatchedGroup(const AtomBase *root) : root_(root) {}
 
 /*
  * Data
  */
 
 // Return set of matched atoms
-const std::set<const BaseAtom *> &NETAMatchedGroup::set() const { return set_; }
+const std::set<const AtomBase *> &NETAMatchedGroup::set() const { return set_; }
 
 // Return identified atoms (if any) in the group
-const std::map<std::string, std::set<const BaseAtom *>> &NETAMatchedGroup::identifiers() const { return identifiers_; }
+const std::map<std::string, std::set<const AtomBase *>> &NETAMatchedGroup::identifiers() const { return identifiers_; }
 
 /*
  * Path Management
  */
 
 // Insert atom into group
-void NETAMatchedGroup::insert(const BaseAtom *i) { set_.insert(i); }
+void NETAMatchedGroup::insert(const AtomBase *i) { set_.insert(i); }
 
 // Return whether the set contains the specified atom
-bool NETAMatchedGroup::contains(const BaseAtom *i) const { return set_.find(i) != set_.end(); }
+bool NETAMatchedGroup::contains(const AtomBase *i) const { return set_.find(i) != set_.end(); }
 
 // Return whether the specified atom is the root atom of the match
-bool NETAMatchedGroup::isRoot(const BaseAtom *i) const { return root_ == i; }
+bool NETAMatchedGroup::isRoot(const AtomBase *i) const { return root_ == i; }
 
 // Merge supplied set into this one, inserting new atoms and copying any relevant identifiers
 void NETAMatchedGroup::merge(const NETAMatchedGroup &other)
@@ -44,4 +44,4 @@ void NETAMatchedGroup::merge(const NETAMatchedGroup &other)
 }
 
 // Add identifier for specified atom
-void NETAMatchedGroup::addIdentifier(const BaseAtom *i, std::string id) { identifiers_[id].insert(i); }
+void NETAMatchedGroup::addIdentifier(const AtomBase *i, std::string id) { identifiers_[id].insert(i); }

--- a/src/neta/matchedGroup.cpp
+++ b/src/neta/matchedGroup.cpp
@@ -6,30 +6,30 @@
 #include "classes/speciesBond.h"
 #include <algorithm>
 
-NETAMatchedGroup::NETAMatchedGroup(const SpeciesAtom *root) : root_(root) {}
+NETAMatchedGroup::NETAMatchedGroup(const BaseAtom *root) : root_(root) {}
 
 /*
  * Data
  */
 
 // Return set of matched atoms
-const std::set<const SpeciesAtom *> &NETAMatchedGroup::set() const { return set_; }
+const std::set<const BaseAtom *> &NETAMatchedGroup::set() const { return set_; }
 
 // Return identified atoms (if any) in the group
-const std::map<std::string, std::set<const SpeciesAtom *>> &NETAMatchedGroup::identifiers() const { return identifiers_; }
+const std::map<std::string, std::set<const BaseAtom *>> &NETAMatchedGroup::identifiers() const { return identifiers_; }
 
 /*
  * Path Management
  */
 
 // Insert atom into group
-void NETAMatchedGroup::insert(const SpeciesAtom *i) { set_.insert(i); }
+void NETAMatchedGroup::insert(const BaseAtom *i) { set_.insert(i); }
 
 // Return whether the set contains the specified atom
-bool NETAMatchedGroup::contains(const SpeciesAtom *i) const { return set_.find(i) != set_.end(); }
+bool NETAMatchedGroup::contains(const BaseAtom *i) const { return set_.find(i) != set_.end(); }
 
 // Return whether the specified atom is the root atom of the match
-bool NETAMatchedGroup::isRoot(const SpeciesAtom *i) const { return root_ == i; }
+bool NETAMatchedGroup::isRoot(const BaseAtom *i) const { return root_ == i; }
 
 // Merge supplied set into this one, inserting new atoms and copying any relevant identifiers
 void NETAMatchedGroup::merge(const NETAMatchedGroup &other)
@@ -44,4 +44,4 @@ void NETAMatchedGroup::merge(const NETAMatchedGroup &other)
 }
 
 // Add identifier for specified atom
-void NETAMatchedGroup::addIdentifier(const SpeciesAtom *i, std::string id) { identifiers_[id].insert(i); }
+void NETAMatchedGroup::addIdentifier(const BaseAtom *i, std::string id) { identifiers_[id].insert(i); }

--- a/src/neta/matchedGroup.h
+++ b/src/neta/matchedGroup.h
@@ -9,13 +9,13 @@
 #include <vector>
 
 // Forward Declarations
-class SpeciesAtom;
+class BaseAtom;
 
 // NETA Matched Group
 class NETAMatchedGroup
 {
     public:
-    NETAMatchedGroup(const SpeciesAtom *root = nullptr);
+    NETAMatchedGroup(const BaseAtom *root = nullptr);
     ~NETAMatchedGroup() = default;
 
     /*
@@ -23,30 +23,30 @@ class NETAMatchedGroup
      */
     private:
     // Root atom of the matched group
-    const SpeciesAtom *root_;
+    const BaseAtom *root_;
     // Set of matched atoms
-    std::set<const SpeciesAtom *> set_;
+    std::set<const BaseAtom *> set_;
     // Identified atoms (if any) in path
-    std::map<std::string, std::set<const SpeciesAtom *>> identifiers_;
+    std::map<std::string, std::set<const BaseAtom *>> identifiers_;
 
     public:
     // Return set of matched atoms
-    const std::set<const SpeciesAtom *> &set() const;
+    const std::set<const BaseAtom *> &set() const;
     // Return identified atoms (if any) in the group
-    const std::map<std::string, std::set<const SpeciesAtom *>> &identifiers() const;
+    const std::map<std::string, std::set<const BaseAtom *>> &identifiers() const;
 
     /*
      * Group Management
      */
     public:
     // Insert atom into group
-    void insert(const SpeciesAtom *i);
+    void insert(const BaseAtom *i);
     // Return whether the set contains the specified atom
-    bool contains(const SpeciesAtom *i) const;
+    bool contains(const BaseAtom *i) const;
     // Return whether the specified atom is the root atom of the match
-    bool isRoot(const SpeciesAtom *i) const;
+    bool isRoot(const BaseAtom *i) const;
     // Merge supplied group into this one, inserting new atoms and copying any relevant identifiers
     void merge(const NETAMatchedGroup &other);
     // Add identifier for specified atom
-    void addIdentifier(const SpeciesAtom *i, std::string id);
+    void addIdentifier(const BaseAtom *i, std::string id);
 };

--- a/src/neta/matchedGroup.h
+++ b/src/neta/matchedGroup.h
@@ -9,13 +9,13 @@
 #include <vector>
 
 // Forward Declarations
-class BaseAtom;
+class AtomBase;
 
 // NETA Matched Group
 class NETAMatchedGroup
 {
     public:
-    NETAMatchedGroup(const BaseAtom *root = nullptr);
+    NETAMatchedGroup(const AtomBase *root = nullptr);
     ~NETAMatchedGroup() = default;
 
     /*
@@ -23,30 +23,30 @@ class NETAMatchedGroup
      */
     private:
     // Root atom of the matched group
-    const BaseAtom *root_;
+    const AtomBase *root_;
     // Set of matched atoms
-    std::set<const BaseAtom *> set_;
+    std::set<const AtomBase *> set_;
     // Identified atoms (if any) in path
-    std::map<std::string, std::set<const BaseAtom *>> identifiers_;
+    std::map<std::string, std::set<const AtomBase *>> identifiers_;
 
     public:
     // Return set of matched atoms
-    const std::set<const BaseAtom *> &set() const;
+    const std::set<const AtomBase *> &set() const;
     // Return identified atoms (if any) in the group
-    const std::map<std::string, std::set<const BaseAtom *>> &identifiers() const;
+    const std::map<std::string, std::set<const AtomBase *>> &identifiers() const;
 
     /*
      * Group Management
      */
     public:
     // Insert atom into group
-    void insert(const BaseAtom *i);
+    void insert(const AtomBase *i);
     // Return whether the set contains the specified atom
-    bool contains(const BaseAtom *i) const;
+    bool contains(const AtomBase *i) const;
     // Return whether the specified atom is the root atom of the match
-    bool isRoot(const BaseAtom *i) const;
+    bool isRoot(const AtomBase *i) const;
     // Merge supplied group into this one, inserting new atoms and copying any relevant identifiers
     void merge(const NETAMatchedGroup &other);
     // Add identifier for specified atom
-    void addIdentifier(const BaseAtom *i, std::string id);
+    void addIdentifier(const AtomBase *i, std::string id);
 };

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -21,7 +21,7 @@ NETADefinition::NETADefinition(std::string_view definition) : rootNode_(nullptr)
         create(definition);
 }
 
-NETADefinition::NETADefinition(const SpeciesAtom *i, const std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
+NETADefinition::NETADefinition(const BaseAtom *i, const std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
     : rootNode_(nullptr), valid_(false)
 {
     create(i, maxDepth, flags);
@@ -99,8 +99,8 @@ bool NETADefinition::create(std::string_view definition, const Forcefield *assoc
 }
 
 // Recursively create a NETA string for the specified atom
-std::string netaString(const SpeciesAtom *i, int currentDepth, const std::optional<int> maxDepth,
-                       std::vector<const SpeciesAtom *> &path, const Flags<NETADefinition::NETACreationFlags> &flags = {})
+std::string netaString(const BaseAtom *i, int currentDepth, const std::optional<int> maxDepth,
+                       std::vector<const BaseAtom *> &path, const Flags<NETADefinition::NETACreationFlags> &flags = {})
 {
     // Add this atom to the path
     path.push_back(i);
@@ -138,9 +138,9 @@ std::string netaString(const SpeciesAtom *i, int currentDepth, const std::option
 }
 
 // Create from specified atom and its connectivity
-bool NETADefinition::create(const SpeciesAtom *i, std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
+bool NETADefinition::create(const BaseAtom *i, std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
 {
-    std::vector<const SpeciesAtom *> path;
+    std::vector<const BaseAtom *> path;
     definitionString_ = netaString(i, 0, maxDepth, path, flags);
     return create();
 }
@@ -164,17 +164,17 @@ const std::set<std::string> &NETADefinition::identifiers() const { return identi
  */
 
 // Return score of supplied atom for this definition
-int NETADefinition::score(const SpeciesAtom *i) const
+int NETADefinition::score(const BaseAtom *i) const
 {
     NETAMatchedGroup matchPath(i);
     return rootNode_->score(i, matchPath);
 }
 
 // Return whether the supplied atom matches the definition
-bool NETADefinition::matches(const SpeciesAtom *i) const { return score(i) != NETANode::NoMatch; }
+bool NETADefinition::matches(const BaseAtom *i) const { return score(i) != NETANode::NoMatch; }
 
 // Return the path of matched atoms, including the target atom, if the definition matches
-NETAMatchedGroup NETADefinition::matchedPath(const SpeciesAtom *i) const
+NETAMatchedGroup NETADefinition::matchedPath(const BaseAtom *i) const
 {
     NETAMatchedGroup matchPath(i);
     if (rootNode_->score(i, matchPath) == NETANode::NoMatch)

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -21,7 +21,7 @@ NETADefinition::NETADefinition(std::string_view definition) : rootNode_(nullptr)
         create(definition);
 }
 
-NETADefinition::NETADefinition(const BaseAtom *i, const std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
+NETADefinition::NETADefinition(const AtomBase *i, const std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
     : rootNode_(nullptr), valid_(false)
 {
     create(i, maxDepth, flags);
@@ -99,8 +99,8 @@ bool NETADefinition::create(std::string_view definition, const Forcefield *assoc
 }
 
 // Recursively create a NETA string for the specified atom
-std::string netaString(const BaseAtom *i, int currentDepth, const std::optional<int> maxDepth,
-                       std::vector<const BaseAtom *> &path, const Flags<NETADefinition::NETACreationFlags> &flags = {})
+std::string netaString(const AtomBase *i, int currentDepth, const std::optional<int> maxDepth,
+                       std::vector<const AtomBase *> &path, const Flags<NETADefinition::NETACreationFlags> &flags = {})
 {
     // Add this atom to the path
     path.push_back(i);
@@ -138,9 +138,9 @@ std::string netaString(const BaseAtom *i, int currentDepth, const std::optional<
 }
 
 // Create from specified atom and its connectivity
-bool NETADefinition::create(const BaseAtom *i, std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
+bool NETADefinition::create(const AtomBase *i, std::optional<int> maxDepth, const Flags<NETACreationFlags> &flags)
 {
-    std::vector<const BaseAtom *> path;
+    std::vector<const AtomBase *> path;
     definitionString_ = netaString(i, 0, maxDepth, path, flags);
     return create();
 }
@@ -165,17 +165,17 @@ const std::set<std::string> &NETADefinition::identifiers() const { return identi
  */
 
 // Return score of supplied atom for this definition
-int NETADefinition::score(const BaseAtom *i) const
+int NETADefinition::score(const AtomBase *i) const
 {
     NETAMatchedGroup matchPath(i);
     return rootNode_->score(i, matchPath);
 }
 
 // Return whether the supplied atom matches the definition
-bool NETADefinition::matches(const BaseAtom *i) const { return score(i) != NETANode::NoMatch; }
+bool NETADefinition::matches(const AtomBase *i) const { return score(i) != NETANode::NoMatch; }
 
 // Return the path of matched atoms, including the target atom, if the definition matches
-NETAMatchedGroup NETADefinition::matchedPath(const BaseAtom *i) const
+NETAMatchedGroup NETADefinition::matchedPath(const AtomBase *i) const
 {
     NETAMatchedGroup matchPath(i);
     if (rootNode_->score(i, matchPath) == NETANode::NoMatch)

--- a/src/neta/neta.cpp
+++ b/src/neta/neta.cpp
@@ -105,16 +105,16 @@ std::string netaString(const BaseAtom *i, int currentDepth, const std::optional<
     // Add this atom to the path
     path.push_back(i);
 
+    auto connectedAtoms = i->connectedAtoms();
+
     auto neta = flags.isSet(NETADefinition::NETACreationFlags::IncludeRootElement) && currentDepth == 0
-                    ? std::format("?{}, nbonds={}", Elements::symbol(i->Z()), i->bonds().size())
-                    : std::format("nbonds={}", i->bonds().size());
+                    ? std::format("?{}, nbonds={}", Elements::symbol(i->Z()), connectedAtoms.size())
+                    : std::format("nbonds={}", connectedAtoms.size());
 
     // Add on each connected atom, provided it is not already in the path
     auto nH = 0;
-    for (auto &b : i->bonds())
+    for (auto j : connectedAtoms)
     {
-        auto j = b->partner(i);
-
         // Check for H
         if (!flags.isSet(NETADefinition::NETACreationFlags::ExplicitHydrogens) && j->Z() == Elements::H)
         {
@@ -156,6 +156,7 @@ bool NETADefinition::isValid() const { return valid_; }
 
 // Add an identifier
 void NETADefinition::addIdentifier(std::string identifier) { identifiers_.insert(identifier); }
+
 // Return identifiers
 const std::set<std::string> &NETADefinition::identifiers() const { return identifiers_; }
 

--- a/src/neta/neta.h
+++ b/src/neta/neta.h
@@ -10,7 +10,7 @@
 
 // Forward Declarations
 class Forcefield;
-class SpeciesAtom;
+class BaseAtom;
 
 // NETA Definition
 class NETADefinition
@@ -23,7 +23,7 @@ class NETADefinition
         IncludeRootElement /* Include the root element in NETA definition string */
     };
     explicit NETADefinition(std::string_view definition = "");
-    NETADefinition(const SpeciesAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
+    NETADefinition(const BaseAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
     ~NETADefinition() = default;
 
     /*
@@ -47,7 +47,7 @@ class NETADefinition
     // Set definition string and create definition
     bool create(std::string_view definition, const Forcefield *associatedFF = nullptr);
     // Create from specified atom and its connectivity
-    bool create(const SpeciesAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
+    bool create(const BaseAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
     // Set generating string
     void setDefinitionString(std::string_view definition);
     // Return original generating string
@@ -64,11 +64,11 @@ class NETADefinition
      */
     public:
     // Return score of supplied atom for the definition
-    int score(const SpeciesAtom *i) const;
+    int score(const BaseAtom *i) const;
     // Return whether the supplied atom matches the definition
-    bool matches(const SpeciesAtom *i) const;
+    bool matches(const BaseAtom *i) const;
     // Return the path of matched atoms, including the target atom, if the definition matches
-    NETAMatchedGroup matchedPath(const SpeciesAtom *i) const;
+    NETAMatchedGroup matchedPath(const BaseAtom *i) const;
 
     /*
      * Axes

--- a/src/neta/neta.h
+++ b/src/neta/neta.h
@@ -10,7 +10,7 @@
 
 // Forward Declarations
 class Forcefield;
-class BaseAtom;
+class AtomBase;
 
 // NETA Definition
 class NETADefinition
@@ -23,7 +23,7 @@ class NETADefinition
         IncludeRootElement /* Include the root element in NETA definition string */
     };
     explicit NETADefinition(std::string_view definition = "");
-    NETADefinition(const BaseAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
+    NETADefinition(const AtomBase *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
     ~NETADefinition() = default;
 
     /*
@@ -47,7 +47,7 @@ class NETADefinition
     // Set definition string and create definition
     bool create(std::string_view definition, const Forcefield *associatedFF = nullptr);
     // Create from specified atom and its connectivity
-    bool create(const BaseAtom *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
+    bool create(const AtomBase *i, const std::optional<int> maxDepth = 1, const Flags<NETACreationFlags> &flags = {});
     // Set generating string
     void setDefinitionString(std::string_view definition);
     // Return original generating string
@@ -64,11 +64,11 @@ class NETADefinition
      */
     public:
     // Return score of supplied atom for the definition
-    int score(const BaseAtom *i) const;
+    int score(const AtomBase *i) const;
     // Return whether the supplied atom matches the definition
-    bool matches(const BaseAtom *i) const;
+    bool matches(const AtomBase *i) const;
     // Return the path of matched atoms, including the target atom, if the definition matches
-    NETAMatchedGroup matchedPath(const BaseAtom *i) const;
+    NETAMatchedGroup matchedPath(const AtomBase *i) const;
 
     /*
      * Axes

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -167,7 +167,7 @@ bool NETANode::compareValues(int lhsValue, ComparisonOperator op, int rhsValue)
  */
 
 // Evaluate the provided sequence and return a score
-int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i, NETAMatchedGroup &matchPath)
+int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const BaseAtom *i, NETAMatchedGroup &matchPath)
 {
     auto totalScore = 0;
     auto newMatchPath = matchPath;
@@ -194,7 +194,7 @@ int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const Specie
 void NETANode::setReverseLogic() { reverseLogic_ = true; }
 
 // Evaluate the node and return its score
-int NETANode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETANode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     auto branchScore = sequenceScore(nodes_, i, matchPath);
 

--- a/src/neta/node.cpp
+++ b/src/neta/node.cpp
@@ -167,7 +167,7 @@ bool NETANode::compareValues(int lhsValue, ComparisonOperator op, int rhsValue)
  */
 
 // Evaluate the provided sequence and return a score
-int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const BaseAtom *i, NETAMatchedGroup &matchPath)
+int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const AtomBase *i, NETAMatchedGroup &matchPath)
 {
     auto totalScore = 0;
     auto newMatchPath = matchPath;
@@ -194,7 +194,7 @@ int NETANode::sequenceScore(const NETANode::NETASequence &sequence, const BaseAt
 void NETANode::setReverseLogic() { reverseLogic_ = true; }
 
 // Evaluate the node and return its score
-int NETANode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETANode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     auto branchScore = sequenceScore(nodes_, i, matchPath);
 

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -14,6 +14,7 @@
 // Forward Declarations
 class ForcefieldAtomType;
 class NETADefinition;
+class BaseAtom;
 
 // NETA Node
 class NETANode
@@ -151,11 +152,11 @@ class NETANode
 
     protected:
     // Evaluate the provided sequence and return a score
-    static int sequenceScore(const NETANode::NETASequence &sequence, const SpeciesAtom *i, NETAMatchedGroup &matchPath);
+    static int sequenceScore(const NETANode::NETASequence &sequence, const BaseAtom *i, NETAMatchedGroup &matchPath);
 
     public:
     // Set node to use reverse logic
     void setReverseLogic();
     // Evaluate the node and return its score
-    virtual int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const;
+    virtual int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const;
 };

--- a/src/neta/node.h
+++ b/src/neta/node.h
@@ -14,7 +14,7 @@
 // Forward Declarations
 class ForcefieldAtomType;
 class NETADefinition;
-class BaseAtom;
+class AtomBase;
 
 // NETA Node
 class NETANode
@@ -152,11 +152,11 @@ class NETANode
 
     protected:
     // Evaluate the provided sequence and return a score
-    static int sequenceScore(const NETANode::NETASequence &sequence, const BaseAtom *i, NETAMatchedGroup &matchPath);
+    static int sequenceScore(const NETANode::NETASequence &sequence, const AtomBase *i, NETAMatchedGroup &matchPath);
 
     public:
     // Set node to use reverse logic
     void setReverseLogic();
     // Evaluate the node and return its score
-    virtual int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const;
+    virtual int score(const AtomBase *i, NETAMatchedGroup &matchPath) const;
 };

--- a/src/neta/or.cpp
+++ b/src/neta/or.cpp
@@ -18,7 +18,7 @@ void NETAOrNode::setAlternativeNodes(NETASequence nodes) { altNodes_ = std::move
  */
 
 // Evaluate the node and return its score
-int NETAOrNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETAOrNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     auto score = sequenceScore(nodes_, i, matchPath);
     if (score != NETANode::NoMatch)

--- a/src/neta/or.cpp
+++ b/src/neta/or.cpp
@@ -18,7 +18,7 @@ void NETAOrNode::setAlternativeNodes(NETASequence nodes) { altNodes_ = std::move
  */
 
 // Evaluate the node and return its score
-int NETAOrNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETAOrNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     auto score = sequenceScore(nodes_, i, matchPath);
     if (score != NETANode::NoMatch)

--- a/src/neta/or.h
+++ b/src/neta/or.h
@@ -38,5 +38,5 @@ class NETAOrNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/or.h
+++ b/src/neta/or.h
@@ -38,5 +38,5 @@ class NETAOrNode : public NETANode
      */
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -69,14 +69,14 @@ void NETARingNode::findRings(const BaseAtom *currentAtom, std::vector<SpeciesRin
     path.push_back(currentAtom);
 
     // Loop over bonds to the atom
-    for (const auto *bond : currentAtom->bonds())
+    auto connectedAtoms = currentAtom->connectedAtoms();
+    for (const auto *j : connectedAtoms)
     {
         /*
          * Get the partner atom and compare to first atom in the current path.
          * If it is the currentAtom then we have found a cyclic route back to the originating atom.
          * If not, check whether the atom is already elsewhere in the path - if so, continue with the next bond.
          */
-        const auto *j = bond->partner(currentAtom);
         if ((path.size() >= minSize) && (j == path.at(0)))
         {
             // Special case - if NotEqualTo was specified as the comparison operator, check that against the maximum

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -58,8 +58,8 @@ bool NETARingNode::setModifier(std::string_view modifier, ComparisonOperator op,
  */
 
 // Locate rings in which the specified atom is involved
-void NETARingNode::findRings(const SpeciesAtom *currentAtom, std::vector<SpeciesRing> &rings,
-                             std::vector<const SpeciesAtom *> &path, const int minSize, const int maxSize) const
+void NETARingNode::findRings(const BaseAtom *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const BaseAtom *> &path,
+                             const int minSize, const int maxSize) const
 {
     // Check whether the path is already at the maximum size - if so, return immediately.
     if (path.size() == maxSize)
@@ -102,11 +102,11 @@ void NETARingNode::findRings(const SpeciesAtom *currentAtom, std::vector<Species
 }
 
 // Evaluate the node and return its score
-int NETARingNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETARingNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     // Generate array of rings of specified size that the atom 'i' is present in
     std::vector<SpeciesRing> rings;
-    std::vector<const SpeciesAtom *> ringPath;
+    std::vector<const BaseAtom *> ringPath;
     if (!sizeValue_)
         findRings(i, rings, ringPath, 3, 6);
     else if (sizeValueOperator_ == NETANode::ComparisonOperator::EqualTo)
@@ -136,7 +136,7 @@ int NETARingNode::score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
             // Copy the iterator to use for forward and backward traversal around the ring
             auto forwardIt = ringAtomIt, backwardIt = ringAtomIt;
 
-            std::map<const SpeciesAtom *, std::pair<int, NETAMatchedGroup>> forwardMatches, backwardMatches;
+            std::map<const BaseAtom *, std::pair<int, NETAMatchedGroup>> forwardMatches, backwardMatches;
             auto totalAttemptedNodeMatches = 0;
 
             // Loop over defined nodes

--- a/src/neta/ring.cpp
+++ b/src/neta/ring.cpp
@@ -58,7 +58,7 @@ bool NETARingNode::setModifier(std::string_view modifier, ComparisonOperator op,
  */
 
 // Locate rings in which the specified atom is involved
-void NETARingNode::findRings(const BaseAtom *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const BaseAtom *> &path,
+void NETARingNode::findRings(const AtomBase *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const AtomBase *> &path,
                              const int minSize, const int maxSize) const
 {
     // Check whether the path is already at the maximum size - if so, return immediately.
@@ -102,11 +102,11 @@ void NETARingNode::findRings(const BaseAtom *currentAtom, std::vector<SpeciesRin
 }
 
 // Evaluate the node and return its score
-int NETARingNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETARingNode::score(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     // Generate array of rings of specified size that the atom 'i' is present in
     std::vector<SpeciesRing> rings;
-    std::vector<const BaseAtom *> ringPath;
+    std::vector<const AtomBase *> ringPath;
     if (!sizeValue_)
         findRings(i, rings, ringPath, 3, 6);
     else if (sizeValueOperator_ == NETANode::ComparisonOperator::EqualTo)
@@ -136,7 +136,7 @@ int NETARingNode::score(const BaseAtom *i, NETAMatchedGroup &matchPath) const
             // Copy the iterator to use for forward and backward traversal around the ring
             auto forwardIt = ringAtomIt, backwardIt = ringAtomIt;
 
-            std::map<const BaseAtom *, std::pair<int, NETAMatchedGroup>> forwardMatches, backwardMatches;
+            std::map<const AtomBase *, std::pair<int, NETAMatchedGroup>> forwardMatches, backwardMatches;
             auto totalAttemptedNodeMatches = 0;
 
             // Loop over defined nodes

--- a/src/neta/ring.h
+++ b/src/neta/ring.h
@@ -52,10 +52,10 @@ class NETARingNode : public NETANode
      */
     private:
     // Locate rings in which the specified atom is involved
-    void findRings(const SpeciesAtom *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const SpeciesAtom *> &path,
+    void findRings(const BaseAtom *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const BaseAtom *> &path,
                    const int minSize, const int maxSize) const;
 
     public:
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/ring.h
+++ b/src/neta/ring.h
@@ -52,10 +52,10 @@ class NETARingNode : public NETANode
      */
     private:
     // Locate rings in which the specified atom is involved
-    void findRings(const BaseAtom *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const BaseAtom *> &path,
+    void findRings(const AtomBase *currentAtom, std::vector<SpeciesRing> &rings, std::vector<const AtomBase *> &path,
                    const int minSize, const int maxSize) const;
 
     public:
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/ringAtom.cpp
+++ b/src/neta/ringAtom.cpp
@@ -79,7 +79,7 @@ bool NETARingAtomNode::validRepeatCount(int value) const { return compareValues(
  */
 
 // Return whether we match the specified atom
-int NETARingAtomNode::matches(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const
+int NETARingAtomNode::matches(const BaseAtom *i, NETAMatchedGroup &matchPath) const
 {
     // Evaluate the atom against our elements
     int atomScore = NETANode::NoMatch;
@@ -117,7 +117,7 @@ int NETARingAtomNode::matches(const SpeciesAtom *i, NETAMatchedGroup &matchPath)
 }
 
 // Evaluate the node and return its score
-int NETARingAtomNode::score(const SpeciesAtom *i, NETAMatchedGroup &availableAtoms) const
+int NETARingAtomNode::score(const BaseAtom *i, NETAMatchedGroup &availableAtoms) const
 {
     throw(std::runtime_error("NETARingAtomNode was called via its score() function, but this should never be done.\n"));
 }

--- a/src/neta/ringAtom.cpp
+++ b/src/neta/ringAtom.cpp
@@ -79,7 +79,7 @@ bool NETARingAtomNode::validRepeatCount(int value) const { return compareValues(
  */
 
 // Return whether we match the specified atom
-int NETARingAtomNode::matches(const BaseAtom *i, NETAMatchedGroup &matchPath) const
+int NETARingAtomNode::matches(const AtomBase *i, NETAMatchedGroup &matchPath) const
 {
     // Evaluate the atom against our elements
     int atomScore = NETANode::NoMatch;
@@ -117,7 +117,7 @@ int NETARingAtomNode::matches(const BaseAtom *i, NETAMatchedGroup &matchPath) co
 }
 
 // Evaluate the node and return its score
-int NETARingAtomNode::score(const BaseAtom *i, NETAMatchedGroup &availableAtoms) const
+int NETARingAtomNode::score(const AtomBase *i, NETAMatchedGroup &availableAtoms) const
 {
     throw(std::runtime_error("NETARingAtomNode was called via its score() function, but this should never be done.\n"));
 }

--- a/src/neta/ringAtom.h
+++ b/src/neta/ringAtom.h
@@ -65,7 +65,7 @@ class NETARingAtomNode : public NETANode
      */
     public:
     // Return whether we match the specified atom
-    int matches(const BaseAtom *i, NETAMatchedGroup &matchPath) const;
+    int matches(const AtomBase *i, NETAMatchedGroup &matchPath) const;
     // Evaluate the node and return its score
-    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const AtomBase *i, NETAMatchedGroup &matchPath) const override;
 };

--- a/src/neta/ringAtom.h
+++ b/src/neta/ringAtom.h
@@ -65,7 +65,7 @@ class NETARingAtomNode : public NETANode
      */
     public:
     // Return whether we match the specified atom
-    int matches(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const;
+    int matches(const BaseAtom *i, NETAMatchedGroup &matchPath) const;
     // Evaluate the node and return its score
-    int score(const SpeciesAtom *i, NETAMatchedGroup &matchPath) const override;
+    int score(const BaseAtom *i, NETAMatchedGroup &matchPath) const override;
 };


### PR DESCRIPTION
This PR completes the long journey of immutable species, structure, and generic NETA usage. The dependence on `SpeciesAtom` is removed from the NETA classes and replaced by `BaseAtom`.