### PR TITLE
refactor: Remove ConfigurationAtom::globalIndex().

### DIFF
--- a/src/classes/changeData.cpp
+++ b/src/classes/changeData.cpp
@@ -28,7 +28,7 @@ void ChangeData::setAtom(ConfigurationAtom *i)
 ConfigurationAtom *ChangeData::atom() { return atom_; }
 
 // Return array index of stored Atom
-int ChangeData::atomArrayIndex() const { return atom_->globalIndex(); }
+int ChangeData::atomArrayIndex() const { return atom_->index(); }
 
 // Update local position, and flag as moved
 void ChangeData::updatePosition()

--- a/src/classes/configurationAtom.cpp
+++ b/src/classes/configurationAtom.cpp
@@ -7,13 +7,6 @@
 #include "classes/speciesAtom.h"
 #include <utility>
 
-// Return global index of the atom
-int ConfigurationAtom::globalIndex() const
-{
-    assert(molecule_);
-    return molecule_->globalAtomIndex(this);
-}
-
 /*
  * Location
  */

--- a/src/classes/configurationAtom.h
+++ b/src/classes/configurationAtom.h
@@ -18,13 +18,6 @@ class Molecule;
 class ConfigurationAtom : public Atom<SpeciesBond>
 {
     /*
-     * Properties
-     */
-    public:
-    // Return global index of the atom
-    int globalIndex() const;
-
-    /*
      * Location
      */
     private:

--- a/src/classes/configuration_upkeep.cpp
+++ b/src/classes/configuration_upkeep.cpp
@@ -10,12 +10,16 @@
 // Rationalise object relationships between atoms, molecules, and cells
 void Configuration::updateObjectRelationships()
 {
-    int offset = 0;
+    auto offset = 0;
     for (auto &m : molecules_)
     {
         m->updateAtoms(atoms_, offset);
         offset += m->nAtoms();
     }
+
+    // Set indixes of all atoms
+    for (auto index = 0; index < atoms_.size(); ++index)
+        atoms_[index].setIndex(index);
 
     // If we have a CellArray update the atom locations
     if (cells_.nCells() != 0)

--- a/src/generator/restraintPotential.cpp
+++ b/src/generator/restraintPotential.cpp
@@ -31,7 +31,7 @@ void RestraintPotentialGeneratorNode::restrainMoleculeAtoms(Configuration *cfg, 
     {
         auto pot = std::make_unique<SphericalPotential>();
         pot->setPotential(potential_);
-        pot->setTargetAtomIndices({i->globalIndex()});
+        pot->setTargetAtomIndices({i->index()});
         pot->setOrigin(i->r());
         cfg->addTargetedPotential(std::unique_ptr<ExternalPotential>(std::move(pot)));
     }

--- a/src/kernels/force.cpp
+++ b/src/kernels/force.cpp
@@ -167,7 +167,7 @@ void ForceKernel::totalForces(std::vector<Vector3> &ppForceVector, std::vector<V
                                             return;
                                         // Check for atoms in the same molecule
                                         if (i->molecule() != j->molecule())
-                                            forcesWithoutMim(*i, i->globalIndex(), *j, j->globalIndex(), fLocal);
+                                            forcesWithoutMim(*i, i->index(), *j, j->index(), fLocal);
                                     });
 
             // Interatomic interactions between atoms in this cell and its neighbours


### PR DESCRIPTION
This PR addresses #2418 and removes the highly unnecessary `ConfigurationAtom::globalIndex()` function which used the internal `molecule_` pointer and some pointer arithmetic to work out which index it was in the parent `Configuration`. We already had an `Atom::index_` variable, so now we just set, update, and use that instead.

Running the benchmarks on my system suggest a 5% or so gain in the force routines as a direct result of doing this.