### PR TITLE
chore: Mark missing serialisable data

### DIFF
--- a/src/nodes/angle.cpp
+++ b/src/nodes/angle.cpp
@@ -29,6 +29,20 @@ AngleNode::AngleNode(Graph *parentGraph) : Node(parentGraph)
     addOption("ExcludeSameSiteAC", "Whether to exclude correlations between A and C sites on the same molecule",
               excludeSameSiteAC_);
     addOption("Symmetric", "Whether the calculated angle should be mapped to 0 - 90 (i.e. is symmetric about 90)", symmetric_);
+
+    // Serialisables
+    addSerialisable("distanceHistogramAB", distanceHistogramAB_);
+    addSerialisable("rdfAB", rdfAB_);
+    addSerialisable("distanceHistogramBC", distanceHistogramBC_);
+    addSerialisable("rdfBC", rdfBC_);
+    addSerialisable("angleHistogramABC", angleHistogramABC_);
+    addSerialisable("angleABC", angleABC_);
+    addSerialisable("dAngleHistogramAB", dAngleHistogramAB_);
+    addSerialisable("dAngleAB", dAngleAB_);
+    addSerialisable("dAngleHistogramBC", dAngleHistogramBC_);
+    addSerialisable("dAngleBC", dAngleBC_);
+    addSerialisable("dDAngleHistogramABC", dDAngleHistogramABC_);
+    addSerialisable("dDAngleABC", dDAngleABC_);
 }
 
 /*

--- a/src/nodes/averageMolecule.cpp
+++ b/src/nodes/averageMolecule.cpp
@@ -8,8 +8,14 @@ AverageMoleculeNode::AverageMoleculeNode(Graph *parentGraph) : Node(parentGraph)
     // Inputs
     addInput("Configuration", "Set target configuration for the node", configuration_)->setFlags({ParameterBase::Required});
 
+    // Options
     addOption("Site", "Target site about which to calculate average molecule geometry", targetSite_)
         ->setFlags({ParameterBase::Required});
+
+    // Serialisables
+    addSerialisable("sampledX", sampledX_);
+    addSerialisable("sampledY", sampledY_);
+    addSerialisable("sampledZ", sampledZ_);
 }
 
 /*

--- a/src/nodes/axisAngle.cpp
+++ b/src/nodes/axisAngle.cpp
@@ -22,6 +22,14 @@ AxisAngleNode::AxisAngleNode(Graph *parentGraph) : Node(parentGraph)
     addOption("ExcludeSameMolecule", "Whether to exclude correlations between B and C sites on the same molecule",
               excludeSameMolecule_);
     addOption("Symmetric", "Whether the calculated angle should be mapped to 0 - 90 (i.e. is symmetric about 90)", symmetric_);
+
+    // Serialisables
+    addSerialisable("distanceHistogram", distanceHistogram_);
+    addSerialisable("rdf", rdf_);
+    addSerialisable("axisAngleHistogram", axisAngleHistogram_);
+    addSerialisable("axisAngle", axisAngle_);
+    addSerialisable("dAxisAngleHistogram", dAxisAngleHistogram_);
+    addSerialisable("dAxisAngle", dAxisAngle_);
 }
 
 /*

--- a/src/nodes/bragg.cpp
+++ b/src/nodes/bragg.cpp
@@ -36,7 +36,7 @@ BraggNode::BraggNode(Graph *parentGraph)
     // Serialisables
     addSerialisable("braggReflections", braggReflections_);
     addSerialisable("braggReflectionHistory", braggReflectionHistory_);
-    addSerialisable("braggPartials", braggPartials_);
+    // addSerialisable("braggPartials", braggPartials_);
 }
 
 /*

--- a/src/nodes/bragg.cpp
+++ b/src/nodes/bragg.cpp
@@ -34,7 +34,9 @@ BraggNode::BraggNode(Graph *parentGraph)
     addOption("BraggQBroadening", "Broadening function to apply to Bragg reflections when generating S(Q)", braggQBroadening_);
 
     // Serialisables
-    addSerialisable("weightedGR", braggReflections_);
+    addSerialisable("braggReflections", braggReflections_);
+    addSerialisable("braggReflectionHistory", braggReflectionHistory_);
+    addSerialisable("braggPartials", braggPartials_);
 }
 
 /*

--- a/src/nodes/bragg.h
+++ b/src/nodes/bragg.h
@@ -43,16 +43,16 @@ class BraggNode : public Node
     Number qMax_{1.0};
     // Minimum Q value for Bragg calculation
     Number qMin_{0.01};
+    // Unweighted S(Q)
+    PartialSet *unweightedSQ_{nullptr};
+    // Broadening function to apply to Bragg S(Q)
+    Function1DWrapper braggQBroadening_{Functions1D::Form::GaussianC2, {0.0, 0.02}};
     // Bragg reflections
     std::optional<BraggReflectionVector> braggReflections_;
     // Bragg reflections history
     History<BraggReflectionVector> braggReflectionHistory_;
     // Bragg partials
     std::optional<Array2D<Data1D>> braggPartials_;
-    // Unweighted S(Q)
-    PartialSet *unweightedSQ_{nullptr};
-    // Broadening function to apply to Bragg S(Q)
-    Function1DWrapper braggQBroadening_{Functions1D::Form::GaussianC2, {0.0, 0.02}};
 
     public:
     // Get reflections data

--- a/src/nodes/dAngle.cpp
+++ b/src/nodes/dAngle.cpp
@@ -21,6 +21,14 @@ DAngleNode::DAngleNode(Graph *parentGraph) : Node(parentGraph)
     addOption("AngleRange", "Range (min, max, binwidth) of angle binning", angleRange_);
     addOption("ExcludeSameMolecule", "Whether to exclude correlations between B and C sites on the same molecule",
               excludeSameMolecule_);
+
+    // Serialisables
+    addSerialisable("distanceHistogramBC", distanceHistogramBC_);
+    addSerialisable("rdfBC", rdfBC_);
+    addSerialisable("angleHistogram", angleHistogram_);
+    addSerialisable("angle", angle_);
+    addSerialisable("distanceAngleMap", distanceAngleMap_);
+    addSerialisable("dAngle", dAngle_);
 }
 
 /*

--- a/src/nodes/energy.cpp
+++ b/src/nodes/energy.cpp
@@ -55,7 +55,7 @@ void EnergyNode::clearData()
     totalPairPotentialHistory_.clear();
     totalMoleculePPHistory_.clear();
     totalGeometryHistory_.clear();
-    totalCohesiveHistory.clear();
+    totalCohesiveHistory_.clear();
     bondHistory_.clear();
     angleHistory_.clear();
     torsionHistory_.clear();
@@ -90,7 +90,7 @@ NodeConstants::ProcessResult EnergyNode::process()
     totalEnergyHistory_.push(energy.pairPotential.total() + energy.geometry.total(), podHistoryLength_);
     totalPairPotentialHistory_.push(energy.pairPotential.total(), podHistoryLength_);
     totalMoleculePPHistory_.push(energy.pairPotential.intraMolecular, podHistoryLength_);
-    totalCohesiveHistory.push(energy.pairPotential.interMolecular, podHistoryLength_);
+    totalCohesiveHistory_.push(energy.pairPotential.interMolecular, podHistoryLength_);
     totalGeometryHistory_.push(energy.geometry.total(), podHistoryLength_);
     bondHistory_.push(energy.geometry.bondEnergy, podHistoryLength_);
     angleHistory_.push(energy.geometry.angleEnergy, podHistoryLength_);

--- a/src/nodes/energy.cpp
+++ b/src/nodes/energy.cpp
@@ -21,6 +21,17 @@ EnergyNode::EnergyNode(Graph *parentGraph) : Node(parentGraph)
               stabilityThreshold_);
     addOption("StabilityWindow", "Number of points over which to assess the stability of the energy (per Configuration)",
               stabilityWindow_);
+
+    // Serialisables
+    addSerialisable("totalEnergyHistory", totalEnergyHistory_);
+    addSerialisable("totalPairPotentialHistory", totalPairPotentialHistory_);
+    addSerialisable("totalMoleculePPHistory", totalMoleculePPHistory_);
+    addSerialisable("totalGeometryHistory", totalGeometryHistory_);
+    addSerialisable("totalCohesiveHistory", totalCohesiveHistory_);
+    addSerialisable("bondHistory", bondHistory_);
+    addSerialisable("angleHistory", angleHistory_);
+    addSerialisable("torsionHistory", torsionHistory_);
+    addSerialisable("improperHistory", improperHistory_);
 }
 
 /*

--- a/src/nodes/energy.h
+++ b/src/nodes/energy.h
@@ -33,7 +33,7 @@ class EnergyNode : public Node
     int stabilityWindow_{10};
     // Energy histories
     PODHistory<double> totalEnergyHistory_;
-    PODHistory<double> totalPairPotentialHistory_, totalMoleculePPHistory_, totalGeometryHistory_, totalCohesiveHistory;
+    PODHistory<double> totalPairPotentialHistory_, totalMoleculePPHistory_, totalGeometryHistory_, totalCohesiveHistory_;
     PODHistory<double> bondHistory_, angleHistory_, torsionHistory_, improperHistory_;
 
     public:

--- a/src/nodes/epsr.cpp
+++ b/src/nodes/epsr.cpp
@@ -47,6 +47,13 @@ EPSRNode::EPSRNode(Graph *parentGraph) : Node(parentGraph)
     addOption("Smoothing", "Smoothing to apply to fluctuation coefficients before summation into potential",
               fluctuationSmoothing_);
     addOption("OverwritePotentials", "Overwrite potentials each time rather than summing them", overwritePotentials_);
+
+    // Serialisables
+    addSerialisable("potentialCoefficients", potentialCoefficients_);
+    addSerialisable("estimatedSQ", estimatedSQ_);
+    addSerialisable("estimatedGR", estimatedGR_);
+    addSerialisable("additionalPotentials", additionalPotentials_);
+    addSerialisable("phiArray", phiArray_);
 }
 
 // Return type of the node

--- a/src/nodes/epsr.cpp
+++ b/src/nodes/epsr.cpp
@@ -49,7 +49,7 @@ EPSRNode::EPSRNode(Graph *parentGraph) : Node(parentGraph)
     addOption("OverwritePotentials", "Overwrite potentials each time rather than summing them", overwritePotentials_);
 
     // Serialisables
-    addSerialisable("potentialCoefficients", potentialCoefficients_);
+    // addSerialisable("potentialCoefficients", potentialCoefficients_);
     addSerialisable("estimatedSQ", estimatedSQ_);
     addSerialisable("estimatedGR", estimatedGR_);
     addSerialisable("additionalPotentials", additionalPotentials_);

--- a/src/nodes/epsr.h
+++ b/src/nodes/epsr.h
@@ -128,9 +128,9 @@ class EPSRNode : public Node
     Number pSigma1_{0.01};
     // Width for Poisson functions in real space
     Number pSigma2_{0.01};
-    // Radius at which potential truncation goes to zero (-1.0 to use pair potential maximum range)
+    // Radius at which potential truncation goes to zero (default: use pair potential maximum range)
     std::optional<Number> rMaxPT_;
-    // Radius at which potential truncation begins (-1.0 to set to 2.0 Angstroms under rmaxpt)
+    // Radius at which potential truncation begins (default: 2.0 Angstroms under rmaxpt)
     std::optional<Number> rMinPT_;
     // Degree of smoothing to apply to fluctuation coefficients before summation into potential
     std::optional<Number> fluctuationSmoothing_;
@@ -140,6 +140,10 @@ class EPSRNode : public Node
     EPSRNamedTargetWeights namedWeights_;
     // Total r-factor
     std::optional<Data1D> totalRFactor_;
+    // Ranges to calculate rFactor over
+    std::vector<Range> ranges_;
+    // Run count
+    std::optional<int> runCount_;
     // Empirical potential coefficients
     std::optional<Array2D<std::vector<double>>> potentialCoefficients_;
     // S(Q) from completed scattering matrix
@@ -152,10 +156,6 @@ class EPSRNode : public Node
     std::optional<Data1D> phiArray_;
     // Container for process data for individual target nodes
     TargetProcessDataMap targetProcessData_;
-    // Ranges to calculate rFactor over
-    std::vector<Range> ranges_;
-    // Run count
-    std::optional<int> runCount_;
 
     public:
     // Return target process data for a given node

--- a/src/nodes/gr.h
+++ b/src/nodes/gr.h
@@ -48,10 +48,6 @@ class GRNode : public Node
     private:
     // Target configurations
     Configuration *targetConfiguration_{nullptr};
-    // Raw simulation g(r)
-    std::optional<PartialSet> rawGR_;
-    // Historical raw g(r)
-    History<PartialSet> rawGRHistory_;
     // Unweighted g(r)
     std::optional<PartialSet> unweightedGR_;
     // Number of historical partial sets to combine into final partials
@@ -68,6 +64,10 @@ class GRNode : public Node
     std::optional<Number> requestedRange_;
     // Histograms for RDF calculation
     std::optional<HistogramSet> histograms_;
+    // Raw simulation g(r)
+    std::optional<PartialSet> rawGR_;
+    // Historical raw g(r)
+    History<PartialSet> rawGRHistory_;
 
     public:
     // Clear any local data

--- a/src/nodes/histogramCN.cpp
+++ b/src/nodes/histogramCN.cpp
@@ -16,6 +16,10 @@ HistogramCNNode::HistogramCNNode(Graph *parentGraph) : Node(parentGraph)
               b_);
     addOption("RangeAB", "Distance range (min, max) over which to calculate coordination number from central site",
               distanceRange_);
+
+    // Serialisables
+    addSerialisable("histogram", histogram_);
+    addSerialisable("cn", cn_);
 }
 
 /*

--- a/src/nodes/intraAngle.cpp
+++ b/src/nodes/intraAngle.cpp
@@ -12,6 +12,9 @@ IntraAngleNode::IntraAngleNode(Graph *parentGraph) : Node(parentGraph)
     // Inputs
     addInput("Configuration", "Set target configuration for the node", targetConfiguration_);
 
+    // Outputs
+    addOutput("Configuration", "Output configuration", targetConfiguration_);
+
     // Options
     addOption("SiteA", "Specify site(s) which represent 'A' in the interaction A-B-C", a_);
     addOption("SiteB", "Specify site(s) which represent 'B' in the interaction A-B-C", b_);
@@ -21,8 +24,9 @@ IntraAngleNode::IntraAngleNode(Graph *parentGraph) : Node(parentGraph)
     addOption("AngleRange", "Range (min, max, binwidth) of angle binning", angleRange_);
     addOption("Symmetric", "Whether the calculated angle should be mapped to 0 - 90 (i.e. is symmetric about 90)", symmetric_);
 
-    // Outputs
-    addOutput("Configuration", "Output configuration", targetConfiguration_);
+    // Serialisables
+    addSerialisable("intraAngleHist", intraAngleHist_);
+    addSerialisable("angleABC", angleABC_);
 }
 
 /*

--- a/src/nodes/intraAngle.h
+++ b/src/nodes/intraAngle.h
@@ -37,11 +37,11 @@ class IntraAngleNode : public Node
     Range rangeBC_{0.0, 10.0};
     // Range (min, max, binwidth) of angle axis
     Vector3 angleRange_{0.0, 180.0, 1.0};
+    // Whether the angular range should be considered symmetric about 90
+    bool symmetric_{false};
     // Angle(ABC)
     std::optional<Histogram1D> intraAngleHist_;
     Data1D angleABC_;
-    // Whether the angular range should be considered symmetric about 90
-    bool symmetric_{false};
 
     public:
     // Clear any local data

--- a/src/nodes/intraDistance.cpp
+++ b/src/nodes/intraDistance.cpp
@@ -12,13 +12,17 @@ IntraDistanceNode::IntraDistanceNode(Graph *parentGraph) : Node(parentGraph)
     // Inputs
     addInput("Configuration", "Set target configuration for the node", targetConfiguration_);
 
+    // Outputs
+    addOutput("Configuration", "Output configuration", targetConfiguration_);
+
     // Options
     addOption("SiteA", "Specify site(s) which represent 'A' in the interaction A-B-C", a_);
     addOption("SiteB", "Specify site(s) which represent 'B' in the interaction A-B-C", b_);
     addOption("DistanceRange", "Range (min, max, delta) of distance axis", distanceRange_);
 
-    // Outputs
-    addOutput("Configuration", "Output configuration", targetConfiguration_);
+    // Serialisables
+    addSerialisable("histAB", histAB_);
+    addSerialisable("rdfAB", rdfAB_);
 }
 
 /*

--- a/src/nodes/modifierOSites.cpp
+++ b/src/nodes/modifierOSites.cpp
@@ -21,6 +21,20 @@ ModifierOSitesNode::ModifierOSitesNode(Graph *parentGraph) : Node(parentGraph)
     addOption("DistanceRange", "Distance range (min, max) over which to calculate from the central site", distanceRange_);
     addOption("ModifierDistanceRange", "Distance range (min, max) over which to calculate from the central site",
               modifierDistanceRange_);
+
+    // Serialisables
+    addSerialisable("totalOxygensHistogram", totalOxygensHistogram_);
+    addSerialisable("totalOxygens", totalOxygens_);
+    addSerialisable("oxygenSitesHistogram", oxygenSitesHistogram_);
+    addSerialisable("oxygenSites", oxygenSites_);
+    addSerialisable("histMFO", histMFO_);
+    addSerialisable("distanceMFO", distanceMFO_);
+    addSerialisable("histMNBO", histMNBO_);
+    addSerialisable("distanceMNBO", distanceMNBO_);
+    addSerialisable("histMBO", histMBO_);
+    addSerialisable("distanceMBO", distanceMBO_);
+    addSerialisable("histMOtherO", histMOtherO_);
+    addSerialisable("distanceMOtherO", distanceMOtherO_);
 }
 
 /*

--- a/src/nodes/moleculeTorsion.cpp
+++ b/src/nodes/moleculeTorsion.cpp
@@ -16,6 +16,10 @@ MoleculeTorsionNode::MoleculeTorsionNode(Graph *parentGraph) : Node(parentGraph)
     addOption("J", "Index of atom j in the torsion i-j-k-l", j_);
     addOption("K", "Index of atom k in the torsion i-j-k-l", k_);
     addOption("L", "Index of atom l in the torsion i-j-k-l", l_);
+
+    // Serialisables
+    addSerialisable("histogram", histogram_);
+    addSerialisable("frequency", frequency_);
 }
 
 /*

--- a/src/nodes/neutronSQ.h
+++ b/src/nodes/neutronSQ.h
@@ -33,12 +33,6 @@ class NeutronSQNode : public Node
     PartialSet *unweightedSQ_{nullptr};
     // Unweighted g(r)
     PartialSet *unweightedGR_{nullptr};
-    // Weighted S(Q)
-    std::optional<PartialSet> weightedSQ_;
-    // Weighted g(r)
-    std::optional<PartialSet> weightedGR_;
-    // Representative g(r) calculated from FT of total weighted F(Q)
-    Data1D representativeGR_;
     // Isotopologues to use for constructing weights matrix
     IsotopologueSet isotopologues_;
     // Normalisation to apply to calculated total F(Q)
@@ -57,6 +51,12 @@ class NeutronSQNode : public Node
     StructureFactors::NormalisationType referenceNormalisedTo_{StructureFactors::NoNormalisation};
     // Window function to use when Fourier transforming reference total F(Q) into g(r)
     WindowFunction::Form referenceWindowFunction_{WindowFunction::Form::Lorch0};
+    // Weighted S(Q)
+    std::optional<PartialSet> weightedSQ_;
+    // Weighted g(r)
+    std::optional<PartialSet> weightedGR_;
+    // Representative g(r) calculated from FT of total weighted F(Q)
+    Data1D representativeGR_;
 
     public:
     // Clear any local data

--- a/src/nodes/orientedSDF.cpp
+++ b/src/nodes/orientedSDF.cpp
@@ -22,6 +22,10 @@ OrientedSDFNode::OrientedSDFNode(Graph *parentGraph) : Node(parentGraph)
     addOption("ExcludeSameMolecule", "Whether to exclude correlations between sites on the same molecule",
               excludeSameMolecule_);
     addOption("Symmetric", "Whether the calculated angle should be mapped to 0 - 90 (i.e. is symmetric about 90)", symmetric_);
+
+    // Serialisables
+    addSerialisable("histogram", histogram_);
+    addSerialisable("sdf", sdf_);
 }
 
 // Return type of the node

--- a/src/nodes/qSpecies.cpp
+++ b/src/nodes/qSpecies.cpp
@@ -19,6 +19,12 @@ QSpeciesNode::QSpeciesNode(Graph *parentGraph) : Node(parentGraph)
               "Set the site(s) 'NF' for which the distribution around the bonding oxygen sites should be calculated",
               networkFormerSpeciesSites_);
     addOption("DistanceRange", "Distance range (min, max) over which to calculate Q-Species from central site", distanceRange_);
+
+    // Serialisables
+    addSerialisable("qSpeciesHistogram", qSpeciesHistogram_);
+    addSerialisable("qSpecies", qSpecies_);
+    addSerialisable("oxygenSitesHistogram", oxygenSitesHistogram_);
+    addSerialisable("oxygenSites", oxygenSites_);
 }
 
 /*

--- a/src/nodes/sdf.cpp
+++ b/src/nodes/sdf.cpp
@@ -18,6 +18,10 @@ SDFNode::SDFNode(Graph *parentGraph) : Node(parentGraph)
     addOption("RangeZ", "Range along Z axis", rangeZ_);
     addOption("ExcludeSameMolecule", "Whether to exclude correlations between sites on the same molecule",
               excludeSameMolecule_);
+
+    // Serialisables
+    addSerialisable("histogram", histogram_);
+    addSerialisable("sdf", sdf_);
 }
 
 /*

--- a/src/nodes/siteRDF.cpp
+++ b/src/nodes/siteRDF.cpp
@@ -35,6 +35,11 @@ SiteRDFNode::SiteRDFNode(Graph *parentGraph) : Node(parentGraph)
     addOption("RangeC", "Distance range for third coordination number", rangeC_);
     addOption("Instantaneous", "Whether to calculate instantaneous coordination numbers rather than forming an average",
               instantaneous_);
+
+    // Serialisables
+    addSerialisable("sums", sums_);
+    addSerialisable("dataRDF", dataRDF_);
+    addSerialisable("histAB", histAB_);
 }
 
 /*

--- a/src/nodes/siteRDF.cpp
+++ b/src/nodes/siteRDF.cpp
@@ -37,7 +37,7 @@ SiteRDFNode::SiteRDFNode(Graph *parentGraph) : Node(parentGraph)
               instantaneous_);
 
     // Serialisables
-    addSerialisable("sums", sums_);
+    // addSerialisable("sums", sums_);
     addSerialisable("dataRDF", dataRDF_);
     addSerialisable("histAB", histAB_);
 }

--- a/src/nodes/siteRDF.h
+++ b/src/nodes/siteRDF.h
@@ -13,7 +13,6 @@
 #include <optional>
 #include <string_view>
 
-// Calculate RDF Module
 class SiteRDFNode : public Node
 {
     using Sums = std::map<std::string, std::pair<SampledDouble, std::optional<Data1D>>>;
@@ -53,7 +52,6 @@ class SiteRDFNode : public Node
     bool instantaneous_{false};
     // Whether to export instantaneous coordination numbers to disk
     bool exportInstantaneous_{false};
-
     // Sums
     Sums sums_;
     // Site RDF

--- a/src/nodes/sq.cpp
+++ b/src/nodes/sq.cpp
@@ -37,7 +37,7 @@ SQNode::SQNode(Graph *parentGraph)
 
     // Serialisables
     addSerialisable("unweightedSQ", unweightedSQ_);
-    addSerialisable("unweightedSQ", unweightedSQHistory_);
+    addSerialisable("unweightedSQHistory", unweightedSQHistory_);
 }
 
 /*

--- a/src/nodes/sq.h
+++ b/src/nodes/sq.h
@@ -30,10 +30,6 @@ class SQNode : public Node
     private:
     // Unweighted g(r)
     PartialSet *unweightedGR_{nullptr};
-    // Unweighted S(Q)
-    std::optional<PartialSet> unweightedSQ_;
-    // Historical unweighted S(Q)
-    History<PartialSet> unweightedSQHistory_;
     // Number of historical partial sets to combine into final partials
     std::optional<Number> averagingLength_;
     // Broadening function to apply to S(Q)
@@ -46,6 +42,10 @@ class SQNode : public Node
     Number qMin_{0.05};
     // Window function to use when Fourier-transforming reference S(Q) to g(r))
     WindowFunction::Form windowFunction_{WindowFunction::Form::None};
+    // Unweighted S(Q)
+    std::optional<PartialSet> unweightedSQ_;
+    // Historical unweighted S(Q)
+    History<PartialSet> unweightedSQHistory_;
 
     public:
     // Returns the source configuration, belonging to the input GR node

--- a/src/nodes/voxelDensity.cpp
+++ b/src/nodes/voxelDensity.cpp
@@ -15,6 +15,10 @@ VoxelDensityNode::VoxelDensityNode(Graph *parentGraph) : Node(parentGraph)
     addOption("Range", "Range (min, max, delta) of binned property data", binRange_);
     addOption("VoxelSideLength", "Requested side length of a single analysis voxel (Angstroms)", requestedVoxelSideLength_);
     addOption("TargetProperty", "Target property for analysis", targetProperty_);
+
+    // Serialisables
+    addSerialisable("histogram", histogram_);
+    addSerialisable("values", values_);
 }
 
 /*

--- a/src/nodes/xRaySQ.h
+++ b/src/nodes/xRaySQ.h
@@ -39,10 +39,6 @@ class XRaySQNode : public Node
     PartialSet *unweightedSQ_{nullptr};
     // Unweighted g(r)
     PartialSet *unweightedGR_{nullptr};
-    // Weighted S(Q)
-    std::optional<PartialSet> weightedSQ_;
-    // Weighted g(r)
-    std::optional<PartialSet> weightedGR_;
     // Representative g(r) calculated from FT of total weighted F(Q)
     Data1D representativeGR_;
     // Isotopologues to use for constructing weights matrix
@@ -63,6 +59,10 @@ class XRaySQNode : public Node
     StructureFactors::NormalisationType referenceNormalisedTo_{StructureFactors::NoNormalisation};
     // Window function to use when Fourier transforming reference total F(Q) into g(r)
     WindowFunction::Form referenceWindowFunction_{WindowFunction::Form::Lorch0};
+    // Weighted S(Q)
+    std::optional<PartialSet> weightedSQ_;
+    // Weighted g(r)
+    std::optional<PartialSet> weightedGR_;
 
     public:
     // Returns the unweighted SQ


### PR DESCRIPTION
This PR modifies a fair number of nodes to include the necessary `addSerialisable()` calls for their "restartable" data (i.e. that which was tagged with `InRestartFile` in Dissolve1). It will be in draft until #2537 is complete as it depends on the serialisers implemented therein. There are several outstanding "exotic" serialisers that need to be written in order to make the coverage 100%, but these are captured in a separate issue (#2539) to be addressed in the very near future.