### PR TITLE
chore: Species TOML atom indexing

### DIFF
--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -249,7 +249,7 @@ void Species::deserialise(const SerialisedValue &node)
         node, "bonds",
         [this](const SerialisedValue &bond)
         {
-            bonds_.emplace_back(this, &atoms_.at(toml::find<int>(bond, "i") - 1), &atoms_.at(toml::find<int>(bond, "j") - 1))
+            bonds_.emplace_back(this, &atoms_.at(toml::find<int>(bond, "i")), &atoms_.at(toml::find<int>(bond, "j")))
                 .deserialise(bond);
         });
 
@@ -259,37 +259,35 @@ void Species::deserialise(const SerialisedValue &node)
                            [this](const SerialisedValue &angle)
                            {
                                angles_
-                                   .emplace_back(this, &atoms_.at(toml::find<int>(angle, "i") - 1),
-                                                 &atoms_.at(toml::find<int>(angle, "j") - 1),
-                                                 &atoms_.at(toml::find<int>(angle, "k") - 1))
+                                   .emplace_back(this, &atoms_.at(toml::find<int>(angle, "i")),
+                                                 &atoms_.at(toml::find<int>(angle, "j")),
+                                                 &atoms_.at(toml::find<int>(angle, "k")))
                                    .deserialise(angle);
                            });
 
     Serialisable::toMap(node, "commonImpropers", [this](const std::string &name, const SerialisedValue &bond)
                         { commonImpropers_.emplace_back(std::make_unique<CommonImproper>(name))->deserialise(bond); });
-    Serialisable::toVector(node, "impropers",
-                           [this](const SerialisedValue &improper)
-                           {
-                               impropers_
-                                   .emplace_back(this, &atoms_.at(toml::find<int>(improper, "i") - 1),
-                                                 &atoms_.at(toml::find<int>(improper, "j") - 1),
-                                                 &atoms_.at(toml::find<int>(improper, "k") - 1),
-                                                 &atoms_.at(toml::find<int>(improper, "l") - 1))
-                                   .deserialise(improper);
-                           });
+    Serialisable::toVector(
+        node, "impropers",
+        [this](const SerialisedValue &improper)
+        {
+            impropers_
+                .emplace_back(this, &atoms_.at(toml::find<int>(improper, "i")), &atoms_.at(toml::find<int>(improper, "j")),
+                              &atoms_.at(toml::find<int>(improper, "k")), &atoms_.at(toml::find<int>(improper, "l")))
+                .deserialise(improper);
+        });
 
     Serialisable::toMap(node, "commonTorsions", [this](const std::string &name, const SerialisedValue &bond)
                         { commonTorsions_.emplace_back(std::make_unique<CommonTorsion>(name))->deserialise(bond); });
-    Serialisable::toVector(node, "torsions",
-                           [this](const SerialisedValue &torsion)
-                           {
-                               torsions_
-                                   .emplace_back(this, &atoms_.at(toml::find<int>(torsion, "i") - 1),
-                                                 &atoms_.at(toml::find<int>(torsion, "j") - 1),
-                                                 &atoms_.at(toml::find<int>(torsion, "k") - 1),
-                                                 &atoms_.at(toml::find<int>(torsion, "l") - 1))
-                                   .deserialise(torsion);
-                           });
+    Serialisable::toVector(
+        node, "torsions",
+        [this](const SerialisedValue &torsion)
+        {
+            torsions_
+                .emplace_back(this, &atoms_.at(toml::find<int>(torsion, "i")), &atoms_.at(toml::find<int>(torsion, "j")),
+                              &atoms_.at(toml::find<int>(torsion, "k")), &atoms_.at(toml::find<int>(torsion, "l")))
+                .deserialise(torsion);
+        });
 
     Serialisable::toMap(node, "isotopologues", [this](const std::string &name, const SerialisedValue &iso)
                         { isotopologues_.emplace_back(std::make_unique<Isotopologue>(this, name))->deserialise(iso); });

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -238,6 +238,8 @@ void Species::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void Species::deserialise(const SerialisedValue &node)
 {
+    setName(toml::find<std::string>(node, "name"));
+
     Serialisable::toMap(node, "atomTypes", [this](const std::string &name, const auto &data)
                         { atomTypes_.emplace_back(std::make_shared<AtomType>(name))->deserialise(data); });
 

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -60,8 +60,8 @@ bool Species::checkSetUp() const
     {
         if (i.atomType() == nullptr)
         {
-            Messenger::error("Atom {} ({}) of species '{}' has no associated atom type.\n", i.userIndex(),
-                             Elements::symbol(i.Z()), name_);
+            Messenger::error("Atom {} ({}) of species '{}' has no associated atom type.\n", i.index(), Elements::symbol(i.Z()),
+                             name_);
             ++nErrors;
         }
     }
@@ -75,8 +75,8 @@ bool Species::checkSetUp() const
     {
         if ((i.bonds().size() == 0) && (atoms_.size() > 1))
         {
-            Messenger::error("SpeciesAtom {} ({}) participates in no Bonds, but is part of a multi-atom Species.\n",
-                             i.userIndex(), Elements::symbol(i.Z()));
+            Messenger::error("SpeciesAtom {} ({}) participates in no Bonds, but is part of a multi-atom Species.\n", i.index(),
+                             Elements::symbol(i.Z()));
             ++nErrors;
         }
     }

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -204,12 +204,13 @@ void SpeciesAngle::serialise(std::string tag, SerialisedValue &target) const
 {
     SpeciesIntra<SpeciesAngle, AngleFunctions>::serialise(tag, target);
     auto &angle = target[tag];
-    if (i_ != nullptr)
-        angle["i"] = i_->userIndex();
-    if (j_ != nullptr)
-        angle["j"] = j_->userIndex();
-    if (k_ != nullptr)
-        angle["k"] = k_->userIndex();
+
+    if (i_ && j_ && k_)
+    {
+        angle["i"] = i_->index();
+        angle["j"] = j_->index();
+        angle["k"] = k_->index();
+    }
 }
 // Read values from a serialisable value
 void SpeciesAngle::deserialise(const SerialisedValue &node)

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -35,9 +35,6 @@ void SpeciesAtom::setAtomType(const AtomType *at)
 // Return SpeciesAtomType of SpeciesAtom
 const AtomType *SpeciesAtom::atomType() const { return atomType_; }
 
-// Return 'user' index (1->N)
-int SpeciesAtom::userIndex() const { return index_ + 1; }
-
 /*
  * Bond Information
  */
@@ -277,7 +274,7 @@ void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 }
 void SpeciesAtom::deserialise(const SerialisedValue &node)
 {
-    index_ = toml::find<int>(node, "index") - 1;
+    index_ = toml::find<int>(node, "index");
 
     set(toml::find<Elements::Element>(node, "z"), toml::find<Vector3>(node, "r"), toml::find_or<double>(node, "q", 0));
 

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -271,7 +271,7 @@ bool SpeciesAtom::isGeometry(const SpeciesAtom *i, AtomGeometry geom) { return g
 // Express as a serialisable value
 void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"index", userIndex()}, {"z", Z_}, {"r", r_}, {"q", q_}};
+    target[tag] = {{"index", index_}, {"z", Z_}, {"r", r_}, {"q", q_}};
     if (atomType_)
         target[tag]["type"] = atomType_->name().data();
 }

--- a/src/classes/speciesAtom.h
+++ b/src/classes/speciesAtom.h
@@ -41,8 +41,6 @@ class SpeciesAtom : public Atom<const SpeciesBond>
     void setAtomType(const AtomType *at);
     // Return AtomType of Atom
     const AtomType *atomType() const;
-    // Return 'user' index (1->N)
-    int userIndex() const;
 
     /*
      * Intramolecular Information

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -190,10 +190,12 @@ void SpeciesBond::serialise(std::string tag, SerialisedValue &target) const
 {
     SpeciesIntra<SpeciesBond, BondFunctions>::serialise(tag, target);
     auto &bond = target[tag];
-    if (i_ != nullptr)
-        bond["i"] = i_->userIndex();
-    if (j_ != nullptr)
-        bond["j"] = j_->userIndex();
+
+    if (i_ && j_)
+    {
+        bond["i"] = i_->index();
+        bond["j"] = j_->index();
+    }
 }
 
 // Read values from a serialisable value

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -124,14 +124,14 @@ void SpeciesImproper::serialise(std::string tag, SerialisedValue &target) const
 {
     SpeciesIntra<SpeciesImproper, TorsionFunctions>::serialise(tag, target);
     auto &improper = target.at(tag);
-    if (i_ != nullptr)
-        improper["i"] = i_->userIndex();
-    if (j_ != nullptr)
-        improper["j"] = j_->userIndex();
-    if (k_ != nullptr)
-        improper["k"] = k_->userIndex();
-    if (l_ != nullptr)
-        improper["l"] = l_->userIndex();
+
+    if (i_ && j_ && k_ && l_)
+    {
+        improper["i"] = i_->index();
+        improper["j"] = j_->index();
+        improper["k"] = k_->index();
+        improper["l"] = l_->index();
+    }
 }
 
 // Read values from a serialisable value

--- a/src/classes/speciesRing.cpp
+++ b/src/classes/speciesRing.cpp
@@ -57,6 +57,6 @@ void SpeciesRing::print() const
 {
     std::string s = std::format("Ring({}) :", atoms_.size());
     for (const auto *atom : atoms_)
-        s += std::format(" {}({})", atom->userIndex(), Elements::symbol(atom->Z()));
+        s += std::format(" {}({})", atom->index(), Elements::symbol(atom->Z()));
     Messenger::print(s);
 }

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -425,14 +425,14 @@ void SpeciesTorsion::serialise(std::string tag, SerialisedValue &target) const
 {
     SpeciesIntra<SpeciesTorsion, TorsionFunctions>::serialise(tag, target);
     auto &torsion = target[tag];
-    if (i_ != nullptr)
-        torsion["i"] = i_->userIndex();
-    if (j_ != nullptr)
-        torsion["j"] = j_->userIndex();
-    if (k_ != nullptr)
-        torsion["k"] = k_->userIndex();
-    if (l_ != nullptr)
-        torsion["l"] = l_->userIndex();
+
+    if (i_ && j_ && k_ && l_)
+    {
+        torsion["i"] = i_->index();
+        torsion["j"] = j_->index();
+        torsion["k"] = k_->index();
+        torsion["l"] = l_->index();
+    }
 
     torsion["q14"] = electrostatic14Scaling_;
     torsion["v14"] = vdw14Scaling_;

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -238,7 +238,7 @@ void Species::finaliseGeometry()
         {
             Messenger::printVerbose("Bond between Atoms {}-{} is present in a cycle, so a minimal set of attached "
                                     "atoms will be used.\n",
-                                    bond.i()->userIndex(), bond.j()->userIndex());
+                                    bond.i()->index(), bond.j()->index());
             bond.setAttachedAtoms(0, bond.i()->index());
             bond.setAttachedAtoms(1, bond.j()->index());
             bond.setInCycle(true);
@@ -273,7 +273,7 @@ void Species::finaliseGeometry()
         {
             Messenger::printVerbose("Angle between Atoms {}-{}-{} is present in a cycle, so a minimal set of "
                                     "attached atoms will be used.\n",
-                                    angle.i()->userIndex(), angle.j()->userIndex(), angle.k()->userIndex());
+                                    angle.i()->index(), angle.j()->index(), angle.k()->index());
             angle.setAttachedAtoms(0, angle.i()->index());
             angle.setAttachedAtoms(1, angle.k()->index());
             angle.setInCycle(true);
@@ -311,8 +311,7 @@ void Species::finaliseGeometry()
         {
             Messenger::printVerbose("Torsion between Atoms {}-{}-{}-{} is present in a cycle, so a minimal set of "
                                     "attached atoms will be used.\n",
-                                    torsion.i()->userIndex(), torsion.j()->userIndex(), torsion.k()->userIndex(),
-                                    torsion.l()->userIndex());
+                                    torsion.i()->index(), torsion.j()->index(), torsion.k()->index(), torsion.l()->index());
             torsion.setAttachedAtoms(0, torsion.i()->index());
             torsion.setAttachedAtoms(1, torsion.l()->index());
             torsion.setInCycle(true);

--- a/src/classes/species_transform.cpp
+++ b/src/classes/species_transform.cpp
@@ -78,9 +78,5 @@ void Species::load(std::string_view tomlFile)
 
     SerialisedValue contents = toml::parse(std::string(tomlFile));
     if (contents.contains("species"))
-    {
         deserialise(contents["species"]);
-        auto name = contents["species"]["name"].as_string();
-        setName(name.str);
-    }
 }

--- a/src/data/ff/ff.cpp
+++ b/src/data/ff/ff.cpp
@@ -80,7 +80,7 @@ OptionalReferenceWrapper<const ForcefieldAtomType>
 Forcefield::determineAtomType(const SpeciesAtom &i,
                               const std::vector<std::vector<std::reference_wrapper<const ForcefieldAtomType>>> &atomTypes)
 {
-    Messenger::printVerbose("Determining atom type for atom {} ({})\n", i.userIndex(), Elements::symbol(i.Z()));
+    Messenger::printVerbose("Determining atom type for atom {} ({})\n", i.index(), Elements::symbol(i.Z()));
 
     // Go through AtomTypes defined for the target's element, and check NETA scores
     auto bestScore = -1;
@@ -101,8 +101,8 @@ Forcefield::determineAtomType(const SpeciesAtom &i,
     if (bestScore == -1)
         Messenger::printVerbose("  -- no suitable type found.");
     else
-        Messenger::printVerbose("  Best type for atom {} is {} ({}) with a score of {}.\n", i.userIndex(),
-                                bestType->get().index(), bestType->get().name(), bestScore);
+        Messenger::printVerbose("  Best type for atom {} is {} ({}) with a score of {}.\n", i.index(), bestType->get().index(),
+                                bestType->get().name(), bestScore);
 
     return bestType;
 }
@@ -261,7 +261,7 @@ Forcefield::getAtomTypes(const std::vector<const SpeciesAtom *> &atoms, bool det
         auto optType = determineType ? determineAtomType(*i) : atomTypeByName(i->atomType()->name(), i->Z());
         if (!optType)
         {
-            Messenger::error("Couldn't find or assign type for atom {}.\n", i->userIndex());
+            Messenger::error("Couldn't find or assign type for atom {}.\n", i->index());
             return {};
         }
         types.emplace_back(*optType);
@@ -304,8 +304,8 @@ std::vector<int> Forcefield::assignAtomTypes(Species *sp, AtomTypeAssignmentStra
 
         if (!assignAtomType(i, setSpeciesAtomCharges))
         {
-            Messenger::error("No matching forcefield type for atom {} ({}).\n", i.userIndex(), Elements::symbol(i.Z()));
-            failedElements.push_back(i.userIndex());
+            Messenger::error("No matching forcefield type for atom {} ({}).\n", i.index(), Elements::symbol(i.Z()));
+            failedElements.push_back(i.index());
         }
     }
 
@@ -325,10 +325,10 @@ void Forcefield::assignAtomType(const ForcefieldAtomType &ffa, SpeciesAtom &i, b
     if (!at)
     {
         at = i.parent()->addAtomType(i.Z(), ffa.name());
-        Messenger::print("Adding AtomType '{}' for atom {} ({}).\n", at->name(), i.userIndex(), Elements::symbol(i.Z()));
+        Messenger::print("Adding AtomType '{}' for atom {} ({}).\n", at->name(), i.index(), Elements::symbol(i.Z()));
     }
     else
-        Messenger::print("Re-using AtomType '{}' for atom {} ({}).\n", at->name(), i.userIndex(), Elements::symbol(i.Z()));
+        Messenger::print("Re-using AtomType '{}' for atom {} ({}).\n", at->name(), i.index(), Elements::symbol(i.Z()));
 
     // Set type in the SpeciesAtom
     i.setAtomType(at);
@@ -359,7 +359,7 @@ bool Forcefield::assignBondTermParameters(const Species *parent, SpeciesBond &bo
 
     auto optTerm = getBondTerm(atomTypes[0], atomTypes[1]);
     if (!optTerm)
-        return Messenger::error("Failed to locate parameters for bond {}-{} ({}-{}).\n", i->userIndex(), j->userIndex(),
+        return Messenger::error("Failed to locate parameters for bond {}-{} ({}-{}).\n", i->index(), j->index(),
                                 atomTypes[0].get().equivalentName(), atomTypes[1].get().equivalentName());
     const ForcefieldBondTerm &term = *optTerm;
 
@@ -382,8 +382,8 @@ bool Forcefield::assignAngleTermParameters(const Species *parent, SpeciesAngle &
 
     auto optTerm = getAngleTerm(atomTypes[0], atomTypes[1], atomTypes[2]);
     if (!optTerm)
-        return Messenger::error("Failed to locate parameters for angle {}-{}-{} ({}-{}-{}).\n", i->userIndex(), j->userIndex(),
-                                k->userIndex(), atomTypes[0].get().equivalentName(), atomTypes[1].get().equivalentName(),
+        return Messenger::error("Failed to locate parameters for angle {}-{}-{} ({}-{}-{}).\n", i->index(), j->index(),
+                                k->index(), atomTypes[0].get().equivalentName(), atomTypes[1].get().equivalentName(),
                                 atomTypes[2].get().equivalentName());
     const ForcefieldAngleTerm &term = *optTerm;
 
@@ -407,8 +407,8 @@ bool Forcefield::assignTorsionTermParameters(const Species *parent, SpeciesTorsi
 
     auto optTerm = getTorsionTerm(atomTypes[0], atomTypes[1], atomTypes[2], atomTypes[3]);
     if (!optTerm)
-        return Messenger::error("Failed to locate parameters for torsion {}-{}-{}-{} ({}-{}-{}-{}).\n", i->userIndex(),
-                                j->userIndex(), k->userIndex(), l->userIndex(), atomTypes[0].get().equivalentName(),
+        return Messenger::error("Failed to locate parameters for torsion {}-{}-{}-{} ({}-{}-{}-{}).\n", i->index(), j->index(),
+                                k->index(), l->index(), atomTypes[0].get().equivalentName(),
                                 atomTypes[1].get().equivalentName(), atomTypes[2].get().equivalentName(),
                                 atomTypes[3].get().equivalentName());
     const ForcefieldTorsionTerm &term = *optTerm;

--- a/src/data/ff/uff/uff.cpp
+++ b/src/data/ff/uff/uff.cpp
@@ -338,7 +338,7 @@ bool Forcefield_UFF::assignBondTermParameters(const Species *parent, SpeciesBond
     auto typeJ = determineTypes ? determineAtomType(*bond.j()) : atomTypeByName(bond.j()->atomType()->name());
     if (!typeI || !typeJ)
         return Messenger::error("Failed to create parameters for bond {}-{} (atom types could not be determined).\n",
-                                bond.i()->userIndex(), bond.j()->userIndex());
+                                bond.i()->index(), bond.j()->index());
 
     const ForcefieldAtomType &i = *typeI;
     const ForcefieldAtomType &j = *typeJ;
@@ -371,7 +371,7 @@ bool Forcefield_UFF::assignAngleTermParameters(const Species *parent, SpeciesAng
 
     if (!typeI || !typeJ || !typeK)
         Messenger::error("Failed to create parameters for angle {}-{}-{} (atom types could not be determined).\n",
-                         angle.i()->userIndex(), angle.j()->userIndex(), angle.k()->userIndex());
+                         angle.i()->index(), angle.j()->index(), angle.k()->index());
 
     const ForcefieldAtomType &i = *typeI;
     const ForcefieldAtomType &j = *typeJ;
@@ -439,8 +439,7 @@ bool Forcefield_UFF::assignTorsionTermParameters(const Species *parent, SpeciesT
 
     if (!typeI || !typeJ || !typeK || !typeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",
-                         torsion.i()->userIndex(), torsion.j()->userIndex(), torsion.k()->userIndex(),
-                         torsion.l()->userIndex());
+                         torsion.i()->index(), torsion.j()->index(), torsion.k()->index(), torsion.l()->index());
 
     const ForcefieldAtomType &i = *typeI;
     const ForcefieldAtomType &j = *typeJ;
@@ -535,7 +534,7 @@ bool Forcefield_UFF::assignImproperTermParameters(ForcefieldImproperTerm &improp
 
     if (!optTypeI || !optTypeJ || !optTypeK || !optTypeL)
         Messenger::error("Failed to create parameters for torsion {}-{}-{}-{} (atom types could not be determined).\n",
-                         i->userIndex(), j->userIndex(), k->userIndex(), l->userIndex());
+                         i->index(), j->index(), k->index(), l->index());
 
     const ForcefieldAtomType &typeI = *optTypeI;
     const ForcefieldAtomType &typeJ = *optTypeJ;

--- a/tests/data/species/benzene.toml
+++ b/tests/data/species/benzene.toml
@@ -4,15 +4,6 @@ name = "Benzene"
 
 [species.atomTypes]
 
-[species.atomTypes.CA]
-z = "C"
-charge = -0.115
-form = "LJGeometric"
-
-[species.atomTypes.CA.parameters]
-epsilon = 0.29288
-sigma = 3.55
-
 [species.atomTypes.HA]
 z = "H"
 charge = 0.115
@@ -22,9 +13,18 @@ form = "LJGeometric"
 epsilon = 0.12552
 sigma = 2.42
 
+[species.atomTypes.CA]
+z = "C"
+charge = -0.115
+form = "LJGeometric"
+
+[species.atomTypes.CA.parameters]
+epsilon = 0.29288
+sigma = 3.55
+
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 -1.20378,
@@ -34,7 +34,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 2
+index = 1
 z = "H"
 r = [
 -2.0698,
@@ -44,7 +44,7 @@ r = [
 q = 0.115
 type = "HA"
 [[species.atoms]]
-index = 3
+index = 2
 z = "C"
 r = [
 -0.0,
@@ -54,7 +54,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 4
+index = 3
 z = "H"
 r = [
 -0.0,
@@ -64,7 +64,7 @@ r = [
 q = 0.115
 type = "HA"
 [[species.atoms]]
-index = 5
+index = 4
 z = "C"
 r = [
 1.20378,
@@ -74,7 +74,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 6
+index = 5
 z = "H"
 r = [
 2.0698,
@@ -84,7 +84,7 @@ r = [
 q = 0.115
 type = "HA"
 [[species.atoms]]
-index = 7
+index = 6
 z = "C"
 r = [
 1.20378,
@@ -94,7 +94,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 8
+index = 7
 z = "H"
 r = [
 2.0698,
@@ -104,7 +104,7 @@ r = [
 q = 0.115
 type = "HA"
 [[species.atoms]]
-index = 9
+index = 8
 z = "C"
 r = [
 -0.0,
@@ -114,7 +114,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 10
+index = 9
 z = "H"
 r = [
 -0.0,
@@ -124,7 +124,7 @@ r = [
 q = 0.115
 type = "HA"
 [[species.atoms]]
-index = 11
+index = 10
 z = "C"
 r = [
 -1.20378,
@@ -134,7 +134,7 @@ r = [
 q = -0.115
 type = "CA"
 [[species.atoms]]
-index = 12
+index = 11
 z = "H"
 r = [
 -2.0698,
@@ -146,13 +146,6 @@ type = "HA"
 
 [species.commonBonds]
 
-[species.commonBonds.CA-HA]
-form = "Harmonic"
-
-[species.commonBonds.CA-HA.parameters]
-k = 3071.056
-eq = 1.08
-
 [species.commonBonds.CA-CA]
 form = "Harmonic"
 
@@ -160,65 +153,65 @@ form = "Harmonic"
 k = 3924.592
 eq = 1.4
 
-
-
-[[species.bonds]]
-common = "CA-HA"
-i = 1
-j = 2
-[[species.bonds]]
-common = "CA-CA"
-i = 1
-j = 3
-[[species.bonds]]
-common = "CA-HA"
-i = 3
-j = 4
-[[species.bonds]]
-common = "CA-CA"
-i = 3
-j = 5
-[[species.bonds]]
-common = "CA-HA"
-i = 5
-j = 6
-[[species.bonds]]
-common = "CA-CA"
-i = 5
-j = 7
-[[species.bonds]]
-common = "CA-HA"
-i = 7
-j = 8
-[[species.bonds]]
-common = "CA-CA"
-i = 7
-j = 9
-[[species.bonds]]
-common = "CA-HA"
-i = 9
-j = 10
-[[species.bonds]]
-common = "CA-CA"
-i = 9
-j = 11
-[[species.bonds]]
-common = "CA-HA"
-i = 11
-j = 12
-[[species.bonds]]
-common = "CA-CA"
-i = 11
-j = 1
-
-[species.commonAngles]
-
-[species.commonAngles.CA-CA-HA]
+[species.commonBonds.CA-HA]
 form = "Harmonic"
 
-[species.commonAngles.CA-CA-HA.parameters]
-k = 292.88
-eq = 120.0
+[species.commonBonds.CA-HA.parameters]
+k = 3071.056
+eq = 1.08
+
+
+
+[[species.bonds]]
+common = "CA-HA"
+i = 0
+j = 1
+[[species.bonds]]
+common = "CA-CA"
+i = 0
+j = 2
+[[species.bonds]]
+common = "CA-HA"
+i = 2
+j = 3
+[[species.bonds]]
+common = "CA-CA"
+i = 2
+j = 4
+[[species.bonds]]
+common = "CA-HA"
+i = 4
+j = 5
+[[species.bonds]]
+common = "CA-CA"
+i = 4
+j = 6
+[[species.bonds]]
+common = "CA-HA"
+i = 6
+j = 7
+[[species.bonds]]
+common = "CA-CA"
+i = 6
+j = 8
+[[species.bonds]]
+common = "CA-HA"
+i = 8
+j = 9
+[[species.bonds]]
+common = "CA-CA"
+i = 8
+j = 10
+[[species.bonds]]
+common = "CA-HA"
+i = 10
+j = 11
+[[species.bonds]]
+common = "CA-CA"
+i = 10
+j = 0
+
+[species.commonAngles]
 
 [species.commonAngles.CA-CA-CA]
 form = "Harmonic"
@@ -227,107 +220,114 @@ form = "Harmonic"
 k = 527.184
 eq = 120.0
 
+[species.commonAngles.CA-CA-HA]
+form = "Harmonic"
+
+[species.commonAngles.CA-CA-HA.parameters]
+k = 292.88
+eq = 120.0
 
 
+
 [[species.angles]]
 common = "CA-CA-HA"
-i = 2
-j = 1
-k = 3
-[[species.angles]]
-common = "CA-CA-HA"
-i = 2
-j = 1
-k = 11
-[[species.angles]]
-common = "CA-CA-CA"
-i = 11
-j = 1
-k = 3
-[[species.angles]]
-common = "CA-CA-HA"
-i = 4
-j = 3
-k = 5
-[[species.angles]]
-common = "CA-CA-HA"
-i = 4
-j = 3
-k = 1
-[[species.angles]]
-common = "CA-CA-CA"
 i = 1
-j = 3
-k = 5
+j = 0
+k = 2
 [[species.angles]]
 common = "CA-CA-HA"
-i = 6
-j = 5
-k = 7
-[[species.angles]]
-common = "CA-CA-HA"
-i = 6
-j = 5
-k = 3
+i = 1
+j = 0
+k = 10
 [[species.angles]]
 common = "CA-CA-CA"
+i = 10
+j = 0
+k = 2
+[[species.angles]]
+common = "CA-CA-HA"
 i = 3
-j = 5
-k = 7
+j = 2
+k = 4
 [[species.angles]]
 common = "CA-CA-HA"
-i = 8
-j = 7
-k = 9
-[[species.angles]]
-common = "CA-CA-HA"
-i = 8
-j = 7
-k = 5
+i = 3
+j = 2
+k = 0
 [[species.angles]]
 common = "CA-CA-CA"
+i = 0
+j = 2
+k = 4
+[[species.angles]]
+common = "CA-CA-HA"
 i = 5
-j = 7
-k = 9
+j = 4
+k = 6
 [[species.angles]]
 common = "CA-CA-HA"
-i = 10
-j = 9
-k = 11
-[[species.angles]]
-common = "CA-CA-HA"
-i = 10
-j = 9
-k = 7
+i = 5
+j = 4
+k = 2
 [[species.angles]]
 common = "CA-CA-CA"
+i = 2
+j = 4
+k = 6
+[[species.angles]]
+common = "CA-CA-HA"
 i = 7
-j = 9
-k = 11
+j = 6
+k = 8
 [[species.angles]]
 common = "CA-CA-HA"
-i = 12
-j = 11
-k = 1
-[[species.angles]]
-common = "CA-CA-HA"
-i = 12
-j = 11
-k = 9
+i = 7
+j = 6
+k = 4
 [[species.angles]]
 common = "CA-CA-CA"
+i = 4
+j = 6
+k = 8
+[[species.angles]]
+common = "CA-CA-HA"
 i = 9
-j = 11
-k = 1
+j = 8
+k = 10
+[[species.angles]]
+common = "CA-CA-HA"
+i = 9
+j = 8
+k = 6
+[[species.angles]]
+common = "CA-CA-CA"
+i = 6
+j = 8
+k = 10
+[[species.angles]]
+common = "CA-CA-HA"
+i = 11
+j = 10
+k = 0
+[[species.angles]]
+common = "CA-CA-HA"
+i = 11
+j = 10
+k = 8
+[[species.angles]]
+common = "CA-CA-CA"
+i = 8
+j = 10
+k = 0
 
 [species.commonTorsions]
 
-[species.commonTorsions.HA-CA-CA-HA]
+[species.commonTorsions.CA-CA-CA-CA]
 form = "Cos3"
 q14 = 0.5
 v14 = 0.5
 
-[species.commonTorsions.HA-CA-CA-HA.parameters]
+[species.commonTorsions.CA-CA-CA-CA.parameters]
 k1 = 0.0
 k2 = 30.334
 k3 = 0.0
@@ -343,12 +343,12 @@ k2 = 30.334
 k3 = 0.0
 
 
-[species.commonTorsions.CA-CA-CA-CA]
+[species.commonTorsions.HA-CA-CA-HA]
 form = "Cos3"
 q14 = 0.5
 v14 = 0.5
 
-[species.commonTorsions.CA-CA-CA-CA.parameters]
+[species.commonTorsions.HA-CA-CA-HA.parameters]
 k1 = 0.0
 k2 = 30.334
 k3 = 0.0
@@ -357,201 +357,201 @@ k3 = 0.0
 
 [[species.torsions]]
 common = "HA-CA-CA-HA"
-i = 2
-j = 1
-k = 3
-l = 4
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 2
-j = 1
-k = 3
-l = 5
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
 i = 1
-j = 3
-k = 5
-l = 6
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 1
-j = 3
-k = 5
-l = 7
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HA-CA-CA-HA"
-i = 4
-j = 3
-k = 5
-l = 6
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 4
-j = 3
-k = 5
-l = 7
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 3
-j = 5
-k = 7
-l = 8
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 3
-j = 5
-k = 7
-l = 9
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HA-CA-CA-HA"
-i = 6
-j = 5
-k = 7
-l = 8
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 6
-j = 5
-k = 7
-l = 9
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 5
-j = 7
-k = 9
-l = 10
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 5
-j = 7
-k = 9
-l = 11
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HA-CA-CA-HA"
-i = 8
-j = 7
-k = 9
-l = 10
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 8
-j = 7
-k = 9
-l = 11
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 7
-j = 9
-k = 11
-l = 12
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 7
-j = 9
-k = 11
-l = 1
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HA-CA-CA-HA"
-i = 10
-j = 9
-k = 11
-l = 12
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 10
-j = 9
-k = 11
-l = 1
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 9
-j = 11
-k = 1
-l = 2
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 9
-j = 11
-k = 1
-l = 3
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HA-CA-CA-HA"
-i = 12
-j = 11
-k = 1
-l = 2
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CA-CA-CA-HA"
-i = 12
-j = 11
-k = 1
+j = 0
+k = 2
 l = 3
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "CA-CA-CA-HA"
-i = 11
-j = 1
-k = 3
+i = 1
+j = 0
+k = 2
 l = 4
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
-common = "CA-CA-CA-CA"
-i = 11
-j = 1
-k = 3
+common = "CA-CA-CA-HA"
+i = 0
+j = 2
+k = 4
 l = 5
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 0
+j = 2
+k = 4
+l = 6
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HA-CA-CA-HA"
+i = 3
+j = 2
+k = 4
+l = 5
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 3
+j = 2
+k = 4
+l = 6
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 2
+j = 4
+k = 6
+l = 7
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 2
+j = 4
+k = 6
+l = 8
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HA-CA-CA-HA"
+i = 5
+j = 4
+k = 6
+l = 7
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 5
+j = 4
+k = 6
+l = 8
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 4
+j = 6
+k = 8
+l = 9
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 4
+j = 6
+k = 8
+l = 10
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HA-CA-CA-HA"
+i = 7
+j = 6
+k = 8
+l = 9
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 7
+j = 6
+k = 8
+l = 10
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 6
+j = 8
+k = 10
+l = 11
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 6
+j = 8
+k = 10
+l = 0
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HA-CA-CA-HA"
+i = 9
+j = 8
+k = 10
+l = 11
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 9
+j = 8
+k = 10
+l = 0
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 8
+j = 10
+k = 0
+l = 1
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 8
+j = 10
+k = 0
+l = 2
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HA-CA-CA-HA"
+i = 11
+j = 10
+k = 0
+l = 1
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 11
+j = 10
+k = 0
+l = 2
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-HA"
+i = 10
+j = 0
+k = 2
+l = 3
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CA-CA-CA-CA"
+i = 10
+j = 0
+k = 2
+l = 4
 q14 = 0.5
 v14 = 0.5
 
 [species.isotopologues]
 
 [species.isotopologues.C6D6]
-CA = 0
 HA = 2
+CA = 0
 
 

--- a/tests/data/species/difluorobenzene.toml
+++ b/tests/data/species/difluorobenzene.toml
@@ -3,7 +3,7 @@
 name = "Difluorobenzene"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 -1.399,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "C"
 r = [
 -0.561,
@@ -21,7 +21,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 3
+index = 2
 z = "C"
 r = [
 0.839,
@@ -30,7 +30,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 4
+index = 3
 z = "C"
 r = [
 1.399,
@@ -39,7 +39,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 5
+index = 4
 z = "C"
 r = [
 0.56,
@@ -48,7 +48,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 6
+index = 5
 z = "C"
 r = [
 -0.839,
@@ -57,7 +57,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 7
+index = 6
 z = "F"
 r = [
 1.483,
@@ -66,7 +66,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 8
+index = 7
 z = "H"
 r = [
 2.472,
@@ -75,7 +75,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 9
+index = 8
 z = "H"
 r = [
 0.991,
@@ -84,7 +84,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 10
+index = 9
 z = "F"
 r = [
 -1.483,
@@ -93,7 +93,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 11
+index = 10
 z = "H"
 r = [
 -2.472,
@@ -102,7 +102,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 12
+index = 11
 z = "H"
 r = [
 -0.99,
@@ -113,12 +113,20 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
-i = 1
-j = 2
+i = 0
+j = 1
+[[species.bonds]]
+form = "None"
+i = 0
+j = 5
+[[species.bonds]]
+form = "None"
+i = 0
+j = 10
 [[species.bonds]]
 form = "None"
 i = 1
-j = 6
+j = 2
 [[species.bonds]]
 form = "None"
 i = 1
@@ -130,7 +138,7 @@ j = 3
 [[species.bonds]]
 form = "None"
 i = 2
-j = 12
+j = 6
 [[species.bonds]]
 form = "None"
 i = 3
@@ -150,13 +158,5 @@ j = 8
 [[species.bonds]]
 form = "None"
 i = 5
-j = 6
-[[species.bonds]]
-form = "None"
-i = 5
 j = 9
-[[species.bonds]]
-form = "None"
-i = 6
-j = 10
 

--- a/tests/data/species/ethane.toml
+++ b/tests/data/species/ethane.toml
@@ -3,7 +3,7 @@
 name = "Ethane"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 0.0,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "C"
 r = [
 0.0,
@@ -21,7 +21,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 0.0,
@@ -30,7 +30,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 4
+index = 3
 z = "H"
 r = [
 0.881973,
@@ -39,7 +39,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 5
+index = 4
 z = "H"
 r = [
 -0.881973,
@@ -48,7 +48,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 6
+index = 5
 z = "H"
 r = [
 0.0,
@@ -57,7 +57,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 7
+index = 6
 z = "H"
 r = [
 0.881973,
@@ -66,7 +66,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 8
+index = 7
 z = "H"
 r = [
 -0.881973,
@@ -77,15 +77,19 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
+j = 1
+[[species.bonds]]
+form = "None"
+i = 0
 j = 2
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
 j = 3
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
 j = 4
 [[species.bonds]]
 form = "None"
@@ -93,14 +97,10 @@ i = 1
 j = 5
 [[species.bonds]]
 form = "None"
-i = 2
+i = 1
 j = 6
 [[species.bonds]]
 form = "None"
-i = 2
+i = 1
 j = 7
-[[species.bonds]]
-form = "None"
-i = 2
-j = 8
 

--- a/tests/data/species/geometric.toml
+++ b/tests/data/species/geometric.toml
@@ -3,7 +3,7 @@
 name = "Geometric"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "P"
 r = [
 -5.824,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "P"
 r = [
 -1.824,
@@ -21,7 +21,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 3
+index = 2
 z = "F"
 r = [
 -1.824,
@@ -30,11 +30,20 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 4
+index = 3
 z = "P"
 r = [
 2.176,
 3.981,
+0.0,
+]
+q = 0.0
+[[species.atoms]]
+index = 4
+z = "F"
+r = [
+2.176,
+4.981,
 0.0,
 ]
 q = 0.0
@@ -43,21 +52,12 @@ index = 5
 z = "F"
 r = [
 2.176,
-4.981,
-0.0,
-]
-q = 0.0
-[[species.atoms]]
-index = 6
-z = "F"
-r = [
-2.176,
 2.981,
 0.0,
 ]
 q = 0.0
 [[species.atoms]]
-index = 7
+index = 6
 z = "P"
 r = [
 6.176,
@@ -66,7 +66,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 8
+index = 7
 z = "F"
 r = [
 6.176,
@@ -75,7 +75,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 9
+index = 8
 z = "F"
 r = [
 5.241,
@@ -84,7 +84,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 10
+index = 9
 z = "F"
 r = [
 7.111,
@@ -93,7 +93,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 11
+index = 10
 z = "P"
 r = [
 -5.0,
@@ -102,7 +102,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 12
+index = 11
 z = "F"
 r = [
 -5.0,
@@ -111,7 +111,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 13
+index = 12
 z = "F"
 r = [
 -5.0,
@@ -120,7 +120,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 14
+index = 13
 z = "F"
 r = [
 -4.118,
@@ -129,7 +129,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 15
+index = 14
 z = "F"
 r = [
 -5.882,
@@ -138,11 +138,20 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 16
+index = 15
 z = "P"
 r = [
 0.0,
 0.0,
+0.0,
+]
+q = 0.0
+[[species.atoms]]
+index = 16
+z = "F"
+r = [
+0.0,
+1.2,
 0.0,
 ]
 q = 0.0
@@ -151,21 +160,12 @@ index = 17
 z = "F"
 r = [
 0.0,
-1.2,
-0.0,
-]
-q = 0.0
-[[species.atoms]]
-index = 18
-z = "F"
-r = [
-0.0,
 -1.2,
 0.0,
 ]
 q = 0.0
 [[species.atoms]]
-index = 19
+index = 18
 z = "F"
 r = [
 -1.28,
@@ -174,7 +174,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 20
+index = 19
 z = "F"
 r = [
 1.28,
@@ -183,7 +183,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 21
+index = 20
 z = "F"
 r = [
 0.0,
@@ -192,7 +192,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 22
+index = 21
 z = "F"
 r = [
 0.0,
@@ -201,7 +201,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 23
+index = 22
 z = "P"
 r = [
 4.8,
@@ -210,7 +210,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 24
+index = 23
 z = "F"
 r = [
 4.8,
@@ -219,7 +219,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 25
+index = 24
 z = "F"
 r = [
 3.865,
@@ -228,7 +228,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 26
+index = 25
 z = "F"
 r = [
 5.735,
@@ -237,7 +237,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 27
+index = 26
 z = "F"
 r = [
 4.8,
@@ -246,7 +246,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 28
+index = 27
 z = "F"
 r = [
 4.8,
@@ -255,7 +255,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 29
+index = 28
 z = "P"
 r = [
 -3.0,
@@ -264,7 +264,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 30
+index = 29
 z = "F"
 r = [
 -3.0,
@@ -273,7 +273,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 31
+index = 30
 z = "F"
 r = [
 -4.28,
@@ -282,7 +282,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 32
+index = 31
 z = "F"
 r = [
 -1.72,
@@ -291,7 +291,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 33
+index = 32
 z = "P"
 r = [
 3.0,
@@ -300,7 +300,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 34
+index = 33
 z = "F"
 r = [
 3.0,
@@ -309,7 +309,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 35
+index = 34
 z = "F"
 r = [
 3.0,
@@ -318,7 +318,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 36
+index = 35
 z = "F"
 r = [
 1.72,
@@ -327,7 +327,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 37
+index = 36
 z = "F"
 r = [
 4.28,
@@ -338,114 +338,114 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
-i = 2
-j = 3
+i = 1
+j = 2
 [[species.bonds]]
 form = "None"
-i = 4
+i = 3
+j = 4
+[[species.bonds]]
+form = "None"
+i = 3
 j = 5
 [[species.bonds]]
 form = "None"
-i = 4
-j = 6
+i = 6
+j = 7
 [[species.bonds]]
 form = "None"
-i = 7
+i = 6
 j = 8
 [[species.bonds]]
 form = "None"
-i = 7
+i = 6
 j = 9
 [[species.bonds]]
 form = "None"
-i = 7
-j = 10
+i = 10
+j = 11
 [[species.bonds]]
 form = "None"
-i = 11
+i = 10
 j = 12
 [[species.bonds]]
 form = "None"
-i = 11
+i = 10
 j = 13
 [[species.bonds]]
 form = "None"
-i = 11
+i = 10
 j = 14
 [[species.bonds]]
 form = "None"
-i = 11
-j = 15
+i = 15
+j = 16
 [[species.bonds]]
 form = "None"
-i = 16
+i = 15
 j = 17
 [[species.bonds]]
 form = "None"
-i = 16
+i = 15
 j = 18
 [[species.bonds]]
 form = "None"
-i = 16
+i = 15
 j = 19
 [[species.bonds]]
 form = "None"
-i = 16
+i = 15
 j = 20
 [[species.bonds]]
 form = "None"
-i = 16
+i = 15
 j = 21
 [[species.bonds]]
 form = "None"
-i = 16
-j = 22
+i = 22
+j = 23
 [[species.bonds]]
 form = "None"
-i = 23
+i = 22
 j = 24
 [[species.bonds]]
 form = "None"
-i = 23
+i = 22
 j = 25
 [[species.bonds]]
 form = "None"
-i = 23
+i = 22
 j = 26
 [[species.bonds]]
 form = "None"
-i = 23
+i = 22
 j = 27
 [[species.bonds]]
 form = "None"
-i = 23
-j = 28
+i = 28
+j = 29
 [[species.bonds]]
 form = "None"
-i = 29
+i = 28
 j = 30
 [[species.bonds]]
 form = "None"
-i = 29
+i = 28
 j = 31
 [[species.bonds]]
 form = "None"
-i = 29
-j = 32
+i = 32
+j = 33
 [[species.bonds]]
 form = "None"
-i = 33
+i = 32
 j = 34
 [[species.bonds]]
 form = "None"
-i = 33
+i = 32
 j = 35
 [[species.bonds]]
 form = "None"
-i = 33
+i = 32
 j = 36
-[[species.bonds]]
-form = "None"
-i = 33
-j = 37
 

--- a/tests/data/species/hexane.toml
+++ b/tests/data/species/hexane.toml
@@ -4,15 +4,6 @@ name = "Hexane"
 
 [species.atomTypes]
 
-[species.atomTypes.CT]
-z = "C"
-charge = 0.0
-form = "LJGeometric"
-
-[species.atomTypes.CT.parameters]
-epsilon = 0.276144
-sigma = 3.5
-
 [species.atomTypes.HC]
 z = "H"
 charge = 0.0
@@ -22,9 +13,18 @@ form = "LJGeometric"
 epsilon = 0.12552
 sigma = 2.5
 
+[species.atomTypes.CT]
+z = "C"
+charge = 0.0
+form = "LJGeometric"
+
+[species.atomTypes.CT.parameters]
+epsilon = 0.276144
+sigma = 3.5
+
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 1.39441,
@@ -34,7 +34,7 @@ r = [
 q = -0.12
 type = "CT"
 [[species.atoms]]
-index = 2
+index = 1
 z = "C"
 r = [
 2.85416,
@@ -44,7 +44,7 @@ r = [
 q = -0.18
 type = "CT"
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 0.827064,
@@ -54,7 +54,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 4
+index = 3
 z = "C"
 r = [
 0.467798,
@@ -64,7 +64,7 @@ r = [
 q = -0.12
 type = "CT"
 [[species.atoms]]
-index = 5
+index = 4
 z = "H"
 r = [
 1.42555,
@@ -74,7 +74,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 6
+index = 5
 z = "H"
 r = [
 2.94128,
@@ -84,7 +84,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 7
+index = 6
 z = "H"
 r = [
 3.2682,
@@ -94,7 +94,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 8
+index = 7
 z = "H"
 r = [
 3.5558,
@@ -104,7 +104,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 9
+index = 8
 z = "H"
 r = [
 0.094379,
@@ -114,7 +114,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 10
+index = 9
 z = "H"
 r = [
 1.00598,
@@ -124,7 +124,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 11
+index = 10
 z = "C"
 r = [
 -1.35069,
@@ -134,7 +134,7 @@ r = [
 q = -0.12
 type = "CT"
 [[species.atoms]]
-index = 12
+index = 11
 z = "C"
 r = [
 -2.69905,
@@ -144,7 +144,7 @@ r = [
 q = -0.18
 type = "CT"
 [[species.atoms]]
-index = 13
+index = 12
 z = "H"
 r = [
 -1.5003,
@@ -154,7 +154,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 14
+index = 13
 z = "C"
 r = [
 -0.665486,
@@ -164,7 +164,7 @@ r = [
 q = -0.12
 type = "CT"
 [[species.atoms]]
-index = 15
+index = 14
 z = "H"
 r = [
 -0.667963,
@@ -174,7 +174,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 16
+index = 15
 z = "H"
 r = [
 -2.8605,
@@ -184,7 +184,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 17
+index = 16
 z = "H"
 r = [
 -3.48226,
@@ -194,7 +194,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 18
+index = 17
 z = "H"
 r = [
 -3.06981,
@@ -204,7 +204,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 19
+index = 18
 z = "H"
 r = [
 -1.29775,
@@ -214,7 +214,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 20
+index = 19
 z = "H"
 r = [
 -0.24082,
@@ -226,13 +226,6 @@ type = "HC"
 
 [species.commonBonds]
 
-[species.commonBonds.CT-CT]
-form = "Harmonic"
-
-[species.commonBonds.CT-CT.parameters]
-k = 2242.624
-eq = 1.529
-
 [species.commonBonds.CT-HC]
 form = "Harmonic"
 
@@ -240,93 +233,100 @@ form = "Harmonic"
 k = 2845.12
 eq = 1.09
 
+[species.commonBonds.CT-CT]
+form = "Harmonic"
+
+[species.commonBonds.CT-CT.parameters]
+k = 2242.624
+eq = 1.529
 
 
+
 [[species.bonds]]
 common = "CT-CT"
-i = 1
-j = 2
+i = 0
+j = 1
 [[species.bonds]]
 common = "CT-CT"
-i = 1
-j = 4
+i = 0
+j = 3
 [[species.bonds]]
 common = "CT-CT"
-i = 4
-j = 14
+i = 3
+j = 13
 [[species.bonds]]
 common = "CT-CT"
-i = 11
-j = 12
+i = 10
+j = 11
 [[species.bonds]]
 common = "CT-CT"
-i = 11
-j = 14
+i = 10
+j = 13
 [[species.bonds]]
 common = "CT-HC"
-i = 1
-j = 3
+i = 0
+j = 2
+[[species.bonds]]
+common = "CT-HC"
+i = 0
+j = 4
 [[species.bonds]]
 common = "CT-HC"
 i = 1
 j = 5
 [[species.bonds]]
 common = "CT-HC"
-i = 2
+i = 1
 j = 6
 [[species.bonds]]
 common = "CT-HC"
-i = 2
+i = 1
 j = 7
 [[species.bonds]]
 common = "CT-HC"
-i = 2
+i = 3
 j = 8
 [[species.bonds]]
 common = "CT-HC"
-i = 4
+i = 3
 j = 9
 [[species.bonds]]
 common = "CT-HC"
-i = 4
-j = 10
+i = 10
+j = 12
 [[species.bonds]]
 common = "CT-HC"
-i = 11
-j = 13
+i = 10
+j = 14
 [[species.bonds]]
 common = "CT-HC"
 i = 11
 j = 15
 [[species.bonds]]
 common = "CT-HC"
-i = 12
+i = 11
 j = 16
 [[species.bonds]]
 common = "CT-HC"
-i = 12
+i = 11
 j = 17
 [[species.bonds]]
 common = "CT-HC"
-i = 12
+i = 13
 j = 18
 [[species.bonds]]
 common = "CT-HC"
-i = 14
+i = 13
 j = 19
-[[species.bonds]]
-common = "CT-HC"
-i = 14
-j = 20
 
 [species.commonAngles]
 
-[species.commonAngles.CT-CT-CT]
+[species.commonAngles.HC-CT-HC]
 form = "Harmonic"
 
-[species.commonAngles.CT-CT-CT.parameters]
-k = 488.2728
-eq = 112.7
+[species.commonAngles.HC-CT-HC.parameters]
+k = 276.144
+eq = 107.8
 
 [species.commonAngles.CT-CT-HC]
 form = "Harmonic"
@@ -336,207 +336,207 @@ k = 313.8
 eq = 110.7
 
 
-[species.commonAngles.HC-CT-HC]
+[species.commonAngles.CT-CT-CT]
 form = "Harmonic"
 
-[species.commonAngles.HC-CT-HC.parameters]
-k = 276.144
-eq = 107.8
+[species.commonAngles.CT-CT-CT.parameters]
+k = 488.2728
+eq = 112.7
 
 
 
-[[species.angles]]
-common = "CT-CT-CT"
-i = 2
-j = 1
-k = 4
-[[species.angles]]
-common = "CT-CT-CT"
-i = 4
-j = 14
-k = 11
 [[species.angles]]
 common = "CT-CT-CT"
 i = 1
-j = 4
-k = 14
+j = 0
+k = 3
 [[species.angles]]
 common = "CT-CT-CT"
-i = 12
-j = 11
-k = 14
+i = 3
+j = 13
+k = 10
+[[species.angles]]
+common = "CT-CT-CT"
+i = 0
+j = 3
+k = 13
+[[species.angles]]
+common = "CT-CT-CT"
+i = 11
+j = 10
+k = 13
+[[species.angles]]
+common = "CT-CT-HC"
+i = 1
+j = 0
+k = 2
+[[species.angles]]
+common = "CT-CT-HC"
+i = 1
+j = 0
+k = 4
 [[species.angles]]
 common = "CT-CT-HC"
 i = 2
-j = 1
+j = 0
 k = 3
 [[species.angles]]
 common = "CT-CT-HC"
-i = 2
-j = 1
-k = 5
-[[species.angles]]
-common = "CT-CT-HC"
 i = 3
-j = 1
+j = 0
 k = 4
 [[species.angles]]
 common = "CT-CT-HC"
-i = 4
+i = 0
 j = 1
 k = 5
 [[species.angles]]
 common = "CT-CT-HC"
-i = 1
-j = 2
+i = 0
+j = 1
 k = 6
 [[species.angles]]
 common = "CT-CT-HC"
-i = 1
-j = 2
+i = 0
+j = 1
 k = 7
 [[species.angles]]
 common = "CT-CT-HC"
-i = 1
-j = 2
+i = 0
+j = 3
 k = 8
 [[species.angles]]
 common = "CT-CT-HC"
-i = 1
-j = 4
+i = 0
+j = 3
 k = 9
 [[species.angles]]
 common = "CT-CT-HC"
-i = 1
-j = 4
-k = 10
+i = 8
+j = 3
+k = 13
 [[species.angles]]
 common = "CT-CT-HC"
 i = 9
-j = 4
+j = 3
+k = 13
+[[species.angles]]
+common = "CT-CT-HC"
+i = 11
+j = 10
+k = 12
+[[species.angles]]
+common = "CT-CT-HC"
+i = 11
+j = 10
+k = 14
+[[species.angles]]
+common = "CT-CT-HC"
+i = 12
+j = 10
+k = 13
+[[species.angles]]
+common = "CT-CT-HC"
+i = 13
+j = 10
 k = 14
 [[species.angles]]
 common = "CT-CT-HC"
 i = 10
-j = 4
-k = 14
-[[species.angles]]
-common = "CT-CT-HC"
-i = 12
-j = 11
-k = 13
-[[species.angles]]
-common = "CT-CT-HC"
-i = 12
 j = 11
 k = 15
 [[species.angles]]
 common = "CT-CT-HC"
-i = 13
+i = 10
 j = 11
-k = 14
-[[species.angles]]
-common = "CT-CT-HC"
-i = 14
-j = 11
-k = 15
-[[species.angles]]
-common = "CT-CT-HC"
-i = 11
-j = 12
 k = 16
 [[species.angles]]
 common = "CT-CT-HC"
-i = 11
-j = 12
+i = 10
+j = 11
 k = 17
 [[species.angles]]
 common = "CT-CT-HC"
-i = 11
-j = 12
+i = 3
+j = 13
 k = 18
 [[species.angles]]
 common = "CT-CT-HC"
-i = 4
-j = 14
-k = 19
-[[species.angles]]
-common = "CT-CT-HC"
-i = 4
-j = 14
-k = 20
-[[species.angles]]
-common = "CT-CT-HC"
-i = 11
-j = 14
-k = 19
-[[species.angles]]
-common = "CT-CT-HC"
-i = 11
-j = 14
-k = 20
-[[species.angles]]
-common = "HC-CT-HC"
 i = 3
-j = 1
-k = 5
+j = 13
+k = 19
+[[species.angles]]
+common = "CT-CT-HC"
+i = 10
+j = 13
+k = 18
+[[species.angles]]
+common = "CT-CT-HC"
+i = 10
+j = 13
+k = 19
 [[species.angles]]
 common = "HC-CT-HC"
-i = 6
-j = 2
+i = 2
+j = 0
+k = 4
+[[species.angles]]
+common = "HC-CT-HC"
+i = 5
+j = 1
+k = 6
+[[species.angles]]
+common = "HC-CT-HC"
+i = 5
+j = 1
 k = 7
 [[species.angles]]
 common = "HC-CT-HC"
 i = 6
-j = 2
-k = 8
+j = 1
+k = 7
 [[species.angles]]
 common = "HC-CT-HC"
-i = 7
-j = 2
-k = 8
+i = 18
+j = 13
+k = 19
 [[species.angles]]
 common = "HC-CT-HC"
-i = 19
-j = 14
-k = 20
+i = 8
+j = 3
+k = 9
 [[species.angles]]
 common = "HC-CT-HC"
-i = 9
-j = 4
-k = 10
+i = 12
+j = 10
+k = 14
 [[species.angles]]
 common = "HC-CT-HC"
-i = 13
+i = 15
 j = 11
-k = 15
+k = 16
 [[species.angles]]
 common = "HC-CT-HC"
-i = 16
-j = 12
+i = 15
+j = 11
 k = 17
 [[species.angles]]
 common = "HC-CT-HC"
 i = 16
-j = 12
-k = 18
-[[species.angles]]
-common = "HC-CT-HC"
-i = 17
-j = 12
-k = 18
+j = 11
+k = 17
 
 [species.commonTorsions]
 
-[species.commonTorsions.CT-CT-CT-CT]
+[species.commonTorsions.HC-CT-CT-HC]
 form = "Cos3"
 q14 = 0.5
 v14 = 0.5
 
-[species.commonTorsions.CT-CT-CT-CT.parameters]
-k1 = 5.4392
-k2 = -0.2092
-k3 = 0.8368
+[species.commonTorsions.HC-CT-CT-HC.parameters]
+k1 = 0.0
+k2 = 0.0
+k3 = 1.2552
 
 [species.commonTorsions.CT-CT-CT-HC]
 form = "Cos3"
@@ -549,376 +549,376 @@ k2 = 0.0
 k3 = 1.2552
 
 
-[species.commonTorsions.HC-CT-CT-HC]
+[species.commonTorsions.CT-CT-CT-CT]
 form = "Cos3"
 q14 = 0.5
 v14 = 0.5
 
-[species.commonTorsions.HC-CT-CT-HC.parameters]
-k1 = 0.0
-k2 = 0.0
-k3 = 1.2552
+[species.commonTorsions.CT-CT-CT-CT.parameters]
+k1 = 5.4392
+k2 = -0.2092
+k3 = 0.8368
 
 
 
 [[species.torsions]]
 common = "CT-CT-CT-CT"
-i = 12
-j = 11
-k = 14
-l = 4
+i = 11
+j = 10
+k = 13
+l = 3
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "CT-CT-CT-CT"
-i = 1
-j = 4
-k = 14
-l = 11
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-CT"
-i = 2
-j = 1
-k = 4
-l = 14
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 10
-j = 4
-k = 14
-l = 11
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 10
-j = 4
-k = 14
-l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 10
-j = 4
-k = 14
-l = 20
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 12
-j = 11
-k = 14
-l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 12
-j = 11
-k = 14
-l = 20
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 13
-j = 11
-k = 12
-l = 16
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 13
-j = 11
-k = 12
-l = 17
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 13
-j = 11
-k = 12
-l = 18
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 13
-j = 11
-k = 14
-l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 13
-j = 11
-k = 14
-l = 20
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 13
-j = 11
-k = 14
-l = 4
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 14
-j = 11
-k = 12
-l = 16
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 14
-j = 11
-k = 12
-l = 17
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 14
-j = 11
-k = 12
-l = 18
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 1
-j = 4
-k = 14
-l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 1
-j = 4
-k = 14
-l = 20
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 15
-j = 11
-k = 12
-l = 16
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 15
-j = 11
-k = 12
-l = 17
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 15
-j = 11
-k = 12
-l = 18
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 15
-j = 11
-k = 14
-l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 15
-j = 11
-k = 14
-l = 20
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 15
-j = 11
-k = 14
-l = 4
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 2
-j = 1
-k = 4
+i = 0
+j = 3
+k = 13
 l = 10
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
+common = "CT-CT-CT-CT"
+i = 1
+j = 0
+k = 3
+l = 13
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
 common = "CT-CT-CT-HC"
-i = 2
-j = 1
-k = 4
+i = 9
+j = 3
+k = 13
+l = 10
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 9
+j = 3
+k = 13
+l = 18
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 9
+j = 3
+k = 13
+l = 19
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 11
+j = 10
+k = 13
+l = 18
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 11
+j = 10
+k = 13
+l = 19
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 12
+j = 10
+k = 11
+l = 15
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 12
+j = 10
+k = 11
+l = 16
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 12
+j = 10
+k = 11
+l = 17
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 12
+j = 10
+k = 13
+l = 18
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 12
+j = 10
+k = 13
+l = 19
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 12
+j = 10
+k = 13
+l = 3
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 13
+j = 10
+k = 11
+l = 15
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 13
+j = 10
+k = 11
+l = 16
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 13
+j = 10
+k = 11
+l = 17
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 0
+j = 3
+k = 13
+l = 18
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 0
+j = 3
+k = 13
+l = 19
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 14
+j = 10
+k = 11
+l = 15
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 14
+j = 10
+k = 11
+l = 16
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 14
+j = 10
+k = 11
+l = 17
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 14
+j = 10
+k = 13
+l = 18
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 14
+j = 10
+k = 13
+l = 19
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 14
+j = 10
+k = 13
+l = 3
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 1
+j = 0
+k = 3
 l = 9
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 3
-j = 1
-k = 2
-l = 6
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 3
-j = 1
-k = 2
-l = 7
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 3
-j = 1
-k = 2
+common = "CT-CT-CT-HC"
+i = 1
+j = 0
+k = 3
 l = 8
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "HC-CT-CT-HC"
-i = 3
-j = 1
-k = 4
-l = 10
+i = 2
+j = 0
+k = 1
+l = 5
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 2
+j = 0
+k = 1
+l = 6
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 2
+j = 0
+k = 1
+l = 7
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 2
+j = 0
+k = 3
+l = 9
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 2
+j = 0
+k = 3
+l = 13
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 2
+j = 0
+k = 3
+l = 8
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "CT-CT-CT-HC"
 i = 3
-j = 1
-k = 4
-l = 14
+j = 0
+k = 1
+l = 5
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 3
+j = 0
+k = 1
+l = 6
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "CT-CT-CT-HC"
+i = 3
+j = 0
+k = 1
+l = 7
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "HC-CT-CT-HC"
-i = 3
-j = 1
-k = 4
+i = 4
+j = 0
+k = 1
+l = 5
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 4
+j = 0
+k = 1
+l = 6
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 4
+j = 0
+k = 1
+l = 7
+q14 = 0.5
+v14 = 0.5
+[[species.torsions]]
+common = "HC-CT-CT-HC"
+i = 4
+j = 0
+k = 3
 l = 9
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "CT-CT-CT-HC"
 i = 4
-j = 1
-k = 2
-l = 6
+j = 0
+k = 3
+l = 13
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
-common = "CT-CT-CT-HC"
+common = "HC-CT-CT-HC"
 i = 4
-j = 1
-k = 2
-l = 7
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 4
-j = 1
-k = 2
+j = 0
+k = 3
 l = 8
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 5
-j = 1
-k = 2
-l = 6
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 5
-j = 1
-k = 2
-l = 7
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 5
-j = 1
-k = 2
-l = 8
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 5
-j = 1
-k = 4
+common = "CT-CT-CT-HC"
+i = 8
+j = 3
+k = 13
 l = 10
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 5
-j = 1
-k = 4
-l = 14
+common = "HC-CT-CT-HC"
+i = 8
+j = 3
+k = 13
+l = 18
 q14 = 0.5
 v14 = 0.5
 [[species.torsions]]
 common = "HC-CT-CT-HC"
-i = 5
-j = 1
-k = 4
-l = 9
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "CT-CT-CT-HC"
-i = 9
-j = 4
-k = 14
-l = 11
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 9
-j = 4
-k = 14
+i = 8
+j = 3
+k = 13
 l = 19
-q14 = 0.5
-v14 = 0.5
-[[species.torsions]]
-common = "HC-CT-CT-HC"
-i = 9
-j = 4
-k = 14
-l = 20
 q14 = 0.5
 v14 = 0.5
 

--- a/tests/data/species/methane.toml
+++ b/tests/data/species/methane.toml
@@ -3,7 +3,7 @@
 name = "Methane"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 0.0,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "H"
 r = [
 0.0,
@@ -21,7 +21,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 0.0,
@@ -30,7 +30,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 4
+index = 3
 z = "H"
 r = [
 0.881973,
@@ -39,7 +39,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 5
+index = 4
 z = "H"
 r = [
 -0.881973,
@@ -50,18 +50,18 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
+j = 1
+[[species.bonds]]
+form = "None"
+i = 0
 j = 2
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
 j = 3
 [[species.bonds]]
 form = "None"
-i = 1
+i = 0
 j = 4
-[[species.bonds]]
-form = "None"
-i = 1
-j = 5
 

--- a/tests/data/species/methanol.toml
+++ b/tests/data/species/methanol.toml
@@ -4,24 +4,14 @@ name = "Methanol"
 
 [species.atomTypes]
 
-[species.atomTypes.CT]
-z = "C"
-charge = -0.18
-form = "LJGeometric"
-
-[species.atomTypes.CT.parameters]
-epsilon = 0.276
-sigma = 3.55
-
-[species.atomTypes.HC]
+[species.atomTypes.HO]
 z = "H"
-charge = 0.06
+charge = 0.68
 form = "LJGeometric"
 
-[species.atomTypes.HC.parameters]
+[species.atomTypes.HO.parameters]
 epsilon = 0.126
-sigma = 2.5
-
+sigma = 2.4
 
 [species.atomTypes.OH]
 z = "O"
@@ -33,18 +23,28 @@ epsilon = 0.711
 sigma = 3.12
 
 
-[species.atomTypes.HO]
+[species.atomTypes.HC]
 z = "H"
-charge = 0.68
+charge = 0.06
 form = "LJGeometric"
 
-[species.atomTypes.HO.parameters]
+[species.atomTypes.HC.parameters]
 epsilon = 0.126
-sigma = 2.4
+sigma = 2.5
+
+
+[species.atomTypes.CT]
+z = "C"
+charge = -0.18
+form = "LJGeometric"
+
+[species.atomTypes.CT.parameters]
+epsilon = 0.276
+sigma = 3.55
 
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 0.0,
@@ -54,7 +54,7 @@ r = [
 q = -0.18
 type = "CT"
 [[species.atoms]]
-index = 2
+index = 1
 z = "H"
 r = [
 1.1187,
@@ -64,7 +64,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 3
+index = 2
 z = "O"
 r = [
 -0.3683,
@@ -74,7 +74,7 @@ r = [
 q = -0.68
 type = "OH"
 [[species.atoms]]
-index = 4
+index = 3
 z = "H"
 r = [
 -0.3834,
@@ -84,7 +84,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 5
+index = 4
 z = "H"
 r = [
 -0.3834,
@@ -94,7 +94,7 @@ r = [
 q = 0.06
 type = "HC"
 [[species.atoms]]
-index = 6
+index = 5
 z = "H"
 r = [
 -1.3318,
@@ -106,12 +106,12 @@ type = "HO"
 
 [species.commonBonds]
 
-[species.commonBonds.CT-HC]
+[species.commonBonds.HO-OH]
 form = "Harmonic"
 
-[species.commonBonds.CT-HC.parameters]
+[species.commonBonds.HO-OH.parameters]
 k = 3000.0
-eq = 1.12
+eq = 0.964
 
 [species.commonBonds.CT-OH]
 form = "Harmonic"
@@ -121,42 +121,42 @@ k = 3000.0
 eq = 1.41
 
 
-[species.commonBonds.HO-OH]
+[species.commonBonds.CT-HC]
 form = "Harmonic"
 
-[species.commonBonds.HO-OH.parameters]
+[species.commonBonds.CT-HC.parameters]
 k = 3000.0
-eq = 0.964
+eq = 1.12
 
 
 
 [[species.bonds]]
 common = "CT-HC"
-i = 1
-j = 2
+i = 0
+j = 1
 [[species.bonds]]
 common = "CT-OH"
-i = 1
+i = 0
+j = 2
+[[species.bonds]]
+common = "CT-HC"
+i = 0
 j = 3
 [[species.bonds]]
 common = "CT-HC"
-i = 1
+i = 0
 j = 4
 [[species.bonds]]
-common = "CT-HC"
-i = 1
-j = 5
-[[species.bonds]]
 common = "HO-OH"
-i = 3
-j = 6
+i = 2
+j = 5
 
 [species.commonAngles]
 
-[species.commonAngles.HC-CT-OH]
+[species.commonAngles.CT-OH-HO]
 form = "Harmonic"
 
-[species.commonAngles.HC-CT-OH.parameters]
+[species.commonAngles.CT-OH-HO.parameters]
 k = 300.0
 eq = 109.5
 
@@ -168,10 +168,10 @@ k = 300.0
 eq = 109.5
 
 
-[species.commonAngles.CT-OH-HO]
+[species.commonAngles.HC-CT-OH]
 form = "Harmonic"
 
-[species.commonAngles.CT-OH-HO.parameters]
+[species.commonAngles.HC-CT-OH.parameters]
 k = 300.0
 eq = 109.5
 
@@ -179,58 +179,58 @@ eq = 109.5
 
 [[species.angles]]
 common = "HC-CT-OH"
-i = 2
-j = 1
+i = 1
+j = 0
+k = 2
+[[species.angles]]
+common = "HC-CT-HC"
+i = 1
+j = 0
 k = 3
 [[species.angles]]
 common = "HC-CT-HC"
-i = 2
-j = 1
-k = 4
-[[species.angles]]
-common = "HC-CT-HC"
-i = 2
-j = 1
-k = 5
-[[species.angles]]
-common = "HC-CT-OH"
-i = 3
-j = 1
+i = 1
+j = 0
 k = 4
 [[species.angles]]
 common = "HC-CT-OH"
-i = 3
-j = 1
-k = 5
+i = 2
+j = 0
+k = 3
+[[species.angles]]
+common = "HC-CT-OH"
+i = 2
+j = 0
+k = 4
 [[species.angles]]
 common = "HC-CT-HC"
-i = 4
-j = 1
-k = 5
+i = 3
+j = 0
+k = 4
 [[species.angles]]
 common = "CT-OH-HO"
-i = 6
-j = 3
-k = 1
+i = 5
+j = 2
+k = 0
 
 [species.isotopologues]
 
-[species.isotopologues.Deuteriated]
-CT = 0
-HC = 2
-OH = 0
+[species.isotopologues.OD-MethylH]
 HO = 2
+OH = 0
+HC = 0
+CT = 0
 
 [species.isotopologues.MethylD-OH]
-CT = 0
-HC = 2
-OH = 0
 HO = 0
-
-[species.isotopologues.OD-MethylH]
-CT = 0
-HC = 0
 OH = 0
+HC = 2
+CT = 0
+
+[species.isotopologues.Deuteriated]
 HO = 2
+OH = 0
+HC = 2
+CT = 0
 
 

--- a/tests/data/species/n2.toml
+++ b/tests/data/species/n2.toml
@@ -2,8 +2,15 @@
 [species]
 name = "N2"
 
+[species.atomTypes]
+
+[species.atomTypes.N]
+z = "N"
+charge = 0.0
+form = "Undefined"
+
 [[species.atoms]]
-index = 1
+index = 0
 z = "N"
 r = [
 0.0,
@@ -13,7 +20,7 @@ r = [
 q = 0.0
 type = "N"
 [[species.atoms]]
-index = 2
+index = 1
 z = "N"
 r = [
 1.2,
@@ -25,8 +32,8 @@ type = "N"
 
 [[species.bonds]]
 form = "None"
-i = 1
-j = 2
+i = 0
+j = 1
 
 [species.isotopologues]
 

--- a/tests/data/species/no.toml
+++ b/tests/data/species/no.toml
@@ -3,7 +3,7 @@
 name = "Diatomic"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "N"
 r = [
 0.0,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "O"
 r = [
 0.0,
@@ -23,6 +23,6 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
-i = 1
-j = 2
+i = 0
+j = 1
 

--- a/tests/data/species/ppScaleFactorTest.toml
+++ b/tests/data/species/ppScaleFactorTest.toml
@@ -4,15 +4,6 @@ name = "Unnamed"
 
 [species.atomTypes]
 
-[species.atomTypes.C1]
-z = "C"
-charge = -0.1
-form = "LJ"
-
-[species.atomTypes.C1.parameters]
-epsilon = 1.0
-sigma = 3.0
-
 [species.atomTypes.C2]
 z = "C"
 charge = 0.1
@@ -22,9 +13,18 @@ form = "LJ"
 epsilon = 1.0
 sigma = 3.0
 
+[species.atomTypes.C1]
+z = "C"
+charge = -0.1
+form = "LJ"
+
+[species.atomTypes.C1.parameters]
+epsilon = 1.0
+sigma = 3.0
+
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 -1.39,
@@ -34,7 +34,7 @@ r = [
 q = -0.2
 type = "C1"
 [[species.atoms]]
-index = 2
+index = 1
 z = "C"
 r = [
 -0.695,
@@ -44,7 +44,7 @@ r = [
 q = 0.2
 type = "C2"
 [[species.atoms]]
-index = 3
+index = 2
 z = "C"
 r = [
 0.695,
@@ -54,7 +54,7 @@ r = [
 q = 0.2
 type = "C2"
 [[species.atoms]]
-index = 4
+index = 3
 z = "C"
 r = [
 1.39,
@@ -66,23 +66,23 @@ type = "C1"
 
 [[species.bonds]]
 form = "None"
+i = 0
+j = 1
+[[species.bonds]]
+form = "None"
 i = 1
 j = 2
 [[species.bonds]]
 form = "None"
 i = 2
 j = 3
-[[species.bonds]]
-form = "None"
-i = 3
-j = 4
 
 [[species.torsions]]
 form = "None"
-i = 1
-j = 2
-k = 3
-l = 4
+i = 0
+j = 1
+k = 2
+l = 3
 q14 = 0.5
 v14 = 0.5
 

--- a/tests/data/species/rings.toml
+++ b/tests/data/species/rings.toml
@@ -3,7 +3,7 @@
 name = "Rings"
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "C"
 r = [
 -0.208763,
@@ -12,7 +12,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 2
+index = 1
 z = "C"
 r = [
 0.045228,
@@ -21,7 +21,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 3
+index = 2
 z = "C"
 r = [
 1.30057,
@@ -30,7 +30,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 4
+index = 3
 z = "C"
 r = [
 2.36093,
@@ -39,7 +39,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 5
+index = 4
 z = "C"
 r = [
 2.11178,
@@ -48,7 +48,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 6
+index = 5
 z = "C"
 r = [
 0.805131,
@@ -57,7 +57,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 7
+index = 6
 z = "H"
 r = [
 1.46848,
@@ -66,7 +66,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 8
+index = 7
 z = "H"
 r = [
 3.37354,
@@ -75,7 +75,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 9
+index = 8
 z = "H"
 r = [
 2.93942,
@@ -84,7 +84,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 10
+index = 9
 z = "H"
 r = [
 0.596002,
@@ -93,7 +93,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 11
+index = 10
 z = "N"
 r = [
 -1.28915,
@@ -102,7 +102,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 12
+index = 11
 z = "C"
 r = [
 -1.64629,
@@ -111,7 +111,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 13
+index = 12
 z = "C"
 r = [
 -1.78568,
@@ -120,7 +120,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 14
+index = 13
 z = "H"
 r = [
 -1.6198,
@@ -129,7 +129,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 15
+index = 14
 z = "H"
 r = [
 -1.28806,
@@ -138,7 +138,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 16
+index = 15
 z = "H"
 r = [
 -2.87354,
@@ -147,7 +147,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 17
+index = 16
 z = "H"
 r = [
 -2.07593,
@@ -156,7 +156,7 @@ r = [
 ]
 q = 0.0
 [[species.atoms]]
-index = 18
+index = 17
 z = "H"
 r = [
 -2.21386,
@@ -167,16 +167,24 @@ q = 0.0
 
 [[species.bonds]]
 form = "None"
+i = 0
+j = 1
+[[species.bonds]]
+form = "None"
+i = 0
+j = 5
+[[species.bonds]]
+form = "None"
+i = 0
+j = 11
+[[species.bonds]]
+form = "None"
 i = 1
 j = 2
 [[species.bonds]]
 form = "None"
 i = 1
-j = 6
-[[species.bonds]]
-form = "None"
-i = 1
-j = 12
+j = 10
 [[species.bonds]]
 form = "None"
 i = 2
@@ -184,7 +192,7 @@ j = 3
 [[species.bonds]]
 form = "None"
 i = 2
-j = 11
+j = 6
 [[species.bonds]]
 form = "None"
 i = 3
@@ -204,41 +212,33 @@ j = 8
 [[species.bonds]]
 form = "None"
 i = 5
-j = 6
-[[species.bonds]]
-form = "None"
-i = 5
 j = 9
 [[species.bonds]]
 form = "None"
-i = 6
-j = 10
+i = 10
+j = 11
 [[species.bonds]]
 form = "None"
-i = 11
+i = 10
 j = 12
 [[species.bonds]]
 form = "None"
 i = 11
-j = 13
+j = 16
 [[species.bonds]]
 form = "None"
-i = 12
+i = 11
 j = 17
 [[species.bonds]]
 form = "None"
 i = 12
-j = 18
+j = 13
 [[species.bonds]]
 form = "None"
-i = 13
+i = 12
 j = 14
 [[species.bonds]]
 form = "None"
-i = 13
+i = 12
 j = 15
-[[species.bonds]]
-form = "None"
-i = 13
-j = 16
 

--- a/tests/data/species/tetrahedral-argon.toml
+++ b/tests/data/species/tetrahedral-argon.toml
@@ -4,18 +4,18 @@ name = "TetrahedralArgon"
 
 [species.atomTypes]
 
-[species.atomTypes.Ar]
-z = "Ar"
-charge = 0.0
-form = "Undefined"
-
 [species.atomTypes.Phantom]
 z = "Phantom"
 charge = 0.0
 form = "Undefined"
 
+[species.atomTypes.Ar]
+z = "Ar"
+charge = 0.0
+form = "Undefined"
+
 [[species.atoms]]
-index = 1
+index = 0
 z = "Ar"
 r = [
 0.0,
@@ -25,7 +25,7 @@ r = [
 q = 0.0
 type = "Ar"
 [[species.atoms]]
-index = 2
+index = 1
 z = "Phantom"
 r = [
 0.0,
@@ -35,7 +35,7 @@ r = [
 q = 0.0
 type = "Phantom"
 [[species.atoms]]
-index = 3
+index = 2
 z = "Phantom"
 r = [
 0.0,
@@ -45,7 +45,7 @@ r = [
 q = 0.0
 type = "Phantom"
 [[species.atoms]]
-index = 4
+index = 3
 z = "Phantom"
 r = [
 1.15967,
@@ -55,7 +55,7 @@ r = [
 q = 0.0
 type = "Phantom"
 [[species.atoms]]
-index = 5
+index = 4
 z = "Phantom"
 r = [
 -1.15959,
@@ -73,18 +73,18 @@ form = "None"
 
 [[species.bonds]]
 common = "Ar-Phantom"
-i = 1
+i = 0
+j = 1
+[[species.bonds]]
+common = "Ar-Phantom"
+i = 0
 j = 2
 [[species.bonds]]
 common = "Ar-Phantom"
-i = 1
+i = 0
 j = 3
 [[species.bonds]]
 common = "Ar-Phantom"
-i = 1
+i = 0
 j = 4
-[[species.bonds]]
-common = "Ar-Phantom"
-i = 1
-j = 5
 

--- a/tests/data/species/water-dlpoly.toml
+++ b/tests/data/species/water-dlpoly.toml
@@ -4,6 +4,15 @@ name = "Water"
 
 [species.atomTypes]
 
+[species.atomTypes.OW]
+z = "O"
+charge = -0.82
+form = "LJ"
+
+[species.atomTypes.OW.parameters]
+epsilon = 0.6503
+sigma = 3.165492
+
 [species.atomTypes.HW]
 z = "H"
 charge = 0.41
@@ -13,18 +22,9 @@ form = "LJ"
 epsilon = 0.0
 sigma = 0.0
 
-[species.atomTypes.OW]
-z = "O"
-charge = -0.82
-form = "LJ"
-
-[species.atomTypes.OW.parameters]
-epsilon = 0.6503
-sigma = 3.16549
-
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "H"
 r = [
 1.0,
@@ -34,7 +34,7 @@ r = [
 q = 0.41
 type = "HW"
 [[species.atoms]]
-index = 2
+index = 1
 z = "O"
 r = [
 0.0,
@@ -44,7 +44,7 @@ r = [
 q = -0.82
 type = "OW"
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 -0.394583,
@@ -66,12 +66,12 @@ eq = 1.0
 
 [[species.bonds]]
 common = "HW-OW"
-i = 2
-j = 1
+i = 1
+j = 0
 [[species.bonds]]
 common = "HW-OW"
-i = 2
-j = 3
+i = 1
+j = 2
 
 [species.commonAngles]
 
@@ -79,51 +79,28 @@ j = 3
 form = "Harmonic"
 
 [species.commonAngles.HW-OW-HW.parameters]
-k = 317.566
+k = 317.5656
 eq = 113.24
 
 
 [[species.angles]]
 common = "HW-OW-HW"
-i = 1
-j = 2
-k = 3
+i = 0
+j = 1
+k = 2
 
 [species.isotopologues]
 
 [species.isotopologues.D2O]
-HW = 2
 OW = 0
+HW = 2
 
 
 [species.sites]
 
-[species.sites.Origin]
-originAtoms = [
-1,
-]
-xAxisAtoms = [
-0,
-2,
-]
-yAxisAtoms = [
-2,
-]
-
-[species.sites.O]
-originAtoms = [
-1,
-]
-
-[species.sites.H1]
-originAtoms = [
-0,
-]
-
-[species.sites.H2]
-originAtoms = [
-2,
-]
+[species.sites.H-frag]
+type = "Fragment"
+description = "?H, #origin"
 
 [species.sites.COM]
 originMassWeighted = true
@@ -139,27 +116,50 @@ element = [
 "H",
 ]
 
+[species.sites.H2]
+originAtoms = [
+2,
+]
+
+[species.sites.O-frag]
+type = "Fragment"
+description = "?O, #origin"
+
 [species.sites.O-dyn]
 type = "Dynamic"
 element = [
 "O",
 ]
 
-[species.sites.Origin-frag]
-type = "Fragment"
-description = "?O, #origin, -H(#x), -H(#x, #y)"
-
-[species.sites.O-frag]
-type = "Fragment"
-description = "?O, #origin"
-
-[species.sites.H-frag]
-type = "Fragment"
-description = "?H, #origin"
+[species.sites.H1]
+originAtoms = [
+0,
+]
 
 [species.sites.COM-frag]
 type = "Fragment"
 originMassWeighted = true
 description = "?O, #origin, -H(#origin), -H(#origin)"
+
+[species.sites.Origin-frag]
+type = "Fragment"
+description = "?O, #origin, -H(#x), -H(#x, #y)"
+
+[species.sites.O]
+originAtoms = [
+1,
+]
+
+[species.sites.Origin]
+originAtoms = [
+1,
+]
+xAxisAtoms = [
+0,
+2,
+]
+yAxisAtoms = [
+2,
+]
 
 

--- a/tests/data/species/water-with-lps.toml
+++ b/tests/data/species/water-with-lps.toml
@@ -4,14 +4,10 @@ name = "Water"
 
 [species.atomTypes]
 
-[species.atomTypes.OW]
-z = "O"
-charge = -0.82
-form = "LJ"
-
-[species.atomTypes.OW.parameters]
-epsilon = 0.6503
-sigma = 3.16549
+[species.atomTypes.LP]
+z = "Phantom"
+charge = 0.0
+form = "Undefined"
 
 [species.atomTypes.HW]
 z = "H"
@@ -23,13 +19,18 @@ epsilon = 0.0
 sigma = 0.0
 
 
-[species.atomTypes.LP]
-z = "Phantom"
-charge = 0.0
-form = "Undefined"
+[species.atomTypes.OW]
+z = "O"
+charge = -0.82
+form = "LJ"
+
+[species.atomTypes.OW.parameters]
+epsilon = 0.6503
+sigma = 3.165492
+
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "O"
 r = [
 0.0,
@@ -39,7 +40,7 @@ r = [
 q = -0.82
 type = "OW"
 [[species.atoms]]
-index = 2
+index = 1
 z = "H"
 r = [
 1.0,
@@ -49,7 +50,7 @@ r = [
 q = 0.41
 type = "HW"
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 -0.394583,
@@ -59,7 +60,7 @@ r = [
 q = 0.41
 type = "HW"
 [[species.atoms]]
-index = 4
+index = 3
 z = "Phantom"
 r = [
 0.07352,
@@ -69,7 +70,7 @@ r = [
 q = 0.0
 type = "LP"
 [[species.atoms]]
-index = 5
+index = 4
 z = "Phantom"
 r = [
 0.090574,
@@ -81,13 +82,6 @@ type = "LP"
 
 [species.commonBonds]
 
-[species.commonBonds.HW-OW]
-form = "Harmonic"
-
-[species.commonBonds.HW-OW.parameters]
-k = 4431.53
-eq = 1.0
-
 [species.commonBonds.LP-OW]
 form = "Harmonic"
 
@@ -95,33 +89,40 @@ form = "Harmonic"
 k = 300.0
 eq = 0.995
 
+[species.commonBonds.HW-OW]
+form = "Harmonic"
+
+[species.commonBonds.HW-OW.parameters]
+k = 4431.53
+eq = 1.0
+
 
 
 [[species.bonds]]
 common = "HW-OW"
-i = 1
+i = 0
+j = 1
+[[species.bonds]]
+common = "HW-OW"
+i = 0
 j = 2
 [[species.bonds]]
-common = "HW-OW"
-i = 1
+common = "LP-OW"
+i = 0
 j = 3
 [[species.bonds]]
 common = "LP-OW"
-i = 1
+i = 0
 j = 4
-[[species.bonds]]
-common = "LP-OW"
-i = 1
-j = 5
 
 [species.commonAngles]
 
-[species.commonAngles.HW-OW-HW]
+[species.commonAngles.LP-OW-LP]
 form = "Harmonic"
 
-[species.commonAngles.HW-OW-HW.parameters]
-k = 317.566
-eq = 113.24
+[species.commonAngles.LP-OW-LP.parameters]
+k = 40.0
+eq = 109.5
 
 [species.commonAngles.HW-OW-LP]
 form = "Harmonic"
@@ -131,83 +132,54 @@ k = 40.0
 eq = 109.5
 
 
-[species.commonAngles.LP-OW-LP]
+[species.commonAngles.HW-OW-HW]
 form = "Harmonic"
 
-[species.commonAngles.LP-OW-LP.parameters]
-k = 40.0
-eq = 109.5
+[species.commonAngles.HW-OW-HW.parameters]
+k = 317.5656
+eq = 113.24
 
 
 
 [[species.angles]]
 common = "HW-OW-HW"
+i = 1
+j = 0
+k = 2
+[[species.angles]]
+common = "HW-OW-LP"
+i = 1
+j = 0
+k = 3
+[[species.angles]]
+common = "HW-OW-LP"
+i = 1
+j = 0
+k = 4
+[[species.angles]]
+common = "HW-OW-LP"
 i = 2
-j = 1
+j = 0
 k = 3
 [[species.angles]]
 common = "HW-OW-LP"
 i = 2
-j = 1
+j = 0
 k = 4
-[[species.angles]]
-common = "HW-OW-LP"
-i = 2
-j = 1
-k = 5
-[[species.angles]]
-common = "HW-OW-LP"
-i = 3
-j = 1
-k = 4
-[[species.angles]]
-common = "HW-OW-LP"
-i = 3
-j = 1
-k = 5
 [[species.angles]]
 common = "LP-OW-LP"
-i = 4
-j = 1
-k = 5
+i = 3
+j = 0
+k = 4
 
 [species.isotopologues]
 
 [species.isotopologues.D2O]
-OW = 0
 HW = 2
+OW = 0
 
 
 [species.sites]
-
-[species.sites.COM]
-originMassWeighted = true
-originAtoms = [
-0,
-1,
-2,
-]
-
-[species.sites.H2]
-originAtoms = [
-2,
-]
-
-[species.sites.H1]
-originAtoms = [
-0,
-]
-
-[species.sites.H]
-type = "Dynamic"
-element = [
-"H",
-]
-
-[species.sites.O]
-originAtoms = [
-1,
-]
 
 [species.sites.Origin]
 originAtoms = [
@@ -218,6 +190,35 @@ xAxisAtoms = [
 2,
 ]
 yAxisAtoms = [
+2,
+]
+
+[species.sites.O]
+originAtoms = [
+1,
+]
+
+[species.sites.H]
+type = "Dynamic"
+element = [
+"H",
+]
+
+[species.sites.H1]
+originAtoms = [
+0,
+]
+
+[species.sites.H2]
+originAtoms = [
+2,
+]
+
+[species.sites.COM]
+originMassWeighted = true
+originAtoms = [
+0,
+1,
 2,
 ]
 

--- a/tests/data/species/water.toml
+++ b/tests/data/species/water.toml
@@ -4,15 +4,6 @@ name = "Water"
 
 [species.atomTypes]
 
-[species.atomTypes.HW]
-z = "H"
-charge = 0.41
-form = "LJ"
-
-[species.atomTypes.HW.parameters]
-epsilon = 0.0
-sigma = 0.0
-
 [species.atomTypes.OW]
 z = "O"
 charge = -0.82
@@ -22,9 +13,18 @@ form = "LJ"
 epsilon = 0.6503
 sigma = 3.165492
 
+[species.atomTypes.HW]
+z = "H"
+charge = 0.41
+form = "LJ"
+
+[species.atomTypes.HW.parameters]
+epsilon = 0.0
+sigma = 0.0
+
 
 [[species.atoms]]
-index = 1
+index = 0
 z = "O"
 r = [
 0.0,
@@ -34,7 +34,7 @@ r = [
 q = 0.0
 type = "OW"
 [[species.atoms]]
-index = 2
+index = 1
 z = "H"
 r = [
 1.0,
@@ -44,7 +44,7 @@ r = [
 q = 0.0
 type = "HW"
 [[species.atoms]]
-index = 3
+index = 2
 z = "H"
 r = [
 -0.394583,
@@ -66,12 +66,12 @@ eq = 1.0
 
 [[species.bonds]]
 common = "HW-OW"
-i = 1
-j = 2
+i = 0
+j = 1
 [[species.bonds]]
 common = "HW-OW"
-i = 1
-j = 3
+i = 0
+j = 2
 
 [species.commonAngles]
 
@@ -85,47 +85,22 @@ eq = 113.24
 
 [[species.angles]]
 common = "HW-OW-HW"
-i = 2
-j = 1
-k = 3
+i = 1
+j = 0
+k = 2
 
 [species.isotopologues]
 
 [species.isotopologues.D2O]
-HW = 2
 OW = 0
+HW = 2
 
 
 [species.sites]
 
-[species.sites.COM]
-originMassWeighted = true
-originAtoms = [
-0,
-1,
-2,
-]
-
-[species.sites.H2]
-originAtoms = [
-2,
-]
-
-[species.sites.H1]
-originAtoms = [
-1,
-]
-
-[species.sites.H]
-type = "Dynamic"
-element = [
-"H",
-]
-
-[species.sites.O]
-originAtoms = [
-0,
-]
+[species.sites.H-frag]
+type = "Fragment"
+description = "?H, #origin"
 
 [species.sites.Origin]
 originAtoms = [
@@ -139,11 +114,29 @@ yAxisAtoms = [
 2,
 ]
 
-[species.sites.H-dyn]
+[species.sites.COM-frag]
+type = "Fragment"
+originMassWeighted = true
+description = "?O, #origin, -H(#origin), -H(#origin)"
+
+[species.sites.Origin-frag]
+type = "Fragment"
+description = "?O, #origin, -H(#x), -H(#x, #y)"
+
+[species.sites.O]
+originAtoms = [
+0,
+]
+
+[species.sites.H]
 type = "Dynamic"
 element = [
 "H",
 ]
+
+[species.sites.O-frag]
+type = "Fragment"
+description = "?O, #origin"
 
 [species.sites.O-dyn]
 type = "Dynamic"
@@ -151,21 +144,28 @@ element = [
 "O",
 ]
 
-[species.sites.Origin-frag]
-type = "Fragment"
-description = "?O, #origin, -H(#x), -H(#x, #y)"
+[species.sites.H1]
+originAtoms = [
+1,
+]
 
-[species.sites.O-frag]
-type = "Fragment"
-description = "?O, #origin"
+[species.sites.H-dyn]
+type = "Dynamic"
+element = [
+"H",
+]
 
-[species.sites.H-frag]
-type = "Fragment"
-description = "?H, #origin"
+[species.sites.H2]
+originAtoms = [
+2,
+]
 
-[species.sites.COM-frag]
-type = "Fragment"
+[species.sites.COM]
 originMassWeighted = true
-description = "?O, #origin, -H(#origin), -H(#origin)"
+originAtoms = [
+0,
+1,
+2,
+]
 
 

--- a/tests/ff/water-1000.cpp
+++ b/tests/ff/water-1000.cpp
@@ -4,7 +4,6 @@
 #include "kernels/force.h"
 #include "nodes/dissolve.h"
 #include "tests/graphData.h"
-#include "tests/tempFile.h"
 #include "tests/testData.h"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
A tidy-up PR to remove the use of user indices (1 -> N) from the code and our serialised TOML files.  Also implements the setting of a `Species` name within it's `deserialise()` (a forgotten action from a previous PR comment).