### PR TITLE
feat: Variant parameters

### DIFF
--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     }
 
     // Check that types are compatible
-    if (!targetInput->acceptsOutput(sourceOutput.get()))
+    if (!targetInput->acceptsDataFromSource(sourceOutput.get()))
     {
         Messenger::error("Source output ({}@{}) and target input ({}@{}) edge types are not compatible - {} vs {}.\n",
                          definition.sourceOutput, sourceNode->name(), definition.targetInput, targetNode->name(),

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -221,7 +221,7 @@ NodeConstants::ProcessResult Edge::pull()
         }
 
         // Copy the parameter data over
-        if (!targetInput_.assign(&sourceOutput_))
+        if (!targetInput_.assignDataFromSource(&sourceOutput_))
         {
             Messenger::error("Failed to assign value from {}@{} to {}@{}.\n", sourceOutput_.name(), sourceNode_.name(),
                              targetInput_.name(), targetNode_.name());
@@ -241,7 +241,7 @@ NodeConstants::ProcessResult Edge::pull()
 NodeConstants::ProcessResult LoopEdge::pull()
 {
     // Copy the parameter data over
-    if (!analogue().assign(&sourceOutput_))
+    if (!analogue().assignDataFromSource(&sourceOutput_))
         return NodeConstants::ProcessResult::Failed;
 
     sourceNode().setUpdateRequired();

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -235,8 +235,8 @@ class Node : public Serialisable<>
             Messenger::exception("Output parameter '{}' already exists, and can't be added again.", outputName);
 
         auto param = outputs_
-                         .emplace(std::make_pair(outputName, ParameterFactory::createPointer<ClassObject>(
-                                                                 this, outputName, description, object, {})))
+                         .emplace(std::make_pair(
+                             outputName, ParameterFactory::createPointer<ClassObject>(this, outputName, description, object)))
                          .first->second;
         param->setFlags(ParameterBase::ParameterFlags::Output);
         return param;

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -51,3 +51,15 @@ void ParameterBase::clearDataInParent() const { parent_->clearData(); }
 
 // Mark edges for re-pull in parent node
 void ParameterBase::markIncomingEdgesForPull() const { parent_->markIncomingEdgesForPull(this); }
+
+// Perform any updates after a successful setData()
+void ParameterBase::updateAfterSet() const
+{
+    // Changing parameters always flags an update as being required, unless the NoUpdate flag is set
+    if (!flags_.isSet(NoUpdate))
+        setParentUpdateRequired();
+
+    // Setting some parameters forces any local data to be cleared
+    if (flags_.isSet(ClearData))
+        clearDataInParent();
+}

--- a/src/nodes/parameter.cpp
+++ b/src/nodes/parameter.cpp
@@ -4,10 +4,8 @@
 #include "nodes/parameter.h"
 #include "nodes/node.h"
 
-ParameterBase::ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType,
-                             std::type_index contextDataType)
-    : parent_(parent), name_(name), description_(description), storedDataType_(storedDataType),
-      contextDataType_(contextDataType)
+ParameterBase::ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType)
+    : parent_(parent), name_(name), description_(description), storedDataType_(storedDataType)
 {
 }
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -23,7 +23,7 @@ template <typename T> class Parameter;
 template <typename T> class SerialisableParameter;
 
 // Return whether the type_index provided matches one of the supplied variant's allowed types
-template <class... Ts> bool is_one_of(std::type_index id, const std::variant<Ts...> &x)
+template <class... Ts> bool is_variant_alternative(std::type_index id, const std::variant<Ts...> &x)
 {
     return ((id == typeid(Ts)) || ...);
 };
@@ -118,10 +118,12 @@ class ParameterBase : public Serialisable<>
     void clearDataInParent() const;
     // Mark edges for re-pull in parent node
     void markIncomingEdgesForPull() const;
+    // Return whether this datatype accepts the specified one
+    virtual bool acceptsDataFromSource(ParameterBase *source) = 0;
+    // Return whether this datatype provides the specified one
+    virtual bool providesDataType(std::type_index id) = 0;
     // Assign the value of another parameter to this one
     virtual bool assign(ParameterBase *other) = 0;
-    // Return whether this parameter accepts the output type of the other
-    virtual bool acceptsOutput(ParameterBase *other) const = 0;
     // The type's representation as a raw int (only valid for int and enum)
     virtual int getAsInt() const { return -1; }
     // Set type's representation as a raw int (only valid for int and enum)
@@ -351,9 +353,62 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             return true;
         return false;
     }
+    // Return whether this datatype accepts data from the specified source
+    bool acceptsDataFromSource(ParameterBase *source) override
+    {
+        auto id = source->storedDataType();
+
+        // Optionals and vectors
+        if constexpr (is_instance_of_v<DataClass, std::optional> || is_instance_of_v<DataClass, std::vector>)
+        {
+            // Can be set from another identical DataClass or a plain object of the value_type
+            return id == storedDataType_ || id == typeid(typename DataClass::value_type);
+        }
+
+        // Vectors
+        if constexpr (is_instance_of_v<DataClass, std::vector>)
+        {
+            // Vectors can be set from another identical DataClass or a single object of the value_type
+            return id == storedDataType_ || id == typeid(typename DataClass::value_type);
+        }
+
+        // Variants
+        if constexpr (is_instance_of_v<DataClass, std::variant>)
+        {
+            // Variants can be set from another identical type or any type which matches one of our alternatives
+            return id == storedDataType_ || is_variant_alternative(id, data_);
+        }
+
+        // Normal data types can be set from several different types of object
+        return source->providesDataType(storedDataType_);
+    }
+    // Return whether this datatype provides the specified one
+    bool providesDataType(std::type_index id) override
+    {
+        if (id == storedDataType_)
+            return true;
+
+        // Optionals
+        if constexpr (is_instance_of_v<DataClass, std::optional>)
+        {
+            // Optionals provide the value_type
+            return id == typeid(typename DataClass::value_type);
+        }
+
+        // Variants
+        if constexpr (is_instance_of_v<DataClass, std::variant>)
+        {
+            // Variants might_ contain the correct data - we only return here if it is a possibility
+            return is_variant_alternative(id, data_);
+        }
+
+        return false;
+    }
     // Assign the value of another parameter to this one.
     bool assign(ParameterBase *other) override
     {
+        std::cout << std::format("Assign source output {} ({}) to target input {} ({})\n", name_, storedDataType_.name(),
+                                 other->name(), other->storedDataType().name());
         if constexpr (std::is_pointer<DataClass>())
         {
             // If we are a pointer type, getting a nullptr is disallowed
@@ -432,41 +487,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         {
             setData(other->get<DataClass>());
             return true;
-        }
-
-        return false;
-    }
-    // Return whether this parameter accepts the output type of the other
-    bool acceptsOutput(ParameterBase *other) const override
-    {
-        if (storedDataType_ == other->storedDataType())
-            return true;
-
-        // Normal data types can be set from optional values
-        if (typeid(std::optional<DataClass>) == other->storedDataType())
-            return true;
-        else if constexpr (is_instance_of_v<DataClass, std::vector>)
-        {
-            // Vectors can accept a single value of the contained type
-            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
-                return true;
-        }
-        else if constexpr (is_instance_of_v<DataClass, std::optional>)
-        {
-            // Optionals can accept non-optional data
-            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
-                return true;
-        }
-        else if constexpr (is_instance_of_v<DataClass, std::variant>)
-        {
-            printf("CHECKING VARIANT TYPE.....\n");
-            if (is_one_of(other->storedDataType(), data_))
-            {
-                printf("TIS A MATCH!!!!!\n");
-                return true;
-            }
-            else
-                printf("NOPE.\n");
         }
 
         return false;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -406,7 +406,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         else if (typeid(std::optional<DataClass>) == other->storedDataType())
         {
             // Data types can be set from a std::optional containing the same type
-
             auto otherData = other->get<std::optional<DataClass>>();
             if (otherData.has_value())
             {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -197,7 +197,7 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 template <class... Ts> class VariantParameterData
 {
     public:
-    // Varaint data
+    // Variant data
     std::variant<std::monostate, Ts...> data;
 
     // Return whether the type_index provided matches one of the supplied variant's allowed types

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -217,7 +217,7 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 }; // namespace ParameterFactory
 
 // Put the data of the supplied parameter into the supplied variant
-template <class... Ts> bool put_into(ParameterBase *other, std::variant<Ts...> &x)
+template <class... Ts> bool emplace(ParameterBase *other, std::variant<Ts...> &x)
 {
     return ((other->storedDataType() == typeid(Ts)
              ? (std::cout << std::format("{} matches {}\n", other->storedDataType().name(), typeid(Ts).name()),
@@ -472,7 +472,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         {
             // Variants can be set from any matching type
             printf("TRYING TO SET THE VARIANT...\n");
-            if (put_into(other, data_))
+            if (emplace(other, data_))
             {
                 printf("DID IT!\n");
                 updateAfterSet();

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -123,7 +123,9 @@ class ParameterBase : public Serialisable<>
     // Return whether this datatype provides the specified one
     virtual bool providesDataType(std::type_index id) = 0;
     // Assign the value of another parameter to this one
-    virtual bool assign(ParameterBase *other) = 0;
+    virtual bool assignDataFromSource(ParameterBase *source) = 0;
+    // Assign the value of this parameter to the target one
+    virtual bool assignTo(ParameterBase *destination) = 0;
     // The type's representation as a raw int (only valid for int and enum)
     virtual int getAsInt() const { return -1; }
     // Set type's representation as a raw int (only valid for int and enum)
@@ -224,7 +226,24 @@ template <class... Ts> bool emplace(ParameterBase *other, std::variant<Ts...> &x
                 x = other->get<Ts>()),
              true : false) ||
             ...);
-};
+}
+
+// Return the alternative index matching the type specified (if any)
+template <class... Ts> int alternative_index(std::type_index id, std::variant<Ts...> &x)
+{
+    auto index = -1;
+    auto result = -1;
+    ((result = (id == typeid(Ts)) ? index : result, ++result) || ...);
+    return result;
+}
+
+// Return the alternative index matching the type specified (if any)
+template <class... Ts> int emplace_into(std::variant<Ts...> &x, ParameterBase *destination)
+{
+    auto result = false;
+    ((result = (destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(x)), true : result)) || ...);
+    return result;
+}
 
 // Primary type for a Parameter to a specific DataClass
 template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
@@ -306,9 +325,8 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             data_ = value;
         else if constexpr (std::is_enum_v<DataClass>)
             data_ = static_cast<DataClass>(value);
-        else
-            Messenger::exception("Tried to extract int value from non integral type {}", storedDataType_.name());
-        return;
+
+        Messenger::exception("Tried to extract int value from non integral type {}", storedDataType_.name());
     }
 
     /*
@@ -404,34 +422,25 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
 
         return false;
     }
-    // Assign the value of another parameter to this one.
-    bool assign(ParameterBase *other) override
+    // Assign the value of another parameter to this one
+    bool assignDataFromSource(ParameterBase *source) override
     {
-        std::cout << std::format("Assign source output {} ({}) to target input {} ({})\n", name_, storedDataType_.name(),
-                                 other->name(), other->storedDataType().name());
-        if constexpr (std::is_pointer<DataClass>())
-        {
-            // If we are a pointer type, getting a nullptr is disallowed
-            setData(other->get<DataClass>());
-
-            return data_ != nullptr;
-        }
-        else if constexpr (is_instance_of_v<DataClass, std::vector>)
+        if constexpr (is_instance_of_v<DataClass, std::vector>)
         {
             // If we represent a std::vector container we can conditionally check for a single data item being passed
 
             // Vector to vector
-            if (storedDataType_ == other->storedDataType())
+            if (storedDataType_ == source->storedDataType())
             {
-                setData(other->get<DataClass>());
+                setData(source->get<DataClass>());
 
                 return true;
             }
 
             // Single value to vector
-            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
+            if (std::type_index(typeid(typename DataClass::value_type)) == source->storedDataType())
             {
-                data_.push_back(other->get<typename DataClass::value_type>());
+                data_.push_back(source->get<typename DataClass::value_type>());
 
                 updateAfterSet();
 
@@ -443,25 +452,25 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             // Optional arguments can be set from the base class (i.e. with no std::optional container) as well as std::optional
 
             // Optional to optional
-            if (storedDataType_ == other->storedDataType())
+            if (storedDataType_ == source->storedDataType())
             {
-                setData(other->get<DataClass>());
+                setData(source->get<DataClass>());
 
                 return true;
             }
 
             // Base type into std::optional
-            if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
+            if (std::type_index(typeid(typename DataClass::value_type)) == source->storedDataType())
             {
-                setData(other->get<typename DataClass::value_type>());
+                setData(source->get<typename DataClass::value_type>());
 
                 return true;
             }
         }
-        else if (typeid(std::optional<DataClass>) == other->storedDataType())
+        else if (typeid(std::optional<DataClass>) == source->storedDataType())
         {
             // Data types can be set from a std::optional containing the same type
-            auto otherData = other->get<std::optional<DataClass>>();
+            auto otherData = source->get<std::optional<DataClass>>();
             if (otherData.has_value())
             {
                 setData(*otherData);
@@ -471,21 +480,59 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         else if constexpr (is_instance_of_v<DataClass, std::variant>)
         {
             // Variants can be set from any matching type
-            printf("TRYING TO SET THE VARIANT...\n");
-            if (emplace(other, data_))
+            if (emplace(source, data_))
             {
-                printf("DID IT!\n");
                 updateAfterSet();
                 return true;
             }
-            else
-                printf("NO SETTING THAT!\n");
+        }
+        else if (storedDataType_ == source->storedDataType())
+        {
+            // General case - if the stored data types are the same then we can just do a straight assignment
+            setData(source->get<DataClass>());
+
+            // If we are a pointer type, getting a nullptr is disallowed
+            if constexpr (std::is_pointer<DataClass>())
+            {
+                return data_ != nullptr;
+            }
+
+            return true;
+        }
+        else
+        {
+            // Try setting from the source parameter so we have it's full DataClass information - this is necessary for types
+            // like std::variant where we need to know the stored alternative.
+            if (source->assignTo(this))
+            {
+                updateAfterSet();
+                return true;
+            }
         }
 
-        // General case - if the stored data types are the same then we can just do a straight assignment
-        if (storedDataType_ == other->storedDataType())
+        return false;
+    }
+    // Assign the value of this parameter to the target one
+    bool assignTo(ParameterBase *destination) override
+    {
+        if constexpr (is_instance_of_v<DataClass, std::variant>)
         {
-            setData(other->get<DataClass>());
+            // Check that we actually contain a valid value
+            // TODO
+
+            // Check that our stored alternative is a match for the destination type
+            if (emplace_into(data_, destination))
+            {
+                // TODO
+                // destination->updateAfterSet();
+                return true;
+            }
+        }
+        else if (storedDataType_ == destination->storedDataType())
+        {
+            // General case - if the stored data types are the same then we can just do a straight assignment
+            destination->set<DataClass>(data_);
+
             return true;
         }
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -467,6 +467,14 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         }
         else if constexpr (is_instance_of_v<DataClass, std::variant>)
         {
+            // Variant to variant
+            if (storedDataType_ == source->storedDataType())
+            {
+                setData(source->get<DataClass>());
+
+                return true;
+            }
+
             // Variants can be set from any matching type
             if (emplace_into_variant(source, data_))
             {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -42,8 +42,7 @@ struct ParameterLink
 class ParameterBase : public Serialisable<>
 {
     public:
-    ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType,
-                  std::type_index contextDataType);
+    ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType);
     virtual ~ParameterBase() = default;
 
     // Parameter Flags
@@ -75,8 +74,6 @@ class ParameterBase : public Serialisable<>
     std::string description_;
     // Stored data type in the parameter
     std::type_index storedDataType_;
-    // Stored data type of the context
-    std::type_index contextDataType_;
     // Flags for the parameter
     Flags<ParameterBase::ParameterFlags> flags_;
 
@@ -140,21 +137,6 @@ class ParameterBase : public Serialisable<>
             throw(std::runtime_error(std::format("ParameterBase::get() failed to cast, name = {}.\n", name_)));
         return cast->getData();
     }
-    // Get the parameter's context
-    template <typename DataClass> Context<DataClass>::type context()
-    {
-        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
-        if (std::type_index(typeid(typename Context<DataClass>::type)) != contextDataType_)
-            throw(std::runtime_error(std::format("ParameterBase::context() called with wrong type ({} vs {}), name = {}\n",
-                                                 std::type_index(typeid(typename Context<DataClass>::type)).name(),
-                                                 contextDataType_.name(), name_)));
-
-        // Upcast to Parameter<T> (common base of all parameter types)
-        auto cast = dynamic_cast<Parameter<DataClass> *>(this);
-        if (!cast)
-            throw(std::runtime_error(std::format("ParameterBase::context() failed to cast, name = {}.\n", name_)));
-        return cast->getData();
-    }
     // Set the parameter's value
     template <typename DataClass> void set(const DataClass &data)
     {
@@ -187,23 +169,21 @@ class ParameterBase : public Serialisable<>
 namespace ParameterFactory
 {
 template <typename DataClass>
-std::shared_ptr<ParameterBase> create(Node *parent, std::string_view name, std::string_view description, DataClass &value,
-                                      typename Context<DataClass>::type context = {})
+std::shared_ptr<ParameterBase> create(Node *parent, std::string_view name, std::string_view description, DataClass &value)
 {
-    return std::make_shared<Parameter<DataClass>>(parent, name, description, value, context);
+    return std::make_shared<Parameter<DataClass>>(parent, name, description, value);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createPointer(Node *parent, std::string_view name, std::string_view description,
-                                             DataClass &fromObject, typename Context<DataClass>::type context = {})
+                                             DataClass &fromObject)
 {
-    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromObject, context);
+    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromObject);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createPointer(Node *parent, std::string_view name, std::string_view description,
-                                             std::optional<DataClass> &fromOptional,
-                                             typename Context<DataClass>::type context = {})
+                                             std::optional<DataClass> &fromOptional)
 {
-    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromOptional, context);
+    return std::make_shared<Parameter<DataClass *>>(parent, name, description, fromOptional);
 }
 template <typename DataClass>
 std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view name, std::string_view description,
@@ -251,45 +231,33 @@ template <class... Ts> bool variant_has_null_pointer(std::variant<Ts...> &varian
 template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
 {
     public:
-    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
-              typename Context<DataClass>::type context)
+    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
         requires(is_instance_of_v<DataClass, std::vector>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
-                        std::type_index(typeid(typename Context<DataClass>::type))),
-          data_(value), default_(value)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(value), default_(value)
     {
     }
-    Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value,
-              typename Context<DataClass>::type context)
+    Parameter(Node *parent, std::string_view name, std::string_view description, std::remove_pointer_t<DataClass> &value)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
-                        std::type_index(typeid(typename Context<DataClass>::type))),
-          data_(localPointer_), default_(nullptr), dataGetter_([&]() { return &value; }),
-          dataSetter_([](const DataClass &value) { return false; }), context_(context)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(localPointer_), default_(nullptr),
+          dataGetter_([&]() { return &value; }), dataSetter_([](const DataClass &value) { return false; })
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
-              std::optional<std::remove_pointer_t<DataClass>> &targetData, typename Context<DataClass>::type context)
+              std::optional<std::remove_pointer_t<DataClass>> &targetData)
         requires(std::is_pointer_v<DataClass>)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
-                        std::type_index(typeid(typename Context<DataClass>::type))),
-          data_(localPointer_), default_(nullptr),
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(localPointer_), default_(nullptr),
           dataGetter_([&]() { return targetData.has_value() ? &targetData.value() : nullptr; }),
-          dataSetter_([](const DataClass &value) { return false; }), context_(context)
+          dataSetter_([](const DataClass &value) { return false; })
     {
     }
-    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
-              typename Context<DataClass>::type context)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
-                        std::type_index(typeid(typename Context<DataClass>::type))),
-          data_(value), default_(value), context_(context)
+    Parameter(Node *parent, std::string_view name, std::string_view description, DataClass &value)
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(value), default_(value)
     {
     }
     Parameter(Node *parent, std::string_view name, std::string_view description,
               std::shared_ptr<ParameterProxy<DataClass>> &proxy)
-        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass)),
-                        std::type_index(typeid(typename Context<DataClass>::type))),
-          data_(proxy->data), default_(proxy->data), context_{}
+        : ParameterBase(parent, name, description, std::type_index(typeid(DataClass))), data_(proxy->data),
+          default_(proxy->data)
     {
         // Store the proxy data smart pointer to preserve the lifetime of the data
         proxyData_ = proxy;
@@ -337,8 +305,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     protected:
     // Reference to target data
     DataClass &data_;
-    // Reference to target context
-    Context<DataClass>::type context_;
     // Specialised container for local pointer referencing, if relevant
     std::conditional_t<std::is_pointer_v<DataClass>, DataClass, bool> localPointer_;
     // Getter for target data, defaulting so simple return of data_ reference member
@@ -591,7 +557,7 @@ template <typename DataClass> class SerialisableParameter : public Parameter<Dat
     public:
     SerialisableParameter(Node *parent, std::string_view name, std::string_view description, DataClass &value,
                           typename Context<DataClass>::type context = {})
-        : Parameter<DataClass>(parent, name, description, value, context)
+        : Parameter<DataClass>(parent, name, description, value)
     {
     }
     // Helper templates for handling serialisation

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -119,7 +119,7 @@ class ParameterBase : public Serialisable<>
     // Assign the value of another parameter to this one
     virtual bool assignDataFromSource(ParameterBase *source) = 0;
     // Assign the value of this parameter to the target one
-    virtual bool assignTo(ParameterBase *destination) = 0;
+    virtual bool assignDataTo(ParameterBase *destination) = 0;
     // The type's representation as a raw int (only valid for int and enum)
     virtual int getAsInt() const { return -1; }
     // Set type's representation as a raw int (only valid for int and enum)
@@ -227,10 +227,23 @@ template <class... Ts> bool emplace_into_variant(ParameterBase *source, std::var
 // Emplace the variant contents into the destination parameter
 template <class... Ts> bool emplace_variant_into(std::variant<Ts...> &source, ParameterBase *destination)
 {
-    auto result = false;
-    ((result = (destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(source)), true : result)) ||
-     ...);
-    return result;
+    return ((destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(source)), true : false) || ...);
+}
+
+// Check for null pointer in variant, ignoring other types
+template <class... Ts> bool variant_has_null_pointer(std::variant<Ts...> &variant)
+{
+    return std::visit(
+        [](auto &&arg) -> bool
+        {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_pointer_v<T>)
+            {
+                return arg == nullptr;
+            }
+            return false;
+        },
+        variant);
 }
 
 // Primary type for a Parameter to a specific DataClass
@@ -472,12 +485,20 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             {
                 setData(source->get<DataClass>());
 
+                // If the variant now contains a pointer type we need to check for nullptr
+                if (variant_has_null_pointer(data_))
+                    return false;
+
                 return true;
             }
 
             // Variants can be set from any matching type
             if (emplace_into_variant(source, data_))
             {
+                // If the variant now contains a pointer type we need to check for nullptr
+                if (variant_has_null_pointer(data_))
+                    return false;
+
                 updateAfterSet();
                 return true;
             }
@@ -499,7 +520,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         {
             // Try setting from the source parameter so we have it's full DataClass information - this is necessary for types
             // like std::variant where we need to know the stored alternative.
-            if (source->assignTo(this))
+            if (source->assignDataTo(this))
             {
                 updateAfterSet();
                 return true;
@@ -509,7 +530,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         return false;
     }
     // Assign the value of this parameter to the target one
-    bool assignTo(ParameterBase *destination) override
+    bool assignDataTo(ParameterBase *destination) override
     {
         if constexpr (is_instance_of_v<DataClass, std::variant>)
         {

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -112,6 +112,8 @@ class ParameterBase : public Serialisable<>
     void clearDataInParent() const;
     // Mark edges for re-pull in parent node
     void markIncomingEdgesForPull() const;
+    // Perform any updates after a successful setData()
+    void updateAfterSet() const;
     // Return whether this datatype accepts the specified one
     virtual bool acceptsDataFromSource(ParameterBase *source) = 0;
     // Return whether this datatype provides the specified one
@@ -124,7 +126,6 @@ class ParameterBase : public Serialisable<>
     virtual int getAsInt() const { return -1; }
     // Set type's representation as a raw int (only valid for int and enum)
     virtual void setFromInt(int value) { return; }
-
     // Get the parameter's value
     template <typename DataClass> DataClass get()
     {
@@ -351,19 +352,6 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     // Parameter proxy data (if a ParameterLink)
     std::shared_ptr<ParameterProxy<DataClass>> proxyData_;
 
-    private:
-    // Perform any updates after a successful setData()
-    void updateAfterSet() const
-    {
-        // Changing parameters always flags an update as being required, unless the NoUpdate flag is set
-        if (!flags_.isSet(NoUpdate))
-            setParentUpdateRequired();
-
-        // Setting some parameters forces any local data to be cleared
-        if (flags_.isSet(ClearData))
-            clearDataInParent();
-    }
-
     public:
     // Return whether the contained data is an instance of std::vector
     bool isVector() const override
@@ -541,8 +529,8 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             // try to emplace the variant's data into the destination parameter.
             if (emplace_variant_into(data_, destination))
             {
-                // TODO
-                // destination->updateAfterSet();
+                destination->updateAfterSet();
+
                 return true;
             }
         }

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -22,6 +22,12 @@ class ParameterBase;
 template <typename T> class Parameter;
 template <typename T> class SerialisableParameter;
 
+// Return whether the type_index provided matches one of the supplied variant's allowed types
+template <class... Ts> bool is_one_of(std::type_index id, const std::variant<Ts...> &x)
+{
+    return ((id == typeid(Ts)) || ...);
+};
+
 // Parameter Proxy
 template <class T> class ParameterProxy
 {
@@ -207,6 +213,16 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
     return std::make_shared<SerialisableParameter<DataClass>>(parent, name, description, value);
 }
 }; // namespace ParameterFactory
+
+// Put the data of the supplied parameter into the supplied variant
+template <class... Ts> bool put_into(ParameterBase *other, std::variant<Ts...> &x)
+{
+    return ((other->storedDataType() == typeid(Ts)
+             ? (std::cout << std::format("{} matches {}\n", other->storedDataType().name(), typeid(Ts).name()),
+                x = other->get<Ts>()),
+             true : false) ||
+            ...);
+};
 
 // Primary type for a Parameter to a specific DataClass
 template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -225,7 +225,7 @@ template <class... Ts> bool emplace_into_variant(ParameterBase *source, std::var
 }
 
 // Emplace the variant contents into the destination parameter
-template <class... Ts> int emplace_variant_into(std::variant<Ts...> &source, ParameterBase *destination)
+template <class... Ts> bool emplace_variant_into(std::variant<Ts...> &source, ParameterBase *destination)
 {
     auto result = false;
     ((result = (destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(source)), true : result)) ||

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -193,39 +193,43 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 }
 }; // namespace ParameterFactory
 
-// Return whether the type_index provided matches one of the supplied variant's allowed types
-template <class... Ts> bool is_variant_alternative(std::type_index id, const std::variant<Ts...> &x)
+// Parameter Data based on std::variant
+template <class... Ts> class VariantParameterData
 {
-    return ((id == typeid(Ts)) || ...);
-};
+    public:
+    // Varaint data
+    std::variant<std::monostate, Ts...> data;
 
-// Put the data of the source parameter into the destination variant
-template <class... Ts> bool emplace_into_variant(ParameterBase *source, std::variant<Ts...> &destination)
-{
-    return ((source->storedDataType() == typeid(Ts) ? (destination = source->get<Ts>()), true : false) || ...);
-}
-
-// Emplace the variant contents into the destination parameter
-template <class... Ts> bool emplace_variant_into(std::variant<Ts...> &source, ParameterBase *destination)
-{
-    return ((destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(source)), true : false) || ...);
-}
-
-// Check for null pointer in variant, ignoring other types
-template <class... Ts> bool variant_has_null_pointer(std::variant<Ts...> &variant)
-{
-    return std::visit(
-        [](auto &&arg) -> bool
-        {
-            using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_pointer_v<T>)
+    // Return whether the type_index provided matches one of the supplied variant's allowed types
+    bool isAlternative(std::type_index id) const { return ((id == typeid(Ts)) || ...); };
+    // Emplace the data of the source parameter into the variant
+    bool emplaceFrom(ParameterBase *source)
+    {
+        return ((source->storedDataType() == typeid(Ts) ? (data = source->get<Ts>()), true : false) || ...);
+    }
+    // Emplace the variant contents into the destination parameter
+    bool emplaceInto(ParameterBase *destination) const
+    {
+        return ((destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(data)), true : false) || ...);
+    }
+    // Return whether the variant is empty
+    bool isEmpty() const { return data.index() == 0; }
+    // Check for null pointer in variant, ignoring other types
+    bool hasNullPointer()
+    {
+        return std::visit(
+            [](auto &&arg) -> bool
             {
-                return arg == nullptr;
-            }
-            return false;
-        },
-        variant);
-}
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_pointer_v<T>)
+                {
+                    return arg == nullptr;
+                }
+                return false;
+            },
+            data);
+    }
+};
 
 // Primary type for a Parameter to a specific DataClass
 template <typename DataClass> class Parameter : public ParameterBase, public std::enable_shared_from_this<Parameter<DataClass>>
@@ -346,10 +350,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         }
 
         // Variants
-        if constexpr (is_instance_of_v<DataClass, std::variant>)
+        if constexpr (is_instance_of_v<DataClass, VariantParameterData>)
         {
             // Variants can be set from another identical type or any type which matches one of our alternatives
-            return id == storedDataType_ || is_variant_alternative(id, data_);
+            return id == storedDataType_ || data_.isAlternative(id);
         }
 
         // Normal data types can be set from several different types of object
@@ -369,10 +373,10 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         }
 
         // Variants
-        if constexpr (is_instance_of_v<DataClass, std::variant>)
+        if constexpr (is_instance_of_v<DataClass, VariantParameterData>)
         {
             // Variants might_ contain the correct data - we only return here if it is a possibility
-            return is_variant_alternative(id, data_);
+            return data_.isAlternative(id);
         }
 
         return false;
@@ -432,7 +436,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 return true;
             }
         }
-        else if constexpr (is_instance_of_v<DataClass, std::variant>)
+        else if constexpr (is_instance_of_v<DataClass, VariantParameterData>)
         {
             // Variant to variant
             if (storedDataType_ == source->storedDataType())
@@ -440,17 +444,17 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 setData(source->get<DataClass>());
 
                 // If the variant now contains a pointer type we need to check for nullptr
-                if (variant_has_null_pointer(data_))
+                if (data_.hasNullPointer())
                     return false;
 
                 return true;
             }
 
             // Variants can be set from any matching type
-            if (emplace_into_variant(source, data_))
+            if (data_.emplaceFrom(source))
             {
                 // If the variant now contains a pointer type we need to check for nullptr
-                if (variant_has_null_pointer(data_))
+                if (data_.hasNullPointer())
                     return false;
 
                 updateAfterSet();
@@ -486,14 +490,15 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
     // Assign the value of this parameter to the target one
     bool assignDataTo(ParameterBase *destination) override
     {
-        if constexpr (is_instance_of_v<DataClass, std::variant>)
+        if constexpr (is_instance_of_v<DataClass, VariantParameterData>)
         {
             // Check that we actually contain a valid value
-            // TODO
+            if (data_.isEmpty())
+                return false;
 
             // The possibility for a match between the parameters has already been checkwd by the Edge, so here we must just
             // try to emplace the variant's data into the destination parameter.
-            if (emplace_variant_into(data_, destination))
+            if (data_.emplaceInto(destination))
             {
                 destination->updateAfterSet();
 

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -413,6 +413,19 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
                 return true;
             }
         }
+        else if constexpr (is_instance_of_v<DataClass, std::variant>)
+        {
+            // Variants can be set from any matching type
+            printf("TRYING TO SET THE VARIANT...\n");
+            if (put_into(other, data_))
+            {
+                printf("DID IT!\n");
+                updateAfterSet();
+                return true;
+            }
+            else
+                printf("NO SETTING THAT!\n");
+        }
 
         // General case - if the stored data types are the same then we can just do a straight assignment
         if (storedDataType_ == other->storedDataType())
@@ -443,6 +456,17 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             // Optionals can accept non-optional data
             if (std::type_index(typeid(typename DataClass::value_type)) == other->storedDataType())
                 return true;
+        }
+        else if constexpr (is_instance_of_v<DataClass, std::variant>)
+        {
+            printf("CHECKING VARIANT TYPE.....\n");
+            if (is_one_of(other->storedDataType(), data_))
+            {
+                printf("TIS A MATCH!!!!!\n");
+                return true;
+            }
+            else
+                printf("NOPE.\n");
         }
 
         return false;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -22,12 +22,6 @@ class ParameterBase;
 template <typename T> class Parameter;
 template <typename T> class SerialisableParameter;
 
-// Return whether the type_index provided matches one of the supplied variant's allowed types
-template <class... Ts> bool is_variant_alternative(std::type_index id, const std::variant<Ts...> &x)
-{
-    return ((id == typeid(Ts)) || ...);
-};
-
 // Parameter Proxy
 template <class T> class ParameterProxy
 {
@@ -218,30 +212,24 @@ std::shared_ptr<ParameterBase> createSerialisable(Node *parent, std::string_view
 }
 }; // namespace ParameterFactory
 
-// Put the data of the supplied parameter into the supplied variant
-template <class... Ts> bool emplace(ParameterBase *other, std::variant<Ts...> &x)
+// Return whether the type_index provided matches one of the supplied variant's allowed types
+template <class... Ts> bool is_variant_alternative(std::type_index id, const std::variant<Ts...> &x)
 {
-    return ((other->storedDataType() == typeid(Ts)
-             ? (std::cout << std::format("{} matches {}\n", other->storedDataType().name(), typeid(Ts).name()),
-                x = other->get<Ts>()),
-             true : false) ||
-            ...);
+    return ((id == typeid(Ts)) || ...);
+};
+
+// Put the data of the source parameter into the destination variant
+template <class... Ts> bool emplace_into_variant(ParameterBase *source, std::variant<Ts...> &destination)
+{
+    return ((source->storedDataType() == typeid(Ts) ? (destination = source->get<Ts>()), true : false) || ...);
 }
 
-// Return the alternative index matching the type specified (if any)
-template <class... Ts> int alternative_index(std::type_index id, std::variant<Ts...> &x)
-{
-    auto index = -1;
-    auto result = -1;
-    ((result = (id == typeid(Ts)) ? index : result, ++result) || ...);
-    return result;
-}
-
-// Return the alternative index matching the type specified (if any)
-template <class... Ts> int emplace_into(std::variant<Ts...> &x, ParameterBase *destination)
+// Emplace the variant contents into the destination parameter
+template <class... Ts> int emplace_variant_into(std::variant<Ts...> &source, ParameterBase *destination)
 {
     auto result = false;
-    ((result = (destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(x)), true : result)) || ...);
+    ((result = (destination->storedDataType() == typeid(Ts) ? destination->set<Ts>(std::get<Ts>(source)), true : result)) ||
+     ...);
     return result;
 }
 
@@ -480,7 +468,7 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
         else if constexpr (is_instance_of_v<DataClass, std::variant>)
         {
             // Variants can be set from any matching type
-            if (emplace(source, data_))
+            if (emplace_into_variant(source, data_))
             {
                 updateAfterSet();
                 return true;
@@ -520,8 +508,9 @@ template <typename DataClass> class Parameter : public ParameterBase, public std
             // Check that we actually contain a valid value
             // TODO
 
-            // Check that our stored alternative is a match for the destination type
-            if (emplace_into(data_, destination))
+            // The possibility for a match between the parameters has already been checkwd by the Edge, so here we must just
+            // try to emplace the variant's data into the destination parameter.
+            if (emplace_variant_into(data_, destination))
             {
                 // TODO
                 // destination->updateAfterSet();

--- a/src/nodes/setCell.cpp
+++ b/src/nodes/setCell.cpp
@@ -6,11 +6,11 @@
 SetCellNode::SetCellNode(Graph *parentGraph) : Node(parentGraph)
 {
     // Inputs
-    addInput<Configuration *>("Configuration", "Target configuration for the calculation", targetConfiguration_)
+    addInput<CellContainingVariant>("Input", "Target configuration for the calculation", inputVariant_)
         ->setFlags({ParameterBase::Required});
 
     // Outputs
-    addOutput<Configuration *>("Configuration", "Target configuration for the cell definition", targetConfiguration_);
+    addOutput<CellContainingVariant>("Output", "Target configuration for the cell definition", outputVariant_);
 
     // Options
     addOption<Vector3>("Lengths", "Side lengths (A, B, C) of the cell (Angstroms)", lengths_);
@@ -24,10 +24,21 @@ std::string_view SetCellNode::summary() const { return "Define / overwrite a tar
 
 NodeConstants::ProcessResult SetCellNode::process()
 {
-    targetConfiguration_->createBoxAndCells(lengths_, angles_, nonPeriodic_);
+    // Copy the input to the output and work on the output
+    outputVariant_ = inputVariant_;
 
-    if (!targetConfiguration_->box())
-        return NodeConstants::ProcessResult::Failed;
+    std::visit(
+        [&](auto &&arg)
+        {
+            using T = std::decay_t<decltype(arg)>;
+            if constexpr (std::is_same_v<T, Configuration *>)
+                arg->createBoxAndCells(lengths_, angles_, nonPeriodic_);
+            else if constexpr (std::is_same_v<T, Structure>)
+                arg.createBox(lengths_, angles_, nonPeriodic_);
+            else
+                static_assert(false, "Visitor doesn't cater for all possible types.");
+        },
+        outputVariant_);
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/setCell.cpp
+++ b/src/nodes/setCell.cpp
@@ -27,18 +27,20 @@ NodeConstants::ProcessResult SetCellNode::process()
     // Copy the input to the output and work on the output
     outputVariant_ = inputVariant_;
 
-    std::visit(
+    return std::visit(
         [&](auto &&arg)
         {
             using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, Configuration *>)
+            if constexpr (std::is_same_v<T, std::monostate>)
+                return NodeConstants::ProcessResult::Failed;
+            else if constexpr (std::is_same_v<T, Configuration *>)
                 arg->createBoxAndCells(lengths_, angles_, nonPeriodic_);
             else if constexpr (std::is_same_v<T, Structure>)
                 arg.createBox(lengths_, angles_, nonPeriodic_);
             else
                 static_assert(false, "Visitor doesn't cater for all possible types.");
-        },
-        outputVariant_);
 
-    return NodeConstants::ProcessResult::Success;
+            return NodeConstants::ProcessResult::Success;
+        },
+        outputVariant_.data);
 }

--- a/src/nodes/setCell.h
+++ b/src/nodes/setCell.h
@@ -14,7 +14,7 @@ class SetCellNode : public Node
     SetCellNode(Graph *parentGraph);
     ~SetCellNode() override = default;
 
-    using CellContainingVariant = std::variant<Configuration *, Structure>;
+    using CellContainingVariant = VariantParameterData<Configuration *, Structure>;
 
     /*
      * Definition

--- a/src/nodes/setCell.h
+++ b/src/nodes/setCell.h
@@ -5,14 +5,16 @@
 
 #include "classes/box.h"
 #include "classes/configuration.h"
+#include "classes/structure.h"
 #include "nodes/node.h"
-#include <memory>
 
 class SetCellNode : public Node
 {
     public:
     SetCellNode(Graph *parentGraph);
     ~SetCellNode() override = default;
+
+    using CellContainingVariant = std::variant<Configuration *, Structure>;
 
     /*
      * Definition
@@ -25,8 +27,8 @@ class SetCellNode : public Node
      * Data
      */
     private:
-    // Configuration object
-    Configuration *targetConfiguration_{nullptr};
+    // Cell-containing input and output
+    CellContainingVariant inputVariant_, outputVariant_;
     // Box side length dimensions
     Vector3 lengths_{1.0, 1.0, 1.0};
     // Box angles

--- a/src/nodes/test.cpp
+++ b/src/nodes/test.cpp
@@ -39,13 +39,6 @@ std::string_view TestNode::summary() const { return "A node to allow unit testin
 // Return the optional Configuration
 const std::optional<Configuration> &TestNode::optionalConfiguration() const { return optionalConfiguration_; }
 
-// Set the variant
-void TestNode::setVariant(std::variant<Structure, Number, std::string, Configuration *> value)
-{
-    variant_ = value;
-    setUpdateRequired();
-}
-
 // Return the variant
 TestNode::TestVariant TestNode::variant() { return variant_; }
 

--- a/src/nodes/test.cpp
+++ b/src/nodes/test.cpp
@@ -6,17 +6,20 @@
 TestNode::TestNode(Graph *parentGraph) : Node(parentGraph)
 {
     // Inputs
-    addInput<Configuration *>("ConfigurationInput", "A configuration input", configurationInput_);
+    addInput<Configuration *>("Configuration", "A configuration input", configuration_);
     addInput("CreateConfiguration", "Whether to create the optional configuration on run", createConfiguration_);
     addInput("Number", "A single number", number_);
-    addInput("OptionalNumber", "A single number", optionalNumber_);
     addInput("NumberVector", "A vector of numbers", numberVector_);
+    addInput("OptionalNumber", "A single number", optionalNumber_);
+    addInput("Variant", "A variant", variant_);
 
     // Outputs
+    addOutput<Configuration *>("Configuration", "A configuration output", configuration_);
     addOptionalPointerOutput<Configuration>("OptionalConfiguration", "An optional Configuration", optionalConfiguration_);
     addOutput("Number", "A single number", number_);
     addOutput("NumberVector", "A vector of numbers", numberVector_);
     addOutput("OptionalNumber", "An optional number", optionalNumber_);
+    addOutput("Variant", "A variant", variant_);
 }
 
 /*
@@ -35,6 +38,16 @@ std::string_view TestNode::summary() const { return "A node to allow unit testin
 
 // Return the optional Configuration
 const std::optional<Configuration> &TestNode::optionalConfiguration() const { return optionalConfiguration_; }
+
+// Set the variant
+void TestNode::setVariant(std::variant<Structure, Number, std::string, Configuration *> value)
+{
+    variant_ = value;
+    setUpdateRequired();
+}
+
+// Return the variant
+TestNode::TestVariant TestNode::variant() { return variant_; }
 
 /*
  * Processing & Validity

--- a/src/nodes/test.h
+++ b/src/nodes/test.h
@@ -40,14 +40,18 @@ class TestNode : public Node
     // Optional number
     std::optional<Number> optionalNumber_;
     // Variant
-    using TestVariant = std::variant<Structure, Number, std::string, Configuration *>;
+    using TestVariant = VariantParameterData<Structure, Number, std::string, Configuration *>;
     TestVariant variant_;
 
     public:
     // Return the optional Configuration
     const std::optional<Configuration> &optionalConfiguration() const;
     // Set the variant
-    void setVariant(TestVariant value);
+    template <class T> void setVariant(T value)
+    {
+        variant_.data = value;
+        setUpdateRequired();
+    }
     // Return the variant
     TestVariant variant();
 

--- a/src/nodes/test.h
+++ b/src/nodes/test.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "classes/configuration.h"
+#include "classes/structure.h"
 #include "nodes/node.h"
 
 // Test Node
@@ -27,7 +28,7 @@ class TestNode : public Node
      */
     private:
     // Configuration pointer input
-    Configuration *configurationInput_{nullptr};
+    Configuration *configuration_{nullptr};
     // Optional configuration output
     std::optional<Configuration> optionalConfiguration_;
     // Whether our processing loop creates a valid optional Configuration data
@@ -38,10 +39,17 @@ class TestNode : public Node
     std::vector<Number> numberVector_;
     // Optional number
     std::optional<Number> optionalNumber_;
+    // Variant
+    using TestVariant = std::variant<Structure, Number, std::string, Configuration *>;
+    TestVariant variant_;
 
     public:
     // Return the optional Configuration
     const std::optional<Configuration> &optionalConfiguration() const;
+    // Set the variant
+    void setVariant(TestVariant value);
+    // Return the variant
+    TestVariant variant();
 
     /*
      * Processing & Validity

--- a/tests/graphData.h
+++ b/tests/graphData.h
@@ -73,7 +73,8 @@ class TestGraph : public DissolveGraph
         return node;
     }
     // Create species insertion node chain
-    Node *createAndInsertSpecies(Node *cfgSourceNode, const std::vector<std::pair<std::string, int>> &species, double rho,
+    Node *createAndInsertSpecies(Node *cfgSourceNode, std::string cfgSourceOutput,
+                                 const std::vector<std::pair<std::string, int>> &species, double rho,
                                  Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits,
                                  InsertNode::BoxActionStyle boxActionStyle = InsertNode::BoxActionStyle::AddVolume)
     {
@@ -108,9 +109,13 @@ class TestGraph : public DissolveGraph
             EXPECT_TRUE(fetchHead()->setOption<Units::DensityUnits>("DensityUnits", rhoUnits));
             EXPECT_TRUE(currentGraph_->addEdge({std::string(speciesNode.name()), "Species", insertNodeName, "Species"}));
             EXPECT_TRUE(
-                currentGraph_->addEdge({std::string(cfgSourceNode->name()), "Configuration", insertNodeName, "Configuration"}));
+                currentGraph_->addEdge({std::string(cfgSourceNode->name()), cfgSourceOutput, insertNodeName, "Configuration"}));
 
             cfgSourceNode = fetchHead();
+
+            // After the first InsertNode addition the source output name reverts to "Configuration" (it may previously have
+            // been Output from SetCell)
+            cfgSourceOutput = "Configuration";
         }
 
         return fetchHead();
@@ -184,13 +189,12 @@ class TestGraph : public DissolveGraph
     Node *createConfiguration(std::string name, const std::vector<std::pair<std::string, int>> &species, double rho,
                               Units::DensityUnits rhoUnits = Units::DensityUnits::AtomsPerAngstromUnits)
     {
-        // Create configuration and SetCell nodes
+        // Create configuration
         EXPECT_TRUE(appendNode("Configuration", name));
-        EXPECT_TRUE(appendNode("SetCell"));
-        EXPECT_TRUE(currentGraph_->addEdge({name, "Configuration", "SetCell", "Configuration"}));
 
         // Add Species and Insert nodes
-        return createAndInsertSpecies(fetchHead(), species, rho, rhoUnits, InsertNode::BoxActionStyle::AddVolume);
+        return createAndInsertSpecies(fetchHead(), "Configuration", species, rho, rhoUnits,
+                                      InsertNode::BoxActionStyle::AddVolume);
     }
     // Create basic configuration graph, returning the last node
     Node *createConfiguration(std::string name, const std::vector<std::pair<std::string, int>> &species,
@@ -201,10 +205,10 @@ class TestGraph : public DissolveGraph
         EXPECT_TRUE(appendNode("SetCell"));
         fetchHead()->setOption<Vector3>("Lengths", cellLengths);
         fetchHead()->setOption<Vector3>("Angles", cellAngles);
-        EXPECT_TRUE(currentGraph_->addEdge({name, "Configuration", "SetCell", "Configuration"}));
+        EXPECT_TRUE(currentGraph_->addEdge({name, "Configuration", "SetCell", "Input"}));
 
         // Add Species and Insert nodes
-        return createAndInsertSpecies(fetchHead(), species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
+        return createAndInsertSpecies(fetchHead(), "Output", species, 0.1, Units::DensityUnits::AtomsPerAngstromUnits,
                                       InsertNode::BoxActionStyle::None);
     }
     // Append a set coordinates node with a structure import input

--- a/tests/nodes/parameters.cpp
+++ b/tests/nodes/parameters.cpp
@@ -75,11 +75,11 @@ TEST_F(ParametersTest, OptionalPointerOutput)
 {
     auto createOptA = a_->findInput("CreateConfiguration");
     ASSERT_TRUE(createOptA);
-    auto configInputB = b_->findInput("ConfigurationInput");
+    auto configInputB = b_->findInput("Configuration");
     ASSERT_TRUE(configInputB);
 
     // Create an edge between nodes
-    ASSERT_TRUE(testGraph_.addEdge({"TestA", "OptionalConfiguration", "TestB", "ConfigurationInput"}));
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "OptionalConfiguration", "TestB", "Configuration"}));
 
     // Inputs to TestB should be valid (there is no optional data yet, but the Edge definitions are correct)
     EXPECT_TRUE(b_->inputsAreValid());
@@ -224,6 +224,140 @@ TEST_F(ParametersTest, VectorInputOutput)
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), std::vector<Number>());
     EXPECT_EQ(numbersB->get<std::vector<Number>>().size(), 0);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), numbersB->get<std::vector<Number>>());
+}
+
+TEST_F(ParametersTest, VariantToVariant)
+{
+    auto variantOutput = a_->findOutput("Variant");
+    ASSERT_TRUE(variantOutput);
+    auto variantInput = b_->findInput("Variant");
+    ASSERT_TRUE(variantInput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Variant", "TestB", "Variant"}));
+
+    // Set variant on A
+    a_->setVariant(Number(5.0));
+
+    // Run the graph from B
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Number>(b_->variant()));
+    EXPECT_EQ(std::get<Number>(b_->variant()), std::get<Number>(a_->variant()));
+
+    // Set the variant on A to a different type
+    a_->setVariant(Structure());
+
+    // Run the graph from B
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 1);
+    EXPECT_EQ(b_->versionIndex(), 1);
+    ASSERT_NO_THROW(std::get<Structure>(b_->variant()));
+}
+
+TEST_F(ParametersTest, VariantToOther)
+{
+    auto variantOutput = a_->findOutput("Variant");
+    ASSERT_TRUE(variantOutput);
+    auto numberInput = b_->findInput("Number");
+    ASSERT_TRUE(numberInput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Variant", "TestB", "Number"}));
+
+    // Set variant on A
+    a_->setVariant(Number(5.0));
+
+    // Run the graph from B
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Number>(a_->variant()));
+    EXPECT_EQ(numberInput->get<Number>(), std::get<Number>(a_->variant()));
+}
+
+TEST_F(ParametersTest, OtherToVariant)
+{
+    auto numberOutput = a_->findOutput("Number");
+    ASSERT_TRUE(numberOutput);
+    auto variantInput = b_->findInput("Variant");
+    ASSERT_TRUE(variantInput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Number", "TestB", "Variant"}));
+
+    // Set value on A
+    numberOutput->set<Number>(Number(5.0));
+
+    // Run the graph from B
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Number>(b_->variant()));
+    EXPECT_EQ(numberOutput->get<Number>(), std::get<Number>(b_->variant()));
+}
+
+TEST_F(ParametersTest, VariantToPointer)
+{
+    auto variantOutput = a_->findOutput("Variant");
+    ASSERT_TRUE(variantOutput);
+    auto configurationInput = b_->findInput("Configuration");
+    ASSERT_TRUE(configurationInput);
+
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Variant", "TestB", "Configuration"}));
+
+    // Set variant on A
+    Configuration cfg;
+    a_->setVariant(&cfg);
+
+    // Run the graph from B
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Configuration *>(a_->variant()));
+    EXPECT_EQ(configurationInput->get<Configuration *>(), &cfg);
+}
+
+TEST_F(ParametersTest, PointerToVariant)
+{
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Configuration", "TestB", "Variant"}));
+
+    // Run the graph from B - should fail as the pointer in A doesn't exist yet
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Failed);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), NodeConstants::InvalidVersion);
+
+    // Now set the configuration input and run again
+    Configuration cfg;
+    a_->setInput("Configuration", &cfg);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 1);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant()));
+    EXPECT_EQ(std::get<Configuration *>(b_->variant()), &cfg);
+}
+
+TEST_F(ParametersTest, OptionalPointerToVariant)
+{
+    // Create an edge between nodes
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "OptionalConfiguration", "TestB", "Variant"}));
+
+    // Run the graph from B - should fail as the optional hasn't been created so there is no pointer to return
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Failed);
+    EXPECT_EQ(a_->versionIndex(), 0);
+    EXPECT_EQ(b_->versionIndex(), NodeConstants::InvalidVersion);
+
+    // Now set the configuration input and run again
+    a_->setInput("CreateConfiguration", true);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(a_->versionIndex(), 1);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant()));
+    ASSERT_TRUE(a_->optionalConfiguration().has_value());
+    EXPECT_EQ(std::get<Configuration *>(b_->variant()), &a_->optionalConfiguration().value());
 }
 
 } // namespace UnitTest

--- a/tests/nodes/parameters.cpp
+++ b/tests/nodes/parameters.cpp
@@ -9,109 +9,99 @@
 
 namespace UnitTest
 {
-TEST(ParametersTest, NumberToOptionalNumber)
+class ParametersTest : public ::testing::Test
 {
-    TestGraph testGraph;
+    public:
+    ParametersTest()
+    {
+        a_ = dynamic_cast<TestNode *>(testGraph_.addNode(std::make_unique<TestNode>(&testGraph_), "TestA"));
+        EXPECT_TRUE(a_);
+        b_ = dynamic_cast<TestNode *>(testGraph_.addNode(std::make_unique<TestNode>(&testGraph_), "TestB"));
+        EXPECT_TRUE(b_);
+    }
 
-    // Create a couple of TestNodes
-    auto *a = dynamic_cast<TestNode *>(testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA"));
-    ASSERT_TRUE(a);
-    auto numberOutput = a->findOutput("Number");
+    protected:
+    TestGraph testGraph_;
+    TestNode *a_{nullptr}, *b_{nullptr};
+};
+
+TEST_F(ParametersTest, NumberToOptionalNumber)
+{
+    auto numberOutput = a_->findOutput("Number");
     ASSERT_TRUE(numberOutput);
-    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
-    ASSERT_TRUE(b);
-    auto optionalNumberImput = b->findInput("OptionalNumber");
+    auto optionalNumberImput = b_->findInput("OptionalNumber");
     ASSERT_TRUE(optionalNumberImput);
 
     // Create an edge between nodes
-    ASSERT_TRUE(testGraph.addEdge({"TestA", "Number", "TestB", "OptionalNumber"}));
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "Number", "TestB", "OptionalNumber"}));
 
     // Set number value input (shared with output)
-    ASSERT_TRUE(a->setInput<Number>("Number", 1.234));
+    ASSERT_TRUE(a_->setInput<Number>("Number", 1.234));
 
     // Run b
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 0);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 0);
 
     // Check optional value
-    auto optional = b->getInputValue<std::optional<Number>>("OptionalNumber");
+    auto optional = b_->getInputValue<std::optional<Number>>("OptionalNumber");
     ASSERT_TRUE(optional.has_value());
     EXPECT_DOUBLE_EQ(1.234, optional->asDouble());
 }
 
-TEST(ParametersTest, OptionalNumberToNumber)
+TEST_F(ParametersTest, OptionalNumberToNumber)
 {
-    TestGraph testGraph;
-
-    // Create a couple of TestNodes
-    auto *a = dynamic_cast<TestNode *>(testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA"));
-    ASSERT_TRUE(a);
-    auto optionalNumberOutput = a->findOutput("OptionalNumber");
+    auto optionalNumberOutput = a_->findOutput("OptionalNumber");
     ASSERT_TRUE(optionalNumberOutput);
-    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
-    ASSERT_TRUE(b);
-    auto numberImput = b->findInput("Number");
+    auto numberImput = b_->findInput("Number");
     ASSERT_TRUE(numberImput);
 
     // Create an edge between nodes
-    ASSERT_TRUE(testGraph.addEdge({"TestA", "OptionalNumber", "TestB", "Number"}));
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "OptionalNumber", "TestB", "Number"}));
 
     // Run b - should fail as there is no optional value to pull along the edge
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Failed);
-    EXPECT_EQ(b->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Failed);
+    EXPECT_EQ(b_->versionIndex(), NodeConstants::InvalidVersion);
 
     // Set number value input (shared with output)
-    ASSERT_TRUE(a->setInput<std::optional<Number>>("OptionalNumber", 1.234));
+    ASSERT_TRUE(a_->setInput<std::optional<Number>>("OptionalNumber", 1.234));
 
     // Run again and check value
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 0);
-    EXPECT_DOUBLE_EQ(1.234, b->getInputValue<Number>("Number").asDouble());
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 0);
+    EXPECT_DOUBLE_EQ(1.234, b_->getInputValue<Number>("Number").asDouble());
 }
 
-TEST(ParametersTest, OptionalPointerOutput)
+TEST_F(ParametersTest, OptionalPointerOutput)
 {
-    TestGraph testGraph;
-
-    // Create a couple of TestNodes
-    auto *a = dynamic_cast<TestNode *>(testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA"));
-    ASSERT_TRUE(a);
-    auto createOptA = a->findInput("CreateConfiguration");
+    auto createOptA = a_->findInput("CreateConfiguration");
     ASSERT_TRUE(createOptA);
-    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
-    ASSERT_TRUE(b);
-    auto configInputB = b->findInput("ConfigurationInput");
+    auto configInputB = b_->findInput("ConfigurationInput");
     ASSERT_TRUE(configInputB);
 
     // Create an edge between nodes
-    ASSERT_TRUE(testGraph.addEdge({"TestA", "OptionalConfiguration", "TestB", "ConfigurationInput"}));
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "OptionalConfiguration", "TestB", "ConfigurationInput"}));
 
     // Inputs to TestB should be valid (there is no optional data yet, but the Edge definitions are correct)
-    EXPECT_TRUE(b->inputsAreValid());
-    EXPECT_FALSE(b->isUpToDate());
-    EXPECT_EQ(b->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_TRUE(b_->inputsAreValid());
+    EXPECT_FALSE(b_->isUpToDate());
+    EXPECT_EQ(b_->versionIndex(), NodeConstants::InvalidVersion);
 
     // Running TestB should fail since there is no optional data to retrieve via the Edge
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Failed);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Failed);
 
     // Flag TestA to create the optional data if it doesn't exist, and rerun TestB
     createOptA->set(true);
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
 
     // Double-check the value of the pointer for sanity's sake
-    EXPECT_EQ(&a->optionalConfiguration().value(), configInputB->get<Configuration *>());
+    EXPECT_EQ(&a_->optionalConfiguration().value(), configInputB->get<Configuration *>());
 }
 
-TEST(ParametersTest, VectorParameter)
+TEST_F(ParametersTest, VectorParameter)
 {
-    TestGraph testGraph;
-
-    // Create a couple of TestNodes
-    auto *a = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA");
-    ASSERT_TRUE(a);
-    auto numbersABase = a->findInput("NumberVector");
+    auto numbersABase = a_->findInput("NumberVector");
     ASSERT_TRUE(numbersABase);
-    auto numbersA = a->findInput("NumberVector");
+    auto numbersA = a_->findInput("NumberVector");
     ASSERT_TRUE(numbersA);
 
     // Try to set the base class with a vector
@@ -121,7 +111,7 @@ TEST(ParametersTest, VectorParameter)
     EXPECT_ANY_THROW(numbersABase->set(Number{1.0}));
 
     // Create a Number node
-    auto n1 = testGraph.addNode(std::make_unique<NumberNode>(&testGraph), "Number1");
+    auto n1 = testGraph_.createNode("Number", "Number1");
     ASSERT_TRUE(n1);
     auto number1 = n1->findOption("X");
     number1->set(Number{1.0});
@@ -139,33 +129,26 @@ TEST(ParametersTest, VectorParameter)
     EXPECT_DOUBLE_EQ(numbersA->get<std::vector<Number>>()[4].asDouble(), 4.0);
 }
 
-TEST(ParametersTest, VectorInputOutput)
+TEST_F(ParametersTest, VectorInputOutput)
 {
-    TestGraph testGraph;
-
-    // Create a couple of TestNodes
-    auto *a = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestA");
-    ASSERT_TRUE(a);
-    auto numbersA = a->findInput("NumberVector");
+    auto numbersA = a_->findInput("NumberVector");
     ASSERT_TRUE(numbersA);
-    auto *b = testGraph.addNode(std::make_unique<TestNode>(&testGraph), "TestB");
-    ASSERT_TRUE(b);
-    auto numbersB = b->findInput("NumberVector");
+    auto numbersB = b_->findInput("NumberVector");
     ASSERT_TRUE(numbersB);
 
     // Create an edge linking the vector output from A to the vector input of B
-    ASSERT_TRUE(testGraph.addEdge({"TestA", "NumberVector", "TestB", "NumberVector"}));
+    ASSERT_TRUE(testGraph_.addEdge({"TestA", "NumberVector", "TestB", "NumberVector"}));
 
     // Create three Number nodes as inputs for TestA's number vector
-    auto *n1 = testGraph.addNode(std::make_unique<NumberNode>(&testGraph), "Number1");
+    auto *n1 = testGraph_.createNode("Number", "Number1");
     ASSERT_TRUE(n1);
     auto number1 = n1->findOption("X");
     ASSERT_TRUE(number1);
-    auto *n2 = testGraph.addNode(std::make_unique<NumberNode>(&testGraph), "Number2");
+    auto *n2 = testGraph_.createNode("Number", "Number2");
     ASSERT_TRUE(n2);
     auto number2 = n2->findOption("X");
     ASSERT_TRUE(number2);
-    auto *n3 = testGraph.addNode(std::make_unique<NumberNode>(&testGraph), "Number3");
+    auto *n3 = testGraph_.createNode("Number", "Number3");
     ASSERT_TRUE(n3);
     auto number3 = n3->findOption("X");
     ASSERT_TRUE(number3);
@@ -176,18 +159,18 @@ TEST(ParametersTest, VectorInputOutput)
     number3->set(Number{8.0});
 
     // Link all three numbers in to the TestA vector
-    ASSERT_TRUE(testGraph.addEdge({"Number1", "X", "TestA", "NumberVector"}));
-    ASSERT_TRUE(testGraph.addEdge({"Number2", "X", "TestA", "NumberVector"}));
-    ASSERT_TRUE(testGraph.addEdge({"Number3", "X", "TestA", "NumberVector"}));
+    ASSERT_TRUE(testGraph_.addEdge({"Number1", "X", "TestA", "NumberVector"}));
+    ASSERT_TRUE(testGraph_.addEdge({"Number2", "X", "TestA", "NumberVector"}));
+    ASSERT_TRUE(testGraph_.addEdge({"Number3", "X", "TestA", "NumberVector"}));
 
     // Run the TestB node to pull the number edge vector from TestA, using the numbers from the three number nodes
-    EXPECT_TRUE(a->inputsAreValid());
-    EXPECT_TRUE(b->inputsAreValid());
-    EXPECT_FALSE(a->isUpToDate());
-    EXPECT_FALSE(b->isUpToDate());
-    EXPECT_EQ(b->versionIndex(), NodeConstants::InvalidVersion);
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 0);
+    EXPECT_TRUE(a_->inputsAreValid());
+    EXPECT_TRUE(b_->inputsAreValid());
+    EXPECT_FALSE(a_->isUpToDate());
+    EXPECT_FALSE(b_->isUpToDate());
+    EXPECT_EQ(b_->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 0);
 
     // Check the number vectors on TestA and TestB
     EXPECT_EQ(numbersA->get<std::vector<Number>>().size(), 3);
@@ -198,45 +181,45 @@ TEST(ParametersTest, VectorInputOutput)
     // Adjust the numbers - this should invalidate both TestA and TestB
     number1->set(Number{1.0});
     number3->set(Number{2.0});
-    EXPECT_TRUE(a->inputsAreValid());
-    EXPECT_TRUE(b->inputsAreValid());
-    EXPECT_FALSE(a->isUpToDate());
-    EXPECT_FALSE(b->isUpToDate());
+    EXPECT_TRUE(a_->inputsAreValid());
+    EXPECT_TRUE(b_->inputsAreValid());
+    EXPECT_FALSE(a_->isUpToDate());
+    EXPECT_FALSE(b_->isUpToDate());
 
     // Run again and check the result
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 1);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 1);
     EXPECT_EQ(numbersA->get<std::vector<Number>>().size(), 3);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), (std::vector<Number>{{1.0}, {6.0}, {2.0}}));
     EXPECT_EQ(numbersB->get<std::vector<Number>>().size(), 3);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), numbersB->get<std::vector<Number>>());
 
     // Remove a single edge - this should flag TestA and TestB as being out of date
-    EXPECT_TRUE(testGraph.removeEdge({"Number1", "X", "TestA", "NumberVector"}));
-    EXPECT_TRUE(a->inputsAreValid());
-    EXPECT_TRUE(b->inputsAreValid());
-    EXPECT_FALSE(a->isUpToDate());
-    EXPECT_FALSE(b->isUpToDate());
+    EXPECT_TRUE(testGraph_.removeEdge({"Number1", "X", "TestA", "NumberVector"}));
+    EXPECT_TRUE(a_->inputsAreValid());
+    EXPECT_TRUE(b_->inputsAreValid());
+    EXPECT_FALSE(a_->isUpToDate());
+    EXPECT_FALSE(b_->isUpToDate());
 
     // Run again and check the result
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 2);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 2);
     EXPECT_EQ(numbersA->get<std::vector<Number>>().size(), 2);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), (std::vector<Number>{{6.0}, {2.0}}));
     EXPECT_EQ(numbersB->get<std::vector<Number>>().size(), 2);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), numbersB->get<std::vector<Number>>());
 
     // Remove both of the other edges
-    EXPECT_TRUE(testGraph.removeEdge({"Number3", "X", "TestA", "NumberVector"}));
-    EXPECT_TRUE(testGraph.removeEdge({"Number2", "X", "TestA", "NumberVector"}));
-    EXPECT_TRUE(a->inputsAreValid());
-    EXPECT_TRUE(b->inputsAreValid());
-    EXPECT_FALSE(a->isUpToDate());
-    EXPECT_FALSE(b->isUpToDate());
+    EXPECT_TRUE(testGraph_.removeEdge({"Number3", "X", "TestA", "NumberVector"}));
+    EXPECT_TRUE(testGraph_.removeEdge({"Number2", "X", "TestA", "NumberVector"}));
+    EXPECT_TRUE(a_->inputsAreValid());
+    EXPECT_TRUE(b_->inputsAreValid());
+    EXPECT_FALSE(a_->isUpToDate());
+    EXPECT_FALSE(b_->isUpToDate());
 
     // Run again and check the result
-    EXPECT_EQ(b->run(), NodeConstants::ProcessResult::Success);
-    EXPECT_EQ(b->versionIndex(), 3);
+    EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
+    EXPECT_EQ(b_->versionIndex(), 3);
     EXPECT_EQ(numbersA->get<std::vector<Number>>().size(), 0);
     EXPECT_EQ(numbersA->get<std::vector<Number>>(), std::vector<Number>());
     EXPECT_EQ(numbersB->get<std::vector<Number>>().size(), 0);

--- a/tests/nodes/parameters.cpp
+++ b/tests/nodes/parameters.cpp
@@ -243,8 +243,8 @@ TEST_F(ParametersTest, VariantToVariant)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 0);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Number>(b_->variant()));
-    EXPECT_EQ(std::get<Number>(b_->variant()), std::get<Number>(a_->variant()));
+    ASSERT_NO_THROW(std::get<Number>(b_->variant().data));
+    EXPECT_EQ(std::get<Number>(b_->variant().data), std::get<Number>(a_->variant().data));
 
     // Set the variant on A to a different type
     a_->setVariant(Structure());
@@ -253,7 +253,7 @@ TEST_F(ParametersTest, VariantToVariant)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 1);
     EXPECT_EQ(b_->versionIndex(), 1);
-    ASSERT_NO_THROW(std::get<Structure>(b_->variant()));
+    ASSERT_NO_THROW(std::get<Structure>(b_->variant().data));
 }
 
 TEST_F(ParametersTest, VariantToOther)
@@ -273,8 +273,8 @@ TEST_F(ParametersTest, VariantToOther)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 0);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Number>(a_->variant()));
-    EXPECT_EQ(numberInput->get<Number>(), std::get<Number>(a_->variant()));
+    ASSERT_NO_THROW(std::get<Number>(a_->variant().data));
+    EXPECT_EQ(numberInput->get<Number>(), std::get<Number>(a_->variant().data));
 }
 
 TEST_F(ParametersTest, OtherToVariant)
@@ -294,8 +294,8 @@ TEST_F(ParametersTest, OtherToVariant)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 0);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Number>(b_->variant()));
-    EXPECT_EQ(numberOutput->get<Number>(), std::get<Number>(b_->variant()));
+    ASSERT_NO_THROW(std::get<Number>(b_->variant().data));
+    EXPECT_EQ(numberOutput->get<Number>(), std::get<Number>(b_->variant().data));
 }
 
 TEST_F(ParametersTest, VariantToPointer)
@@ -316,7 +316,7 @@ TEST_F(ParametersTest, VariantToPointer)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 0);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Configuration *>(a_->variant()));
+    ASSERT_NO_THROW(std::get<Configuration *>(a_->variant().data));
     EXPECT_EQ(configurationInput->get<Configuration *>(), &cfg);
 }
 
@@ -336,8 +336,8 @@ TEST_F(ParametersTest, PointerToVariant)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 1);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant()));
-    EXPECT_EQ(std::get<Configuration *>(b_->variant()), &cfg);
+    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant().data));
+    EXPECT_EQ(std::get<Configuration *>(b_->variant().data), &cfg);
 }
 
 TEST_F(ParametersTest, OptionalPointerToVariant)
@@ -355,9 +355,9 @@ TEST_F(ParametersTest, OptionalPointerToVariant)
     EXPECT_EQ(b_->run(), NodeConstants::ProcessResult::Success);
     EXPECT_EQ(a_->versionIndex(), 1);
     EXPECT_EQ(b_->versionIndex(), 0);
-    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant()));
+    ASSERT_NO_THROW(std::get<Configuration *>(b_->variant().data));
     ASSERT_TRUE(a_->optionalConfiguration().has_value());
-    EXPECT_EQ(std::get<Configuration *>(b_->variant()), &a_->optionalConfiguration().value());
+    EXPECT_EQ(std::get<Configuration *>(b_->variant().data), &a_->optionalConfiguration().value());
 }
 
 } // namespace UnitTest

--- a/tests/nodes/parameters.cpp
+++ b/tests/nodes/parameters.cpp
@@ -127,11 +127,11 @@ TEST(ParametersTest, VectorParameter)
     number1->set(Number{1.0});
 
     // Assign the number node to the vector
-    EXPECT_TRUE(numbersA->assign(number1.get()));
+    EXPECT_TRUE(numbersA->assignDataFromSource(number1.get()));
 
     // Assign another number
     number1->set(Number{4.0});
-    EXPECT_TRUE(numbersA->assign(number1.get()));
+    EXPECT_TRUE(numbersA->assignDataFromSource(number1.get()));
 
     // Check vector contents
     ASSERT_EQ(numbersA->get<std::vector<Number>>().size(), 5);


### PR DESCRIPTION
This PR attempts to allow `std::variant` as a workable `Parameter` data type, driven from the need to use `SetCellNode` to work on both `Configuration`s as well as `Structure`s. To neaten things up at the end I introduced `VariantParameterData` (see `nodes/parameter.h`) to tidy things up and force the use of `std::monostate` as the first alternative in the variant.

### TODO
- [x] Assigning a `std::variant`-based `Parameter` currently fails - needs a refactor to be able to switch to using a setter on the variant (source) `Parameter` rather than a getter from the destination `Parameter`.
- [x] Empty type (because our `std::variant` can be empty?
- [x] Unit tests