### PR TITLE
chore: Remove lazy species intra accessors

### DIFF
--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -127,7 +127,7 @@ void Species::print() const
         Messenger::print("      I     J    Form             Parameters\n");
         Messenger::print("    ---------------------------------------------------------------------------------\n");
         for (const auto &bond : bonds_)
-            Messenger::print("   {:4d}  {:4d}    {}{:<12}  {}\n", bond.indexI() + 1, bond.indexJ() + 1,
+            Messenger::print("   {:4d}  {:4d}    {}{:<12}  {}\n", bond.i()->index() + 1, bond.j()->index() + 1,
                              bond.commonTerm() ? '@' : ' ', BondFunctions::forms().keyword(bond.interactionForm()),
                              bond.interactionPotential().parametersAsString());
     }
@@ -138,8 +138,8 @@ void Species::print() const
         Messenger::print("      I     J     K    Form             Parameters\n");
         Messenger::print("    ---------------------------------------------------------------------------------------\n");
         for (const auto &angle : angles_)
-            Messenger::print("   {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", angle.indexI() + 1, angle.indexJ() + 1,
-                             angle.indexK() + 1, angle.commonTerm() ? '@' : ' ',
+            Messenger::print("   {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", angle.i()->index() + 1, angle.j()->index() + 1,
+                             angle.k()->index() + 1, angle.commonTerm() ? '@' : ' ',
                              AngleFunctions::forms().keyword(angle.interactionForm()),
                              angle.interactionPotential().parametersAsString());
     }
@@ -151,9 +151,9 @@ void Species::print() const
         Messenger::print("    ---------------------------------------------------------------------------------------------\n");
         // Loop over Torsions
         for (const auto &torsion : torsions())
-            Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", torsion.indexI() + 1, torsion.indexJ() + 1,
-                             torsion.indexK() + 1, torsion.indexL() + 1, torsion.commonTerm() ? '@' : ' ',
-                             TorsionFunctions::forms().keyword(torsion.interactionForm()),
+            Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", torsion.i()->index() + 1,
+                             torsion.j()->index() + 1, torsion.k()->index() + 1, torsion.l()->index() + 1,
+                             torsion.commonTerm() ? '@' : ' ', TorsionFunctions::forms().keyword(torsion.interactionForm()),
                              torsion.interactionPotential().parametersAsString());
     }
 
@@ -164,9 +164,9 @@ void Species::print() const
         Messenger::print("    ---------------------------------------------------------------------------------------------\n");
         // Loop over Impropers
         for (auto &improper : impropers())
-            Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", improper.indexI() + 1, improper.indexJ() + 1,
-                             improper.indexK() + 1, improper.indexL() + 1, improper.commonTerm() ? '@' : ' ',
-                             TorsionFunctions::forms().keyword(improper.interactionForm()),
+            Messenger::print("   {:4d}  {:4d}  {:4d}  {:4d}    {}{:<12}  {}\n", improper.i()->index() + 1,
+                             improper.j()->index() + 1, improper.k()->index() + 1, improper.l()->index() + 1,
+                             improper.commonTerm() ? '@' : ' ', TorsionFunctions::forms().keyword(improper.interactionForm()),
                              improper.interactionPotential().parametersAsString());
     }
 }

--- a/src/classes/speciesAngle.cpp
+++ b/src/classes/speciesAngle.cpp
@@ -32,41 +32,6 @@ SpeciesAtom *SpeciesAngle::k() const { return k_; }
 // Return vector of involved atoms
 std::vector<const SpeciesAtom *> SpeciesAngle::atoms() const { return {i_, j_, k_}; }
 
-// Return index (in parent Species) of first SpeciesAtom
-int SpeciesAngle::indexI() const
-{
-    assert(i_);
-    return i_->index();
-}
-
-// Return index (in parent Species) of second (central) SpeciesAtom
-int SpeciesAngle::indexJ() const
-{
-    assert(j_);
-    return j_->index();
-}
-
-// Return index (in parent Species) of third SpeciesAtom
-int SpeciesAngle::indexK() const
-{
-    assert(k_);
-    return k_->index();
-}
-
-// Return index (in parent Species) of nth SpeciesAtom in interaction
-int SpeciesAngle::index(int n) const
-{
-    if (n == 0)
-        return indexI();
-    else if (n == 1)
-        return indexJ();
-    else if (n == 2)
-        return indexK();
-
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesAngle::index(int). Returning 0...\n", n);
-    return 0;
-}
-
 // Return whether Atoms in Angle match those specified
 bool SpeciesAngle::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k) const
 {

--- a/src/classes/speciesAngle.h
+++ b/src/classes/speciesAngle.h
@@ -40,14 +40,6 @@ class SpeciesAngle : public SpeciesIntra<SpeciesAngle, AngleFunctions>
     SpeciesAtom *k() const;
     // Return vector of involved atoms
     std::vector<const SpeciesAtom *> atoms() const override;
-    // Return index (in parent Species) of first SpeciesAtom
-    int indexI() const;
-    // Return index (in parent Species) of second (central) SpeciesAtom
-    int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
-    int indexK() const;
-    // Return index (in parent Species) of nth SpeciesAtom
-    int index(int n) const;
     // Return whether SpeciesAtom match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k) const;
 

--- a/src/classes/speciesBond.cpp
+++ b/src/classes/speciesBond.cpp
@@ -24,32 +24,6 @@ SpeciesBond::~SpeciesBond() = default;
 // Return vector of involved atoms
 std::vector<const SpeciesAtom *> SpeciesBond::atoms() const { return {i_, j_}; }
 
-// Return index (in parent Species) of first SpeciesAtom
-int SpeciesBond::indexI() const
-{
-    assert(i_);
-    return i_->index();
-}
-
-// Return index (in parent Species) of second SpeciesAtom
-int SpeciesBond::indexJ() const
-{
-    assert(j_);
-    return j_->index();
-}
-
-// Return index (in parent Species) of nth SpeciesAtom in interaction
-int SpeciesBond::index(int n) const
-{
-    if (n == 0)
-        return indexI();
-    else if (n == 1)
-        return indexJ();
-
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesBond::index(int). Returning 0...\n", n);
-    return 0;
-}
-
 // Return whether SpeciesAtoms in Angle match those specified
 bool SpeciesBond::matches(const SpeciesAtom *i, const SpeciesAtom *j) const
 {

--- a/src/classes/speciesBond.h
+++ b/src/classes/speciesBond.h
@@ -27,12 +27,6 @@ class SpeciesBond : public Bond<SpeciesAtom>, public SpeciesIntra<SpeciesBond, B
     public:
     // Return vector of involved atoms
     std::vector<const SpeciesAtom *> atoms() const override;
-    // Return index (in parent Species) of first SpeciesAtom
-    int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
-    int indexJ() const;
-    // Return index (in parent Species) of nth SpeciesAtom
-    int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j) const;
 

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -34,12 +34,6 @@ SpeciesAtom *SpeciesImproper::l() const { return l_; }
 // Return vector of involved atoms
 std::vector<const SpeciesAtom *> SpeciesImproper::atoms() const { return {i_, j_, k_, l_}; }
 
-// Return whether the improper uses the specified SpeciesAtom
-bool SpeciesImproper::uses(SpeciesAtom *spAtom) const
-{
-    return ((i_ == spAtom) || (j_ == spAtom) || (k_ == spAtom) || (l_ == spAtom));
-}
-
 // Return whether Atoms in Improper match those specified
 bool SpeciesImproper::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const
 {

--- a/src/classes/speciesImproper.cpp
+++ b/src/classes/speciesImproper.cpp
@@ -40,50 +40,6 @@ bool SpeciesImproper::uses(SpeciesAtom *spAtom) const
     return ((i_ == spAtom) || (j_ == spAtom) || (k_ == spAtom) || (l_ == spAtom));
 }
 
-// Return index (in parent Species) of first SpeciesAtom
-int SpeciesImproper::indexI() const
-{
-    assert(i_);
-    return i_->index();
-}
-
-// Return index (in parent Species) of second (central) SpeciesAtom
-int SpeciesImproper::indexJ() const
-{
-    assert(j_);
-    return j_->index();
-}
-
-// Return index (in parent Species) of third SpeciesAtom
-int SpeciesImproper::indexK() const
-{
-    assert(k_);
-    return k_->index();
-}
-
-// Return index (in parent Species) of fourth SpeciesAtom
-int SpeciesImproper::indexL() const
-{
-    assert(l_);
-    return l_->index();
-}
-
-// Return index (in parent Species) of nth SpeciesAtom in interaction
-int SpeciesImproper::index(int n) const
-{
-    if (n == 0)
-        return indexI();
-    else if (n == 1)
-        return indexJ();
-    else if (n == 2)
-        return indexK();
-    else if (n == 3)
-        return indexL();
-
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesImproper::index(int). Returning 0...\n", n);
-    return 0;
-}
-
 // Return whether Atoms in Improper match those specified
 bool SpeciesImproper::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const
 {

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -46,18 +46,9 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     std::vector<const SpeciesAtom *> atoms() const override;
     // Return whether the improper uses the specified SpeciesAtom
     bool uses(SpeciesAtom *spAtom) const;
-    // Return index (in parent Species) of first SpeciesAtom
-    int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
-    int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
-    int indexK() const;
-    // Return index (in parent Species) of fourth SpeciesAtom
-    int indexL() const;
-    // Return index (in parent Species) of nth SpeciesAtom in interaction
-    int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
+
     /*
      * Interaction Parameters
      */

--- a/src/classes/speciesImproper.h
+++ b/src/classes/speciesImproper.h
@@ -44,8 +44,6 @@ class SpeciesImproper : public SpeciesIntra<SpeciesImproper, TorsionFunctions>
     SpeciesAtom *l() const;
     // Return vector of involved atoms
     std::vector<const SpeciesAtom *> atoms() const override;
-    // Return whether the improper uses the specified SpeciesAtom
-    bool uses(SpeciesAtom *spAtom) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
 

--- a/src/classes/speciesTorsion.cpp
+++ b/src/classes/speciesTorsion.cpp
@@ -35,50 +35,6 @@ SpeciesAtom *SpeciesTorsion::l() const { return l_; }
 // Return vector of involved atoms
 std::vector<const SpeciesAtom *> SpeciesTorsion::atoms() const { return {i_, j_, k_, l_}; }
 
-// Return index (in parent Species) of first SpeciesAtom
-int SpeciesTorsion::indexI() const
-{
-    assert(i_);
-    return i_->index();
-}
-
-// Return index (in parent Species) of second (central) SpeciesAtom
-int SpeciesTorsion::indexJ() const
-{
-    assert(j_);
-    return j_->index();
-}
-
-// Return index (in parent Species) of third SpeciesAtom
-int SpeciesTorsion::indexK() const
-{
-    assert(k_);
-    return k_->index();
-}
-
-// Return index (in parent Species) of fourth SpeciesAtom
-int SpeciesTorsion::indexL() const
-{
-    assert(l_);
-    return l_->index();
-}
-
-// Return index (in parent Species) of nth SpeciesAtom in interaction
-int SpeciesTorsion::index(int n) const
-{
-    if (n == 0)
-        return indexI();
-    else if (n == 1)
-        return indexJ();
-    else if (n == 2)
-        return indexK();
-    else if (n == 3)
-        return indexL();
-
-    Messenger::error("SpeciesAtom index {} is out of range in SpeciesTorsion::index(int). Returning 0...\n", n);
-    return 0;
-}
-
 // Return whether Atoms in Torsion match those specified
 bool SpeciesTorsion::matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const
 {

--- a/src/classes/speciesTorsion.h
+++ b/src/classes/speciesTorsion.h
@@ -44,16 +44,6 @@ class SpeciesTorsion : public SpeciesIntra<SpeciesTorsion, TorsionFunctions>
     SpeciesAtom *l() const;
     // Return vector of involved atoms
     std::vector<const SpeciesAtom *> atoms() const override;
-    // Return index (in parent Species) of first SpeciesAtom
-    int indexI() const;
-    // Return index (in parent Species) of second SpeciesAtom
-    int indexJ() const;
-    // Return index (in parent Species) of third SpeciesAtom
-    int indexK() const;
-    // Return index (in parent Species) of fourth SpeciesAtom
-    int indexL() const;
-    // Return index (in parent Species) of nth SpeciesAtom in interaction
-    int index(int n) const;
     // Return whether SpeciesAtoms match those specified
     bool matches(const SpeciesAtom *i, const SpeciesAtom *j, const SpeciesAtom *k, const SpeciesAtom *l) const;
 

--- a/src/classes/species_io.cpp
+++ b/src/classes/species_io.cpp
@@ -796,13 +796,13 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             if (bond.commonTerm())
             {
                 if (!parser.writeLineF("{}{}  {:3d}  {:3d}  @{}\n", newPrefix,
-                                       keywords().keyword(Species::SpeciesKeyword::Bond), bond.indexI() + 1, bond.indexJ() + 1,
-                                       bond.commonTerm()->name()))
+                                       keywords().keyword(Species::SpeciesKeyword::Bond), bond.i()->index() + 1,
+                                       bond.j()->index() + 1, bond.commonTerm()->name()))
                     return false;
             }
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {} {}\n", newPrefix,
-                                        keywords().keyword(Species::SpeciesKeyword::Bond), bond.indexI() + 1, bond.indexJ() + 1,
-                                        BondFunctions::forms().keyword(bond.interactionForm()),
+                                        keywords().keyword(Species::SpeciesKeyword::Bond), bond.i()->index() + 1,
+                                        bond.j()->index() + 1, BondFunctions::forms().keyword(bond.interactionForm()),
                                         bond.interactionPotential().parametersAsString()))
                 return false;
         }
@@ -820,13 +820,13 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             if (angle.commonTerm())
             {
                 if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  @{}\n", newPrefix,
-                                       keywords().keyword(Species::SpeciesKeyword::Angle), angle.indexI() + 1,
-                                       angle.indexJ() + 1, angle.indexK() + 1, angle.commonTerm()->name()))
+                                       keywords().keyword(Species::SpeciesKeyword::Angle), angle.i()->index() + 1,
+                                       angle.j()->index() + 1, angle.k()->index() + 1, angle.commonTerm()->name()))
                     return false;
             }
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
-                                        keywords().keyword(Species::SpeciesKeyword::Angle), angle.indexI() + 1,
-                                        angle.indexJ() + 1, angle.indexK() + 1,
+                                        keywords().keyword(Species::SpeciesKeyword::Angle), angle.i()->index() + 1,
+                                        angle.j()->index() + 1, angle.k()->index() + 1,
                                         AngleFunctions::forms().keyword(angle.interactionForm()),
                                         angle.interactionPotential().parametersAsString()))
                 return false;
@@ -850,8 +850,8 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             if (torsion.commonTerm())
             {
                 if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  @{}\n", newPrefix,
-                                       keywords().keyword(Species::SpeciesKeyword::Torsion), torsion.indexI() + 1,
-                                       torsion.indexJ() + 1, torsion.indexK() + 1, torsion.indexL() + 1,
+                                       keywords().keyword(Species::SpeciesKeyword::Torsion), torsion.i()->index() + 1,
+                                       torsion.j()->index() + 1, torsion.k()->index() + 1, torsion.l()->index() + 1,
                                        torsion.commonTerm()->name()))
                     return false;
             }
@@ -864,8 +864,8 @@ bool Species::write(LineParser &parser, std::string_view prefix)
                     return false;
 
                 if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
-                                       keywords().keyword(Species::SpeciesKeyword::Torsion), torsion.indexI() + 1,
-                                       torsion.indexJ() + 1, torsion.indexK() + 1, torsion.indexL() + 1,
+                                       keywords().keyword(Species::SpeciesKeyword::Torsion), torsion.i()->index() + 1,
+                                       torsion.j()->index() + 1, torsion.k()->index() + 1, torsion.l()->index() + 1,
                                        TorsionFunctions::forms().keyword(torsion.interactionForm()),
                                        torsion.interactionPotential().parametersAsString()))
                     return false;
@@ -889,13 +889,14 @@ bool Species::write(LineParser &parser, std::string_view prefix)
             if (imp.commonTerm())
             {
                 if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  @{}\n", newPrefix,
-                                       keywords().keyword(Species::SpeciesKeyword::Improper), imp.indexI() + 1,
-                                       imp.indexJ() + 1, imp.indexK() + 1, imp.indexL() + 1, imp.commonTerm()->name()))
+                                       keywords().keyword(Species::SpeciesKeyword::Improper), imp.i()->index() + 1,
+                                       imp.j()->index() + 1, imp.k()->index() + 1, imp.l()->index() + 1,
+                                       imp.commonTerm()->name()))
                     return false;
             }
             else if (!parser.writeLineF("{}{}  {:3d}  {:3d}  {:3d}  {:3d}  {}  {}\n", newPrefix,
-                                        keywords().keyword(Species::SpeciesKeyword::Improper), imp.indexI() + 1,
-                                        imp.indexJ() + 1, imp.indexK() + 1, imp.indexL() + 1,
+                                        keywords().keyword(Species::SpeciesKeyword::Improper), imp.i()->index() + 1,
+                                        imp.j()->index() + 1, imp.k()->index() + 1, imp.l()->index() + 1,
                                         TorsionFunctions::forms().keyword(imp.interactionForm()),
                                         imp.interactionPotential().parametersAsString()))
                 return false;

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "gui/models/speciesAngleModel.h"
+#include "classes/speciesAtom.h"
 
 SpeciesAngleModel::SpeciesAngleModel() : angles_(nullptr) {}
 
@@ -44,9 +45,11 @@ QVariant SpeciesAngleModel::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
             case (DataType::IndexI):
+                return angle.i()->index() + 1;
             case (DataType::IndexJ):
+                return angle.j()->index() + 1;
             case (DataType::IndexK):
-                return angle.index(index.column()) + 1;
+                return angle.k()->index() + 1;
             case (DataType::Form):
                 return angle.commonTerm() ? QString::fromStdString("@" + std::string(angle.commonTerm()->name()))
                                           : QString::fromStdString(AngleFunctions::forms().keyword(angle.interactionForm()));

--- a/src/gui/models/speciesAngleModel.cpp
+++ b/src/gui/models/speciesAngleModel.cpp
@@ -3,6 +3,7 @@
 
 #include "gui/models/speciesAngleModel.h"
 #include "classes/speciesAtom.h"
+#include "classes/speciesBond.h"
 
 SpeciesAngleModel::SpeciesAngleModel() : angles_(nullptr) {}
 

--- a/src/gui/models/speciesBondModel.cpp
+++ b/src/gui/models/speciesBondModel.cpp
@@ -46,8 +46,9 @@ QVariant SpeciesBondModel::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
             case (DataType::IndexI):
+                return bond.i()->index() + 1;
             case (DataType::IndexJ):
-                return bond.index(index.column()) + 1;
+                return bond.j()->index() + 1;
             case (DataType::Form):
                 return bond.commonTerm()
                            ? QString::fromStdString("@" + std::string(bond.commonTerm()->name()))

--- a/src/gui/models/speciesBondModel.h
+++ b/src/gui/models/speciesBondModel.h
@@ -6,7 +6,6 @@
 #include "classes/speciesAtom.h"
 #include "classes/speciesBond.h"
 #include <QAbstractTableModel>
-#include <QModelIndex>
 
 class SpeciesBondModel : public QAbstractTableModel
 {

--- a/src/gui/models/speciesImproperModel.cpp
+++ b/src/gui/models/speciesImproperModel.cpp
@@ -45,10 +45,13 @@ QVariant SpeciesImproperModel::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
             case (DataType::IndexI):
+                return improper.i()->index() + 1;
             case (DataType::IndexJ):
+                return improper.j()->index() + 1;
             case (DataType::IndexK):
+                return improper.k()->index() + 1;
             case (DataType::IndexL):
-                return improper.index(index.column()) + 1;
+                return improper.l()->index() + 1;
             case (DataType::Form):
                 return improper.commonTerm()
                            ? QString::fromStdString("@" + std::string(improper.commonTerm()->name()))

--- a/src/gui/models/speciesTorsionModel.cpp
+++ b/src/gui/models/speciesTorsionModel.cpp
@@ -45,10 +45,13 @@ QVariant SpeciesTorsionModel::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
             case (DataType::IndexI):
+                return torsion.i()->index() + 1;
             case (DataType::IndexJ):
+                return torsion.j()->index() + 1;
             case (DataType::IndexK):
+                return torsion.k()->index() + 1;
             case (DataType::IndexL):
-                return torsion.index(index.column()) + 1;
+                return torsion.l()->index() + 1;
             case (DataType::Form):
                 return torsion.commonTerm()
                            ? QString::fromStdString("@" + std::string(torsion.commonTerm()->name()))

--- a/src/gui/render/renderableConfiguration.cpp
+++ b/src/gui/render/renderableConfiguration.cpp
@@ -121,7 +121,7 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
                 {
                     // Blindly get partner Atom 'j' - don't check if it is the true partner, only if it is
                     // the same as 'i' (in which case we skip it, ensuring we draw every bond only once)
-                    auto partner = i.molecule()->atom(bond->indexJ());
+                    auto partner = i.molecule()->atom(bond->j()->index());
                     if (&i == partner)
                         continue;
 
@@ -163,7 +163,7 @@ void RenderableConfiguration::recreatePrimitives(const View &view, const ColourD
             {
                 // Blindly get partner Atom 'j' - don't check if it is the true partner, only if it is the same
                 // as 'i' (in which case we skip it, ensuring we draw every bond only once)
-                auto partner = i.molecule()->atom(bond->indexJ());
+                auto partner = i.molecule()->atom(bond->j()->index());
                 if (&i == partner)
                     continue;
 

--- a/src/kernels/energy.cpp
+++ b/src/kernels/energy.cpp
@@ -427,29 +427,29 @@ Kernel::EnergyResult EnergyKernel::totalEnergySimple() const
         // Bond energy
         for (const auto &bond : molN->species()->bonds())
             geometryEnergy.bondEnergy +=
-                bond.energy(box_->minimumDistance(molN->atom(bond.indexI())->r(), molN->atom(bond.indexJ())->r()));
+                bond.energy(box_->minimumDistance(molN->atom(bond.i()->index())->r(), molN->atom(bond.j()->index())->r()));
 
         // Angle energy
         for (const auto &angle : molN->species()->angles())
         {
             geometryEnergy.angleEnergy += angle.energy(box_->angleInRadians(
-                molN->atom(angle.indexI())->r(), molN->atom(angle.indexJ())->r(), molN->atom(angle.indexK())->r()));
+                molN->atom(angle.i()->index())->r(), molN->atom(angle.j()->index())->r(), molN->atom(angle.k()->index())->r()));
         }
 
         // Torsion energy
         for (const auto &torsion : molN->species()->torsions())
         {
-            geometryEnergy.torsionEnergy +=
-                torsion.energy(box_->torsionInRadians(molN->atom(torsion.indexI())->r(), molN->atom(torsion.indexJ())->r(),
-                                                      molN->atom(torsion.indexK())->r(), molN->atom(torsion.indexL())->r()));
+            geometryEnergy.torsionEnergy += torsion.energy(
+                box_->torsionInRadians(molN->atom(torsion.i()->index())->r(), molN->atom(torsion.j()->index())->r(),
+                                       molN->atom(torsion.k()->index())->r(), molN->atom(torsion.l()->index())->r()));
         }
 
         // Improper energy
         for (const auto &imp : molN->species()->impropers())
         {
             geometryEnergy.improperEnergy +=
-                imp.energy(box_->torsionInRadians(molN->atom(imp.indexI())->r(), molN->atom(imp.indexJ())->r(),
-                                                  molN->atom(imp.indexK())->r(), molN->atom(imp.indexL())->r()));
+                imp.energy(box_->torsionInRadians(molN->atom(imp.i()->index())->r(), molN->atom(imp.j()->index())->r(),
+                                                  molN->atom(imp.k()->index())->r(), molN->atom(imp.l()->index())->r()));
         }
     }
 

--- a/src/kernels/force.cpp
+++ b/src/kernels/force.cpp
@@ -316,26 +316,27 @@ void ForceKernel::totalForcesSimple(std::vector<Vector3> &ppForceVector, std::ve
         {
             // Bond forces
             for (const auto &bond : molN->species()->bonds())
-                bondForces(bond, *molN->atom(bond.indexI()), offsetN + bond.indexI(), *molN->atom(bond.indexJ()),
-                           offsetN + bond.indexJ(), geometryForceVector);
+                bondForces(bond, *molN->atom(bond.i()->index()), offsetN + bond.i()->index(), *molN->atom(bond.j()->index()),
+                           offsetN + bond.j()->index(), geometryForceVector);
 
             // Angle forces
             for (const auto &angle : molN->species()->angles())
-                angleForces(angle, *molN->atom(angle.indexI()), offsetN + angle.indexI(), *molN->atom(angle.indexJ()),
-                            offsetN + angle.indexJ(), *molN->atom(angle.indexK()), offsetN + angle.indexK(),
-                            geometryForceVector);
+                angleForces(angle, *molN->atom(angle.i()->index()), offsetN + angle.i()->index(),
+                            *molN->atom(angle.j()->index()), offsetN + angle.j()->index(), *molN->atom(angle.k()->index()),
+                            offsetN + angle.k()->index(), geometryForceVector);
 
             // Torsion forces
             for (const auto &torsion : molN->species()->torsions())
-                torsionForces(torsion, *molN->atom(torsion.indexI()), offsetN + torsion.indexI(), *molN->atom(torsion.indexJ()),
-                              offsetN + torsion.indexJ(), *molN->atom(torsion.indexK()), offsetN + torsion.indexK(),
-                              *molN->atom(torsion.indexL()), offsetN + torsion.indexL(), geometryForceVector);
+                torsionForces(torsion, *molN->atom(torsion.i()->index()), offsetN + torsion.i()->index(),
+                              *molN->atom(torsion.j()->index()), offsetN + torsion.j()->index(),
+                              *molN->atom(torsion.k()->index()), offsetN + torsion.k()->index(),
+                              *molN->atom(torsion.l()->index()), offsetN + torsion.l()->index(), geometryForceVector);
 
             // Improper forces
             for (const auto &imp : molN->species()->impropers())
-                improperForces(imp, *molN->atom(imp.indexI()), offsetN + imp.indexI(), *molN->atom(imp.indexJ()),
-                               offsetN + imp.indexJ(), *molN->atom(imp.indexK()), offsetN + imp.indexK(),
-                               *molN->atom(imp.indexL()), offsetN + imp.indexL(), geometryForceVector);
+                improperForces(imp, *molN->atom(imp.i()->index()), offsetN + imp.i()->index(), *molN->atom(imp.j()->index()),
+                               offsetN + imp.j()->index(), *molN->atom(imp.k()->index()), offsetN + imp.k()->index(),
+                               *molN->atom(imp.l()->index()), offsetN + imp.l()->index(), geometryForceVector);
         }
     }
 

--- a/src/kernels/geometry.cpp
+++ b/src/kernels/geometry.cpp
@@ -320,33 +320,34 @@ Kernel::GeometryEnergyValue GeometryKernel::totalGeometryEnergy(const Configurat
         // Loop over bonds
         localEnergies.bondEnergy = std::accumulate(
             mol->species()->bonds().begin(), mol->species()->bonds().end(), 0.0, [&](auto const acc, const auto &t)
-            { return acc + bondEnergy(t, mol->atom(t.indexI())->r(), mol->atom(t.indexJ())->r()); });
+            { return acc + bondEnergy(t, mol->atom(t.i()->index())->r(), mol->atom(t.j()->index())->r()); });
 
         // Loop over angles
-        localEnergies.angleEnergy = std::accumulate(
-            mol->species()->angles().begin(), mol->species()->angles().end(), 0.0,
-            [&](auto const acc, const auto &t)
-            {
-                return acc + angleEnergy(t, mol->atom(t.indexI())->r(), mol->atom(t.indexJ())->r(), mol->atom(t.indexK())->r());
-            });
+        localEnergies.angleEnergy =
+            std::accumulate(mol->species()->angles().begin(), mol->species()->angles().end(), 0.0,
+                            [&](auto const acc, const auto &t)
+                            {
+                                return acc + angleEnergy(t, mol->atom(t.i()->index())->r(), mol->atom(t.j()->index())->r(),
+                                                         mol->atom(t.k()->index())->r());
+                            });
 
         // Loop over torsions
         localEnergies.torsionEnergy =
             std::accumulate(mol->species()->torsions().begin(), mol->species()->torsions().end(), 0.0,
                             [&](auto const acc, const auto &t)
                             {
-                                return acc + torsionEnergy(t, mol->atom(t.indexI())->r(), mol->atom(t.indexJ())->r(),
-                                                           mol->atom(t.indexK())->r(), mol->atom(t.indexL())->r());
+                                return acc + torsionEnergy(t, mol->atom(t.i()->index())->r(), mol->atom(t.j()->index())->r(),
+                                                           mol->atom(t.k()->index())->r(), mol->atom(t.l()->index())->r());
                             });
 
         // Loop over impropers
-        localEnergies.improperEnergy =
-            std::accumulate(mol->species()->impropers().begin(), mol->species()->impropers().end(), 0.0,
-                            [&](auto const acc, const auto &imp)
-                            {
-                                return acc + improperEnergy(imp, mol->atom(imp.indexI())->r(), mol->atom(imp.indexJ())->r(),
-                                                            mol->atom(imp.indexK())->r(), mol->atom(imp.indexL())->r());
-                            });
+        localEnergies.improperEnergy = std::accumulate(
+            mol->species()->impropers().begin(), mol->species()->impropers().end(), 0.0,
+            [&](auto const acc, const auto &imp)
+            {
+                return acc + improperEnergy(imp, mol->atom(imp.i()->index())->r(), mol->atom(imp.j()->index())->r(),
+                                            mol->atom(imp.k()->index())->r(), mol->atom(imp.l()->index())->r());
+            });
 
         return localEnergies;
     };
@@ -369,17 +370,17 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const ConfigurationAt
     Kernel::GeometryEnergyValue energy;
 
     // Add energy from SpeciesAngle terms
-    energy.bondEnergy =
-        std::accumulate(spAtom->bonds().begin(), spAtom->bonds().end(), 0.0, [this, &mol](const auto acc, const auto *bond)
-                        { return acc + bondEnergy(*bond, mol.atom(bond->indexI())->r(), mol.atom(bond->indexJ())->r()); });
+    energy.bondEnergy = std::accumulate(
+        spAtom->bonds().begin(), spAtom->bonds().end(), 0.0, [this, &mol](const auto acc, const auto *bond)
+        { return acc + bondEnergy(*bond, mol.atom(bond->i()->index())->r(), mol.atom(bond->j()->index())->r()); });
 
     // Add energy from SpeciesAngle terms
     energy.angleEnergy =
         std::accumulate(spAtom->angles().begin(), spAtom->angles().end(), 0.0,
                         [this, &mol](const auto acc, const auto *angle)
                         {
-                            return acc + angleEnergy(*angle, mol.atom(angle->indexI())->r(), mol.atom(angle->indexJ())->r(),
-                                                     mol.atom(angle->indexK())->r());
+                            return acc + angleEnergy(*angle, mol.atom(angle->i()->index())->r(),
+                                                     mol.atom(angle->j()->index())->r(), mol.atom(angle->k()->index())->r());
                         });
 
     // Add energy from SpeciesTorsion terms
@@ -387,8 +388,8 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const ConfigurationAt
         spAtom->torsions().begin(), spAtom->torsions().end(), 0.0,
         [this, &mol](const auto acc, const auto *torsion)
         {
-            return acc + torsionEnergy(*torsion, mol.atom(torsion->indexI())->r(), mol.atom(torsion->indexJ())->r(),
-                                       mol.atom(torsion->indexK())->r(), mol.atom(torsion->indexL())->r());
+            return acc + torsionEnergy(*torsion, mol.atom(torsion->i()->index())->r(), mol.atom(torsion->j()->index())->r(),
+                                       mol.atom(torsion->k()->index())->r(), mol.atom(torsion->l()->index())->r());
         });
 
     // Add energy from SpeciesImproper terms
@@ -396,8 +397,8 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const ConfigurationAt
         spAtom->impropers().begin(), spAtom->impropers().end(), 0.0,
         [this, &mol](const auto acc, const auto *improper)
         {
-            return acc + improperEnergy(*improper, mol.atom(improper->indexI())->r(), mol.atom(improper->indexJ())->r(),
-                                        mol.atom(improper->indexK())->r(), mol.atom(improper->indexL())->r());
+            return acc + improperEnergy(*improper, mol.atom(improper->i()->index())->r(), mol.atom(improper->j()->index())->r(),
+                                        mol.atom(improper->k()->index())->r(), mol.atom(improper->l()->index())->r());
         });
 
     return energy;
@@ -409,18 +410,18 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const Molecule &mol) 
     Kernel::GeometryEnergyValue energy;
 
     // Loop over Bonds
-    energy.bondEnergy =
-        dissolve::transform_reduce(ParallelPolicies::par, mol.species()->bonds().begin(), mol.species()->bonds().end(), 0.0,
-                                   std::plus<double>(), [&mol, this](const auto &bond)
-                                   { return bondEnergy(bond, mol.atom(bond.indexI())->r(), mol.atom(bond.indexJ())->r()); });
+    energy.bondEnergy = dissolve::transform_reduce(
+        ParallelPolicies::par, mol.species()->bonds().begin(), mol.species()->bonds().end(), 0.0, std::plus<double>(),
+        [&mol, this](const auto &bond)
+        { return bondEnergy(bond, mol.atom(bond.i()->index())->r(), mol.atom(bond.j()->index())->r()); });
 
     // Loop over Angles
     energy.angleEnergy = dissolve::transform_reduce(
         ParallelPolicies::seq, mol.species()->angles().begin(), mol.species()->angles().end(), 0.0, std::plus<double>(),
         [&mol, this](const auto &angle) -> double
         {
-            return angleEnergy(angle, mol.atom(angle.indexI())->r(), mol.atom(angle.indexJ())->r(),
-                               mol.atom(angle.indexK())->r());
+            return angleEnergy(angle, mol.atom(angle.i()->index())->r(), mol.atom(angle.j()->index())->r(),
+                               mol.atom(angle.k()->index())->r());
         });
 
     // Loop over Torsions
@@ -428,8 +429,8 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const Molecule &mol) 
         ParallelPolicies::par, mol.species()->torsions().begin(), mol.species()->torsions().end(), 0.0, std::plus<double>(),
         [&mol, this](const auto &torsion) -> double
         {
-            return torsionEnergy(torsion, mol.atom(torsion.indexI())->r(), mol.atom(torsion.indexJ())->r(),
-                                 mol.atom(torsion.indexK())->r(), mol.atom(torsion.indexL())->r());
+            return torsionEnergy(torsion, mol.atom(torsion.i()->index())->r(), mol.atom(torsion.j()->index())->r(),
+                                 mol.atom(torsion.k()->index())->r(), mol.atom(torsion.l()->index())->r());
         });
 
     // Loop over Impropers
@@ -437,8 +438,8 @@ Kernel::GeometryEnergyValue GeometryKernel::geometryEnergy(const Molecule &mol) 
         ParallelPolicies::par, mol.species()->impropers().begin(), mol.species()->impropers().end(), 0.0, std::plus<double>(),
         [&mol, this](const auto &improper) -> double
         {
-            return improperEnergy(improper, mol.atom(improper.indexI())->r(), mol.atom(improper.indexJ())->r(),
-                                  mol.atom(improper.indexK())->r(), mol.atom(improper.indexL())->r());
+            return improperEnergy(improper, mol.atom(improper.i()->index())->r(), mol.atom(improper.j()->index())->r(),
+                                  mol.atom(improper.k()->index())->r(), mol.atom(improper.l()->index())->r());
         });
 
     return energy;
@@ -451,21 +452,23 @@ void GeometryKernel::totalGeometryForces(const Molecule &mol, std::vector<Vector
 
     // Loop over bonds
     for (const auto &bond : mol.species()->bonds())
-        bondForces(bond, *mol.atom(bond.indexI()), offset + bond.indexI(), *mol.atom(bond.indexJ()), offset + bond.indexJ(), f);
+        bondForces(bond, *mol.atom(bond.i()->index()), offset + bond.i()->index(), *mol.atom(bond.j()->index()),
+                   offset + bond.j()->index(), f);
 
     // Loop over angles
     for (const auto &angle : mol.species()->angles())
-        angleForces(angle, *mol.atom(angle.indexI()), offset + angle.indexI(), *mol.atom(angle.indexJ()),
-                    offset + angle.indexJ(), *mol.atom(angle.indexK()), offset + angle.indexK(), f);
+        angleForces(angle, *mol.atom(angle.i()->index()), offset + angle.i()->index(), *mol.atom(angle.j()->index()),
+                    offset + angle.j()->index(), *mol.atom(angle.k()->index()), offset + angle.k()->index(), f);
 
     // Loop over torsions
     for (const auto &torsion : mol.species()->torsions())
-        torsionForces(torsion, *mol.atom(torsion.indexI()), offset + torsion.indexI(), *mol.atom(torsion.indexJ()),
-                      offset + torsion.indexJ(), *mol.atom(torsion.indexK()), offset + torsion.indexK(),
-                      *mol.atom(torsion.indexL()), offset + torsion.indexL(), f);
+        torsionForces(torsion, *mol.atom(torsion.i()->index()), offset + torsion.i()->index(), *mol.atom(torsion.j()->index()),
+                      offset + torsion.j()->index(), *mol.atom(torsion.k()->index()), offset + torsion.k()->index(),
+                      *mol.atom(torsion.l()->index()), offset + torsion.l()->index(), f);
 
     // Loop over impropers
     for (const auto &imp : mol.species()->impropers())
-        improperForces(imp, *mol.atom(imp.indexI()), offset + imp.indexI(), *mol.atom(imp.indexJ()), offset + imp.indexJ(),
-                       *mol.atom(imp.indexK()), offset + imp.indexK(), *mol.atom(imp.indexL()), offset + imp.indexL(), f);
+        improperForces(imp, *mol.atom(imp.i()->index()), offset + imp.i()->index(), *mol.atom(imp.j()->index()),
+                       offset + imp.j()->index(), *mol.atom(imp.k()->index()), offset + imp.k()->index(),
+                       *mol.atom(imp.l()->index()), offset + imp.l()->index(), f);
 }

--- a/src/modules/energy/process.cpp
+++ b/src/modules/energy/process.cpp
@@ -208,8 +208,8 @@ Module::ExecutionResult EnergyModule::process(Dissolve &dissolve)
             // Bond energy
             for (const auto &bond : molN->species()->bonds())
             {
-                r = targetConfiguration_->box()->minimumDistance(molN->atom(bond.indexI())->r(),
-                                                                 molN->atom(bond.indexJ())->r());
+                r = targetConfiguration_->box()->minimumDistance(molN->atom(bond.i()->index())->r(),
+                                                                 molN->atom(bond.j()->index())->r());
                 correctIntraEnergy += bond.energy(r);
             }
 
@@ -217,23 +217,24 @@ Module::ExecutionResult EnergyModule::process(Dissolve &dissolve)
             for (const auto &angle : molN->species()->angles())
             {
                 correctIntraEnergy += angle.energy(targetConfiguration_->box()->angleInRadians(
-                    molN->atom(angle.indexI())->r(), molN->atom(angle.indexJ())->r(), molN->atom(angle.indexK())->r()));
+                    molN->atom(angle.i()->index())->r(), molN->atom(angle.j()->index())->r(),
+                    molN->atom(angle.k()->index())->r()));
             }
 
             // Torsion energy
             for (const auto &torsion : molN->species()->torsions())
             {
                 correctIntraEnergy += torsion.energy(targetConfiguration_->box()->torsionInRadians(
-                    molN->atom(torsion.indexI())->r(), molN->atom(torsion.indexJ())->r(), molN->atom(torsion.indexK())->r(),
-                    molN->atom(torsion.indexL())->r()));
+                    molN->atom(torsion.i()->index())->r(), molN->atom(torsion.j()->index())->r(),
+                    molN->atom(torsion.k()->index())->r(), molN->atom(torsion.l()->index())->r()));
             }
 
             // Improper energy
             for (const auto &imp : molN->species()->impropers())
             {
                 correctIntraEnergy += imp.energy(targetConfiguration_->box()->torsionInRadians(
-                    molN->atom(imp.indexI())->r(), molN->atom(imp.indexJ())->r(), molN->atom(imp.indexK())->r(),
-                    molN->atom(imp.indexL())->r()));
+                    molN->atom(imp.i()->index())->r(), molN->atom(imp.j()->index())->r(), molN->atom(imp.k()->index())->r(),
+                    molN->atom(imp.l()->index())->r()));
             }
         }
 

--- a/src/modules/forces/process.cpp
+++ b/src/modules/forces/process.cpp
@@ -147,25 +147,25 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
             for (const auto &bond : molN->species()->bonds())
             {
                 // Grab pointers to atoms involved in bond
-                auto *i = molN->atom(bond.indexI());
-                auto *j = molN->atom(bond.indexJ());
+                auto *i = molN->atom(bond.i()->index());
+                auto *j = molN->atom(bond.j()->index());
 
                 // Determine final forces
                 auto vecij = box->minimumVector(i->r(), j->r());
                 auto r = vecij.magAndNormalise();
                 vecij *= bond.force(r);
 
-                fIntra[offsetN + bond.indexI()] -= vecij;
-                fIntra[offsetN + bond.indexJ()] += vecij;
+                fIntra[offsetN + bond.i()->index()] -= vecij;
+                fIntra[offsetN + bond.j()->index()] += vecij;
             }
 
             // Angle forces
             for (const auto &angle : molN->species()->angles())
             {
                 // Grab pointers to atoms involved in angle
-                auto *i = molN->atom(angle.indexI());
-                auto *j = molN->atom(angle.indexJ());
-                auto *k = molN->atom(angle.indexK());
+                auto *i = molN->atom(angle.i()->index());
+                auto *j = molN->atom(angle.j()->index());
+                auto *k = molN->atom(angle.k()->index());
 
                 // Get vectors 'j-i' and 'j-k'
                 auto vecji = box->minimumVector(j->r(), i->r());
@@ -182,19 +182,19 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                 forcek *= force / magjk;
 
                 // Store forces
-                fIntra[offsetN + angle.indexI()] += forcei;
-                fIntra[offsetN + angle.indexJ()] -= forcei + forcek;
-                fIntra[offsetN + angle.indexK()] += forcek;
+                fIntra[offsetN + angle.i()->index()] += forcei;
+                fIntra[offsetN + angle.j()->index()] -= forcei + forcek;
+                fIntra[offsetN + angle.k()->index()] += forcek;
             }
 
             // Torsion forces
             for (const auto &torsion : molN->species()->torsions())
             {
                 // Grab pointers to atoms involved in angle
-                auto *i = molN->atom(torsion.indexI());
-                auto *j = molN->atom(torsion.indexJ());
-                auto *k = molN->atom(torsion.indexK());
-                auto *l = molN->atom(torsion.indexL());
+                auto *i = molN->atom(torsion.i()->index());
+                auto *j = molN->atom(torsion.j()->index());
+                auto *k = molN->atom(torsion.k()->index());
+                auto *l = molN->atom(torsion.l()->index());
 
                 // Calculate vectors, ensuring we account for minimum image
                 auto vecji = box->minimumVector(i->r(), j->r());
@@ -206,11 +206,11 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                 auto du_dphi = torsion.force(tp.phi);
 
                 // Sum forces on Atoms
-                fIntra[offsetN + torsion.indexI()].add(du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(0)),
-                                                       du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(1)),
-                                                       du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(2)));
+                fIntra[offsetN + torsion.i()->index()].add(du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(0)),
+                                                           du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(1)),
+                                                           du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(2)));
 
-                fIntra[offsetN + torsion.indexJ()].add(
+                fIntra[offsetN + torsion.j()->index()].add(
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(0) - tp.dxpj_dkj.columnAsVec3(0)) -
                                tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(0))),
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(1) - tp.dxpj_dkj.columnAsVec3(1)) -
@@ -218,7 +218,7 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(2) - tp.dxpj_dkj.columnAsVec3(2)) -
                                tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(2))));
 
-                fIntra[offsetN + torsion.indexK()].add(
+                fIntra[offsetN + torsion.k()->index()].add(
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(0) - tp.dxpk_dlk.columnAsVec3(0)) +
                                tp.dcos_dxpj.dp(tp.dxpj_dkj.columnAsVec3(0))),
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(1) - tp.dxpk_dlk.columnAsVec3(1)) +
@@ -226,19 +226,19 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(2) - tp.dxpk_dlk.columnAsVec3(2)) +
                                tp.dcos_dxpj.dp(tp.dxpj_dkj.columnAsVec3(2))));
 
-                fIntra[offsetN + torsion.indexL()].add(du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(0)),
-                                                       du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(1)),
-                                                       du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(2)));
+                fIntra[offsetN + torsion.l()->index()].add(du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(0)),
+                                                           du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(1)),
+                                                           du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(2)));
             }
 
             // Improper forces
             for (const auto &imp : molN->species()->impropers())
             {
                 // Grab pointers to atoms involved in angle
-                auto *i = molN->atom(imp.indexI());
-                auto *j = molN->atom(imp.indexJ());
-                auto *k = molN->atom(imp.indexK());
-                auto *l = molN->atom(imp.indexL());
+                auto *i = molN->atom(imp.i()->index());
+                auto *j = molN->atom(imp.j()->index());
+                auto *k = molN->atom(imp.k()->index());
+                auto *l = molN->atom(imp.l()->index());
 
                 // Calculate vectors, ensuring we account for minimum image
                 auto vecji = box->minimumVector(i->r(), j->r());
@@ -250,11 +250,11 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                 auto du_dphi = imp.force(tp.phi);
 
                 // Sum forces on Atoms
-                fIntra[offsetN + imp.indexI()].add(du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(0)),
-                                                   du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(1)),
-                                                   du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(2)));
+                fIntra[offsetN + imp.i()->index()].add(du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(0)),
+                                                       du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(1)),
+                                                       du_dphi * tp.dcos_dxpj.dp(tp.dxpj_dij.columnAsVec3(2)));
 
-                fIntra[offsetN + imp.indexJ()].add(
+                fIntra[offsetN + imp.j()->index()].add(
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(0) - tp.dxpj_dkj.columnAsVec3(0)) -
                                tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(0))),
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(1) - tp.dxpj_dkj.columnAsVec3(1)) -
@@ -262,7 +262,7 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                     du_dphi * (tp.dcos_dxpj.dp(-tp.dxpj_dij.columnAsVec3(2) - tp.dxpj_dkj.columnAsVec3(2)) -
                                tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(2))));
 
-                fIntra[offsetN + imp.indexK()].add(
+                fIntra[offsetN + imp.k()->index()].add(
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(0) - tp.dxpk_dlk.columnAsVec3(0)) +
                                tp.dcos_dxpj.dp(tp.dxpj_dkj.columnAsVec3(0))),
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(1) - tp.dxpk_dlk.columnAsVec3(1)) +
@@ -270,9 +270,9 @@ Module::ExecutionResult ForcesModule::process(Dissolve &dissolve)
                     du_dphi * (tp.dcos_dxpk.dp(tp.dxpk_dkj.columnAsVec3(2) - tp.dxpk_dlk.columnAsVec3(2)) +
                                tp.dcos_dxpj.dp(tp.dxpj_dkj.columnAsVec3(2))));
 
-                fIntra[offsetN + imp.indexL()].add(du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(0)),
-                                                   du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(1)),
-                                                   du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(2)));
+                fIntra[offsetN + imp.l()->index()].add(du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(0)),
+                                                       du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(1)),
+                                                       du_dphi * tp.dcos_dxpk.dp(tp.dxpk_dlk.columnAsVec3(2)));
             }
         }
         timer.stop();

--- a/src/modules/intraShake/process.cpp
+++ b/src/modules/intraShake/process.cpp
@@ -108,8 +108,8 @@ Module::ExecutionResult IntraShakeModule::process(Dissolve &dissolve)
                 for (const auto &bond : mol->species()->bonds())
                 {
                     // Get Atom pointers
-                    auto i = mol->atom(bond.indexI());
-                    auto j = mol->atom(bond.indexJ());
+                    auto i = mol->atom(bond.i()->index());
+                    auto j = mol->atom(bond.j()->index());
 
                     // Select random terminus
                     auto terminus = DissolveMath::random() > 0.5 ? 1 : 0;
@@ -152,9 +152,9 @@ Module::ExecutionResult IntraShakeModule::process(Dissolve &dissolve)
                 for (const auto &angle : mol->species()->angles())
                 {
                     // Get Atom pointers
-                    auto i = mol->atom(angle.indexI());
-                    auto j = mol->atom(angle.indexJ());
-                    auto k = mol->atom(angle.indexK());
+                    auto i = mol->atom(angle.i()->index());
+                    auto j = mol->atom(angle.j()->index());
+                    auto k = mol->atom(angle.k()->index());
 
                     // Select random terminus
                     auto terminus = DissolveMath::random() > 0.5 ? 1 : 0;
@@ -204,8 +204,8 @@ Module::ExecutionResult IntraShakeModule::process(Dissolve &dissolve)
                         continue;
 
                     // Get Atom pointers
-                    auto j = mol->atom(torsion.indexJ());
-                    auto k = mol->atom(torsion.indexK());
+                    auto j = mol->atom(torsion.j()->index());
+                    auto k = mol->atom(torsion.k()->index());
 
                     // Select random terminus
                     auto terminus = DissolveMath::random() > 0.5 ? 1 : 0;


### PR DESCRIPTION
A little (!) tidy-up PR to remove functions like `indexI()` and `indexJ()` from `SpeciesIntra`-derived classes - those functions were just "beautification wrappers" hiding calls to (e.g.) `i_->index()` - since they are used in hot loops I reasoned that we were probably better off being honest!