### PR TITLE
refactor: Applicative parsers

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,29 +1,29 @@
 add_library(
   base
   applicative.cpp
-  parserLibrary.cpp
   cbor.cpp
-  enumOptionsBase.cpp
-  geometry.cpp
-  lineParser.cpp
-  lock.cpp
-  messenger.cpp
-  outputHandler.cpp
-  sysFunc.cpp
-  timer.cpp
-  units.cpp
-  version.cpp
   enumOption.h
-  enumOptionsBase.h
   enumOptions.h
+  enumOptionsBase.cpp
+  enumOptionsBase.h
+  geometry.cpp
   geometry.h
+  lineParser.cpp
   lineParser.h
+  lock.cpp
   lock.h
+  messenger.cpp
   messenger.h
+  outputHandler.cpp
   outputHandler.h
+  parserLibrary.cpp
+  sysFunc.cpp
   sysFunc.h
+  timer.cpp
   timer.h
+  units.cpp
   units.h
+  version.cpp
   version.h
 )
 

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(
   base
+  applicative.cpp
   cbor.cpp
   enumOptionsBase.cpp
   geometry.cpp

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
   base
   applicative.cpp
+  parserLibrary.cpp
   cbor.cpp
   enumOptionsBase.cpp
   geometry.cpp

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -35,6 +35,11 @@ Parser<std::string> spaces()
 {
     return takeWhile([](const char c) { return isspace(c); });
 }
+// A parser that accepts space and tab
+Parser<std::string> inline_spaces()
+{
+    return takeWhile([](const char c) { return c == ' ' || c == '\t'; });
+}
 // A parse that accepts any amount of visible characters
 Parser<std::string> graphs()
 {

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -16,7 +16,7 @@ Parser<std::string_view> literal(std::string_view constant) { return Parser<std:
 Parser<std::string> takeWhile(std::function<bool(char)> f)
 {
     Parser<std::string> result(
-        [f](auto &input) -> parser_output<std::string>
+        [f](auto &input) -> ParserOutput<std::string>
         {
             if (input.eof())
                 return {};

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "applicative.h"
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+
+namespace parsers
+{
+
+// A parser that expects an exact string
+Parser<std::string_view> literal(std::string_view constant) { return Parser<std::string_view>(constant); }
+
+Parser<std::string_view> takeWhile(std::function<bool(char)> f)
+{
+    Parser<std::string_view> result(
+        [f](const auto input) -> parser_output<std::string_view>
+        {
+            if (input.empty())
+                return {};
+            auto it = std::find_if(input.begin(), input.end(), [f](const auto x) { return !f(x); });
+            if (it == input.begin())
+                return {};
+            return {{std::string_view(input.begin(), it), std::string_view(it, input.end())}};
+        });
+    return result;
+}
+
+// A parser that accepts an integer greater than or equal to zero
+Parser<int> natural()
+{
+    auto result = digits();
+    return result.map(
+        [](const auto terms) -> int
+        {
+            int total = 0;
+            for (auto term : terms)
+                total = 10 * total + (term - '0');
+            return total;
+        });
+}
+
+// Take an optional minus sign and a whole number to create an integer
+int nat2int(std::optional<std::string_view> minus, int number)
+{
+    if (minus)
+        return -number;
+    return number;
+}
+
+// A parser that accepts an integer
+Parser<int> integer() { return (maybe("-"_p) & natural()).apply(nat2int); }
+
+// Take the numbers before the decimal, some optional digits after the period, and an optional exponent, and return a double.
+double nat2dbl(int before, std::optional<std::string_view> after, std::optional<int> exponent)
+{
+    double result = before;
+    if (after)
+    {
+        double magnitude = 1;
+        double total = 0;
+        for (auto digit : *after)
+        {
+            total = total * 10 + (digit - '0');
+            magnitude *= 10;
+        }
+        if (result < 0)
+            total *= -1;
+        result += total / magnitude;
+    }
+    if (exponent)
+    {
+        result *= pow(10, *exponent);
+    }
+    return result;
+}
+
+// A parser that accepts a real, floating point number
+Parser<double> real()
+{
+    auto result = integer() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> integer());
+    return result.apply(nat2dbl);
+}
+
+// A parser that accepts and amount of whitespace
+Parser<std::string_view> spaces() { return takeWhile(std::isspace); }
+// A parse that accepts any amount of visible characters
+Parser<std::string_view> graphs() { return takeWhile(std::isgraph); }
+// A parse that accepts any amount of alphanumeric characters
+Parser<std::string_view> alphanums() { return takeWhile(std::isalnum); }
+// A parse that accepts any amount of letters
+Parser<std::string_view> alphas() { return takeWhile(std::isalpha); }
+// A parse that accepts any amount of upper case letters
+Parser<std::string_view> uppers() { return takeWhile(std::isupper); }
+// A parse that accepts any amount of lower case letters
+Parser<std::string_view> lowers() { return takeWhile(std::islower); }
+// A parse that accepts any amount of punctuation case letters
+Parser<std::string_view> punctuations() { return takeWhile(std::ispunct); }
+// A parser that accepts any amount of digit characters
+Parser<std::string_view> digits() { return takeWhile(std::isdigit); }
+
+// A quick wrapper for easily making parses from strings
+Parser<std::string_view> operator""_p(const char *text, size_t size) { return literal(std::string_view(text, size)); }
+} // namespace parsers

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -76,7 +76,7 @@ Parser<std::string> digits()
     return takeWhile([](const char c) { return std::isdigit(c); });
 }
 
-// A parser that accepts any amount of digit characters
+// A parser that continues until a newline
 Parser<std::string> inlines()
 {
     return takeWhile([](const auto c) { return c != '\r' && c != '\n'; });

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -7,7 +7,7 @@
 #include <cmath>
 #include <sstream>
 
-namespace parsers
+namespace Parsers
 {
 
 // A parser that expects an exact string
@@ -87,4 +87,4 @@ Parser<std::string_view> newlines() { return "\r\n"_p | "\n"_p; }
 
 // A quick wrapper for easily making parses from strings
 Parser<std::string_view> operator""_p(const char *text, size_t size) { return literal(std::string_view(text, size)); }
-} // namespace parsers
+} // namespace Parsers

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "applicative.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cmath>
@@ -27,62 +28,6 @@ Parser<std::string_view> takeWhile(std::function<bool(char)> f)
     return result;
 }
 
-// A parser that accepts an integer greater than or equal to zero
-Parser<int> natural()
-{
-    auto result = digits();
-    return result.map(
-        [](const auto terms) -> int
-        {
-            int total = 0;
-            for (auto term : terms)
-                total = 10 * total + (term - '0');
-            return total;
-        });
-}
-
-// Take an optional minus sign and a whole number to create an integer
-int nat2int(std::optional<std::string_view> minus, int number)
-{
-    if (minus)
-        return -number;
-    return number;
-}
-
-// A parser that accepts an integer
-Parser<int> integer() { return (maybe("-"_p) & natural()).apply(nat2int); }
-
-// Take the numbers before the decimal, some optional digits after the period, and an optional exponent, and return a double.
-double nat2dbl(int before, std::optional<std::string_view> after, std::optional<int> exponent)
-{
-    double result = before;
-    if (after)
-    {
-        double magnitude = 1;
-        double total = 0;
-        for (auto digit : *after)
-        {
-            total = total * 10 + (digit - '0');
-            magnitude *= 10;
-        }
-        if (result < 0)
-            total *= -1;
-        result += total / magnitude;
-    }
-    if (exponent)
-    {
-        result *= pow(10, *exponent);
-    }
-    return result;
-}
-
-// A parser that accepts a real, floating point number
-Parser<double> real()
-{
-    auto result = integer() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> integer());
-    return result.apply(nat2dbl);
-}
-
 // A parser that accepts and amount of whitespace
 Parser<std::string_view> spaces() { return takeWhile(std::isspace); }
 // A parse that accepts any amount of visible characters
@@ -99,6 +44,15 @@ Parser<std::string_view> lowers() { return takeWhile(std::islower); }
 Parser<std::string_view> punctuations() { return takeWhile(std::ispunct); }
 // A parser that accepts any amount of digit characters
 Parser<std::string_view> digits() { return takeWhile(std::isdigit); }
+
+// A parser that accepts any amount of digit characters
+Parser<std::string_view> inlines()
+{
+    return takeWhile([](const auto c) { return c != '\r' && c != '\n'; });
+}
+
+// A parser that accepts any amount of digit characters
+Parser<std::string_view> newlines() { return "\r\n"_p | "\n"_p; }
 
 // A quick wrapper for easily making parses from strings
 Parser<std::string_view> operator""_p(const char *text, size_t size) { return literal(std::string_view(text, size)); }

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -82,7 +82,7 @@ Parser<std::string> inlines()
     return takeWhile([](const auto c) { return c != '\r' && c != '\n'; });
 }
 
-// A parser that accepts any amount of digit characters
+// A parser that matches newline characters
 Parser<std::string_view> newlines() { return "\r\n"_p | "\n"_p; }
 
 // A quick wrapper for easily making parses from strings

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -4,8 +4,8 @@
 #include "applicative.h"
 
 #include <algorithm>
-#include <cctype>
 #include <cmath>
+#include <sstream>
 
 namespace parsers
 {
@@ -13,40 +13,66 @@ namespace parsers
 // A parser that expects an exact string
 Parser<std::string_view> literal(std::string_view constant) { return Parser<std::string_view>(constant); }
 
-Parser<std::string_view> takeWhile(std::function<bool(char)> f)
+Parser<std::string> takeWhile(std::function<bool(char)> f)
 {
-    Parser<std::string_view> result(
-        [f](const auto input) -> parser_output<std::string_view>
+    Parser<std::string> result(
+        [f](auto &input) -> parser_output<std::string>
         {
-            if (input.empty())
+            if (input.eof())
                 return {};
-            auto it = std::find_if(input.begin(), input.end(), [f](const auto x) { return !f(x); });
-            if (it == input.begin())
+            std::string result = "";
+            while (f(input.peek()))
+                result.push_back(input.get());
+            if (result.empty())
                 return {};
-            return {{std::string_view(input.begin(), it), std::string_view(it, input.end())}};
+            return {{result, input}};
         });
     return result;
 }
 
 // A parser that accepts and amount of whitespace
-Parser<std::string_view> spaces() { return takeWhile(std::isspace); }
+Parser<std::string> spaces()
+{
+    return takeWhile([](const char c) { return isspace(c); });
+}
 // A parse that accepts any amount of visible characters
-Parser<std::string_view> graphs() { return takeWhile(std::isgraph); }
+Parser<std::string> graphs()
+{
+    return takeWhile([](const char c) { return std::isgraph(c); });
+}
 // A parse that accepts any amount of alphanumeric characters
-Parser<std::string_view> alphanums() { return takeWhile(std::isalnum); }
+Parser<std::string> alphanums()
+{
+    return takeWhile([](const char c) { return std::isalnum(c); });
+}
 // A parse that accepts any amount of letters
-Parser<std::string_view> alphas() { return takeWhile(std::isalpha); }
+Parser<std::string> alphas()
+{
+    return takeWhile([](const char c) { return std::isalpha(c); });
+}
 // A parse that accepts any amount of upper case letters
-Parser<std::string_view> uppers() { return takeWhile(std::isupper); }
+Parser<std::string> uppers()
+{
+    return takeWhile([](const char c) { return std::isupper(c); });
+}
 // A parse that accepts any amount of lower case letters
-Parser<std::string_view> lowers() { return takeWhile(std::islower); }
+Parser<std::string> lowers()
+{
+    return takeWhile([](const char c) { return std::islower(c); });
+}
 // A parse that accepts any amount of punctuation case letters
-Parser<std::string_view> punctuations() { return takeWhile(std::ispunct); }
+Parser<std::string> punctuations()
+{
+    return takeWhile([](const char c) { return std::ispunct(c); });
+}
 // A parser that accepts any amount of digit characters
-Parser<std::string_view> digits() { return takeWhile(std::isdigit); }
+Parser<std::string> digits()
+{
+    return takeWhile([](const char c) { return std::isdigit(c); });
+}
 
 // A parser that accepts any amount of digit characters
-Parser<std::string_view> inlines()
+Parser<std::string> inlines()
 {
     return takeWhile([](const auto c) { return c != '\r' && c != '\n'; });
 }

--- a/src/base/applicative.cpp
+++ b/src/base/applicative.cpp
@@ -36,7 +36,7 @@ Parser<std::string> spaces()
     return takeWhile([](const char c) { return isspace(c); });
 }
 // A parser that accepts space and tab
-Parser<std::string> inline_spaces()
+Parser<std::string> inlineSpaces()
 {
     return takeWhile([](const char c) { return c == ' ' || c == '\t'; });
 }

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -334,10 +334,9 @@ template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
             }
             else
             {
-                std::optional<T> empty;
                 input.clear();
                 input.seekg(location);
-                return {{empty, input}};
+                return {{{}, input}};
             }
         });
     return result;

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -314,8 +314,11 @@ template <typename T> Parser<T> pure(T constant)
 }
 
 // A parser that always fails
-template <typename T>
-Parser<T> null([](const auto x) -> parser_output<T> { return std::nullopt; });
+template <typename T> Parser<T> null()
+{
+    Parser<T> result = ([](const auto x) -> parser_output<T> { return std::nullopt; });
+    return result;
+}
 
 // Modify a parser so that the parsed value is wrapped in a
 // std::optional.  If the parser would have failed, act as though

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -394,6 +394,8 @@ Parser<std::string> digits();
 
 // A parser that accepts and amount of whitespace
 Parser<std::string> spaces();
+// A parser that accepts space and tab
+Parser<std::string> inline_spaces();
 
 // A parser that accepts any amount of visible characters
 Parser<std::string> graphs();

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -21,7 +21,7 @@ namespace parsers
 template <typename T>
 concept TupleLike = requires { std::tuple_size<T>::value; };
 
-// The simplest defintion of an applicative parser is a function that
+// The simplest definition of an applicative parser is a function that
 // takes a stream and, if the parse succeeds, returns the parsed
 // value and the rest of the stream.  To make life simpler, we
 // define the parser_output<T> for the return type of the function.

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -69,6 +69,8 @@ template <typename T> class Parser
     public:
     // Parse a string and, if possible, return the value and the remainder
     parser_output<T> parse(std::string_view input) const { return lambda_(input); };
+    // Parse a string and, if possible, return the value and the remainder
+    parser_output<T> operator()(std::string_view input) const { return lambda_(input); }
 
     // Create a new parser that takes the output of the old parser and
     // passes it through a function
@@ -125,7 +127,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[body, middle] = *first;
-                    auto second = other.parse(middle);
+                    auto second = other(middle);
                     if (second)
                     {
                         return {{body, std::get<1>(*second)}};
@@ -154,7 +156,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[body, middle] = *first;
-                    return other.parse(middle);
+                    return other(middle);
                 }
                 else
                 {
@@ -173,7 +175,7 @@ template <typename T> class Parser
             [method, other](const std::string_view input) -> parser_output<T>
             {
                 auto first = method(input);
-                return first ? first : other.parse(input);
+                return first ? first : other(input);
             });
         return result;
     }
@@ -200,7 +202,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[fst, middle] = *first;
-                    auto second = other.parse(middle);
+                    auto second = other(middle);
                     if (second)
                     {
                         auto &[snd, final] = *second;
@@ -230,7 +232,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[fst, middle] = *first;
-                    auto second = other.parse(middle);
+                    auto second = other(middle);
                     if (second)
                     {
                         auto &[snd, final] = *second;
@@ -260,7 +262,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[fst, middle] = *first;
-                    auto second = other.parse(middle);
+                    auto second = other(middle);
                     if (second)
                     {
                         auto &[snd, final] = *second;
@@ -290,7 +292,7 @@ template <typename T> class Parser
                 if (first)
                 {
                     auto &[fst, middle] = *first;
-                    auto second = other.parse(middle);
+                    auto second = other(middle);
                     if (second)
                     {
                         auto &[snd, final] = *second;
@@ -327,7 +329,7 @@ template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
     Parser<std::optional<T>> result(
         [inner](const std::string_view input) -> parser_output<std::optional<T>>
         {
-            auto first = inner.parse(input);
+            auto first = inner(input);
             if (first)
             {
                 auto &[body, remainder] = *first;
@@ -353,7 +355,7 @@ template <typename T> Parser<std::vector<T>> some(Parser<T> inner)
             auto ctx = input;
             while (!ctx.empty())
             {
-                auto trial = inner.parse(ctx);
+                auto trial = inner(ctx);
                 if (trial)
                 {
                     auto &[body, remainder] = *trial;

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -315,7 +315,7 @@ template <typename T> Parser<T> pure(T constant)
 
 // A parser that always fails
 template <typename T>
-Parser<T> null([](const auto x) -> parser_output<T> { return {}; });
+Parser<T> null([](const auto x) -> parser_output<T> { return std::nullopt; });
 
 // Modify a parser so that the parsed value is wrapped in a
 // std::optional.  If the parser would have failed, act as though

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -1,0 +1,431 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string_view>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+namespace parsers
+{
+
+// A concept to check if a type is a tuple.  This is built in in
+// C++23, be we can do this for now.
+template <typename T>
+concept TupleLike = requires { std::tuple_size<T>::value; };
+
+// The simplest defintion of an applicative parser is a function that
+// takes a string_view and, if the parse succeeds, returns the parsed
+// value and the rest of the string_view.  To make life simpler, we
+// define the parser_output<T> for the return type of the function.
+// This *could* have further implications because there are more
+// complicated parsers we could create.
+template <typename T> using parser_output = std::optional<std::tuple<T, std::string_view>>;
+
+// This concept type checks that a given lambda matches the definition
+// given in the paragraph above.
+template <typename Lambda, typename T>
+concept ApParse = requires(Lambda lam, std::string_view input) {
+    { lam(input) } -> std::convertible_to<parser_output<T>>;
+};
+
+// It's fully possible to just use the functions as the parsers, but, if we wrap them un a struct, we can use operator
+// overloading to more easily combine smaller parsers into larger parsers.
+template <typename T> class Parser
+{
+
+    public:
+    // Wrap a parser lambda in a structure
+    template <typename Lambda>
+        requires ApParse<Lambda, T>
+    Parser(Lambda lambda) : lambda_(lambda)
+    {
+    }
+
+    // Create a parser that matches and exact string
+    template <typename = std::enable_if<std::is_same<T, std::string_view>::value>>
+    Parser(std::string_view constant)
+        : lambda_(
+              [constant](const std::string_view input) -> parser_output<std::string_view>
+              {
+                  if (input.starts_with(constant))
+                      return {{constant, input.substr(constant.size())}};
+                  else
+                      return {};
+              })
+    {
+    }
+
+    private:
+    // The actual function that we have wrapped.  We need to wrap this
+    // in a std::function instead of using a lambda so that we don't
+    // have to handle the exact type of the bound lambda
+    std::function<parser_output<T>(std::string_view)> lambda_;
+
+    public:
+    // Parse a string and, if possible, return the value and the remainder
+    parser_output<T> parse(std::string_view input) const { return lambda_(input); };
+
+    // Create a new parser that takes the output of the old parser and
+    // passes it through a function
+    template <typename Lambda> auto map(Lambda f) -> Parser<decltype(f(std::declval<T>()))>
+    {
+        auto &method = lambda_;
+        Parser<decltype(f(std::declval<T>()))> result(
+            [method, f](const std::string_view input) -> parser_output<decltype(f(std::declval<T>()))>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[body, remainder] = *first;
+                    return {{f(body), remainder}};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+
+    // Same as map, but unpacks the tuple and passes the individual
+    // parts as arguments.  This greatly simplifies creating mapping
+    // functions
+    template <typename Lambda>
+        requires(TupleLike<T>)
+    auto apply(Lambda f) -> Parser<decltype(std::apply(f, std::declval<T>()))>
+    {
+        auto &method = lambda_;
+        Parser<decltype(std::apply(f, std::declval<T>()))> result(
+            [method, f](const std::string_view input) -> parser_output<decltype(std::apply(f, std::declval<T>()))>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[body, remainder] = *first;
+                    return {{std::apply(f, body), remainder}};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+
+    // Insist that this parse is followed by another parse, but we
+    // ignore the output of that other parser
+    template <typename U> Parser<T> operator<<(Parser<U> other)
+    {
+        auto &method = lambda_;
+        Parser<T> result(
+            [method, other](const std::string_view input) -> parser_output<T>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[body, middle] = *first;
+                    auto second = other.parse(middle);
+                    if (second)
+                    {
+                        return {{body, std::get<1>(*second)}};
+                    }
+                    else
+                    {
+                        return {};
+                    }
+                }
+                else
+                {
+                    return {};
+                }
+            });
+        return result;
+    }
+
+    // Confirm that this parser passes, but ignore its output and return the value of a subsequent parser
+    template <typename U> Parser<U> operator>>(Parser<U> other)
+    {
+        auto &method = lambda_;
+        Parser<U> result(
+            [method, other](const std::string_view input) -> parser_output<U>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[body, middle] = *first;
+                    return other.parse(middle);
+                }
+                else
+                {
+                    return {};
+                }
+            });
+        return result;
+    }
+
+    // If this parser fails, try an alternate parser instead of
+    // immediately failing.
+    Parser<T> operator|(Parser<T> other)
+    {
+        auto &method = lambda_;
+        Parser<T> result(
+            [method, other](const std::string_view input) -> parser_output<T>
+            {
+                auto first = method(input);
+                return first ? first : other.parse(input);
+            });
+        return result;
+    }
+
+    // If this parser fails, try an alternate literal string parser
+    // instead of immediately failing.
+    template <typename = std::enable_if<std::is_same<T, std::string_view>::value>>
+    Parser<std::string_view> operator|(std::string_view other)
+    {
+        return Parser<std::string_view>(other) | *this;
+    }
+
+    // After confirming that this parser passes, apply a second parser
+    // on the remainder and collect both values.
+    template <typename U>
+        requires(!TupleLike<T> && !TupleLike<U>)
+    auto operator&(Parser<U> other) -> Parser<std::tuple<T, U>>
+    {
+        auto &method = lambda_;
+        Parser<std::tuple<T, U>> result(
+            [method, other](const std::string_view input) -> parser_output<std::tuple<T, U>>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[fst, middle] = *first;
+                    auto second = other.parse(middle);
+                    if (second)
+                    {
+                        auto &[snd, final] = *second;
+                        return {{{fst, snd}, final}};
+                    }
+                    else
+                        return {};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+
+    // After confirming that this parser passes, apply a second parser
+    // on the remainder and collect both values.
+    template <typename U>
+        requires(TupleLike<T> && !TupleLike<U>)
+    auto operator&(Parser<U> other) -> Parser<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))>
+    {
+        auto &method = lambda_;
+        Parser<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))> result(
+            [method, other](const std::string_view input)
+                -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[fst, middle] = *first;
+                    auto second = other.parse(middle);
+                    if (second)
+                    {
+                        auto &[snd, final] = *second;
+                        return {{std::tuple_cat(fst, std::make_tuple(snd)), final}};
+                    }
+                    else
+                        return {};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+
+    // After confirming that this parser passes, apply a second parser
+    // on the remainder and collect both values.
+    template <typename U>
+        requires(!TupleLike<T> && TupleLike<U>)
+    auto operator&(Parser<U> other) -> Parser<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))>
+    {
+        auto &method = lambda_;
+        Parser<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))> result(
+            [method, other](const std::string_view input)
+                -> parser_output<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[fst, middle] = *first;
+                    auto second = other.parse(middle);
+                    if (second)
+                    {
+                        auto &[snd, final] = *second;
+                        return {{std::tuple_cat(std::make_tuple(fst), snd), final}};
+                    }
+                    else
+                        return {};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+
+    // After confirming that this parser passes, apply a second parser
+    // on the remainder and collect both values.
+    template <typename U>
+        requires(TupleLike<T> && TupleLike<U>)
+    auto operator&(Parser<U> other) -> Parser<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
+    {
+        auto &method = lambda_;
+        Parser<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))> result(
+            [method, other](
+                const std::string_view input) -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
+            {
+                auto first = method(input);
+                if (first)
+                {
+                    auto &[fst, middle] = *first;
+                    auto second = other.parse(middle);
+                    if (second)
+                    {
+                        auto &[snd, final] = *second;
+                        return {{std::tuple_cat(fst, snd), final}};
+                    }
+                    else
+                        return {};
+                }
+                else
+                    return {};
+            });
+        return result;
+    }
+};
+
+// Create a parser that always succeeds and returns a constant value
+template <typename T> Parser<T> pure(T constant)
+{
+    Parser<T> result([constant](const std::string_view input) -> parser_output<int> { return {{constant, input}}; });
+    return result;
+}
+
+// A parser that always fails
+template <typename T>
+Parser<T> null([](const auto x) -> parser_output<std::string_view> { return {}; });
+
+// Parser<std::string_view> literal(std::string_view constant);
+
+// Modify a parser so that the parsed value is wrapped in a
+// std::optional.  If the parser would have failed, act as though
+// the parse succeeded, but make the std::optional empty.
+template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
+{
+    Parser<std::optional<T>> result(
+        [inner](const std::string_view input) -> parser_output<std::optional<T>>
+        {
+            auto first = inner.parse(input);
+            if (first)
+            {
+                auto &[body, remainder] = *first;
+                return {{{body}, remainder}};
+            }
+            else
+            {
+                std::optional<T> empty;
+                return {{empty, input}};
+            }
+        });
+    return result;
+}
+
+// Insist that a parser passes at least once, but collect as many
+// parsed values as possible.
+template <typename T> Parser<std::vector<T>> some(Parser<T> inner)
+{
+    Parser<std::vector<T>> result(
+        [inner](const std::string_view input) -> parser_output<std::vector<T>>
+        {
+            std::vector<T> collection;
+            auto ctx = input;
+            while (!ctx.empty())
+            {
+                auto trial = inner.parse(ctx);
+                if (trial)
+                {
+                    auto &[body, remainder] = *trial;
+                    collection.push_back(body);
+                    ctx = remainder;
+                }
+                else
+                    break;
+            }
+
+            if (collection.empty())
+                return {};
+            return {{collection, ctx}};
+        });
+    return result;
+}
+
+// A parser that expects an exact string
+Parser<std::string_view> literal(std::string_view constant);
+// A parser that accepts any amount of digit characters
+Parser<std::string_view> digits();
+
+// A parser that accepts an integer greater than or equal to zero
+Parser<int> natural();
+
+// A parser that accepts an integer
+Parser<int> integer();
+
+// A parser that accepts a real, floating point number
+Parser<double> real();
+
+// A parser that accepts and amount of whitespace
+Parser<std::string_view> spaces();
+
+// A parse that accepts any amount of visible characters
+Parser<std::string_view> graphs();
+// A parse that accepts any amount of alphanumeric characters
+Parser<std::string_view> alphanums();
+// A parse that accepts any amount of letters
+Parser<std::string_view> alphas();
+// A parse that accepts any amount of upper case letters
+Parser<std::string_view> uppers();
+// A parse that accepts any amount of lower case letters
+Parser<std::string_view> lowers();
+// A parse that accepts any amount of punctuation case letters
+Parser<std::string_view> punctuations();
+
+// A quick wrapper for easily making parses from strings
+Parser<std::string_view> operator""_p(const char *text, size_t size);
+
+// A quick overload to easily ignore strings around a parser
+template <typename T> Parser<T> operator<<(Parser<T> body, std::string_view other)
+{
+    return body << Parser<std::string_view>(other);
+}
+
+// A quick overload to easily ignore strings around a parser
+template <typename T> Parser<T> operator>>(std::string_view other, Parser<T> body)
+{
+    return Parser<std::string_view>(other) >> body;
+}
+
+// A quick overload to easily require strings around a parser
+template <typename T> auto operator&(Parser<T> self, std::string_view other) -> decltype(self & Parser<std::string_view>(other))
+{
+    return self & Parser<std::string_view>(other);
+}
+
+// A quick overload to easily require strings around a parser
+template <typename T> auto operator&(std::string_view other, Parser<T> self) -> decltype(Parser<std::string_view>(other) & self)
+{
+    return Parser<std::string_view>(other) & self;
+}
+
+}; // namespace parsers

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -71,6 +71,14 @@ template <typename T> class Parser
     parser_output<T> parse(std::string_view input) const { return lambda_(input); };
     // Parse a string and, if possible, return the value and the remainder
     parser_output<T> operator()(std::string_view input) const { return lambda_(input); }
+    // Parse a string and enforce that it parsed the entire input
+    std::optional<T> exact(std::string_view input) const
+    {
+        auto result = lambda_(input);
+        if (result && std::get<1>(*result) == "")
+            return std::get<0>(*result);
+        return {};
+    }
 
     // Create a new parser that takes the output of the old parser and
     // passes it through a function

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -27,13 +27,13 @@ concept TupleLike = requires { std::tuple_size<T>::value; };
 // define the parser_output<T> for the return type of the function.
 // This *could* have further implications because there are more
 // complicated parsers we could create.
-template <typename T> using parser_output = std::optional<std::tuple<T, std::istream &>>;
+template <typename T> using ParserOutput = std::optional<std::tuple<T, std::istream &>>;
 
 // This concept type checks that a given lambda matches the definition
 // given in the paragraph above.
 template <typename Lambda, typename T>
 concept ApParse = requires(Lambda lam, std::istream input) {
-    { lam(input) } -> std::convertible_to<parser_output<T>>;
+    { lam(input) } -> std::convertible_to<ParserOutput<T>>;
 };
 
 // It's fully possible to just use the functions as the parsers, but,
@@ -54,7 +54,7 @@ template <typename T> class Parser
     template <typename = std::enable_if<std::is_same<T, std::string_view>::value>>
     Parser(std::string_view constant)
         : lambda_(
-              [constant](std::istream &input) -> parser_output<std::string_view>
+              [constant](std::istream &input) -> ParserOutput<std::string_view>
               {
                   for (auto c : constant)
                       if (c != input.get())
@@ -68,13 +68,13 @@ template <typename T> class Parser
     // The actual function that we have wrapped.  We need to wrap this
     // in a std::function instead of using a lambda so that we don't
     // have to handle the exact type of the bound lambda
-    std::function<parser_output<T>(std::istream &)> lambda_;
+    std::function<ParserOutput<T>(std::istream &)> lambda_;
 
     public:
     // Parse a string and, if possible, return the value and the remainder
-    parser_output<T> parse(std::istream &input) const { return lambda_(input); };
+    ParserOutput<T> parse(std::istream &input) const { return lambda_(input); };
     // Parse a string and, if possible, return the value and the remainder
-    parser_output<T> operator()(std::istream &input) const { return lambda_(input); }
+    ParserOutput<T> operator()(std::istream &input) const { return lambda_(input); }
     // Parse a string and enforce that it parsed the entire input
     std::optional<T> exact(std::istream &input) const
     {
@@ -90,7 +90,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(f(std::declval<T>()))> result(
-            [method, f](std::istream &input) -> parser_output<decltype(f(std::declval<T>()))>
+            [method, f](std::istream &input) -> ParserOutput<decltype(f(std::declval<T>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -120,7 +120,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<T> result(
-            [method, other](std::istream &input) -> parser_output<T>
+            [method, other](std::istream &input) -> ParserOutput<T>
             {
                 auto first = method(input);
                 if (first)
@@ -145,7 +145,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<U> result(
-            [method, other](std::istream &input) -> parser_output<U>
+            [method, other](std::istream &input) -> ParserOutput<U>
             {
                 auto first = method(input);
                 if (first)
@@ -165,7 +165,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<T> result(
-            [method, other](std::istream &input) -> parser_output<T>
+            [method, other](std::istream &input) -> ParserOutput<T>
             {
                 auto location = input.tellg();
                 auto first = method(input);
@@ -194,7 +194,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<std::tuple<T, U>> result(
-            [method, other](std::istream &input) -> parser_output<std::tuple<T, U>>
+            [method, other](std::istream &input) -> ParserOutput<std::tuple<T, U>>
             {
                 auto first = method(input);
                 if (first)
@@ -224,7 +224,7 @@ template <typename T> class Parser
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))> result(
             [method, other](std::istream &input)
-                -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))>
+                -> ParserOutput<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))>
             {
                 auto first = method(input);
                 if (first)
@@ -254,7 +254,7 @@ template <typename T> class Parser
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))> result(
             [method, other](std::istream &input)
-                -> parser_output<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))>
+                -> ParserOutput<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -283,8 +283,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))> result(
-            [method,
-             other](std::istream &input) -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
+            [method, other](std::istream &input) -> ParserOutput<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -309,14 +308,14 @@ template <typename T> class Parser
 // Create a parser that always succeeds and returns a constant value
 template <typename T> Parser<T> pure(T constant)
 {
-    Parser<T> result([constant](std::istream &input) -> parser_output<int> { return {{constant, input}}; });
+    Parser<T> result([constant](std::istream &input) -> ParserOutput<int> { return {{constant, input}}; });
     return result;
 }
 
 // A parser that always fails
 template <typename T> Parser<T> null()
 {
-    Parser<T> result = ([](const auto x) -> parser_output<T> { return std::nullopt; });
+    Parser<T> result = ([](const auto x) -> ParserOutput<T> { return std::nullopt; });
     return result;
 }
 
@@ -326,7 +325,7 @@ template <typename T> Parser<T> null()
 template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
 {
     Parser<std::optional<T>> result(
-        [inner](std::istream &input) -> parser_output<std::optional<T>>
+        [inner](std::istream &input) -> ParserOutput<std::optional<T>>
         {
             auto location = input.tellg();
             auto first = inner(input);
@@ -350,7 +349,7 @@ template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
 template <typename T> Parser<std::vector<T>> some(Parser<T> inner)
 {
     Parser<std::vector<T>> result(
-        [inner](std::istream &input) -> parser_output<std::vector<T>>
+        [inner](std::istream &input) -> ParserOutput<std::vector<T>>
         {
             std::vector<T> collection;
             auto location = input.tellg();

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -4,9 +4,12 @@
 #pragma once
 
 #include <functional>
+#include <iostream>
 #include <optional>
+#include <sstream>
 #include <string_view>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -24,12 +27,12 @@ concept TupleLike = requires { std::tuple_size<T>::value; };
 // define the parser_output<T> for the return type of the function.
 // This *could* have further implications because there are more
 // complicated parsers we could create.
-template <typename T> using parser_output = std::optional<std::tuple<T, std::string_view>>;
+template <typename T> using parser_output = std::optional<std::tuple<T, std::istream &>>;
 
 // This concept type checks that a given lambda matches the definition
 // given in the paragraph above.
 template <typename Lambda, typename T>
-concept ApParse = requires(Lambda lam, std::string_view input) {
+concept ApParse = requires(Lambda lam, std::istream input) {
     { lam(input) } -> std::convertible_to<parser_output<T>>;
 };
 
@@ -50,12 +53,12 @@ template <typename T> class Parser
     template <typename = std::enable_if<std::is_same<T, std::string_view>::value>>
     Parser(std::string_view constant)
         : lambda_(
-              [constant](const std::string_view input) -> parser_output<std::string_view>
+              [constant](std::istream &input) -> parser_output<std::string_view>
               {
-                  if (input.starts_with(constant))
-                      return {{constant, input.substr(constant.size())}};
-                  else
-                      return {};
+                  for (auto c : constant)
+                      if (c != input.get())
+                          return {};
+                  return {{constant, input}};
               })
     {
     }
@@ -64,18 +67,18 @@ template <typename T> class Parser
     // The actual function that we have wrapped.  We need to wrap this
     // in a std::function instead of using a lambda so that we don't
     // have to handle the exact type of the bound lambda
-    std::function<parser_output<T>(std::string_view)> lambda_;
+    std::function<parser_output<T>(std::istream &)> lambda_;
 
     public:
     // Parse a string and, if possible, return the value and the remainder
-    parser_output<T> parse(std::string_view input) const { return lambda_(input); };
+    parser_output<T> parse(std::istream &input) const { return lambda_(input); };
     // Parse a string and, if possible, return the value and the remainder
-    parser_output<T> operator()(std::string_view input) const { return lambda_(input); }
+    parser_output<T> operator()(std::istream &input) const { return lambda_(input); }
     // Parse a string and enforce that it parsed the entire input
-    std::optional<T> exact(std::string_view input) const
+    std::optional<T> exact(std::istream &input) const
     {
         auto result = lambda_(input);
-        if (result && std::get<1>(*result) == "")
+        if (result && input.get() == -1)
             return std::get<0>(*result);
         return {};
     }
@@ -86,7 +89,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(f(std::declval<T>()))> result(
-            [method, f](const std::string_view input) -> parser_output<decltype(f(std::declval<T>()))>
+            [method, f](std::istream &input) -> parser_output<decltype(f(std::declval<T>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -109,7 +112,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(std::apply(f, std::declval<T>()))> result(
-            [method, f](const std::string_view input) -> parser_output<decltype(std::apply(f, std::declval<T>()))>
+            [method, f](std::istream &input) -> parser_output<decltype(std::apply(f, std::declval<T>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -129,7 +132,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<T> result(
-            [method, other](const std::string_view input) -> parser_output<T>
+            [method, other](std::istream &input) -> parser_output<T>
             {
                 auto first = method(input);
                 if (first)
@@ -137,13 +140,9 @@ template <typename T> class Parser
                     auto &[body, middle] = *first;
                     auto second = other(middle);
                     if (second)
-                    {
                         return {{body, std::get<1>(*second)}};
-                    }
                     else
-                    {
                         return {};
-                    }
                 }
                 else
                 {
@@ -158,7 +157,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<U> result(
-            [method, other](const std::string_view input) -> parser_output<U>
+            [method, other](std::istream &input) -> parser_output<U>
             {
                 auto first = method(input);
                 if (first)
@@ -167,9 +166,7 @@ template <typename T> class Parser
                     return other(middle);
                 }
                 else
-                {
                     return {};
-                }
             });
         return result;
     }
@@ -180,10 +177,15 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<T> result(
-            [method, other](const std::string_view input) -> parser_output<T>
+            [method, other](std::istream &input) -> parser_output<T>
             {
+                auto location = input.tellg();
                 auto first = method(input);
-                return first ? first : other(input);
+                if (first)
+                    return first;
+                input.clear();
+                input.seekg(location);
+                return other(input);
             });
         return result;
     }
@@ -204,7 +206,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<std::tuple<T, U>> result(
-            [method, other](const std::string_view input) -> parser_output<std::tuple<T, U>>
+            [method, other](std::istream &input) -> parser_output<std::tuple<T, U>>
             {
                 auto first = method(input);
                 if (first)
@@ -233,7 +235,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))> result(
-            [method, other](const std::string_view input)
+            [method, other](std::istream &input)
                 -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::make_tuple(std::declval<U>())))>
             {
                 auto first = method(input);
@@ -263,7 +265,7 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))> result(
-            [method, other](const std::string_view input)
+            [method, other](std::istream &input)
                 -> parser_output<decltype(std::tuple_cat(std::make_tuple(std::declval<T>()), std::declval<U>()))>
             {
                 auto first = method(input);
@@ -293,8 +295,8 @@ template <typename T> class Parser
     {
         auto &method = lambda_;
         Parser<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))> result(
-            [method, other](
-                const std::string_view input) -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
+            [method,
+             other](std::istream &input) -> parser_output<decltype(std::tuple_cat(std::declval<T>(), std::declval<U>()))>
             {
                 auto first = method(input);
                 if (first)
@@ -319,15 +321,13 @@ template <typename T> class Parser
 // Create a parser that always succeeds and returns a constant value
 template <typename T> Parser<T> pure(T constant)
 {
-    Parser<T> result([constant](const std::string_view input) -> parser_output<int> { return {{constant, input}}; });
+    Parser<T> result([constant](std::istream &input) -> parser_output<int> { return {{constant, input}}; });
     return result;
 }
 
 // A parser that always fails
 template <typename T>
-Parser<T> null([](const auto x) -> parser_output<std::string_view> { return {}; });
-
-// Parser<std::string_view> literal(std::string_view constant);
+Parser<T> null([](const auto x) -> parser_output<T> { return {}; });
 
 // Modify a parser so that the parsed value is wrapped in a
 // std::optional.  If the parser would have failed, act as though
@@ -335,8 +335,9 @@ Parser<T> null([](const auto x) -> parser_output<std::string_view> { return {}; 
 template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
 {
     Parser<std::optional<T>> result(
-        [inner](const std::string_view input) -> parser_output<std::optional<T>>
+        [inner](std::istream &input) -> parser_output<std::optional<T>>
         {
+            auto location = input.tellg();
             auto first = inner(input);
             if (first)
             {
@@ -346,6 +347,8 @@ template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
             else
             {
                 std::optional<T> empty;
+                input.clear();
+                input.seekg(location);
                 return {{empty, input}};
             }
         });
@@ -357,26 +360,29 @@ template <typename T> Parser<std::optional<T>> maybe(Parser<T> inner)
 template <typename T> Parser<std::vector<T>> some(Parser<T> inner)
 {
     Parser<std::vector<T>> result(
-        [inner](const std::string_view input) -> parser_output<std::vector<T>>
+        [inner](std::istream &input) -> parser_output<std::vector<T>>
         {
             std::vector<T> collection;
-            auto ctx = input;
-            while (!ctx.empty())
+            auto location = input.tellg();
+            while (!input.eof())
             {
-                auto trial = inner(ctx);
+                auto trial = inner(input);
                 if (trial)
                 {
-                    auto &[body, remainder] = *trial;
+                    auto &[body, _] = *trial;
                     collection.push_back(body);
-                    ctx = remainder;
+                    location = input.tellg();
                 }
                 else
+                {
+                    input.clear();
+                    input.seekg(location);
                     break;
+                }
             }
-
             if (collection.empty())
                 return {};
-            return {{collection, ctx}};
+            return {{collection, input}};
         });
     return result;
 }
@@ -384,25 +390,25 @@ template <typename T> Parser<std::vector<T>> some(Parser<T> inner)
 // A parser that expects an exact string
 Parser<std::string_view> literal(std::string_view constant);
 // A parser that accepts any amount of digit characters
-Parser<std::string_view> digits();
+Parser<std::string> digits();
 
 // A parser that accepts and amount of whitespace
-Parser<std::string_view> spaces();
+Parser<std::string> spaces();
 
 // A parser that accepts any amount of visible characters
-Parser<std::string_view> graphs();
+Parser<std::string> graphs();
 // A parser that accepts any amount of alphanumeric characters
-Parser<std::string_view> alphanums();
+Parser<std::string> alphanums();
 // A parser that accepts any amount of letters
-Parser<std::string_view> alphas();
+Parser<std::string> alphas();
 // A parser that accepts any amount of upper case letters
-Parser<std::string_view> uppers();
+Parser<std::string> uppers();
 // A parser that accepts any amount of lower case letters
-Parser<std::string_view> lowers();
+Parser<std::string> lowers();
 // A parser that accepts any amount of punctuation case letters
-Parser<std::string_view> punctuations();
+Parser<std::string> punctuations();
 // A parser that continues until a newline
-Parser<std::string_view> inlines();
+Parser<std::string> inlines();
 // A parser that matches newline characters
 Parser<std::string_view> newlines();
 

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -384,7 +384,7 @@ Parser<std::string> digits();
 // A parser that accepts any amount of whitespace
 Parser<std::string> spaces();
 // A parser that accepts space and tab
-Parser<std::string> inline_spaces();
+Parser<std::string> inlineSpaces();
 
 // A parser that accepts any amount of visible characters
 Parser<std::string> graphs();

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -111,20 +111,7 @@ template <typename T> class Parser
         requires(TupleLike<T>)
     auto apply(Lambda f) -> Parser<decltype(std::apply(f, std::declval<T>()))>
     {
-        auto &method = lambda_;
-        Parser<decltype(std::apply(f, std::declval<T>()))> result(
-            [method, f](std::istream &input) -> parser_output<decltype(std::apply(f, std::declval<T>()))>
-            {
-                auto first = method(input);
-                if (first)
-                {
-                    auto &[body, remainder] = *first;
-                    return {{std::apply(f, body), remainder}};
-                }
-                else
-                    return {};
-            });
-        return result;
+        return map([f](const T tup) { return std::apply(f, tup); });
     }
 
     // Insist that this parse is followed by another parse, but we

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -13,7 +13,7 @@
 #include <utility>
 #include <vector>
 
-namespace parsers
+namespace Parsers
 {
 
 // A concept to check if a type is a tuple.  This is built in in
@@ -431,4 +431,4 @@ template <typename T> auto operator&(std::string_view other, Parser<T> self) -> 
     return Parser<std::string_view>(other) & self;
 }
 
-}; // namespace parsers
+}; // namespace Parsers

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -386,15 +386,6 @@ Parser<std::string_view> literal(std::string_view constant);
 // A parser that accepts any amount of digit characters
 Parser<std::string_view> digits();
 
-// A parser that accepts an integer greater than or equal to zero
-Parser<int> natural();
-
-// A parser that accepts an integer
-Parser<int> integer();
-
-// A parser that accepts a real, floating point number
-Parser<double> real();
-
 // A parser that accepts and amount of whitespace
 Parser<std::string_view> spaces();
 

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -389,18 +389,22 @@ Parser<std::string_view> digits();
 // A parser that accepts and amount of whitespace
 Parser<std::string_view> spaces();
 
-// A parse that accepts any amount of visible characters
+// A parser that accepts any amount of visible characters
 Parser<std::string_view> graphs();
-// A parse that accepts any amount of alphanumeric characters
+// A parser that accepts any amount of alphanumeric characters
 Parser<std::string_view> alphanums();
-// A parse that accepts any amount of letters
+// A parser that accepts any amount of letters
 Parser<std::string_view> alphas();
-// A parse that accepts any amount of upper case letters
+// A parser that accepts any amount of upper case letters
 Parser<std::string_view> uppers();
-// A parse that accepts any amount of lower case letters
+// A parser that accepts any amount of lower case letters
 Parser<std::string_view> lowers();
-// A parse that accepts any amount of punctuation case letters
+// A parser that accepts any amount of punctuation case letters
 Parser<std::string_view> punctuations();
+// A parser that continues until a newline
+Parser<std::string_view> inlines();
+// A parser that matches newline characters
+Parser<std::string_view> newlines();
 
 // A quick wrapper for easily making parses from strings
 Parser<std::string_view> operator""_p(const char *text, size_t size);

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -22,8 +22,8 @@ template <typename T>
 concept TupleLike = requires { std::tuple_size<T>::value; };
 
 // The simplest defintion of an applicative parser is a function that
-// takes a string_view and, if the parse succeeds, returns the parsed
-// value and the rest of the string_view.  To make life simpler, we
+// takes a stream and, if the parse succeeds, returns the parsed
+// value and the rest of the stream.  To make life simpler, we
 // define the parser_output<T> for the return type of the function.
 // This *could* have further implications because there are more
 // complicated parsers we could create.
@@ -36,8 +36,9 @@ concept ApParse = requires(Lambda lam, std::istream input) {
     { lam(input) } -> std::convertible_to<parser_output<T>>;
 };
 
-// It's fully possible to just use the functions as the parsers, but, if we wrap them un a struct, we can use operator
-// overloading to more easily combine smaller parsers into larger parsers.
+// It's fully possible to just use the functions as the parsers, but,
+// if we wrap them in a struct, we can use operator overloading to
+// more easily combine smaller parsers into larger parsers.
 template <typename T> class Parser
 {
 

--- a/src/base/applicative.h
+++ b/src/base/applicative.h
@@ -382,7 +382,7 @@ Parser<std::string_view> literal(std::string_view constant);
 // A parser that accepts any amount of digit characters
 Parser<std::string> digits();
 
-// A parser that accepts and amount of whitespace
+// A parser that accepts any amount of whitespace
 Parser<std::string> spaces();
 // A parser that accepts space and tab
 Parser<std::string> inline_spaces();

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -59,7 +59,7 @@ Parser<Vector3> vector3()
 
 Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
 {
-    auto parser = alphas() & inline_spaces() >> vector3() & maybe(inline_spaces() >> real() << maybe(inline_spaces()));
+    auto parser = alphas() & inlineSpaces() >> vector3() & maybe(inlineSpaces() >> real() << maybe(inlineSpaces()));
     return parser;
 }
 

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -50,4 +50,10 @@ Parser<double> real()
     auto result = maybe("-"_p) & digits() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> maybe("-"_p) & digits());
     return result.apply(nat2dbl);
 }
+
+Parser<Vector3> vector3()
+{
+    return (real() & spaces() >> real() & spaces() >> real())
+        .apply([](double x, double y, double z) { return Vector3(x, y, z); });
+}
 } // namespace parsers

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -51,6 +51,7 @@ Parser<double> real()
     return result.apply(nat2dbl);
 }
 
+// A parser that accepts a 3-vector of floating point numbers
 Parser<Vector3> vector3()
 {
     return (real() & spaces() >> real() & spaces() >> real())

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -4,7 +4,7 @@
 #include "base/parserLibrary.h"
 #include <format>
 
-namespace parsers
+namespace Parsers
 {
 
 // A parser that accepts an integer greater than or equal to zero
@@ -57,10 +57,10 @@ Parser<Vector3> vector3()
         .apply([](double x, double y, double z) { return Vector3(x, y, z); });
 }
 
-parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
+Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
 {
     auto parser = alphas() & inline_spaces() >> vector3() & maybe(inline_spaces() >> real() << maybe(inline_spaces()));
     return parser;
 }
 
-} // namespace parsers
+} // namespace Parsers

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "base/parserLibrary.h"
+#include <format>
+
+namespace parsers
+{
+
+// A parser that accepts an integer greater than or equal to zero
+Parser<int> natural()
+{
+    auto result = digits();
+    return result.map(
+        [](const auto terms) -> int
+        {
+            int total = 0;
+            for (auto term : terms)
+                total = 10 * total + (term - '0');
+            return total;
+        });
+}
+
+// Take an optional minus sign and a whole number to create an integer
+int nat2int(std::optional<std::string_view> minus, int number)
+{
+    if (minus)
+        return -number;
+    return number;
+}
+
+// A parser that accepts an integer
+Parser<int> integer() { return (maybe("-"_p) & natural()).apply(nat2int); }
+
+// Take the numbers before the decimal, some optional digits after the period, and an optional exponent, and return a double.
+double nat2dbl(std::optional<std::string_view> minus, std::string_view front, std::optional<std::string_view> decimals,
+               std::optional<std::tuple<std::optional<::std::string_view>, std::string_view>> exponent)
+{
+    auto basic = std::format("{}{}", minus.value_or(""), front);
+    if (decimals)
+        basic += std::format(".{}", *decimals);
+    if (exponent)
+        basic += std::format("e{}{}", std::get<0>(*exponent).value_or(""), std::get<1>(*exponent));
+    return std::stod(basic);
+}
+
+// A parser that accepts a real, floating point number
+Parser<double> real()
+{
+    auto result = maybe("-"_p) & digits() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> maybe("-"_p) & digits());
+    return result.apply(nat2dbl);
+}
+} // namespace parsers

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -59,7 +59,7 @@ Parser<Vector3> vector3()
 
 parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
 {
-    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real() << maybe(spaces()));
+    auto parser = alphas() & inline_spaces() >> vector3() << inline_spaces() & maybe(real() << maybe(inline_spaces()));
     return parser;
 }
 

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -47,7 +47,7 @@ double nat2dbl(std::optional<std::string_view> minus, std::string_view front, st
 // A parser that accepts a real, floating point number
 Parser<double> real()
 {
-    auto result = maybe("-"_p) & digits() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> maybe("-"_p) & digits());
+    auto result = maybe("-"_p) & digits() & maybe("." >> digits()) & maybe(("e"_p | "E"_p) >> maybe("-"_p | "+"_p) & digits());
     return result.apply(nat2dbl);
 }
 
@@ -59,7 +59,7 @@ Parser<Vector3> vector3()
 
 parsers::Parser<std::tuple<std::string_view, Vector3, std::optional<double>>> structureAtom()
 {
-    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real());
+    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real() << spaces());
     return parser;
 }
 

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -59,7 +59,7 @@ Parser<Vector3> vector3()
 
 parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
 {
-    auto parser = alphas() & inline_spaces() >> vector3() << inline_spaces() & maybe(real() << maybe(inline_spaces()));
+    auto parser = alphas() & inline_spaces() >> vector3() & maybe(inline_spaces() >> real() << maybe(inline_spaces()));
     return parser;
 }
 

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -57,10 +57,4 @@ Parser<Vector3> vector3()
         .apply([](double x, double y, double z) { return Vector3(x, y, z); });
 }
 
-Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
-{
-    auto parser = alphas() & inlineSpaces() >> vector3() & maybe(inlineSpaces() >> real() << maybe(inlineSpaces()));
-    return parser;
-}
-
 } // namespace Parsers

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -57,9 +57,9 @@ Parser<Vector3> vector3()
         .apply([](double x, double y, double z) { return Vector3(x, y, z); });
 }
 
-parsers::Parser<std::tuple<std::string_view, Vector3, std::optional<double>>> structureAtom()
+parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom()
 {
-    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real() << spaces());
+    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real() << maybe(spaces()));
     return parser;
 }
 

--- a/src/base/parserLibrary.cpp
+++ b/src/base/parserLibrary.cpp
@@ -56,4 +56,11 @@ Parser<Vector3> vector3()
     return (real() & spaces() >> real() & spaces() >> real())
         .apply([](double x, double y, double z) { return Vector3(x, y, z); });
 }
+
+parsers::Parser<std::tuple<std::string_view, Vector3, std::optional<double>>> structureAtom()
+{
+    auto parser = alphas() & spaces() >> vector3() << spaces() & maybe(real());
+    return parser;
+}
+
 } // namespace parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -19,6 +19,5 @@ Parser<int> integer();
 Parser<double> real();
 
 Parser<Vector3> vector3();
-Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom();
 
 }; // namespace Parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -19,6 +19,6 @@ Parser<int> integer();
 Parser<double> real();
 
 Parser<Vector3> vector3();
-Parser<std::tuple<std::string_view, Vector3, std::optional<double>>> structureAtom();
+Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom();
 
 }; // namespace parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#pragma once
+
+#include "base/applicative.h"
+#include "math/vector3.h"
+
+namespace parsers
+{
+
+// A parser that accepts an integer greater than or equal to zero
+Parser<int> natural();
+
+// A parser that accepts an integer
+Parser<int> integer();
+
+// A parser that accepts a real, floating point number
+Parser<double> real();
+
+}; // namespace parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -19,4 +19,6 @@ Parser<int> integer();
 Parser<double> real();
 
 Parser<Vector3> vector3();
+Parser<std::tuple<std::string_view, Vector3, std::optional<double>>> structureAtom();
+
 }; // namespace parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -18,4 +18,5 @@ Parser<int> integer();
 // A parser that accepts a real, floating point number
 Parser<double> real();
 
+Parser<Vector3> vector3();
 }; // namespace parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -18,6 +18,7 @@ Parser<int> integer();
 // A parser that accepts a real, floating point number
 Parser<double> real();
 
+// A parser that accepts a 3-vector of floating point numbers
 Parser<Vector3> vector3();
 
 }; // namespace Parsers

--- a/src/base/parserLibrary.h
+++ b/src/base/parserLibrary.h
@@ -6,7 +6,7 @@
 #include "base/applicative.h"
 #include "math/vector3.h"
 
-namespace parsers
+namespace Parsers
 {
 
 // A parser that accepts an integer greater than or equal to zero
@@ -21,4 +21,4 @@ Parser<double> real();
 Parser<Vector3> vector3();
 Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom();
 
-}; // namespace parsers
+}; // namespace Parsers

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -38,28 +38,22 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
     if (!infile)
         return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
     return read(infile, structure_);
-
-    // // Open file and check that we're OK to proceed importing from it
-    // LineParser parser;
-    // if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
-    //     return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
-
-    // return read(parser, structure_);
 }
 
 // Read structure from the specified file parser
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace parsers;
-    auto xyz =
-        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
-            .parse(input);
+    auto xyz = (maybe(inline_spaces()) >> natural() << newlines() &
+                inlines() >> newlines() >> some(structureAtom() << maybe(inline_spaces()) << maybe(newlines())))
+                   .parse(input);
 
     if (!xyz)
         return NodeConstants::ProcessResult::Failed;
     auto &rest = std::get<1>(*xyz);
     auto &[nAtoms, atoms] = std::get<0>(*xyz);
 
+    structure.clear();
     for (auto &[elem, v, q] : atoms)
         structure.addAtom(Elements::element(elem), v, q.value_or(0.0));
     assert(nAtoms == atoms.size());

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -51,7 +51,8 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace parsers;
-    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(input);
+    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << newlines()))
+                   .parse(input);
 
     if (!xyz)
         return NodeConstants::ProcessResult::Failed;

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -37,9 +37,7 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
     std::ifstream infile{filePath_};
     if (!infile)
         return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
-    std::ostringstream oss{};
-    oss << infile.rdbuf();
-    return read(oss.view(), structure_);
+    return read(infile, structure_);
 
     // // Open file and check that we're OK to proceed importing from it
     // LineParser parser;
@@ -50,14 +48,14 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 }
 
 // Read structure from the specified file parser
-NodeConstants::ProcessResult ImportXYZStructureNode::read(std::string_view input, Structure &structure)
+NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace parsers;
     auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(input);
 
     if (!xyz)
         return NodeConstants::ProcessResult::Failed;
-    auto rest = std::get<1>(*xyz);
+    auto &rest = std::get<1>(*xyz);
     auto &[nAtoms, atoms] = std::get<0>(*xyz);
 
     for (auto &[elem, v, q] : atoms)

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -44,9 +44,7 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace Parsers;
-    auto xyz = (maybe(inlineSpaces()) >> natural() << newlines() &
-                inlines() >> newlines() >> some(structureAtom() << maybe(inlineSpaces()) << maybe(newlines())))
-                   .parse(input);
+    auto xyz = structureBlock().parse(input);
 
     if (!xyz)
         return NodeConstants::ProcessResult::Failed;
@@ -59,4 +57,19 @@ NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, S
     assert(nAtoms == atoms.size());
 
     return NodeConstants::ProcessResult::Success;
+}
+
+Parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> ImportXYZStructureNode::structureAtom()
+{
+    using namespace Parsers;
+    auto parser = alphas() & inlineSpaces() >> vector3() & maybe(inlineSpaces() >> real() << maybe(inlineSpaces()));
+    return parser;
+}
+
+Parsers::Parser<std::tuple<int, std::vector<std::tuple<std::string, Vector3, std::optional<double>>>>>
+ImportXYZStructureNode::structureBlock()
+{
+    using namespace Parsers;
+    return maybe(inlineSpaces()) >> natural() << newlines() &
+           inlines() >> newlines() >> some(structureAtom() << maybe(inlineSpaces()) << maybe(newlines()));
 }

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -43,7 +43,7 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 // Read structure from the specified input stream
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
-    using namespace parsers;
+    using namespace Parsers;
     auto xyz = (maybe(inline_spaces()) >> natural() << newlines() &
                 inlines() >> newlines() >> some(structureAtom() << maybe(inline_spaces()) << maybe(newlines())))
                    .parse(input);

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -2,6 +2,9 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "nodes/importXYZStructure.h"
+#include "base/parserLibrary.h"
+#include <fstream>
+#include <iostream>
 
 ImportXYZStructureNode::ImportXYZStructureNode(Graph *parentGraph) : Node(parentGraph)
 {
@@ -31,32 +34,35 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 {
     structure_.clear();
 
-    // Open file and check that we're OK to proceed importing from it
-    LineParser parser;
-    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+    std::ifstream infile{filePath_};
+    if (!infile)
         return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
+    std::ostringstream oss{};
+    oss << infile.rdbuf();
+    return read(oss.view(), structure_);
 
-    return read(parser, structure_);
+    // // Open file and check that we're OK to proceed importing from it
+    // LineParser parser;
+    // if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+    //     return error("Couldn't open file '{}' for loading XYZ data.\n", filePath_);
+
+    // return read(parser, structure_);
 }
 
 // Read structure from the specified file parser
-NodeConstants::ProcessResult ImportXYZStructureNode::read(LineParser &parser, Structure &structure)
+NodeConstants::ProcessResult ImportXYZStructureNode::read(std::string_view input, Structure &structure)
 {
-    // Read natoms
-    if (parser.getArgsDelim() != LineParser::Success)
-        return NodeConstants::ProcessResult::Failed;
-    auto nAtoms = parser.argi(0);
+    using namespace parsers;
+    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(input);
 
-    // Skip title
-    if (parser.skipLines(1) != LineParser::Success)
+    if (!xyz)
         return NodeConstants::ProcessResult::Failed;
+    auto rest = std::get<1>(*xyz);
+    auto &[nAtoms, atoms] = std::get<0>(*xyz);
 
-    for (auto n = 0; n < nAtoms; ++n)
-    {
-        if (parser.getArgsDelim() != LineParser::Success)
-            return NodeConstants::ProcessResult::Failed;
-        structure.addAtom(Elements::element(parser.argsv(0)), parser.arg3d(1), parser.hasArg(4) ? parser.argd(4) : 0.0);
-    }
+    for (auto &[elem, v, q] : atoms)
+        structure.addAtom(Elements::element(elem), v, q.value_or(0.0));
+    assert(nAtoms == atoms.size());
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -51,8 +51,9 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace parsers;
-    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << newlines()))
-                   .parse(input);
+    auto xyz =
+        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
+            .parse(input);
 
     if (!xyz)
         return NodeConstants::ProcessResult::Failed;

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -40,7 +40,7 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
     return read(infile, structure_);
 }
 
-// Read structure from the specified file parser
+// Read structure from the specified input stream
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace parsers;

--- a/src/nodes/importXYZStructure.cpp
+++ b/src/nodes/importXYZStructure.cpp
@@ -44,8 +44,8 @@ NodeConstants::ProcessResult ImportXYZStructureNode::process()
 NodeConstants::ProcessResult ImportXYZStructureNode::read(std::istream &input, Structure &structure)
 {
     using namespace Parsers;
-    auto xyz = (maybe(inline_spaces()) >> natural() << newlines() &
-                inlines() >> newlines() >> some(structureAtom() << maybe(inline_spaces()) << maybe(newlines())))
+    auto xyz = (maybe(inlineSpaces()) >> natural() << newlines() &
+                inlines() >> newlines() >> some(structureAtom() << maybe(inlineSpaces()) << maybe(newlines())))
                    .parse(input);
 
     if (!xyz)

--- a/src/nodes/importXYZStructure.h
+++ b/src/nodes/importXYZStructure.h
@@ -39,5 +39,5 @@ class ImportXYZStructureNode : public Node
 
     public:
     // Read structure from the specified file parser
-    static NodeConstants::ProcessResult read(LineParser &parser, Structure &structure);
+    static NodeConstants::ProcessResult read(std::string_view, Structure &structure);
 };

--- a/src/nodes/importXYZStructure.h
+++ b/src/nodes/importXYZStructure.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "base/applicative.h"
 #include "classes/structure.h"
 #include "nodes/node.h"
 
@@ -40,4 +41,8 @@ class ImportXYZStructureNode : public Node
     public:
     // Read structure from the specified file parser
     static NodeConstants::ProcessResult read(std::istream &input, Structure &structure);
+    static Parsers::Parser<std::tuple<std::string, Vector3, std::optional<double>>> structureAtom();
+
+    static Parsers::Parser<std::tuple<int, std::vector<std::tuple<std::string, Vector3, std::optional<double>>>>>
+    structureBlock();
 };

--- a/src/nodes/importXYZStructure.h
+++ b/src/nodes/importXYZStructure.h
@@ -39,5 +39,5 @@ class ImportXYZStructureNode : public Node
 
     public:
     // Read structure from the specified file parser
-    static NodeConstants::ProcessResult read(std::string_view, Structure &structure);
+    static NodeConstants::ProcessResult read(std::istream &input, Structure &structure);
 };

--- a/src/nodes/importXYZTrajectory.cpp
+++ b/src/nodes/importXYZTrajectory.cpp
@@ -46,8 +46,7 @@ NodeConstants::ProcessResult ImportXYZTrajectoryNode::process()
         error("Couldn't open trajectory file '{}'.\n", filePath_);
         return NodeConstants::ProcessResult::Failed;
     }
-    std::ostringstream oss{};
-    oss << infile.rdbuf();
+    infile.seekg(filePosition_);
 
     // // Open the file
     // LineParser parser;
@@ -63,12 +62,12 @@ NodeConstants::ProcessResult ImportXYZTrajectoryNode::process()
     structure_.clear();
 
     // Get the frame read result
-    auto frameResult = ImportXYZStructureNode::read(oss.view(), structure_);
+    auto frameResult = ImportXYZStructureNode::read(infile, structure_);
     if (frameResult != NodeConstants::ProcessResult::Success)
         return frameResult;
 
     // Store the new trajectory file position
-    // filePosition_ = parser.tellg();
+    filePosition_ = infile.tellg();
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/importXYZTrajectory.cpp
+++ b/src/nodes/importXYZTrajectory.cpp
@@ -48,19 +48,6 @@ NodeConstants::ProcessResult ImportXYZTrajectoryNode::process()
     }
     infile.seekg(filePosition_);
 
-    // // Open the file
-    // LineParser parser;
-    // if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
-    // {
-    //     error("Couldn't open trajectory file '{}'.\n", filePath_);
-    //     return NodeConstants::ProcessResult::Failed;
-    // }
-
-    // // Seek to the next file position
-    // parser.seekg(filePosition_);
-
-    structure_.clear();
-
     // Get the frame read result
     auto frameResult = ImportXYZStructureNode::read(infile, structure_);
     if (frameResult != NodeConstants::ProcessResult::Success)

--- a/src/nodes/importXYZTrajectory.cpp
+++ b/src/nodes/importXYZTrajectory.cpp
@@ -40,26 +40,35 @@ NodeConstants::ProcessResult ImportXYZTrajectoryNode::process()
 {
     message("Reading XYZ trajectory file frame from '{}'...\n", filePath_);
 
-    // Open the file
-    LineParser parser;
-    if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+    std::ifstream infile{filePath_};
+    if (!infile)
     {
         error("Couldn't open trajectory file '{}'.\n", filePath_);
         return NodeConstants::ProcessResult::Failed;
     }
+    std::ostringstream oss{};
+    oss << infile.rdbuf();
 
-    // Seek to the next file position
-    parser.seekg(filePosition_);
+    // // Open the file
+    // LineParser parser;
+    // if ((!parser.openInput(filePath_)) || (!parser.isFileGoodForReading()))
+    // {
+    //     error("Couldn't open trajectory file '{}'.\n", filePath_);
+    //     return NodeConstants::ProcessResult::Failed;
+    // }
+
+    // // Seek to the next file position
+    // parser.seekg(filePosition_);
 
     structure_.clear();
 
     // Get the frame read result
-    auto frameResult = ImportXYZStructureNode::read(parser, structure_);
+    auto frameResult = ImportXYZStructureNode::read(oss.view(), structure_);
     if (frameResult != NodeConstants::ProcessResult::Success)
         return frameResult;
 
     // Store the new trajectory file position
-    filePosition_ = parser.tellg();
+    // filePosition_ = parser.tellg();
 
     return NodeConstants::ProcessResult::Success;
 }

--- a/src/nodes/importXYZTrajectory.h
+++ b/src/nodes/importXYZTrajectory.h
@@ -28,7 +28,7 @@ class ImportXYZTrajectoryNode : public Node
     // File path
     std::string filePath_;
     // Last read file position
-    std::streampos filePosition_ = 0;
+    std::streampos filePosition_{0};
     // Structure
     Structure structure_;
 

--- a/src/nodes/importXYZTrajectory.h
+++ b/src/nodes/importXYZTrajectory.h
@@ -28,7 +28,7 @@ class ImportXYZTrajectoryNode : public Node
     // File path
     std::string filePath_;
     // Last read file position
-    std::streampos filePosition_;
+    std::streampos filePosition_ = 0;
     // Structure
     Structure structure_;
 

--- a/tests/io/CMakeLists.txt
+++ b/tests/io/CMakeLists.txt
@@ -1,3 +1,4 @@
+dissolve_add_test(SRC applicative.cpp)
 dissolve_add_test(SRC cbor.cpp)
 dissolve_add_test(SRC intraParameterParse.cpp)
 dissolve_add_test(SRC version.cpp)

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -105,7 +105,11 @@ TEST(ApplicativeTest, BasicParser)
 
 TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
 
-TEST(ApplicativeTest, StructureAtom) { test_exact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6}); }
+TEST(ApplicativeTest, StructureAtom)
+{
+    test_exact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6});
+    test_exact("He 0.5 0.5 0.5", structureAtom(), {"He", Vector3(0.5, 0.5, 0.5), {}});
+}
 
 TEST(ApplicativeTest, XYZStructure)
 {
@@ -140,6 +144,24 @@ TEST(ApplicativeTest, XYZStructure)
         EXPECT_EQ(r, std::get<1>(terms[index]));
         ++index;
     }
+}
+
+TEST(ApplicativeTest, Helium)
+{
+
+    std::ifstream infile{"xyz/voxelDensity-helium.xyz"};
+    ASSERT_TRUE(infile);
+    auto xyz =
+        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
+            .parse(infile);
+    ASSERT_TRUE(xyz);
+    auto &[value, rest] = *xyz;
+    EXPECT_EQ(rest.get(), -1);
+    auto &terms = std::get<1>(value);
+    EXPECT_EQ(terms.size(), std::get<0>(value));
+    int index = 0;
+    for (auto &[elem, r, q] : terms)
+        EXPECT_EQ(elem, "He");
 }
 
 } // namespace UnitTest

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -13,7 +13,7 @@ namespace UnitTest
 using namespace Parsers;
 using namespace std::literals;
 
-template <typename T> void test_parser(std::string_view input, Parser<T> parser, std::optional<T> expected)
+template <typename T> void testParser(std::string_view input, Parser<T> parser, std::optional<T> expected)
 {
     std::cout << "Base string:\t" << input << std::endl;
     std::istringstream stream{std::string(input)};
@@ -23,7 +23,7 @@ template <typename T> void test_parser(std::string_view input, Parser<T> parser,
     else
         EXPECT_EQ(std::get<0>(*result), *expected);
 }
-template <typename T> void test_exact(std::string_view input, Parser<T> parser, T expected)
+template <typename T> void testExact(std::string_view input, Parser<T> parser, T expected)
 {
     std::cout << "Base string:\t" << input << std::endl;
     std::istringstream stream{std::string(input)};
@@ -34,81 +34,81 @@ template <typename T> void test_exact(std::string_view input, Parser<T> parser, 
 
 TEST(ApplicativeTest, BasicStrings)
 {
-    test_parser("Foo", "Fo"_p, {"Fo"});
-    test_parser("Foobar", "Foo"_p, {"Foo"});
+    testParser("Foo", "Fo"_p, {"Fo"});
+    testParser("Foobar", "Foo"_p, {"Foo"});
 }
 TEST(ApplicativeTest, Ignoring)
 {
-    test_exact("Foobar", "Foo"_p << "bar"_p, "Foo"sv);
-    test_exact("Foobar", "Foo" >> "bar"_p, "bar"sv);
+    testExact("Foobar", "Foo"_p << "bar"_p, "Foo"sv);
+    testExact("Foobar", "Foo" >> "bar"_p, "bar"sv);
 }
 TEST(ApplicativeTest, Joining)
 {
-    test_exact("Foobar", "Foo"_p & "bar", {"Foo", "bar"});
-    test_parser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{1, 2, 3, 4}});
-    test_exact("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {"Fo", "ob", "a", "r"});
-    test_exact("Foobar", ("Fo"_p & "ob") & "ar", {"Fo", "ob", "ar"});
-    test_exact("Foobar", "Fo" & ("ob"_p & "ar"), {"Fo", "ob", "ar"});
-    test_parser("Foobar", (pure(1) & pure(2)) & pure(3), {{1, 2, 3}});
-    test_parser("Foobar", pure(1) & (pure(2) & pure(3)), {{1, 2, 3}});
+    testExact("Foobar", "Foo"_p & "bar", {"Foo", "bar"});
+    testParser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{1, 2, 3, 4}});
+    testExact("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {"Fo", "ob", "a", "r"});
+    testExact("Foobar", ("Fo"_p & "ob") & "ar", {"Fo", "ob", "ar"});
+    testExact("Foobar", "Fo" & ("ob"_p & "ar"), {"Fo", "ob", "ar"});
+    testParser("Foobar", (pure(1) & pure(2)) & pure(3), {{1, 2, 3}});
+    testParser("Foobar", pure(1) & (pure(2) & pure(3)), {{1, 2, 3}});
 }
 
 TEST(ApplicativeTest, Choices)
 {
-    test_exact("Foo", "Foo"_p | "Bar", "Foo"sv);
-    test_exact("Bar", "Foo"_p | "Bar", "Bar"sv);
-    test_parser("Quux", "Foo"_p | "Bar", {});
+    testExact("Foo", "Foo"_p | "Bar", "Foo"sv);
+    testExact("Bar", "Foo"_p | "Bar", "Bar"sv);
+    testParser("Quux", "Foo"_p | "Bar", {});
 }
 
 TEST(ApplicativeTest, NaturalNumbers)
 {
-    test_parser("123foo", natural(), {123});
+    testParser("123foo", natural(), {123});
     auto triplet = natural() & "," >> natural() & "," >> natural();
-    test_exact("123,456,789", triplet, {123, 456, 789});
+    testExact("123,456,789", triplet, {123, 456, 789});
     auto vecsum = triplet.apply([](const auto x, const auto y, const auto z) -> int { return x + y + z; });
-    test_exact("123,456,789", vecsum, 123 + 456 + 789);
+    testExact("123,456,789", vecsum, 123 + 456 + 789);
 }
 
 TEST(ApplicativeTest, Optionals)
 {
-    test_exact("123,456", maybe(natural() << ",") & natural(), {{123}, 456});
-    test_exact("456", maybe(natural() << ",") & natural(), {std::nullopt, 456});
-    test_exact("-456", integer(), -456);
-    test_exact("456", integer(), 456);
+    testExact("123,456", maybe(natural() << ",") & natural(), {{123}, 456});
+    testExact("456", maybe(natural() << ",") & natural(), {std::nullopt, 456});
+    testExact("-456", integer(), -456);
+    testExact("456", integer(), 456);
 }
 
 TEST(ApplicativeTest, MultipleTerms)
 {
     // Parse multiple terms
-    test_exact("123, 456,   789,012", some(integer() << maybe(","_p << maybe(spaces()))), {123, 456, 789, 12});
+    testExact("123, 456,   789,012", some(integer() << maybe(","_p << maybe(spaces()))), {123, 456, 789, 12});
     // Completely fail the parse if no copies are present
-    test_parser("789", some(integer() << ","), {});
+    testParser("789", some(integer() << ","), {});
 }
 
 TEST(ApplicativeTest, RealNumbers)
 {
-    test_exact("-12.0543", real(), -12.0543);
-    test_exact("1.02E-3", real(), 1.02e-3);
-    test_exact("-3E-4", real(), -3e-4);
-    test_exact("-71.2e3", real(), -71.2e3);
+    testExact("-12.0543", real(), -12.0543);
+    testExact("1.02E-3", real(), 1.02e-3);
+    testExact("-3E-4", real(), -3e-4);
+    testExact("-71.2e3", real(), -71.2e3);
 }
 
 TEST(ApplicativeTest, BasicParser)
 {
-    test_parser("  \t foo", spaces(), {"  \t "});
-    test_exact("HW", alphas(), "HW"s);
-    test_parser("1qaz.QAZ foo", graphs(), {"1qaz.QAZ"});
-    test_parser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(), {{"1", "qaz", ".", "QAZ", " "}});
+    testParser("  \t foo", spaces(), {"  \t "});
+    testExact("HW", alphas(), "HW"s);
+    testParser("1qaz.QAZ foo", graphs(), {"1qaz.QAZ"});
+    testParser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(), {{"1", "qaz", ".", "QAZ", " "}});
 
-    test_exact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"s);
+    testExact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"s);
 }
 
-TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
+TEST(ApplicativeTest, Vector) { testExact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
 
 TEST(ApplicativeTest, StructureAtom)
 {
-    test_exact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6});
-    test_exact("He 0.5 0.5 0.5", structureAtom(), {"He", Vector3(0.5, 0.5, 0.5), {}});
+    testExact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6});
+    testExact("He 0.5 0.5 0.5", structureAtom(), {"He", Vector3(0.5, 0.5, 0.5), {}});
 }
 
 TEST(ApplicativeTest, XYZStructure)
@@ -118,7 +118,6 @@ TEST(ApplicativeTest, XYZStructure)
     auto xyz =
         (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
             .parse(infile);
-    // auto xyz = (maybe(spaces()) >> natural() ).parse(oss.view());
 
     ASSERT_TRUE(xyz);
     auto &[value, rest] = *xyz;
@@ -157,7 +156,7 @@ TEST(ApplicativeTest, Helium)
     EXPECT_EQ(rest.get(), -1);
     auto &terms = std::get<1>(value);
     EXPECT_EQ(terms.size(), std::get<0>(value));
-    int index = 0;
+    auto index = 0;
     for (auto &[elem, r, q] : terms)
         EXPECT_EQ(elem, "He");
 }

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -18,10 +18,9 @@ template <typename T> void test_parser(std::string_view input, Parser<T> parser,
 }
 template <typename T> void test_exact(std::string_view input, Parser<T> parser, T expected)
 {
-    auto result = parser(input);
+    auto result = parser.exact(input);
     ASSERT_TRUE(result);
-    EXPECT_EQ(std::get<1>(*result), "");
-    EXPECT_EQ(std::get<0>(*result), expected);
+    EXPECT_EQ(*result, expected);
 }
 
 TEST(ApplicativeTest, BasicStrings)

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -4,6 +4,7 @@
 #include "base/applicative.h"
 #include "base/parserLibrary.h"
 #include <gtest/gtest.h>
+#include <sstream>
 #include <string_view>
 
 namespace UnitTest
@@ -12,22 +13,29 @@ namespace UnitTest
 using namespace parsers;
 using namespace std::literals;
 
-template <typename T> void test_parser(std::string_view input, Parser<T> parser, parser_output<T> expected)
+template <typename T> void test_parser(std::string_view input, Parser<T> parser, std::optional<T> expected)
 {
-    auto result = parser(input);
-    EXPECT_EQ(result, expected);
+    std::cout << "Base string:\t" << input << std::endl;
+    std::istringstream stream{std::string(input)};
+    auto result = parser(stream);
+    if (!result)
+        EXPECT_FALSE(expected);
+    else
+        EXPECT_EQ(std::get<0>(*result), *expected);
 }
 template <typename T> void test_exact(std::string_view input, Parser<T> parser, T expected)
 {
-    auto result = parser.exact(input);
+    std::cout << "Base string:\t" << input << std::endl;
+    std::istringstream stream{std::string(input)};
+    auto result = parser.exact(stream);
     ASSERT_TRUE(result);
     EXPECT_EQ(*result, expected);
 }
 
 TEST(ApplicativeTest, BasicStrings)
 {
-    test_parser("Foo", "Fo"_p, {{"Fo", "o"}});
-    test_parser("Foobar", "Foo"_p, {{"Foo", "bar"}});
+    test_parser("Foo", "Fo"_p, {"Fo"});
+    test_parser("Foobar", "Foo"_p, {"Foo"});
 }
 TEST(ApplicativeTest, Ignoring)
 {
@@ -37,12 +45,12 @@ TEST(ApplicativeTest, Ignoring)
 TEST(ApplicativeTest, Joining)
 {
     test_exact("Foobar", "Foo"_p & "bar", {"Foo", "bar"});
-    test_parser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{{1, 2, 3, 4}, "Foobar"}});
+    test_parser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{1, 2, 3, 4}});
     test_exact("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {"Fo", "ob", "a", "r"});
     test_exact("Foobar", ("Fo"_p & "ob") & "ar", {"Fo", "ob", "ar"});
     test_exact("Foobar", "Fo" & ("ob"_p & "ar"), {"Fo", "ob", "ar"});
-    test_parser("Foobar", (pure(1) & pure(2)) & pure(3), {{{1, 2, 3}, "Foobar"}});
-    test_parser("Foobar", pure(1) & (pure(2) & pure(3)), {{{1, 2, 3}, "Foobar"}});
+    test_parser("Foobar", (pure(1) & pure(2)) & pure(3), {{1, 2, 3}});
+    test_parser("Foobar", pure(1) & (pure(2) & pure(3)), {{1, 2, 3}});
 }
 
 TEST(ApplicativeTest, Choices)
@@ -54,7 +62,7 @@ TEST(ApplicativeTest, Choices)
 
 TEST(ApplicativeTest, NaturalNumbers)
 {
-    test_parser("123foo", natural(), {{123, "foo"}});
+    test_parser("123foo", natural(), {123});
     auto triplet = natural() & "," >> natural() & "," >> natural();
     test_exact("123,456,789", triplet, {123, 456, 789});
     auto vecsum = triplet.apply([](const auto x, const auto y, const auto z) -> int { return x + y + z; });
@@ -87,31 +95,29 @@ TEST(ApplicativeTest, RealNumbers)
 
 TEST(ApplicativeTest, BasicParser)
 {
-    test_parser("  \t foo", spaces(), {{"  \t ", "foo"}});
-    test_parser("1qaz.QAZ foo", graphs(), {{"1qaz.QAZ", " foo"}});
-    test_parser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(),
-                {{{"1", "qaz", ".", "QAZ", " "}, "foo"}});
+    test_parser("  \t foo", spaces(), {"  \t "});
+    test_exact("HW", alphas(), "HW"s);
+    test_parser("1qaz.QAZ foo", graphs(), {"1qaz.QAZ"});
+    test_parser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(), {{"1", "qaz", ".", "QAZ", " "}});
 
-    test_exact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"sv);
+    test_exact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"s);
 }
 
 TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
 
-TEST(ApplicativeTest, StructureAtom) { test_exact("HW 1 2.5 -3e-4 5", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5}); }
+TEST(ApplicativeTest, StructureAtom) { test_exact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6}); }
 
 TEST(ApplicativeTest, XYZStructure)
 {
 
     std::ifstream infile{"xyz/c2so3.xyz"};
     ASSERT_TRUE(infile);
-    std::ostringstream oss{};
-    oss << infile.rdbuf();
-    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(oss.view());
+    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(infile);
     // auto xyz = (maybe(spaces()) >> natural() ).parse(oss.view());
 
     ASSERT_TRUE(xyz);
     auto &[value, rest] = *xyz;
-    ASSERT_EQ(rest, "");
+    EXPECT_TRUE(rest.eof());
     auto &terms = std::get<1>(value);
     EXPECT_EQ(terms.size(), std::get<0>(value));
 

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -112,12 +112,14 @@ TEST(ApplicativeTest, XYZStructure)
 
     std::ifstream infile{"xyz/c2so3.xyz"};
     ASSERT_TRUE(infile);
-    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(infile);
+    auto xyz =
+        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
+            .parse(infile);
     // auto xyz = (maybe(spaces()) >> natural() ).parse(oss.view());
 
     ASSERT_TRUE(xyz);
     auto &[value, rest] = *xyz;
-    EXPECT_TRUE(rest.eof());
+    EXPECT_EQ(rest.get(), -1);
     auto &terms = std::get<1>(value);
     EXPECT_EQ(terms.size(), std::get<0>(value));
 

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -3,17 +3,27 @@
 
 #include "base/applicative.h"
 #include <gtest/gtest.h>
+#include <string_view>
 
 namespace UnitTest
 {
 
 using namespace parsers;
+using namespace std::literals;
 
 template <typename T> void test_parser(std::string_view input, Parser<T> parser, parser_output<T> expected)
 {
     auto result = parser(input);
-    ASSERT_EQ(result, expected);
+    EXPECT_EQ(result, expected);
 }
+template <typename T> void test_exact(std::string_view input, Parser<T> parser, T expected)
+{
+    auto result = parser(input);
+    ASSERT_TRUE(result);
+    EXPECT_EQ(std::get<1>(*result), "");
+    EXPECT_EQ(std::get<0>(*result), expected);
+}
+
 TEST(ApplicativeTest, BasicStrings)
 {
     test_parser("Foo", "Fo"_p, {{"Fo", "o"}});
@@ -21,24 +31,24 @@ TEST(ApplicativeTest, BasicStrings)
 }
 TEST(ApplicativeTest, Ignoring)
 {
-    test_parser("Foobar", "Foo"_p << "bar"_p, {{"Foo", ""}});
-    test_parser("Foobar", "Foo" >> "bar"_p, {{"bar", ""}});
+    test_exact("Foobar", "Foo"_p << "bar"_p, "Foo"sv);
+    test_exact("Foobar", "Foo" >> "bar"_p, "bar"sv);
 }
 TEST(ApplicativeTest, Joining)
 {
-    test_parser("Foobar", "Foo"_p & "bar", {{{"Foo", "bar"}, ""}});
+    test_exact("Foobar", "Foo"_p & "bar", {"Foo", "bar"});
     test_parser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{{1, 2, 3, 4}, "Foobar"}});
-    test_parser("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {{{"Fo", "ob", "a", "r"}, ""}});
-    test_parser("Foobar", ("Fo"_p & "ob") & "ar", {{{"Fo", "ob", "ar"}, ""}});
-    test_parser("Foobar", "Fo" & ("ob"_p & "ar"), {{{"Fo", "ob", "ar"}, ""}});
+    test_exact("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {"Fo", "ob", "a", "r"});
+    test_exact("Foobar", ("Fo"_p & "ob") & "ar", {"Fo", "ob", "ar"});
+    test_exact("Foobar", "Fo" & ("ob"_p & "ar"), {"Fo", "ob", "ar"});
     test_parser("Foobar", (pure(1) & pure(2)) & pure(3), {{{1, 2, 3}, "Foobar"}});
     test_parser("Foobar", pure(1) & (pure(2) & pure(3)), {{{1, 2, 3}, "Foobar"}});
 }
 
 TEST(ApplicativeTest, Choices)
 {
-    test_parser("Foo", "Foo"_p | "Bar", {{"Foo", ""}});
-    test_parser("Bar", "Foo"_p | "Bar", {{"Bar", ""}});
+    test_exact("Foo", "Foo"_p | "Bar", "Foo"sv);
+    test_exact("Bar", "Foo"_p | "Bar", "Bar"sv);
     test_parser("Quux", "Foo"_p | "Bar", {});
 }
 
@@ -46,32 +56,32 @@ TEST(ApplicativeTest, NaturalNumbers)
 {
     test_parser("123foo", natural(), {{123, "foo"}});
     auto triplet = natural() & "," >> natural() & "," >> natural();
-    test_parser("123,456,789", triplet, {{{123, 456, 789}, ""}});
+    test_exact("123,456,789", triplet, {123, 456, 789});
     auto vecsum = triplet.apply([](const auto x, const auto y, const auto z) -> int { return x + y + z; });
-    test_parser("123,456,789", vecsum, {{123 + 456 + 789, ""}});
+    test_exact("123,456,789", vecsum, 123 + 456 + 789);
 }
 
 TEST(ApplicativeTest, Optionals)
 {
-    test_parser("123,456", maybe(natural() << ",") & natural(), {{{{123}, 456}, ""}});
-    test_parser("456", maybe(natural() << ",") & natural(), {{{std::nullopt, 456}, ""}});
-    test_parser("-456", integer(), {{-456, ""}});
-    test_parser("456", integer(), {{456, ""}});
+    test_exact("123,456", maybe(natural() << ",") & natural(), {{123}, 456});
+    test_exact("456", maybe(natural() << ",") & natural(), {std::nullopt, 456});
+    test_exact("-456", integer(), -456);
+    test_exact("456", integer(), 456);
 }
 
 TEST(ApplicativeTest, MultipleTerms)
 {
     // Parse multiple terms
-    test_parser("123, 456,   789,012", some(integer() << maybe(","_p << maybe(spaces()))), {{{123, 456, 789, 12}, ""}});
+    test_exact("123, 456,   789,012", some(integer() << maybe(","_p << maybe(spaces()))), {123, 456, 789, 12});
     // Completely fail the parse if no copies are present
     test_parser("789", some(integer() << ","), {});
 }
 
 TEST(ApplicativeTest, RealNumbers)
 {
-    test_parser("-12.0543", real(), {{-12.0543, ""}});
-    test_parser("1.02E-3", real(), {{1.02e-3, ""}});
-    test_parser("-71.2e3", real(), {{-71.2e3, ""}});
+    test_exact("-12.0543", real(), -12.0543);
+    test_exact("1.02E-3", real(), 1.02e-3);
+    test_exact("-71.2e3", real(), -71.2e3);
 }
 
 TEST(ApplicativeTest, BasicParser)
@@ -81,6 +91,6 @@ TEST(ApplicativeTest, BasicParser)
     test_parser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(),
                 {{{"1", "qaz", ".", "QAZ", " "}, "foo"}});
 
-    test_parser("\"Foo\"", "\"" >> alphas() << "\"", {{"Foo", ""}});
+    test_exact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"sv);
 }
 } // namespace UnitTest

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -94,4 +94,6 @@ TEST(ApplicativeTest, BasicParser)
 
     test_exact("\"Foo\"", "\"" >> alphas() << "\"", "Foo"sv);
 }
+
+TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
 } // namespace UnitTest

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -96,4 +96,7 @@ TEST(ApplicativeTest, BasicParser)
 }
 
 TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 2.5, -3e-1)); }
+
+TEST(ApplicativeTest, StructureAtom) { test_exact("HW 1 2.5 -3e-4 5", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5}); }
+
 } // namespace UnitTest

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -3,6 +3,7 @@
 
 #include "base/applicative.h"
 #include "base/parserLibrary.h"
+#include "nodes/importXYZStructure.h"
 #include <gtest/gtest.h>
 #include <sstream>
 #include <string_view>
@@ -107,17 +108,15 @@ TEST(ApplicativeTest, Vector) { testExact("1 2.5 -3e-1", vector3(), Vector3(1, 2
 
 TEST(ApplicativeTest, StructureAtom)
 {
-    testExact("HW 1 2.5 -3e-4 5.6", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6});
-    testExact("He 0.5 0.5 0.5", structureAtom(), {"He", Vector3(0.5, 0.5, 0.5), {}});
+    testExact("HW 1 2.5 -3e-4 5.6", ImportXYZStructureNode::structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5.6});
+    testExact("He 0.5 0.5 0.5", ImportXYZStructureNode::structureAtom(), {"He", Vector3(0.5, 0.5, 0.5), {}});
 }
 
 TEST(ApplicativeTest, XYZStructure)
 {
     std::ifstream infile{"xyz/c2so3.xyz"};
     ASSERT_TRUE(infile);
-    auto xyz =
-        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
-            .parse(infile);
+    auto xyz = ImportXYZStructureNode::structureBlock().parse(infile);
 
     ASSERT_TRUE(xyz);
     auto &[value, rest] = *xyz;
@@ -148,9 +147,7 @@ TEST(ApplicativeTest, Helium)
 {
     std::ifstream infile{"xyz/voxelDensity-helium.xyz"};
     ASSERT_TRUE(infile);
-    auto xyz =
-        (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom() << maybe(newlines())))
-            .parse(infile);
+    auto xyz = ImportXYZStructureNode::structureBlock().parse(infile);
     ASSERT_TRUE(xyz);
     auto &[value, rest] = *xyz;
     EXPECT_EQ(rest.get(), -1);

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "base/applicative.h"
+#include "base/parserLibrary.h"
 #include <gtest/gtest.h>
 #include <string_view>
 
@@ -80,6 +81,7 @@ TEST(ApplicativeTest, RealNumbers)
 {
     test_exact("-12.0543", real(), -12.0543);
     test_exact("1.02E-3", real(), 1.02e-3);
+    test_exact("-3E-4", real(), -3e-4);
     test_exact("-71.2e3", real(), -71.2e3);
 }
 

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -113,7 +113,6 @@ TEST(ApplicativeTest, StructureAtom)
 
 TEST(ApplicativeTest, XYZStructure)
 {
-
     std::ifstream infile{"xyz/c2so3.xyz"};
     ASSERT_TRUE(infile);
     auto xyz =

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2026 Team Dissolve and contributors
+
+#include "base/applicative.h"
+#include <gtest/gtest.h>
+
+namespace UnitTest
+{
+
+using namespace parsers;
+
+template <typename T> void test_parser(std::string_view input, Parser<T> parser, parser_output<T> expected)
+{
+    auto result = parser.parse(input);
+    ASSERT_EQ(result, expected);
+}
+TEST(ApplicativeTest, BasicStrings)
+{
+    test_parser("Foo", "Fo"_p, {{"Fo", "o"}});
+    test_parser("Foobar", "Foo"_p, {{"Foo", "bar"}});
+}
+TEST(ApplicativeTest, Ignoring)
+{
+    test_parser("Foobar", "Foo"_p << "bar"_p, {{"Foo", ""}});
+    test_parser("Foobar", "Foo" >> "bar"_p, {{"bar", ""}});
+}
+TEST(ApplicativeTest, Joining)
+{
+    test_parser("Foobar", "Foo"_p & "bar", {{{"Foo", "bar"}, ""}});
+    test_parser("Foobar", (pure(1) & pure(2)) & (pure(3) & pure(4)), {{{1, 2, 3, 4}, "Foobar"}});
+    test_parser("Foobar", ("Fo"_p & "ob") & ("a" & "r"_p), {{{"Fo", "ob", "a", "r"}, ""}});
+    test_parser("Foobar", ("Fo"_p & "ob") & "ar", {{{"Fo", "ob", "ar"}, ""}});
+    test_parser("Foobar", "Fo" & ("ob"_p & "ar"), {{{"Fo", "ob", "ar"}, ""}});
+    test_parser("Foobar", (pure(1) & pure(2)) & pure(3), {{{1, 2, 3}, "Foobar"}});
+    test_parser("Foobar", pure(1) & (pure(2) & pure(3)), {{{1, 2, 3}, "Foobar"}});
+}
+
+TEST(ApplicativeTest, Choices)
+{
+    test_parser("Foo", "Foo"_p | "Bar", {{"Foo", ""}});
+    test_parser("Bar", "Foo"_p | "Bar", {{"Bar", ""}});
+    test_parser("Quux", "Foo"_p | "Bar", {});
+}
+
+TEST(ApplicativeTest, NaturalNumbers)
+{
+    test_parser("123foo", natural(), {{123, "foo"}});
+    auto triplet = natural() & "," >> natural() & "," >> natural();
+    test_parser("123,456,789", triplet, {{{123, 456, 789}, ""}});
+    auto vecsum = triplet.apply([](const auto x, const auto y, const auto z) -> int { return x + y + z; });
+    test_parser("123,456,789", vecsum, {{123 + 456 + 789, ""}});
+}
+
+TEST(ApplicativeTest, Optionals)
+{
+    test_parser("123,456", maybe(natural() << ",") & natural(), {{{{123}, 456}, ""}});
+    test_parser("456", maybe(natural() << ",") & natural(), {{{std::nullopt, 456}, ""}});
+    test_parser("-456", integer(), {{-456, ""}});
+    test_parser("456", integer(), {{456, ""}});
+}
+
+TEST(ApplicativeTest, MultipleTerms)
+{
+    // Parse multiple terms
+    test_parser("123, 456,   789,012", some(integer() << maybe(","_p << maybe(spaces()))), {{{123, 456, 789, 12}, ""}});
+    // Completely fail the parse if no copies are present
+    test_parser("789", some(integer() << ","), {});
+}
+
+TEST(ApplicativeTest, RealNumbers)
+{
+    test_parser("-12.0543", real(), {{-12.0543, ""}});
+    test_parser("1.02E-3", real(), {{1.02e-3, ""}});
+    test_parser("-71.2e3", real(), {{-71.2e3, ""}});
+}
+
+TEST(ApplicativeTest, BasicParser)
+{
+    test_parser("  \t foo", spaces(), {{"  \t ", "foo"}});
+    test_parser("1qaz.QAZ foo", graphs(), {{"1qaz.QAZ", " foo"}});
+    test_parser("1qaz.QAZ foo", digits() & lowers() & punctuations() & uppers() & spaces(),
+                {{{"1", "qaz", ".", "QAZ", " "}, "foo"}});
+
+    test_parser("\"Foo\"", "\"" >> alphas() << "\"", {{"Foo", ""}});
+}
+} // namespace UnitTest

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -11,7 +11,7 @@ using namespace parsers;
 
 template <typename T> void test_parser(std::string_view input, Parser<T> parser, parser_output<T> expected)
 {
-    auto result = parser.parse(input);
+    auto result = parser(input);
     ASSERT_EQ(result, expected);
 }
 TEST(ApplicativeTest, BasicStrings)

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -136,7 +136,7 @@ TEST(ApplicativeTest, XYZStructure)
         {"H", {1.000760, 0.124469, -2.713254}},
 
     };
-    int index = 0;
+    auto index = 0;
     for (auto &[elem, r] : expected)
     {
         EXPECT_EQ(elem, std::get<0>(terms[index]));

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -10,7 +10,7 @@
 namespace UnitTest
 {
 
-using namespace parsers;
+using namespace Parsers;
 using namespace std::literals;
 
 template <typename T> void test_parser(std::string_view input, Parser<T> parser, std::optional<T> expected)

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -147,7 +147,6 @@ TEST(ApplicativeTest, XYZStructure)
 
 TEST(ApplicativeTest, Helium)
 {
-
     std::ifstream infile{"xyz/voxelDensity-helium.xyz"};
     ASSERT_TRUE(infile);
     auto xyz =

--- a/tests/io/applicative.cpp
+++ b/tests/io/applicative.cpp
@@ -99,4 +99,39 @@ TEST(ApplicativeTest, Vector) { test_exact("1 2.5 -3e-1", vector3(), Vector3(1, 
 
 TEST(ApplicativeTest, StructureAtom) { test_exact("HW 1 2.5 -3e-4 5", structureAtom(), {"HW", Vector3(1, 2.5, -3e-4), 5}); }
 
+TEST(ApplicativeTest, XYZStructure)
+{
+
+    std::ifstream infile{"xyz/c2so3.xyz"};
+    ASSERT_TRUE(infile);
+    std::ostringstream oss{};
+    oss << infile.rdbuf();
+    auto xyz = (maybe(spaces()) >> natural() << spaces() & inlines() >> newlines() >> some(structureAtom())).parse(oss.view());
+    // auto xyz = (maybe(spaces()) >> natural() ).parse(oss.view());
+
+    ASSERT_TRUE(xyz);
+    auto &[value, rest] = *xyz;
+    ASSERT_EQ(rest, "");
+    auto &terms = std::get<1>(value);
+    EXPECT_EQ(terms.size(), std::get<0>(value));
+
+    std::vector<std::tuple<std::string_view, Vector3>> expected{
+
+        {"S", {0.010001, 0.000000, -0.000012}},   {"O", {1.465001, 0.000000, -0.000012}},
+        {"O", {-0.475688, -1.371543, -0.000012}}, {"O", {-0.475688, 0.685772, 1.187779}},
+        {"C", {-0.588181, 0.844607, -1.462914}},  {"C", {-0.079239, 0.124469, -2.712002}},
+        {"H", {-1.678181, 0.844607, -1.462914}},  {"H", {-0.225364, 1.872451, -1.463546}},
+        {"H", {-0.442057, -0.903375, -2.712634}}, {"H", {-0.443088, 0.638209, -3.601825}},
+        {"H", {1.000760, 0.124469, -2.713254}},
+
+    };
+    int index = 0;
+    for (auto &[elem, r] : expected)
+    {
+        EXPECT_EQ(elem, std::get<0>(terms[index]));
+        EXPECT_EQ(r, std::get<1>(terms[index]));
+        ++index;
+    }
+}
+
 } // namespace UnitTest


### PR DESCRIPTION
This PR adds an applicative parsing library.  Additionally, as a proof of concept, the ImportXYZStructure Node and ImportXYZTrajectory Node are both updates to use an applicative parser and remove the dependency on LineParser.  If this code looks like a worthwhile avenue, other instances of LineParser can be converted to use the parsers.

Currently, the parser does not return error messages on failed parses, but it's possible to allow for more informative messages in the future if we change 

```cpp
template <typename T> using parser_output = std::optional<std::tuple<T, std::istream &>>;
```

to

```cpp
template <typename T> using parser_output = std::variant<std::tuple<T, std::istream &>, ErrorMessage>;
```

As a simple tutorial on how to use the parsers, it's worth starting by looking at tests/io/applicative.cpp, as the tests build up the different combinators.