### PR TITLE
fix: Stop trying to include a now-deleted benchmarkConfig.h

### DIFF
--- a/benchmark/common/problems.h
+++ b/benchmark/common/problems.h
@@ -3,7 +3,6 @@
 
 #pragma once
 
-#include "benchmarkConfig.h"
 #include "classes/box.h"
 #include "classes/coreData.h"
 #include "expression/variable.h"


### PR DESCRIPTION
Another fix. Sorry!