### PR TITLE
refactor: Remove dissolve object from graphs

### DIFF
--- a/src/main/dissolve.cpp
+++ b/src/main/dissolve.cpp
@@ -10,7 +10,7 @@ Dissolve::Dissolve(CoreData &coreData) : coreData_(coreData)
     // Set core simulation variables
     restartFileFrequency_ = 10;
 
-    graphNode_ = std::make_unique<DissolveGraph>(*this);
+    graphNode_ = std::make_unique<DissolveGraph>();
 
     // Clear everything
     clear();
@@ -50,7 +50,7 @@ void Dissolve::clear()
     nIterationsPerformed_ = 0;
 
     // Graph
-    graphNode_ = std::make_unique<DissolveGraph>(*this);
+    graphNode_ = std::make_unique<DissolveGraph>();
 
     // I/O
     setInputFilename("");

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -20,7 +20,7 @@ std::string_view DissolveGraph::type() const { return "Dissolve"; }
 std::string_view DissolveGraph::summary() const { return "Parent node of all simulations"; }
 
 // Return the current iteration count
-int DissolveGraph::iteration() const { return dissolve_.iteration(); }
+int DissolveGraph::iteration() const { return iteration_; }
 
 // Access a pair potential
 PairPotential *DissolveGraph::pairPotential(const AtomType *at1, const AtomType *at2) const

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -23,9 +23,9 @@ std::string_view DissolveGraph::summary() const { return "Parent node of all sim
 int DissolveGraph::iteration() const { return iteration_; }
 
 // Access a pair potential
-PairPotential *DissolveGraph::pairPotential(const AtomType *at1, const AtomType *at2) const
+PairPotential &DissolveGraph::pairPotential(const AtomType *at1, const AtomType *at2)
 {
-    return dissolve_.pairPotential(at1, at2);
+    return pairPotentials_.get(at1->name(), at2->name());
 }
 
 // Return the DissolveGraph reference

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -19,8 +19,14 @@ std::string_view DissolveGraph::type() const { return "Dissolve"; }
 // Return short summary of the node's purpose
 std::string_view DissolveGraph::summary() const { return "Parent node of all simulations"; }
 
-// Return dissolve
-Dissolve &DissolveGraph::dissolve() const { return dissolve_; }
+// Return the current iteration count
+int DissolveGraph::iteration() const { return dissolve_.iteration(); }
+
+// Access a pair potential
+PairPotential *DissolveGraph::pairPotential(const AtomType *at1, const AtomType *at2) const
+{
+    return dissolve_.pairPotential(at1, at2);
+}
 
 // Return the DissolveGraph reference
 DissolveGraph *DissolveGraph::dissolveGraph() { return this; }

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -4,7 +4,7 @@
 #include "nodes/dissolve.h"
 #include "kernels/producer.h"
 
-DissolveGraph::DissolveGraph(Dissolve &dissolve) : Graph(nullptr), dissolve_(dissolve) {}
+DissolveGraph::DissolveGraph() : Graph(nullptr) {}
 
 /*
  * Definitions (Virtuals)

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -19,9 +19,6 @@ std::string_view DissolveGraph::type() const { return "Dissolve"; }
 // Return short summary of the node's purpose
 std::string_view DissolveGraph::summary() const { return "Parent node of all simulations"; }
 
-// Return the current iteration count
-int DissolveGraph::iteration() const { return iteration_; }
-
 // Access a pair potential
 PairPotential &DissolveGraph::pairPotential(const AtomType *at1, const AtomType *at2)
 {

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -37,6 +37,8 @@ class DissolveGraph : public Graph
     private:
     // Dissolve reference
     Dissolve &dissolve_;
+    // Current Iteration
+    int iteration_;
 
     public:
     // Return the current iteration count

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -17,7 +17,7 @@ class PotentialMap;
 class DissolveGraph : public Graph
 {
     public:
-    DissolveGraph(Dissolve &dissolve);
+    DissolveGraph();
     ~DissolveGraph() = default;
 
     /*
@@ -35,8 +35,6 @@ class DissolveGraph : public Graph
      * Data
      */
     private:
-    // Dissolve reference
-    Dissolve &dissolve_;
     // Current Iteration
     int iteration_;
 

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -44,7 +44,7 @@ class DissolveGraph : public Graph
     // Return the current iteration count
     int iteration() const override;
     // Access a pair potential
-    PairPotential *pairPotential(const AtomType *at1, const AtomType *at2) const override;
+    PairPotential &pairPotential(const AtomType *at1, const AtomType *at2) override;
     // Return the DissolveGraph reference
     DissolveGraph *dissolveGraph() override;
 

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -39,8 +39,10 @@ class DissolveGraph : public Graph
     Dissolve &dissolve_;
 
     public:
-    // Return dissolve
-    Dissolve &dissolve() const;
+    // Return the current iteration count
+    int iteration() const override;
+    // Access a pair potential
+    PairPotential *pairPotential(const AtomType *at1, const AtomType *at2) const override;
     // Return the DissolveGraph reference
     DissolveGraph *dissolveGraph() override;
 

--- a/src/nodes/dissolve.h
+++ b/src/nodes/dissolve.h
@@ -34,13 +34,7 @@ class DissolveGraph : public Graph
     /*
      * Data
      */
-    private:
-    // Current Iteration
-    int iteration_;
-
     public:
-    // Return the current iteration count
-    int iteration() const override;
     // Access a pair potential
     PairPotential &pairPotential(const AtomType *at1, const AtomType *at2) override;
     // Return the DissolveGraph reference

--- a/src/nodes/epsrHelpers.cpp
+++ b/src/nodes/epsrHelpers.cpp
@@ -230,7 +230,7 @@ bool EPSRNode::generateEmpiricalPotentials(const std::vector<const AtomType *> &
                                 if (applyPotentials_)
                                 {
                                     // Grab pointer to the relevant pair potential (if it exists)
-                                    auto *pp = dissolve().pairPotential(at1, at2);
+                                    auto *pp = pairPotential(at1, at2);
                                     if (pp)
                                         pp->setAdditionalPotential(ep);
                                 }

--- a/src/nodes/epsrHelpers.cpp
+++ b/src/nodes/epsrHelpers.cpp
@@ -230,9 +230,8 @@ bool EPSRNode::generateEmpiricalPotentials(const std::vector<const AtomType *> &
                                 if (applyPotentials_)
                                 {
                                     // Grab pointer to the relevant pair potential (if it exists)
-                                    auto *pp = pairPotential(at1, at2);
-                                    if (pp)
-                                        pp->setAdditionalPotential(ep);
+                                    auto pp = pairPotential(at1, at2);
+                                    pp.setAdditionalPotential(ep);
                                 }
                             });
 

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -309,10 +309,7 @@ void Node::setParent(Graph *graph) { parentGraph_ = graph; }
 int Node::iteration() const { return parentGraph_->iteration(); }
 
 // Access a pair potential
-PairPotential *Node::pairPotential(const AtomType *at1, const AtomType *at2) const
-{
-    return parentGraph_->pairPotential(at1, at2);
-}
+PairPotential &Node::pairPotential(const AtomType *at1, const AtomType *at2) { return parentGraph_->pairPotential(at1, at2); }
 
 // Return the DissolveGraph reference
 DissolveGraph *Node::dissolveGraph() { return parentGraph_->dissolveGraph(); }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -306,7 +306,7 @@ Graph *Node::parentGraph() const { return parentGraph_; }
 void Node::setParent(Graph *graph) { parentGraph_ = graph; }
 
 // Return the current iteration count
-int Node::iteration() const { return parentGraph_->iteration(); }
+int Node::iteration() const { return iteration_; }
 
 // Access a pair potential
 PairPotential &Node::pairPotential(const AtomType *at1, const AtomType *at2) { return parentGraph_->pairPotential(at1, at2); }

--- a/src/nodes/node.cpp
+++ b/src/nodes/node.cpp
@@ -305,8 +305,14 @@ Graph *Node::parentGraph() const { return parentGraph_; }
 // This is private so that only designated friend classes can do this.
 void Node::setParent(Graph *graph) { parentGraph_ = graph; }
 
-// Return the Dissolve reference
-Dissolve &Node::dissolve() const { return parentGraph_->dissolve(); }
+// Return the current iteration count
+int Node::iteration() const { return parentGraph_->iteration(); }
+
+// Access a pair potential
+PairPotential *Node::pairPotential(const AtomType *at1, const AtomType *at2) const
+{
+    return parentGraph_->pairPotential(at1, at2);
+}
 
 // Return the DissolveGraph reference
 DissolveGraph *Node::dissolveGraph() { return parentGraph_->dissolveGraph(); }

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -21,6 +21,7 @@
 class Graph;
 class Edge;
 class DissolveGraph;
+class PairPotential;
 
 // Node Base
 class Node : public Serialisable<>
@@ -315,8 +316,10 @@ class Node : public Serialisable<>
     void markIncomingEdgesForPull(const ParameterBase *toParameter) const;
     // Returns the node parent graph
     Graph *parentGraph() const;
-    // Return the Dissolve reference
-    virtual Dissolve &dissolve() const;
+    // Return the current iteration count
+    virtual int iteration() const;
+    // Access a pair potential
+    virtual PairPotential *pairPotential(const AtomType *at1, const AtomType *at2) const;
     // Return the DissolveGraph reference
     virtual DissolveGraph *dissolveGraph();
 

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -317,7 +317,7 @@ class Node : public Serialisable<>
     // Returns the node parent graph
     Graph *parentGraph() const;
     // Return the current iteration count
-    virtual int iteration() const;
+    int iteration() const;
     // Access a pair potential
     virtual PairPotential &pairPotential(const AtomType *at1, const AtomType *at2);
     // Return the DissolveGraph reference
@@ -329,6 +329,8 @@ class Node : public Serialisable<>
     private:
     // Accumulated timing information (in seconds)
     SampledDouble timing_;
+    // Current iteration number
+    int iteration_ = 0;
 
     public:
     // Clear any local data

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -319,7 +319,7 @@ class Node : public Serialisable<>
     // Return the current iteration count
     virtual int iteration() const;
     // Access a pair potential
-    virtual PairPotential *pairPotential(const AtomType *at1, const AtomType *at2) const;
+    virtual PairPotential &pairPotential(const AtomType *at1, const AtomType *at2);
     // Return the DissolveGraph reference
     virtual DissolveGraph *dissolveGraph();
 

--- a/src/nodes/siteRDF.cpp
+++ b/src/nodes/siteRDF.cpp
@@ -114,7 +114,7 @@ NodeConstants::ProcessResult SiteRDFNode::process()
             sumN += Integrator::sum(dataCN, ranges[i]);
             if (sumNInst)
             {
-                sumNInst->addPoint(dissolve().iteration(), sumN.value());
+                sumNInst->addPoint(iteration(), sumN.value());
                 if (exportInstantaneous_)
                 {
                     Data1DExportFileFormat exportFormat(std::format("{}_Sum{}.txt", name(), rangeName));

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -26,10 +26,12 @@ namespace UnitTest
 class TestGraph : public DissolveGraph
 {
     public:
-    TestGraph() : dissolve(coreData), currentGraph_(this) { Node::echo_ = true; }
+    TestGraph() : currentGraph_(this)
+    {
+        Node::echo_ = true;
+        PairPotential::setChargeSource(PairPotential::ChargeSource::Automatic);
+    }
     ~TestGraph() { exportMermaidGraph(); }
-    CoreData coreData;
-    Dissolve dissolve;
 
     public:
     // Container for data 1D import filename and whether or not it is a histogram

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -26,7 +26,7 @@ namespace UnitTest
 class TestGraph : public DissolveGraph
 {
     public:
-    TestGraph() : DissolveGraph(dissolve), dissolve(coreData), currentGraph_(this) { Node::echo_ = true; }
+    TestGraph() : dissolve(coreData), currentGraph_(this) { Node::echo_ = true; }
     ~TestGraph() { exportMermaidGraph(); }
     CoreData coreData;
     Dissolve dissolve;

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -13,7 +13,7 @@ namespace UnitTest
 class GraphCoreTest : public ::testing::Test
 {
     public:
-    GraphCoreTest() : dissolve_(coreData_), root_(dissolve_) {}
+    GraphCoreTest() : dissolve_(coreData_) {}
 
     // Create a graph for testing
     void createGraph()
@@ -71,7 +71,7 @@ TEST_F(GraphCoreTest, Serialisation)
 
     CoreData cd;
     Dissolve d(cd);
-    DissolveGraph copy(d);
+    DissolveGraph copy;
     auto serialised = root_.into_toml();
 
     SerialisedValue contents = toml::parse("dissolve/input/simple_addition_graph.toml");

--- a/tests/nodes/graph.cpp
+++ b/tests/nodes/graph.cpp
@@ -13,7 +13,7 @@ namespace UnitTest
 class GraphCoreTest : public ::testing::Test
 {
     public:
-    GraphCoreTest() : dissolve_(coreData_) {}
+    GraphCoreTest() {}
 
     // Create a graph for testing
     void createGraph()
@@ -59,8 +59,6 @@ class GraphCoreTest : public ::testing::Test
 
     protected:
     // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
-    CoreData coreData_;
-    Dissolve dissolve_;
     DissolveGraph root_;
     AddNode *x_{nullptr}, *y_{nullptr}, *z_{nullptr};
 };

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -14,7 +14,7 @@ namespace UnitTest
 class IterableGraphTest : public ::testing::Test
 {
     public:
-    IterableGraphTest() : dissolve_(coreData_), root_(dissolve_) {}
+    IterableGraphTest() : dissolve_(coreData_) {}
 
     // Create a graph for testing
     void createGraph()
@@ -77,7 +77,7 @@ TEST_F(IterableGraphTest, BasicNonLoopingSeries)
 {
     CoreData coreData;
     Dissolve dissolve(coreData);
-    auto root = std::make_unique<DissolveGraph>(dissolve);
+    auto root = std::make_unique<DissolveGraph>();
     auto loop = dynamic_cast<IterableGraph *>(root->createNode("Iterator", "Iterator"));
     auto i = dynamic_cast<NumberNode *>(root->createNode("Number", "i"));
     auto a = dynamic_cast<AddNode *>(loop->createNode("Add", "a"));

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -14,7 +14,7 @@ namespace UnitTest
 class IterableGraphTest : public ::testing::Test
 {
     public:
-    IterableGraphTest() : dissolve_(coreData_) {}
+    IterableGraphTest() {}
 
     // Create a graph for testing
     void createGraph()
@@ -65,8 +65,6 @@ class IterableGraphTest : public ::testing::Test
 
     protected:
     // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
-    CoreData coreData_;
-    Dissolve dissolve_;
     DissolveGraph root_;
     NumberNode *i_{nullptr};
     AddNode *x_{nullptr}, *y_{nullptr};

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -12,7 +12,7 @@ namespace UnitTest
 class SubGraphTest : public ::testing::Test
 {
     public:
-    SubGraphTest() : dissolve_(coreData_), root_(dissolve_) {}
+    SubGraphTest() : dissolve_(coreData_) {}
 
     // Create a graph for testing (no edges)
     void createGraph()

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -12,7 +12,7 @@ namespace UnitTest
 class SubGraphTest : public ::testing::Test
 {
     public:
-    SubGraphTest() : dissolve_(coreData_) {}
+    SubGraphTest() {}
 
     // Create a graph for testing (no edges)
     void createGraph()
@@ -76,8 +76,6 @@ class SubGraphTest : public ::testing::Test
 
     protected:
     // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
-    CoreData coreData_;
-    Dissolve dissolve_;
     DissolveGraph root_;
     Graph *graphA_{nullptr};
     AddNode *x_{nullptr}, *y_{nullptr}, *z_{nullptr}, *w_{nullptr};


### PR DESCRIPTION
This should wait until after #2457

This breaks the connection between the `DisolveGraph` node and the old `Dissolve` object.  `DissolveGraph` contains no `Dissolve` or `CoreData` objects.

## Direct access

There were two places where the old `Dissolve` object was directly being accessed.  The first was in getting the iteration number and the second was accessing the pair potentials.  There was already a `pairPotentials_` member, so I used that for the second.  As for the first, I've currently added a global iteration count to the `DissolveGraph`, but we had also discussed possibly giving each node its own iteration count.

## Indirect Access

I spent far more time than I should have tracking down the fact that the constructor on `CoreData` globally sets the pair potential charge source.  Thus, removing the `CoreData` from the `DissolveGraph` would cause certain tests to fail, despite not accessing `CoreData`.  I have currently added that command into the constructor on `TestGraph`, but it might be more appropriate for `DissolveGraph`.