### PR TITLE
feat: Optional data parameters

### DIFF
--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -114,14 +114,23 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
 
     // Check that types are compatible
     if (!targetInput->acceptsOutput(sourceOutput.get()))
+    {
+        Messenger::error("Source output ({}@{}) and target input ({}@{}) edge types are not compatible - {} vs {}.\n",
+                         definition.sourceOutput, sourceNode->name(), definition.targetInput, targetNode->name(),
+                         sourceOutput->storedDataType().name(), targetInput->storedDataType().name());
         return {};
+    }
 
     // Create the edge
     auto edge = std::make_unique<EdgeConstructor>(*sourceNode, *sourceOutput, *targetNode, *targetInput);
 
     // Notify nodes about the new edge
     if (!sourceNode->linkEdge(edge.get()) || !targetNode->linkEdge(edge.get()))
+    {
+        Messenger::error("Failed to link edge between source output {}@{} and target input {}@{}.\n", definition.sourceOutput,
+                         sourceNode->name(), definition.targetInput, targetNode->name());
         return {};
+    }
 
     return edge;
 }

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -222,7 +222,11 @@ NodeConstants::ProcessResult Edge::pull()
 
         // Copy the parameter data over
         if (!targetInput_.assign(&sourceOutput_))
+        {
+            Messenger::error("Failed to assign value from {}@{} to {}@{}.\n", sourceOutput_.name(), sourceNode_.name(),
+                             targetInput_.name(), targetNode_.name());
             return NodeConstants::ProcessResult::Failed;
+        }
 
         // All succeeded, so update version index
         sourceNodeVersionIndex_ = sourceNode_.versionIndex();

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -338,17 +338,17 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     // Assign the value of another parameter to this one.
     bool assign(ParameterBase *other) override
     {
-        // If we are a pointer type, getting a nullptr is disallowed
         if constexpr (std::is_pointer<DataClass>())
         {
+            // If we are a pointer type, getting a nullptr is disallowed
             setData(other->get<DataClass>());
 
             return data_ != nullptr;
         }
-
-        // If we represent a std::vector container we can conditionally check for a single data item being passed
-        if constexpr (is_instance_of_v<DataClass, std::vector>)
+        else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
+            // If we represent a std::vector container we can conditionally check for a single data item being passed
+
             // Vector to vector
             if (storedDataType_ == other->storedDataType())
             {
@@ -367,10 +367,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 return true;
             }
         }
-
-        // Optional arguments can be set from the base class (i.e. with no std::optional container) as well as std::optional
-        if constexpr (is_instance_of_v<DataClass, std::optional>)
+        else if constexpr (is_instance_of_v<DataClass, std::optional>)
         {
+            // Optional arguments can be set from the base class (i.e. with no std::optional container) as well as std::optional
+
             // Optional to optional
             if (storedDataType_ == other->storedDataType())
             {
@@ -387,10 +387,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 return true;
             }
         }
-
-        // Data types can be set from a std::optional containing the same type
-        if (typeid(std::optional<DataClass>) == other->storedDataType())
+        else if (typeid(std::optional<DataClass>) == other->storedDataType())
         {
+            // Data types can be set from a std::optional containing the same type
+
             auto otherData = other->get<std::optional<DataClass>>();
             if (otherData.has_value())
             {
@@ -417,18 +417,15 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         // Normal data types can be set from optional values
         if (typeid(std::optional<DataClass>) == other->storedDataType())
             return true;
-
-        // Vectors can accept a single value of the contained type
-        if constexpr (is_instance_of_v<DataClass, std::vector>)
+        else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
-            // If we represent a std::vector container we can accept a single data item
+            // Vectors can accept a single value of the contained type
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
         }
-
-        // Optionals can accept non-optional data
-        if constexpr (is_instance_of_v<DataClass, std::optional>)
+        else if constexpr (is_instance_of_v<DataClass, std::optional>)
         {
+            // Optionals can accept non-optional data
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
         }

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -338,15 +338,26 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     // Assign the value of another parameter to this one.
     bool assign(ParameterBase *other) override
     {
-        // If the stored data types are the same then we can just do a straight assignment
-        if (storedDataType_ == other->storedDataType())
+        // If we are a pointer type, getting a nullptr is disallowed
+        if constexpr (std::is_pointer<DataClass>())
         {
             setData(other->get<DataClass>());
-            return true;
+
+            return data_ != nullptr;
         }
-        else if constexpr (is_instance_of_v<DataClass, std::vector>)
+
+        // If we represent a std::vector container we can conditionally check for a single data item being passed
+        if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
-            // If we represent a std::vector container we can conditionally check for a single data item being passed
+            // Vector to vector
+            if (storedDataType_ == other->storedDataType())
+            {
+                setData(other->get<DataClass>());
+
+                return true;
+            }
+
+            // Single value to vector
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
             {
                 data_.push_back(other->get<typename DataClass::value_type>());
@@ -355,26 +366,33 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 
                 return true;
             }
-            else
-                return false;
         }
-        else if constexpr (is_instance_of_v<DataClass, std::optional>)
+
+        // Optional arguments can be set from the base class (i.e. with no std::optional container) as well as std::optional
+        if constexpr (is_instance_of_v<DataClass, std::optional>)
         {
-            // Optional arguments can of course accept the base class (i.e. with no std::optional container)
+            // Optional to optional
+            if (storedDataType_ == other->storedDataType())
+            {
+                setData(other->get<DataClass>());
+
+                return true;
+            }
+
+            // Base type into std::optional
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
             {
                 setData(other->get<typename DataClass::value_type>());
 
                 return true;
             }
-            else
-                return false;
         }
-        else if constexpr (std::is_pointer<DataClass>())
+
+        // General case - if the stored data types are the same then we can just do a straight assignment
+        if (storedDataType_ == other->storedDataType())
         {
-            // If we are a pointer type, getting a nullptr is disallowed
-            if (data_ == nullptr)
-                return false;
+            setData(other->get<DataClass>());
+            return true;
         }
 
         return false;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -388,6 +388,17 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             }
         }
 
+        // Data types can be set from a std::optional containing the same type
+        if (typeid(std::optional<DataClass>) == other->storedDataType())
+        {
+            auto otherData = other->get<std::optional<DataClass>>();
+            if (otherData.has_value())
+            {
+                setData(*otherData);
+                return true;
+            }
+        }
+
         // General case - if the stored data types are the same then we can just do a straight assignment
         if (storedDataType_ == other->storedDataType())
         {
@@ -402,17 +413,26 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     {
         if (storedDataType_ == other->storedDataType())
             return true;
-        else if constexpr (is_instance_of_v<DataClass, std::vector>)
+
+        // Normal data types can be set from optional values
+        if (typeid(std::optional<DataClass>) == other->storedDataType())
+            return true;
+
+        // Vectors can accept a single value of the contained type
+        if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
             // If we represent a std::vector container we can accept a single data item
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
         }
-        else if constexpr (is_instance_of_v<DataClass, std::optional>)
+
+        // Optionals can accept non-optional data
+        if constexpr (is_instance_of_v<DataClass, std::optional>)
         {
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
         }
+
         return false;
     }
     // Invalidate the vector data (instances of std::vector only)

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -340,7 +340,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     {
         // If the stored data types are the same then we can just do a straight assignment
         if (storedDataType_ == other->storedDataType())
+        {
             setData(other->get<DataClass>());
+            return true;
+        }
         else if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
             // If we represent a std::vector container we can conditionally check for a single data item being passed
@@ -349,19 +352,32 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 data_.push_back(other->get<typename DataClass::value_type>());
 
                 updateAfterSet();
+
+                return true;
             }
             else
                 return false;
         }
-
-        // If we are a pointer type, getting a nullptr is disallowed
-        if constexpr (std::is_pointer<DataClass>())
+        else if constexpr (is_instance_of_v<DataClass, std::optional>)
         {
+            // Optional arguments can of course accept the base class (i.e. with no std::optional container)
+            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
+            {
+                setData(other->get<typename DataClass::value_type>());
+
+                return true;
+            }
+            else
+                return false;
+        }
+        else if constexpr (std::is_pointer<DataClass>())
+        {
+            // If we are a pointer type, getting a nullptr is disallowed
             if (data_ == nullptr)
                 return false;
         }
 
-        return true;
+        return false;
     }
     // Return whether this parameter accepts the output type of the other
     bool acceptsOutput(ParameterBase *other) const override
@@ -374,7 +390,11 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
         }
-
+        else if constexpr (is_instance_of_v<DataClass, std::optional>)
+        {
+            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
+                return true;
+        }
         return false;
     }
     // Invalidate the vector data (instances of std::vector only)

--- a/src/nodes/test.cpp
+++ b/src/nodes/test.cpp
@@ -8,11 +8,15 @@ TestNode::TestNode(Graph *parentGraph) : Node(parentGraph)
     // Inputs
     addInput<Configuration *>("ConfigurationInput", "A configuration input", configurationInput_);
     addInput("CreateConfiguration", "Whether to create the optional configuration on run", createConfiguration_);
+    addInput("Number", "A single number", number_);
+    addInput("OptionalNumber", "A single number", optionalNumber_);
     addInput("NumberVector", "A vector of numbers", numberVector_);
 
     // Outputs
     addOptionalPointerOutput<Configuration>("OptionalConfiguration", "An optional Configuration", optionalConfiguration_);
+    addOutput("Number", "A single number", number_);
     addOutput("NumberVector", "A vector of numbers", numberVector_);
+    addOutput("OptionalNumber", "An optional number", optionalNumber_);
 }
 
 /*

--- a/src/nodes/test.h
+++ b/src/nodes/test.h
@@ -32,8 +32,12 @@ class TestNode : public Node
     std::optional<Configuration> optionalConfiguration_;
     // Whether our processing loop creates a valid optional Configuration data
     bool createConfiguration_{false};
+    // Number
+    Number number_;
     // Number vector
     std::vector<Number> numberVector_;
+    // Optional number
+    std::optional<Number> optionalNumber_;
 
     public:
     // Return the optional Configuration

--- a/tests/nodes/parameters.cpp
+++ b/tests/nodes/parameters.cpp
@@ -9,6 +9,66 @@
 
 namespace UnitTest
 {
+TEST(ParametersTest, NumberToOptionalNumber)
+{
+    TestGraph testGraph;
+
+    // Create a couple of TestNodes
+    auto *a = dynamic_cast<TestNode *>(testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA"));
+    ASSERT_TRUE(a);
+    auto numberOutput = a->findOutput("Number");
+    ASSERT_TRUE(numberOutput);
+    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
+    ASSERT_TRUE(b);
+    auto optionalNumberImput = b->findInput("OptionalNumber");
+    ASSERT_TRUE(optionalNumberImput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph.addEdge({"TestA", "Number", "TestB", "OptionalNumber"}));
+
+    // Set number value input (shared with output)
+    ASSERT_TRUE(a->setInput<Number>("Number", 1.234));
+
+    // Run b
+    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b->versionIndex(), 0);
+
+    // Check optional value
+    auto optional = b->getInputValue<std::optional<Number>>("OptionalNumber");
+    ASSERT_TRUE(optional.has_value());
+    EXPECT_DOUBLE_EQ(1.234, optional->asDouble());
+}
+
+TEST(ParametersTest, OptionalNumberToNumber)
+{
+    TestGraph testGraph;
+
+    // Create a couple of TestNodes
+    auto *a = dynamic_cast<TestNode *>(testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA"));
+    ASSERT_TRUE(a);
+    auto optionalNumberOutput = a->findOutput("OptionalNumber");
+    ASSERT_TRUE(optionalNumberOutput);
+    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
+    ASSERT_TRUE(b);
+    auto numberImput = b->findInput("Number");
+    ASSERT_TRUE(numberImput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph.addEdge({"TestA", "OptionalNumber", "TestB", "Number"}));
+
+    // Run b - should fail as there is no optional value to pull along the edge
+    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Failed);
+    EXPECT_EQ(b->versionIndex(), NodeConstants::InvalidVersion);
+
+    // Set number value input (shared with output)
+    ASSERT_TRUE(a->setInput<std::optional<Number>>("OptionalNumber", 1.234));
+
+    // Run again and check value
+    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b->versionIndex(), 0);
+    EXPECT_DOUBLE_EQ(1.234, b->getInputValue<Number>("Number").asDouble());
+}
+
 TEST(ParametersTest, OptionalPointerOutput)
 {
     TestGraph testGraph;


### PR DESCRIPTION
The best way to describe this PR is that it adjusts the `Parameter` class to make `std::optional` "first-class datatypes". Such inputs are required for the upcoming changes to the `SpeciesNode` class.  I also extend the unit test for parameters and add in some useful error reporting in `Edge`.