### PR TITLE
build: Specifically request windows-2022

### DIFF
--- a/.github/workflows/_build_and_package.yml
+++ b/.github/workflows/_build_and_package.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ "${{ inputs.osxRunner }}", windows-latest ]
+        os: [ "${{ inputs.osxRunner }}", windows-2022 ]
     runs-on: ${{ matrix.os }}
     steps:
     - name: 'Download Source Tarfiles'

--- a/.github/workflows/cacheConan.yml
+++ b/.github/workflows/cacheConan.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2022]
         target: [dissolve-gui]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -16,7 +16,7 @@ jobs:
       checkoutRef: ${{ github.event.pull_request.head.sha }}
 
   MsvcDev:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: [Checkout]
     steps:
     - name: Checkout


### PR DESCRIPTION
Until June when `windows-latest` will use VS2026, this PR keeps us on the older version until we fix the nasty issues it brings with it.

https://github.com/actions/runner-images/issues/14017