### PR TITLE
refactor: De-template Serialisable

### DIFF
--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -3,11 +3,11 @@
 
 #pragma once
 
-#include <toml11/toml.hpp>
 #include "templates/keyedVector.h"
 #include "templates/orderedMap.h"
 #include "templates/resolvableKeyedVector.h"
 #include <map>
+#include <toml11/toml.hpp>
 #include <vector>
 
 // The type we use for the nodes of our serialisation tree
@@ -27,7 +27,7 @@ class Serialisable
     // Express as a serialisable value
     virtual void serialise(std::string tag, SerialisedValue &target) const = 0;
     // Read values from a serialisable value
-    virtual void deserialise(const SerialisedValue &node) { }
+    virtual void deserialise(const SerialisedValue &node) {}
 
     /* Functions that hook into the toml11 library */
     // Wrapper for deserialise that toml11 will check for

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include <toml11/toml.hpp>
-
 #include "templates/keyedVector.h"
 #include "templates/orderedMap.h"
 #include "templates/resolvableKeyedVector.h"
@@ -19,43 +18,16 @@ using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::Orde
 template <typename T>
 concept serialisablePointer = requires(T a, std::string tag, SerialisedValue target) { a->serialise(tag, target); };
 
-// The associated context for type T This type does double duty.
-// First, since the struct has not actual members, it is a Unit type
-// (a type with only one possible value).  This is why the default
-// inner type is SerialisableContext<void> - says that we have no
-// context and the type has no size.  The second duty is acting as a
-// type level function.  Normally, you would just add an inner type to
-// a class (e.g. NodeValue::Context) to perform this function.
-// Unfortunately, you can't add an inner type to a primative type
-// (e.g. float).  By specialising this template, we can create a
-// mapping between types and the context that they require.
-template <typename T> struct SerialisableContext
-{
-    using type = SerialisableContext<void>;
-};
-
 // An interface for classes that can be serialised into an input file
-template <typename... Contexts> class Serialisable
+class Serialisable
 {
     public:
+    Serialisable() = default;
+    virtual ~Serialisable() = default;
     // Express as a serialisable value
     virtual void serialise(std::string tag, SerialisedValue &target) const = 0;
     // Read values from a serialisable value
-    virtual void deserialise(const SerialisedValue &node, Contexts... context) { return; }
-
-    // When a type has only one context and that context is empty
-    // (i.e. is a Unit type), then we can create a simple overload
-    // that skips the need to add the second parameter.  This does not
-    // conflict with the definition above because it only becomes
-    // instantiated when the Contexts pack is not empty, so the above
-    // definition of deserialise takes two parameters.  We also insist
-    // that it is only called for empty types to ensure that we do not
-    // accidentally create a value with its default constructor.
-    template <typename = std::enable_if<sizeof...(Contexts) == 1 && (std::is_empty<Contexts>::value && ...)>>
-    void deserialise(const SerialisedValue &node)
-    {
-        deserialise(node, {});
-    }
+    virtual void deserialise(const SerialisedValue &node) { }
 
     /* Functions that hook into the toml11 library */
     // Wrapper for deserialise that toml11 will check for

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -89,7 +89,7 @@ class AtomBase
 };
 
 // Atom
-template <typename BondClass> class Atom : public AtomBase, public Serialisable<>
+template <typename BondClass> class Atom : public AtomBase, public Serialisable
 {
     public:
     Atom() = default;

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -140,12 +140,12 @@ template <typename BondClass> class Atom : public AtomBase, public Serialisable
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         target[tag] = {{"index", index_}, {"z", Z_}, {"r", r_}, {"q", q_}};
     }
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node)
+    void deserialise(const SerialisedValue &node) override
     {
         index_ = toml::find<int>(node, "index");
 

--- a/src/classes/atom.h
+++ b/src/classes/atom.h
@@ -93,7 +93,7 @@ template <typename BondClass> class Atom : public AtomBase, public Serialisable
 {
     public:
     Atom() = default;
-    virtual ~Atom() = default;
+    virtual ~Atom() override = default;
 
     /*
      * Coordinate Manipulation Operators
@@ -125,9 +125,9 @@ template <typename BondClass> class Atom : public AtomBase, public Serialisable
         return nullptr;
     }
     // Return number of bonds
-    int nBonds() const { return bonds_.size(); }
+    int nBonds() const override { return bonds_.size(); }
     // Return indices of other AtomBases to which this one is connected
-    std::vector<AtomBase *> connectedAtoms() const
+    std::vector<AtomBase *> connectedAtoms() const override
     {
         std::vector<AtomBase *> connections;
         for (const auto *bond : bonds_)

--- a/src/classes/atomType.h
+++ b/src/classes/atomType.h
@@ -14,7 +14,7 @@
 #include <vector>
 
 // AtomType Definition
-class AtomType : public Serialisable<>, public std::enable_shared_from_this<AtomType>
+class AtomType : public Serialisable, public std::enable_shared_from_this<AtomType>
 {
     public:
     AtomType(Elements::Element Z = Elements::Unknown);

--- a/src/classes/bond.h
+++ b/src/classes/bond.h
@@ -9,7 +9,7 @@
 class AtomBase;
 
 // Bond
-template <class AtomClass> class Bond : public Serialisable<>
+template <class AtomClass> class Bond : public Serialisable
 {
     public:
     Bond(AtomClass *i = nullptr, AtomClass *j = nullptr) : i_(i), j_(j) {}

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -16,7 +16,7 @@ class Cell;
 class Data1D;
 
 // Basic Box Definition
-class Box : public Serialisable<>
+class Box : public Serialisable
 {
     public:
     // Box Type Enum

--- a/src/classes/braggReflection.h
+++ b/src/classes/braggReflection.h
@@ -8,7 +8,7 @@
 #include "templates/array2D.h"
 
 // BraggReflection Class
-class BraggReflection : public Serialisable<>
+class BraggReflection : public Serialisable
 {
     public:
     BraggReflection();
@@ -78,7 +78,7 @@ class BraggReflection : public Serialisable<>
 };
 
 // BraggReflectionVector class
-class BraggReflectionVector : public Serialisable<>
+class BraggReflectionVector : public Serialisable
 {
     public:
     BraggReflectionVector() = default;

--- a/src/classes/braggReflection.h
+++ b/src/classes/braggReflection.h
@@ -74,7 +74,7 @@ class BraggReflection : public Serialisable
     // Write data through specified parser
     bool serialise(LineParser &parser) const;
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    void serialise(std::string tag, SerialisedValue &target) const override;
 };
 
 // BraggReflectionVector class
@@ -105,7 +105,7 @@ class BraggReflectionVector : public Serialisable
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -62,7 +62,7 @@ void Configuration::serialise(std::string tag, SerialisedValue &target) const
 }
 
 // Read values from a serialisable value
-void Configuration::deserialise(const SerialisedValue &node, const CoreData &data)
+void Configuration::deserialise(const SerialisedValue &node)
 {
     setTemperature(toml::find_or<double>(node, "temperature", defaultTemperature_));
     requestedSizeFactor_ = toml::find_or<double>(node, "sizeFactor", defaultSizeFactor_);

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -23,7 +23,7 @@ class ProcessPool;
 class Species;
 
 // Configuration
-class Configuration : public Serialisable<const CoreData &>
+class Configuration : public Serialisable
 {
     public:
     Configuration();
@@ -252,5 +252,5 @@ class Configuration : public Serialisable<const CoreData &>
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &data) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/isotopologue.h
+++ b/src/classes/isotopologue.h
@@ -20,7 +20,7 @@ class CoreData;
 /*
  * Isotopologue Definition
  */
-class Isotopologue : public Serialisable<>
+class Isotopologue : public Serialisable
 {
     public:
     Isotopologue(const Species *parent, std::string name = "");

--- a/src/classes/isotopologueSet.cpp
+++ b/src/classes/isotopologueSet.cpp
@@ -102,7 +102,7 @@ void IsotopologueSet::serialise(std::string tag, SerialisedValue &target) const
 }
 
 // Read values from a serialisable value
-void IsotopologueSet::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void IsotopologueSet::deserialise(const SerialisedValue &node)
 {
     clear();
 

--- a/src/classes/isotopologueSet.cpp
+++ b/src/classes/isotopologueSet.cpp
@@ -113,12 +113,6 @@ void IsotopologueSet::deserialise(const SerialisedValue &node)
               toMap(topes, [&](const std::string &isoName, const SerialisedValue &population)
                     { set[isoName] = population.as_floating(); });
           });
-
-    // Need to resolve species
-    std::map<std::string, const Species *> speciesMap;
-    for (const auto &sp : coreData.species())
-        speciesMap[std::string(sp.get()->name())] = sp.get();
-    resolve(speciesMap);
 }
 
 // Resolve internal resolvable name references with supplied data

--- a/src/classes/isotopologueSet.h
+++ b/src/classes/isotopologueSet.h
@@ -12,7 +12,7 @@ class Isotopologue;
 class LineParser;
 
 // IsotopologueSet - Isotopologues for one or more Species
-class IsotopologueSet : public Serialisable<const CoreData &>, ResolvableContext
+class IsotopologueSet : public Serialisable, ResolvableContext
 {
     public:
     IsotopologueSet() = default;
@@ -54,7 +54,7 @@ class IsotopologueSet : public Serialisable<const CoreData &>, ResolvableContext
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Resolve internal resolvable name references with supplied data
     void resolve(const std::map<std::string, const Species *> &speciesInScope) override;
 };

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -222,5 +222,5 @@ class PairPotential : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/pairPotential.h
+++ b/src/classes/pairPotential.h
@@ -13,7 +13,7 @@
 class AtomType;
 
 // PairPotential Definition
-class PairPotential : Serialisable<>
+class PairPotential : public Serialisable
 {
     public:
     PairPotential(std::string_view nameI = {}, std::string_view nameJ = {});

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -9,7 +9,7 @@
 #include <string>
 
 // PairPotential Override Definition
-class PairPotentialOverride : public Serialisable<>
+class PairPotentialOverride : public Serialisable
 {
     public:
     // Override Types

--- a/src/classes/pairPotentialOverride.h
+++ b/src/classes/pairPotentialOverride.h
@@ -58,5 +58,5 @@ class PairPotentialOverride : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/partialSet.h
+++ b/src/classes/partialSet.h
@@ -10,7 +10,7 @@
 #include "templates/resolvable.h"
 
 // Set of Partials
-class PartialSet : public Serialisable<>, ResolvableContext
+class PartialSet : public Serialisable, ResolvableContext
 {
     public:
     PartialSet() = default;

--- a/src/classes/potentialSet.h
+++ b/src/classes/potentialSet.h
@@ -10,7 +10,7 @@
 class AtomType;
 
 // Set of Potentials
-class PotentialSet : public Serialisable<>
+class PotentialSet : public Serialisable
 {
     public:
     PotentialSet();

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -341,5 +341,5 @@ class Species : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -24,7 +24,7 @@ class CommonImproper;
 class Structure;
 
 // Species Definition
-class Species : public Serialisable<>
+class Species : public Serialisable
 {
     public:
     Species(std::string name = "Unnamed");

--- a/src/classes/speciesIntra.h
+++ b/src/classes/speciesIntra.h
@@ -14,7 +14,7 @@ class SpeciesAtom;
 class Species;
 
 // Base class for intramolecular interactions within Species
-template <class Intra, class Functions> class SpeciesIntra : public Serialisable<>
+template <class Intra, class Functions> class SpeciesIntra : public Serialisable
 {
     public:
     explicit SpeciesIntra(Species *parent, typename Functions::Form form) : parent_(parent), interactionPotential_(form) {};

--- a/src/classes/speciesSite.h
+++ b/src/classes/speciesSite.h
@@ -22,7 +22,7 @@ class Species;
 class SpeciesAtom;
 
 // Species Site Definition
-class SpeciesSite : public Serialisable<>
+class SpeciesSite : public Serialisable
 {
     public:
     // Site Type

--- a/src/classes/speciesSites.h
+++ b/src/classes/speciesSites.h
@@ -10,7 +10,7 @@ class SpeciesSite;
 class Species;
 
 // SpeciesSites - Sites from one or more Species
-class SpeciesSites : public Serialisable<>, ResolvableContext
+class SpeciesSites : public Serialisable, ResolvableContext
 {
     public:
     SpeciesSites() = default;

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -35,7 +35,7 @@ class StructureAtom : public Atom<Bond<StructureAtom>>
 };
 
 // Structure
-class Structure : public Serialisable<>
+class Structure : public Serialisable
 {
     public:
     Structure();

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -123,5 +123,5 @@ class Structure : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/expression/value.h
+++ b/src/expression/value.h
@@ -7,7 +7,7 @@
 #include <string>
 
 // Expression Value
-class ExpressionValue : public Serialisable<>
+class ExpressionValue : public Serialisable
 {
     public:
     ExpressionValue();

--- a/src/expression/variable.h
+++ b/src/expression/variable.h
@@ -6,7 +6,7 @@
 #include "expression/value.h"
 
 // Variable
-class ExpressionVariable : public Serialisable<>
+class ExpressionVariable : public Serialisable
 {
     public:
     ExpressionVariable(const ExpressionValue &value = ExpressionValue());

--- a/src/expression/variable.h
+++ b/src/expression/variable.h
@@ -48,5 +48,5 @@ class ExpressionVariable : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/base.h
+++ b/src/keywords/base.h
@@ -24,7 +24,7 @@ class Species;
 class SpeciesSite;
 
 // Keyword Base Class
-class KeywordBase : public Serialisable<CoreData const &>
+class KeywordBase : public Serialisable
 {
     public:
     KeywordBase(const std::type_index typeIndex);
@@ -72,7 +72,7 @@ class KeywordBase : public Serialisable<CoreData const &>
     // Express as a serialisable value
     virtual void serialise(std::string tag, SerialisedValue &target) const override = 0;
     // Read values from a serialisable value
-    virtual void deserialise(const SerialisedValue &node, const CoreData &coreData) override {};
+    virtual void deserialise(const SerialisedValue &node) override {};
 
     /*
      * Keyword Types

--- a/src/keywords/bool.cpp
+++ b/src/keywords/bool.cpp
@@ -56,4 +56,4 @@ bool BoolKeyword::serialise(LineParser &parser, std::string_view keywordName, st
 void BoolKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void BoolKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_boolean(); }
+void BoolKeyword::deserialise(const SerialisedValue &node) { data_ = node.as_boolean(); }

--- a/src/keywords/bool.h
+++ b/src/keywords/bool.h
@@ -42,5 +42,5 @@ class BoolKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/configuration.cpp
+++ b/src/keywords/configuration.cpp
@@ -61,7 +61,8 @@ void ConfigurationKeyword::serialise(std::string tag, SerialisedValue &target) c
 }
 
 // Read values from a serialisable value
-void ConfigurationKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void ConfigurationKeyword::deserialise(const SerialisedValue &node)
 {
-    data_ = coreData.findConfiguration(std::string_view(std::string(node.as_string())));
+    // TODO DISSOLVE2 Broken, but to be removed anyway.
+    // data_ = coreData.findConfiguration(std::string_view(std::string(node.as_string())));
 }

--- a/src/keywords/configuration.h
+++ b/src/keywords/configuration.h
@@ -38,7 +38,7 @@ class ConfigurationKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 
     /*
      * Object Management

--- a/src/keywords/configurationVector.cpp
+++ b/src/keywords/configurationVector.cpp
@@ -75,25 +75,26 @@ void ConfigurationVectorKeyword::serialise(std::string tag, SerialisedValue &tar
 }
 
 // Read values from a serialisable value
-void ConfigurationVectorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void ConfigurationVectorKeyword::deserialise(const SerialisedValue &node)
 {
-    toVector(node,
-             [&coreData, this](const auto &name)
-             {
-                 auto *cfg = coreData.findConfiguration(std::string_view(std::string(name.as_string())));
-                 if (!cfg)
-                     throw toml::type_error(
-                         std::format("Error defining Configuration targets - no Configuration named '{}' exists.\n",
-                                     std::string(name.as_string())),
-                         name.location());
-
-                 // Check that the configuration isn't already present
-                 if (std::find(data_.begin(), data_.end(), cfg) != data_.end())
-                     throw toml::type_error(std::format("Configuration '{}' has already been referenced.\n", cfg->name()),
-                                            name.location());
-
-                 data_.push_back(cfg);
-             });
+    // TODO DISSOLVE2 Broken, but to be removed anyway.
+    // toVector(node,
+    //          [&coreData, this](const auto &name)
+    //          {
+    //              auto *cfg = coreData.findConfiguration(std::string_view(std::string(name.as_string())));
+    //              if (!cfg)
+    //                  throw toml::type_error(
+    //                      std::format("Error defining Configuration targets - no Configuration named '{}' exists.\n",
+    //                                  std::string(name.as_string())),
+    //                      name.location());
+    //
+    //              // Check that the configuration isn't already present
+    //              if (std::find(data_.begin(), data_.end(), cfg) != data_.end())
+    //                  throw toml::type_error(std::format("Configuration '{}' has already been referenced.\n", cfg->name()),
+    //                                         name.location());
+    //
+    //              data_.push_back(cfg);
+    //          });
 }
 
 // Has not changed from initial value

--- a/src/keywords/configurationVector.h
+++ b/src/keywords/configurationVector.h
@@ -49,7 +49,7 @@ class ConfigurationVectorKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/double.cpp
+++ b/src/keywords/double.cpp
@@ -77,7 +77,7 @@ bool DoubleKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 void DoubleKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = toml::get<double>(node); }
+void DoubleKeyword::deserialise(const SerialisedValue &node) { data_ = toml::get<double>(node); }
 
 // Has not changed from initial value
 bool DoubleKeyword::isDefault() const { return data_ == default_; }

--- a/src/keywords/double.h
+++ b/src/keywords/double.h
@@ -50,5 +50,5 @@ class DoubleKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/enumOptions.h
+++ b/src/keywords/enumOptions.h
@@ -113,5 +113,5 @@ template <class E> class EnumOptionsKeyword : public EnumOptionsBaseKeyword
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override { target[tag] = optionData_.keyword(data_); }
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override { data_ = optionData_.deserialise(node); }
+    void deserialise(const SerialisedValue &node) override { data_ = optionData_.deserialise(node); }
 };

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -43,7 +43,7 @@ bool ExpressionKeyword::serialise(LineParser &parser, std::string_view keywordNa
 void ExpressionKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_.expressionString(); }
 
 // Read values from a serialisable value
-void ExpressionKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void ExpressionKeyword::deserialise(const SerialisedValue &node)
 {
     setData(std::string_view(std::string(node.as_string())));
 }

--- a/src/keywords/expression.cpp
+++ b/src/keywords/expression.cpp
@@ -43,10 +43,7 @@ bool ExpressionKeyword::serialise(LineParser &parser, std::string_view keywordNa
 void ExpressionKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_.expressionString(); }
 
 // Read values from a serialisable value
-void ExpressionKeyword::deserialise(const SerialisedValue &node)
-{
-    setData(std::string_view(std::string(node.as_string())));
-}
+void ExpressionKeyword::deserialise(const SerialisedValue &node) { setData(std::string_view(std::string(node.as_string()))); }
 
 // Has not changed from initial value
 bool ExpressionKeyword::isDefault() const { return data_.expressionString() == default_; }

--- a/src/keywords/expression.h
+++ b/src/keywords/expression.h
@@ -44,5 +44,5 @@ class ExpressionKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/function1D.cpp
+++ b/src/keywords/function1D.cpp
@@ -68,7 +68,7 @@ void Function1DKeyword::serialise(std::string tag, SerialisedValue &target) cons
 }
 
 // Read values from a serialisable value
-void Function1DKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void Function1DKeyword::deserialise(const SerialisedValue &node)
 {
     data_.setFormAndParameters(Functions1D::forms().deserialise(node.at("type")),
                                toml::find<std::vector<double>>(node, "parameters"));

--- a/src/keywords/function1D.h
+++ b/src/keywords/function1D.h
@@ -43,5 +43,5 @@ class Function1DKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/integer.cpp
+++ b/src/keywords/integer.cpp
@@ -77,7 +77,7 @@ bool IntegerKeyword::serialise(LineParser &parser, std::string_view keywordName,
 void IntegerKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_integer(); }
+void IntegerKeyword::deserialise(const SerialisedValue &node) { data_ = node.as_integer(); }
 
 // Has not changed from initial value
 bool IntegerKeyword::isDefault() const { return data_ == default_; }

--- a/src/keywords/integer.h
+++ b/src/keywords/integer.h
@@ -47,7 +47,7 @@ class IntegerKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/isotopologueSet.cpp
+++ b/src/keywords/isotopologueSet.cpp
@@ -80,10 +80,7 @@ void IsotopologueSetKeyword::removeReferencesTo(Isotopologue *iso) { data_.remov
 void IsotopologueSetKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void IsotopologueSetKeyword::deserialise(const SerialisedValue &node)
-{
-    data_.deserialise(node, coreData);
-}
+void IsotopologueSetKeyword::deserialise(const SerialisedValue &node) { data_.deserialise(node); }
 
 // Has not changed from initial value
 bool IsotopologueSetKeyword::isDefault() const { return false; }

--- a/src/keywords/isotopologueSet.cpp
+++ b/src/keywords/isotopologueSet.cpp
@@ -80,7 +80,7 @@ void IsotopologueSetKeyword::removeReferencesTo(Isotopologue *iso) { data_.remov
 void IsotopologueSetKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void IsotopologueSetKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void IsotopologueSetKeyword::deserialise(const SerialisedValue &node)
 {
     data_.deserialise(node, coreData);
 }

--- a/src/keywords/isotopologueSet.h
+++ b/src/keywords/isotopologueSet.h
@@ -17,7 +17,7 @@ class IsotopologueSetKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 
     /*
      * Data

--- a/src/keywords/optionalDouble.cpp
+++ b/src/keywords/optionalDouble.cpp
@@ -97,10 +97,7 @@ void OptionalDoubleKeyword::serialise(std::string tag, SerialisedValue &target) 
 }
 
 // Read values from a serialisable value
-void OptionalDoubleKeyword::deserialise(const SerialisedValue &node)
-{
-    setData(toml::get<double>(node));
-}
+void OptionalDoubleKeyword::deserialise(const SerialisedValue &node) { setData(toml::get<double>(node)); }
 
 // Has not changed from initial value
 bool OptionalDoubleKeyword::isDefault() const { return !set_ || !data_; }

--- a/src/keywords/optionalDouble.cpp
+++ b/src/keywords/optionalDouble.cpp
@@ -97,7 +97,7 @@ void OptionalDoubleKeyword::serialise(std::string tag, SerialisedValue &target) 
 }
 
 // Read values from a serialisable value
-void OptionalDoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void OptionalDoubleKeyword::deserialise(const SerialisedValue &node)
 {
     setData(toml::get<double>(node));
 }

--- a/src/keywords/optionalDouble.h
+++ b/src/keywords/optionalDouble.h
@@ -56,7 +56,7 @@ class OptionalDoubleKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/optionalInt.cpp
+++ b/src/keywords/optionalInt.cpp
@@ -97,7 +97,4 @@ void OptionalIntegerKeyword::serialise(std::string tag, SerialisedValue &target)
 }
 
 // Read values from a serialisable value
-void OptionalIntegerKeyword::deserialise(const SerialisedValue &node)
-{
-    setData(toml::get<int>(node));
-}
+void OptionalIntegerKeyword::deserialise(const SerialisedValue &node) { setData(toml::get<int>(node)); }

--- a/src/keywords/optionalInt.cpp
+++ b/src/keywords/optionalInt.cpp
@@ -97,7 +97,7 @@ void OptionalIntegerKeyword::serialise(std::string tag, SerialisedValue &target)
 }
 
 // Read values from a serialisable value
-void OptionalIntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void OptionalIntegerKeyword::deserialise(const SerialisedValue &node)
 {
     setData(toml::get<int>(node));
 }

--- a/src/keywords/optionalInt.h
+++ b/src/keywords/optionalInt.h
@@ -56,5 +56,5 @@ class OptionalIntegerKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/range.cpp
+++ b/src/keywords/range.cpp
@@ -115,7 +115,7 @@ bool RangeKeyword::serialise(LineParser &parser, std::string_view keywordName, s
 void RangeKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void RangeKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }
+void RangeKeyword::deserialise(const SerialisedValue &node) { data_.deserialise(node); }
 
 // Has not changed from initial value
 bool RangeKeyword::isDefault() const { return data_ == default_; }

--- a/src/keywords/range.h
+++ b/src/keywords/range.h
@@ -61,7 +61,7 @@ class RangeKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/rangeVector.cpp
+++ b/src/keywords/rangeVector.cpp
@@ -69,7 +69,7 @@ void RangeVectorKeyword::serialise(std::string tag, SerialisedValue &target) con
 }
 
 // Read values from a serialisable value
-void RangeVectorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void RangeVectorKeyword::deserialise(const SerialisedValue &node)
 {
     toVector(node, [this](const auto &item)
              { data_.emplace_back(toml::find<double>(item, "min"), toml::find<double>(item, "max")); });

--- a/src/keywords/rangeVector.h
+++ b/src/keywords/rangeVector.h
@@ -40,7 +40,7 @@ class RangeVectorKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/species.cpp
+++ b/src/keywords/species.cpp
@@ -56,7 +56,8 @@ void SpeciesKeyword::removeReferencesTo(Species *sp)
 void SpeciesKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_->name(); }
 
 // Read values from a serialisable value
-void SpeciesKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void SpeciesKeyword::deserialise(const SerialisedValue &node)
 {
-    data_ = coreData.findSpecies(DissolveSys::niceName(std::string(node.as_string())));
+    // TODO DISSOLVE2 Broken, but to be removed anyway.
+    // data_ = coreData.findSpecies(DissolveSys::niceName(std::string(node.as_string())));
 }

--- a/src/keywords/species.h
+++ b/src/keywords/species.h
@@ -38,7 +38,7 @@ class SpeciesKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 
     /*
      * Object Management

--- a/src/keywords/speciesSite.cpp
+++ b/src/keywords/speciesSite.cpp
@@ -117,7 +117,8 @@ void SpeciesSiteKeyword::deserialise(const SerialisedValue &node)
     //
     // if (axesRequired_ && (!data_->hasAxes()))
     //     throw toml::type_error(
-    //         std::format("Can't select site '{}' for keyword '{}', as the keyword requires axes specifications to be present.\n",
+    //         std::format("Can't select site '{}' for keyword '{}', as the keyword requires axes specifications to be
+    //         present.\n",
     //                     data_->name(), name()),
     //         node.location());
 }

--- a/src/keywords/speciesSite.cpp
+++ b/src/keywords/speciesSite.cpp
@@ -94,29 +94,30 @@ void SpeciesSiteKeyword::serialise(std::string tag, SerialisedValue &target) con
 }
 
 // Read values from a serialisable value
-void SpeciesSiteKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void SpeciesSiteKeyword::deserialise(const SerialisedValue &node)
 {
-    KeywordBase::deserialise(node, coreData);
-    std::string species = toml::find<std::string>(node, "species");
-    std::string site = toml::find<std::string>(node, "site");
-    // Find target Species (first argument)
-    Species *sp = coreData.findSpecies(species);
-    if (!sp)
-    {
-        throw toml::type_error(std::format("Error setting SpeciesSite - no Species named '{}' exists.\n", species),
-                               node.location());
-    }
-
-    // Find specified Site (second argument) in the Species
-    data_ = sp->findSite(site);
-    if (!data_)
-        throw toml::type_error(
-            std::format("Error setting SpeciesSite - no such site named '{}' exists in Species '{}'.\n", site, sp->name()),
-            node.location());
-
-    if (axesRequired_ && (!data_->hasAxes()))
-        throw toml::type_error(
-            std::format("Can't select site '{}' for keyword '{}', as the keyword requires axes specifications to be present.\n",
-                        data_->name(), name()),
-            node.location());
+    // TODO DISSOLVE2 Broken, but to be removed anyway.
+    // KeywordBase::deserialise(node, coreData);
+    // std::string species = toml::find<std::string>(node, "species");
+    // std::string site = toml::find<std::string>(node, "site");
+    // // Find target Species (first argument)
+    // Species *sp = coreData.findSpecies(species);
+    // if (!sp)
+    // {
+    //     throw toml::type_error(std::format("Error setting SpeciesSite - no Species named '{}' exists.\n", species),
+    //                            node.location());
+    // }
+    //
+    // // Find specified Site (second argument) in the Species
+    // data_ = sp->findSite(site);
+    // if (!data_)
+    //     throw toml::type_error(
+    //         std::format("Error setting SpeciesSite - no such site named '{}' exists in Species '{}'.\n", site, sp->name()),
+    //         node.location());
+    //
+    // if (axesRequired_ && (!data_->hasAxes()))
+    //     throw toml::type_error(
+    //         std::format("Can't select site '{}' for keyword '{}', as the keyword requires axes specifications to be present.\n",
+    //                     data_->name(), name()),
+    //         node.location());
 }

--- a/src/keywords/speciesSite.h
+++ b/src/keywords/speciesSite.h
@@ -46,7 +46,7 @@ class SpeciesSiteKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 
     /*
      * Object Management

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -104,26 +104,7 @@ void SpeciesSiteVectorKeyword::serialise(std::string tag, SerialisedValue &targe
 }
 
 // Read values from a serialisable value
-void SpeciesSiteVectorKeyword::deserialise(const SerialisedValue &node)
-{
-    toVector(node,
-             [this, &coreData](const auto &item)
-             {
-                 auto species = coreData.findSpecies(toml::find<std::string>(item, "species"));
-                 if (species)
-                 {
-                     auto site = species->findSite(toml::find<std::string>(item, "site"));
-                     if (site)
-                         data_.push_back(site);
-                     else
-                         throw toml::type_error(std::format("Cannot find Site {}", toml::find<std::string>(item, "site")),
-                                                item.location());
-                 }
-                 else
-                     toml::type_error(std::format("Cannot find Species {}", toml::find<std::string>(item, "species")),
-                                      item.location());
-             });
-}
+void SpeciesSiteVectorKeyword::deserialise(const SerialisedValue &node) {}
 
 // Has not changed from initial value
 bool SpeciesSiteVectorKeyword::isDefault() const { return data_.empty(); }

--- a/src/keywords/speciesSiteVector.cpp
+++ b/src/keywords/speciesSiteVector.cpp
@@ -104,7 +104,7 @@ void SpeciesSiteVectorKeyword::serialise(std::string tag, SerialisedValue &targe
 }
 
 // Read values from a serialisable value
-void SpeciesSiteVectorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void SpeciesSiteVectorKeyword::deserialise(const SerialisedValue &node)
 {
     toVector(node,
              [this, &coreData](const auto &item)

--- a/src/keywords/speciesSiteVector.h
+++ b/src/keywords/speciesSiteVector.h
@@ -57,7 +57,7 @@ class SpeciesSiteVectorKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/speciesVector.cpp
+++ b/src/keywords/speciesVector.cpp
@@ -68,18 +68,19 @@ void SpeciesVectorKeyword::serialise(std::string tag, SerialisedValue &target) c
 }
 
 // Read values from a serialisable value
-void SpeciesVectorKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData)
+void SpeciesVectorKeyword::deserialise(const SerialisedValue &node)
 {
-    toVector(node,
-             [&coreData, this](const auto &item)
-             {
-                 auto title = toml::get<std::string>(item);
-                 auto *species = coreData.findSpecies(title);
-                 if (!species)
-                     throw toml::type_error(std::format("No Species named '{}' exists.\n", title), item.location());
-
-                 data_.push_back(species);
-             });
+    // TODO DISSOLVE2 Broken, but to be removed anyway.
+    // toVector(node,
+    //          [&coreData, this](const auto &item)
+    //          {
+    //              auto title = toml::get<std::string>(item);
+    //              auto *species = coreData.findSpecies(title);
+    //              if (!species)
+    //                  throw toml::type_error(std::format("No Species named '{}' exists.\n", title), item.location());
+    //
+    //              data_.push_back(species);
+    //          });
 }
 
 // Has not changed from initial value

--- a/src/keywords/speciesVector.h
+++ b/src/keywords/speciesVector.h
@@ -47,7 +47,7 @@ class SpeciesVectorKeyword : public KeywordBase
 
     public:
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
     // Express as a serialisable value

--- a/src/keywords/stdString.cpp
+++ b/src/keywords/stdString.cpp
@@ -42,7 +42,7 @@ bool StringKeyword::serialise(LineParser &parser, std::string_view keywordName, 
 void StringKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void StringKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_ = node.as_string(); }
+void StringKeyword::deserialise(const SerialisedValue &node) { data_ = node.as_string(); }
 
 // Has not changed from initial value
 bool StringKeyword::isDefault() const { return data_ == default_; }

--- a/src/keywords/stdString.h
+++ b/src/keywords/stdString.h
@@ -37,7 +37,7 @@ class StringKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
     // Has not changed from initial value
     bool isDefault() const override;
 };

--- a/src/keywords/store.cpp
+++ b/src/keywords/store.cpp
@@ -267,11 +267,11 @@ SerialisedValue KeywordStore::serialiseOnto(SerialisedValue node) const
 }
 
 // Pull keywords from entries in table
-void KeywordStore::deserialiseFrom(const SerialisedValue &node, const CoreData &coreData)
+void KeywordStore::deserialiseFrom(const SerialisedValue &node)
 {
     for (const auto &section : sections_)
         for (const auto &group : section.groups())
             for (const auto &[keyword, keywordType] : group.keywords())
                 if (node.contains(toml_format(keyword->name())))
-                    keyword->deserialise(node.at(toml_format(keyword->name())), coreData);
+                    keyword->deserialise(node.at(toml_format(keyword->name())));
 }

--- a/src/keywords/store.h
+++ b/src/keywords/store.h
@@ -265,7 +265,7 @@ class KeywordStore
     // Apply the terms in the keyword store to a node
     SerialisedValue serialiseOnto(SerialisedValue node) const;
     // Pull keywords from entries in table
-    void deserialiseFrom(const SerialisedValue &node, const CoreData &coreData);
+    void deserialiseFrom(const SerialisedValue &node);
 
     /*
      * Object Management

--- a/src/keywords/vec3Double.cpp
+++ b/src/keywords/vec3Double.cpp
@@ -104,4 +104,4 @@ bool Vec3DoubleKeyword::isDefault() const { return data_ == default_; }
 void Vec3DoubleKeyword::serialise(std::string tag, SerialisedValue &target) const { data_.serialise(tag, target); }
 
 // Read values from a serialisable value
-void Vec3DoubleKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }
+void Vec3DoubleKeyword::deserialise(const SerialisedValue &node) { data_.deserialise(node); }

--- a/src/keywords/vec3Double.h
+++ b/src/keywords/vec3Double.h
@@ -68,5 +68,5 @@ class Vec3DoubleKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/keywords/vec3Integer.cpp
+++ b/src/keywords/vec3Integer.cpp
@@ -97,7 +97,7 @@ bool Vec3IntegerKeyword::serialise(LineParser &parser, std::string_view keywordN
 void Vec3IntegerKeyword::serialise(std::string tag, SerialisedValue &target) const { target[tag] = data_; }
 
 // Read values from a serialisable value
-void Vec3IntegerKeyword::deserialise(const SerialisedValue &node, const CoreData &coreData) { data_.deserialise(node); }
+void Vec3IntegerKeyword::deserialise(const SerialisedValue &node) { data_.deserialise(node); }
 
 // Has not changed from initial value
 bool Vec3IntegerKeyword::isDefault() const { return data_ == default_; }

--- a/src/keywords/vec3Integer.h
+++ b/src/keywords/vec3Integer.h
@@ -66,5 +66,5 @@ class Vec3IntegerKeyword : public KeywordBase
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node, const CoreData &coreData) override;
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/main/dissolve.h
+++ b/src/main/dissolve.h
@@ -21,7 +21,7 @@ class Isotopologue;
 class Molecule;
 
 // Dissolve Main Class
-class Dissolve : public Serialisable<>
+class Dissolve : public Serialisable
 {
     public:
     Dissolve(CoreData &coreData);

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -109,7 +109,7 @@ void Dissolve::deserialise(const SerialisedValue &originalNode)
           {
               auto *cfg = coreData_.addConfiguration();
               cfg->setName(name);
-              cfg->deserialise(data, coreData_);
+              cfg->deserialise(data);
           });
 }
 

--- a/src/math/data1D.h
+++ b/src/math/data1D.h
@@ -10,7 +10,7 @@
 #include <string>
 
 // One-Dimensional Data
-class Data1D : public Data1DBase, public Serialisable<>
+class Data1D : public Data1DBase, public Serialisable
 {
     public:
     Data1D();

--- a/src/math/data2D.h
+++ b/src/math/data2D.h
@@ -12,7 +12,7 @@
 class Histogram2D;
 
 // One-Dimensional Data
-class Data2D : public Data2DBase, public Serialisable<>
+class Data2D : public Data2DBase, public Serialisable
 {
     public:
     Data2D();

--- a/src/math/function1D.h
+++ b/src/math/function1D.h
@@ -111,7 +111,7 @@ class Functions1D
 };
 
 // Function 1D Wrapper
-class Function1DWrapper : public Serialisable<>
+class Function1DWrapper : public Serialisable
 {
     public:
     Function1DWrapper(Functions1D::Form form = Functions1D::Form::None, const std::vector<double> &params = {});

--- a/src/math/histogram1D.h
+++ b/src/math/histogram1D.h
@@ -97,5 +97,5 @@ class Histogram1D : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/histogram1D.h
+++ b/src/math/histogram1D.h
@@ -7,7 +7,7 @@
 #include "math/sampledDouble.h"
 
 // One-Dimensional Histogram
-class Histogram1D : public Serialisable<>
+class Histogram1D : public Serialisable
 {
     public:
     Histogram1D();

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -11,7 +11,7 @@
 
 // Serialisable Data History
 // Requires that the template class T is itself a Serialisable and implements the += and * operators
-template <class T> class History : public Serialisable<>
+template <class T> class History : public Serialisable
 {
     public:
     History(std::function<T()> initialiser = {}) : initialiser_(std::move(initialiser)) {}
@@ -75,7 +75,7 @@ template <class T> class History : public Serialisable<>
 
 // Serialisable POD Data History
 // History for PODs, e.g. double, int
-template <class T> class PODHistory : public Serialisable<>
+template <class T> class PODHistory : public Serialisable
 {
     private:
     // Stored historical data

--- a/src/math/history.h
+++ b/src/math/history.h
@@ -55,7 +55,7 @@ template <class T> class History : public Serialisable
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         return Serialisable::fromVector(history_, tag, target, [&](const auto &itemPtr) { return itemPtr->into_toml(); });
     }
@@ -110,7 +110,7 @@ template <class T> class PODHistory : public Serialisable
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const
+    void serialise(std::string tag, SerialisedValue &target) const override
     {
         if (history_.empty())
             return;

--- a/src/math/range.h
+++ b/src/math/range.h
@@ -8,7 +8,7 @@
 #include <optional>
 
 // Range
-class Range : public Serialisable<>
+class Range : public Serialisable
 {
     public:
     Range(std::optional<double> minimum = std::nullopt, std::optional<double> maximum = std::nullopt);

--- a/src/math/rangedVector3.h
+++ b/src/math/rangedVector3.h
@@ -8,7 +8,7 @@
 #include <optional>
 
 // Ranged Vector3
-class RangedVector3 : public Serialisable<>
+class RangedVector3 : public Serialisable
 {
     public:
     RangedVector3() = default;

--- a/src/math/sampledData1D.h
+++ b/src/math/sampledData1D.h
@@ -13,7 +13,7 @@
 class Data1D;
 
 // One-Dimensional Data with Statistics
-class SampledData1D : public Data1DBase, public Serialisable<>
+class SampledData1D : public Data1DBase, public Serialisable
 {
     public:
     SampledData1D();

--- a/src/math/sampledData1D.h
+++ b/src/math/sampledData1D.h
@@ -93,5 +93,5 @@ class SampledData1D : public Data1DBase, public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/sampledDouble.h
+++ b/src/math/sampledDouble.h
@@ -11,7 +11,7 @@ class LineParser;
 class ProcessPool;
 
 // Double value with sampling
-class SampledDouble : public Serialisable<>
+class SampledDouble : public Serialisable
 {
     public:
     SampledDouble();

--- a/src/math/sampledVector.h
+++ b/src/math/sampledVector.h
@@ -70,5 +70,5 @@ class SampledVector : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/sampledVector.h
+++ b/src/math/sampledVector.h
@@ -11,7 +11,7 @@ class CoreData;
 class LineParser;
 
 // Vector of double values with sampling
-class SampledVector : public Serialisable<>
+class SampledVector : public Serialisable
 {
     public:
     SampledVector();

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -140,5 +140,5 @@ class Vector3 : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/vector3.h
+++ b/src/math/vector3.h
@@ -9,7 +9,7 @@
 #include <stdexcept>
 
 // 3D Real Vector
-class Vector3 : public Serialisable<>
+class Vector3 : public Serialisable
 {
     public:
     Vector3() = default;

--- a/src/math/vector3i.h
+++ b/src/math/vector3i.h
@@ -115,5 +115,5 @@ class Vector3i : public Serialisable
     // Express as a serialisable value
     void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node);
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/math/vector3i.h
+++ b/src/math/vector3i.h
@@ -12,7 +12,7 @@ class NodeValue;
 class ExpressionVariable;
 
 // 3D Real Vector
-class Vector3i : public Serialisable<>
+class Vector3i : public Serialisable
 {
     public:
     Vector3i() = default;

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -12,7 +12,7 @@
 class Graph;
 
 // Edge Definition
-class EdgeDefinition : public Serialisable<>
+class EdgeDefinition : public Serialisable
 {
     public:
     EdgeDefinition() = default;
@@ -29,7 +29,7 @@ class EdgeDefinition : public Serialisable<>
 };
 
 // Edge
-class Edge : public Serialisable<>
+class Edge : public Serialisable
 {
     friend class LoopEdge;
 

--- a/src/nodes/epsr.h
+++ b/src/nodes/epsr.h
@@ -38,7 +38,7 @@ class EPSRNamedTargetWeights : public Serialisable
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const;
+    void serialise(std::string tag, SerialisedValue &target) const override;
     // Read values from a serialisable value
     void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/epsr.h
+++ b/src/nodes/epsr.h
@@ -18,7 +18,7 @@
 class AtomType;
 class PartialSet;
 
-class EPSRNamedTargetWeights : public Serialisable<>
+class EPSRNamedTargetWeights : public Serialisable
 {
     public:
     EPSRNamedTargetWeights() = default;

--- a/src/nodes/node.h
+++ b/src/nodes/node.h
@@ -24,7 +24,7 @@ class DissolveGraph;
 class PairPotential;
 
 // Node Base
-class Node : public Serialisable<>
+class Node : public Serialisable
 {
     public:
     Node() {}

--- a/src/nodes/number.h
+++ b/src/nodes/number.h
@@ -8,7 +8,7 @@
 #include <variant>
 
 // Node Number
-class Number : public Serialisable<>
+class Number : public Serialisable
 {
     public:
     using NumberVariant = std::variant<int, double>;

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -39,7 +39,7 @@ struct ParameterLink
 };
 
 // Base type for all parameter templates to inherit from
-class ParameterBase : public Serialisable<>
+class ParameterBase : public Serialisable
 {
     public:
     ParameterBase(Node *parent, std::string_view name, std::string_view description, std::type_index storedDataType);

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -42,24 +42,22 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     SerialisableClass(std::string_view key, DataClass &targetData)
         requires(is_optional<DataClass> && is_instance_of_v<typename DataClass::value_type, std::vector> &&
                  std::is_base_of_v<Serialisable, typename DataClass::value_type::value_type>)
-        : SerialisableData(key), data_(targetData),
-          dataSerialiser_(
-              [&]()
-              {
-                  return Serialisable::fromVector(data_.value(),
-                                                                                  [&](const auto &item)
-                                                                                  {
-                                                                                      SerialisedValue outer;
-                                                                                      item.serialise("inner", outer);
-                                                                                      return outer["inner"];
-                                                                                  });
-              }),
+        : SerialisableData(key), data_(targetData), dataSerialiser_(
+                                                        [&]()
+                                                        {
+                                                            return Serialisable::fromVector(data_.value(),
+                                                                                            [&](const auto &item)
+                                                                                            {
+                                                                                                SerialisedValue outer;
+                                                                                                item.serialise("inner", outer);
+                                                                                                return outer["inner"];
+                                                                                            });
+                                                        }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
               {
                   targetData.emplace();
-                  Serialisable::toVector(value, [&](const auto &node)
-                                                                         { data_->emplace_back().deserialise(node); });
+                  Serialisable::toVector(value, [&](const auto &node) { data_->emplace_back().deserialise(node); });
               }),
           dataChecker_([&]() { return targetData.has_value() && !targetData.value().empty(); }),
           dataResolver_(
@@ -93,18 +91,17 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     // Vector of Serialisable
     SerialisableClass(std::string_view key, DataClass &targetData)
         requires(is_instance_of_v<DataClass, std::vector> && std::is_base_of_v<Serialisable, typename DataClass::value_type>)
-        : SerialisableData(key), data_(targetData),
-          dataSerialiser_(
-              [&]()
-              {
-                  return Serialisable::fromVector(data_,
-                                                             [&](const auto &item)
-                                                             {
-                                                                 SerialisedValue outer;
-                                                                 item.serialise("inner", outer);
-                                                                 return outer["inner"];
-                                                             });
-              }),
+        : SerialisableData(key), data_(targetData), dataSerialiser_(
+                                                        [&]()
+                                                        {
+                                                            return Serialisable::fromVector(data_,
+                                                                                            [&](const auto &item)
+                                                                                            {
+                                                                                                SerialisedValue outer;
+                                                                                                item.serialise("inner", outer);
+                                                                                                return outer["inner"];
+                                                                                            });
+                                                        }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
               {

--- a/src/nodes/serialisableData.h
+++ b/src/nodes/serialisableData.h
@@ -41,12 +41,12 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     // Optional Vector of Serialisable
     SerialisableClass(std::string_view key, DataClass &targetData)
         requires(is_optional<DataClass> && is_instance_of_v<typename DataClass::value_type, std::vector> &&
-                 std::is_base_of_v<Serialisable<>, typename DataClass::value_type::value_type>)
+                 std::is_base_of_v<Serialisable, typename DataClass::value_type::value_type>)
         : SerialisableData(key), data_(targetData),
           dataSerialiser_(
               [&]()
               {
-                  return Serialisable<typename DataClass::value_type>::fromVector(data_.value(),
+                  return Serialisable::fromVector(data_.value(),
                                                                                   [&](const auto &item)
                                                                                   {
                                                                                       SerialisedValue outer;
@@ -58,7 +58,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
               [&](const SerialisedValue &value)
               {
                   targetData.emplace();
-                  Serialisable<typename DataClass::value_type>::toVector(value, [&](const auto &node)
+                  Serialisable::toVector(value, [&](const auto &node)
                                                                          { data_->emplace_back().deserialise(node); });
               }),
           dataChecker_([&]() { return targetData.has_value() && !targetData.value().empty(); }),
@@ -73,7 +73,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     }
     // Optional Serialisable
     SerialisableClass(std::string_view key, DataClass &targetData)
-        requires(is_optional<DataClass> && std::is_base_of_v<Serialisable<>, typename DataClass::value_type>)
+        requires(is_optional<DataClass> && std::is_base_of_v<Serialisable, typename DataClass::value_type>)
         : SerialisableData(key), data_(targetData), dataSerialiser_([&]() { return data_.value().into_toml(); }),
           dataDeserialiser_(
               [&](const SerialisedValue &value)
@@ -92,12 +92,12 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     }
     // Vector of Serialisable
     SerialisableClass(std::string_view key, DataClass &targetData)
-        requires(is_instance_of_v<DataClass, std::vector> && std::is_base_of_v<Serialisable<>, typename DataClass::value_type>)
+        requires(is_instance_of_v<DataClass, std::vector> && std::is_base_of_v<Serialisable, typename DataClass::value_type>)
         : SerialisableData(key), data_(targetData),
           dataSerialiser_(
               [&]()
               {
-                  return Serialisable<DataClass>::fromVector(data_,
+                  return Serialisable::fromVector(data_,
                                                              [&](const auto &item)
                                                              {
                                                                  SerialisedValue outer;
@@ -109,7 +109,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
               [&](const SerialisedValue &value)
               {
                   data_.clear();
-                  Serialisable<DataClass>::toVector(value, [&](const auto &node) { data_.emplace_back().deserialise(node); });
+                  Serialisable::toVector(value, [&](const auto &node) { data_.emplace_back().deserialise(node); });
               }),
           dataChecker_([&]() { return !targetData.empty(); }),
           dataResolver_(
@@ -143,7 +143,7 @@ template <typename DataClass> class SerialisableClass : public SerialisableData
     }
     // Serialisable
     SerialisableClass(std::string_view key, DataClass &value)
-        requires(std::is_base_of_v<Serialisable<>, DataClass>)
+        requires(std::is_base_of_v<Serialisable, DataClass>)
         : SerialisableData(key), data_(value), dataResolver_(
                                                    [&](const std::map<std::string, const Species *> &reachableSpecies)
                                                    {

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -17,7 +17,7 @@
  * removing the critical dependence of an immutably ordered vector of AtomTypes.
  */
 using DoubleKeyedMapKey = std::pair<std::string_view, std::string_view>;
-template <typename ValueClass> class DoubleKeyedMap : public Serialisable<>
+template <typename ValueClass> class DoubleKeyedMap : public Serialisable
 {
     public:
     DoubleKeyedMap(bool mirrored = false) : mirroredAreEquivalent_(mirrored) {}

--- a/src/templates/doubleKeyedMap.h
+++ b/src/templates/doubleKeyedMap.h
@@ -171,7 +171,7 @@ template <typename ValueClass> class DoubleKeyedMap : public Serialisable
         target[tag] = result;
     };
     // Read values from a serialisable value
-    void deserialise(const SerialisedValue &node)
+    void deserialise(const SerialisedValue &node) override
     {
         data_.clear();
 

--- a/src/templates/keyedVector.h
+++ b/src/templates/keyedVector.h
@@ -3,8 +3,10 @@
 
 #pragma once
 
+#include <format>
 #include <functional>
 #include <map>
+#include <stdexcept>
 #include <vector>
 
 // Keyed Vector


### PR DESCRIPTION
This PR takes the opportunity to remove the now-unnecessary context on `Serialisable`, allowing it to be simplified down to a normal `class` with templated functions. I am hopeful that this, along with a liberal sprinkling of missing `override` specifiers, will make the output on OSX builds terse enough to actually interpret.