### PR TITLE
refactor: Graph & IterableGraph TOML roundtrip

### DIFF
--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -318,6 +318,7 @@ void Edge::deserialise(const SerialisedValue &node)
 void LoopEdge::serialise(std::string tag, SerialisedValue &target) const
 {
     definition().serialise(tag, target);
+    target[tag]["targetNode"] = "LoopBacks";
     target[tag]["analogue"] = analogue_;
 }
 

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -312,3 +312,13 @@ void Edge::deserialise(const SerialisedValue &node)
     throw std::runtime_error("Cannot directly deserialise edges.  Please contact the Dissolve development team if you are "
                              "seeing this error - this is a bug and NOT your fault.\n");
 }
+
+// Express as a serialisable value
+void LoopEdge::serialise(std::string tag, SerialisedValue &target) const
+{
+    definition().serialise(tag, target);
+    target[tag]["analogue"] = analogue_;
+}
+
+// Read values from a serialisable value
+void LoopEdge::deserialise(const SerialisedValue &node) { Edge::deserialise(node); }

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -3,6 +3,7 @@
 
 #include "nodes/edge.h"
 #include "nodes/graph.h"
+#include "nodes/inputs.h"
 #include "nodes/loopBack.h"
 #include "nodes/outputs.h"
 
@@ -38,11 +39,28 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
         Messenger::error("Source node '{}' does not exist in the graph.\n", definition.sourceNode);
         return {};
     }
+
     auto sourceOutput = sourceNode->findOutput(definition.sourceOutput);
     if (!sourceOutput)
     {
-        Messenger::error("Source node '{}' has no output parameter '{}'.\n", definition.sourceNode, definition.sourceOutput);
-        return {};
+        // If the source node is a Graph's own Inputs node, we will create an edge on the fly - else, throw an error
+        if (!dynamic_cast<InputsNode *>(sourceNode))
+        {
+            Messenger::error("Source node '{}' has no output parameter '{}'.\n", definition.sourceNode,
+                             definition.sourceOutput);
+            return {};
+        }
+
+        // The target node is the parent Graph's own Inputs node, so create a parameter link from the mapped input to the
+        // targetInput
+        auto targetNode = parent->findNode(definition.targetNode);
+        auto link = targetNode->findInput(definition.targetInput)->createParameterLink(definition.sourceOutput);
+        if (!parent->addProxyInput(link.inputParameter, link.outputParameter))
+        {
+            Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
+            return {};
+        }
+        sourceOutput = parent->proxyInputs().findOutput(definition.sourceOutput);
     }
 
     // Confirm that the source is actually an output
@@ -75,13 +93,19 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     {
         // The target node is a Graph: create a parameter link from the sourceOutput and from it a mapped input
         auto graphNode = dynamic_cast<Graph *>(targetNode);
-        auto link = sourceOutput->createParameterLink(definition.targetInput);
-        if (!graphNode->addProxyInput(link.inputParameter, link.outputParameter))
+        auto existingTargetInput = graphNode->findInput(definition.targetInput);
+        if (!existingTargetInput.get())
         {
-            Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
-            return {};
+            auto link = sourceOutput->createParameterLink(definition.targetInput);
+            if (!graphNode->addProxyInput(link.inputParameter, link.outputParameter))
+            {
+                Messenger::error("Failed to add mapped input '{}'.\n", definition.targetInput);
+                return {};
+            }
+            targetInput = link.inputParameter;
         }
-        targetInput = link.inputParameter;
+        else
+            targetInput = existingTargetInput;
     }
     else if (dynamic_cast<OutputsNode *>(targetNode))
     {

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -32,6 +32,7 @@ class EdgeConstructor : public Edge
 // Create an edge from the supplied definition
 std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definition)
 {
+    // Get target node
     auto targetNode = parent->findNode(definition.targetNode);
 
     // Get source node and output

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -32,6 +32,8 @@ class EdgeConstructor : public Edge
 // Create an edge from the supplied definition
 std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definition)
 {
+    auto targetNode = parent->findNode(definition.targetNode);
+
     // Get source node and output
     auto sourceNode = parent->findNode(definition.sourceNode);
     if (!sourceNode)
@@ -53,7 +55,6 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
 
         // The target node is the parent Graph's own Inputs node, so create a parameter link from the mapped input to the
         // targetInput
-        auto targetNode = parent->findNode(definition.targetNode);
         auto link = targetNode->findInput(definition.targetInput)->createParameterLink(definition.sourceOutput);
         if (!parent->addProxyInput(link.inputParameter, link.outputParameter))
         {
@@ -72,7 +73,6 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     }
 
     // Get target node and input
-    auto targetNode = parent->findNode(definition.targetNode);
     if (!targetNode)
     {
         Messenger::error("Target node '{}' does not exist in the graph.\n", definition.targetNode);

--- a/src/nodes/edge.cpp
+++ b/src/nodes/edge.cpp
@@ -34,6 +34,18 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
 {
     // Get target node
     auto targetNode = parent->findNode(definition.targetNode);
+    if (!targetNode)
+    {
+        Messenger::error("Target node '{}' does not exist in the graph.\n", definition.targetNode);
+        return {};
+    }
+
+    // Disallow circular edges (mostly a check for Graph -> Graph connections)
+    if (targetNode == parent)
+    {
+        Messenger::error("Target node is graph '{}' and cannot be the owner of the edge.", definition.targetNode);
+        return {};
+    }
 
     // Get source node and output
     auto sourceNode = parent->findNode(definition.sourceNode);
@@ -70,20 +82,6 @@ std::unique_ptr<Edge> Edge::create(Graph *parent, const EdgeDefinition &definiti
     {
         Messenger::error("Source node '{}' has parameter '{}' but it is not an output.\n", definition.sourceNode,
                          definition.sourceOutput);
-        return {};
-    }
-
-    // Get target node and input
-    if (!targetNode)
-    {
-        Messenger::error("Target node '{}' does not exist in the graph.\n", definition.targetNode);
-        return {};
-    }
-
-    // Disallow circular edges (mostly a check for Graph -> Graph connections)
-    if (targetNode == parent)
-    {
-        Messenger::error("Target node is graph '{}' and cannot be the owner of the edge.", definition.targetNode);
         return {};
     }
 

--- a/src/nodes/edge.h
+++ b/src/nodes/edge.h
@@ -115,4 +115,13 @@ class LoopEdge : public Edge
      *
      */
     ParameterBase *analogue_;
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -45,6 +45,8 @@ void IterableGraph::setLoopBacks()
 
     for (const auto &[name, param] : sources)
         loopBacks_->inputs().insert_or_assign(name, param);
+
+    auto res = true;
 }
 
 // Release loopback by name
@@ -128,23 +130,28 @@ Edge *IterableGraph::removeOutputLoopEdge(std::string_view sourceOutput, Edge *e
 // Add edge between nodes
 bool IterableGraph::addEdge(const EdgeDefinition &definition)
 {
-    if (dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)))
-        setLoopBacks();
-    else if (loopBacks_->findInput(definition.targetInput))
-    {
-        auto edge =
-            Edge::create(this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
-        if (!edge)
-            return false;
+    // Refresh the graph loopbacks
+    setLoopBacks();
 
-        loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
+    // Check if the connection is invertible.
+    // Invertibility is satisfied when the source node (internal to the graph) can output to an existing loopback,
+    // which discounts any edge for which no loopbacks correspond to the target input, as well as the graphs own InputsNode.
+    auto nonInvertibleNode = dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)) ||
+                             !loopBacks_->findInput(definition.targetInput);
 
-        addOutputLoopEdge(definition.sourceOutput, loopEdges_.back().get());
+    // If not invertible, create and return a standard edge
+    if (nonInvertibleNode)
+        return Graph::addEdge(definition);
 
-        return true;
-    }
+    // Create loop edge
+    auto edge =
+        Edge::create(this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
+    if (!edge)
+        return false;
 
-    return Graph::addEdge(definition);
+    loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
+
+    return addOutputLoopEdge(definition.sourceOutput, loopEdges_.back().get());
 }
 
 // Remove edge between nodes

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -87,6 +87,14 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
     return {};
 }
 
+// Add edge between nodes
+bool IterableGraph::addLoopEdge(std::unique_ptr<Edge> edge, std::string_view source)
+{
+    loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
+
+    return addOutputLoopEdge(source, loopEdges_.back().get());
+}
+
 // Add edge to node map
 Edge *IterableGraph::addOutputLoopEdge(std::string_view sourceOutput, Edge *edge)
 {
@@ -136,11 +144,11 @@ bool IterableGraph::addEdge(const EdgeDefinition &definition)
     // Check if the connection is invertible.
     // Invertibility is satisfied when the source node (internal to the graph) can output to an existing loopback,
     // which discounts any edge for which no loopbacks correspond to the target input, as well as the graphs own InputsNode.
-    auto nonInvertibleNode = dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)) ||
-                             !loopBacks_->findInput(definition.targetInput);
+    auto nonInvertible = dynamic_cast<InputsNode *>(parentGraph()->findNode(definition.sourceNode)) ||
+                         !loopBacks_->findInput(definition.targetInput);
 
     // If not invertible, create and return a standard edge
-    if (nonInvertibleNode)
+    if (nonInvertible)
         return Graph::addEdge(definition);
 
     // Create loop edge
@@ -149,9 +157,7 @@ bool IterableGraph::addEdge(const EdgeDefinition &definition)
     if (!edge)
         return false;
 
-    loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
-
-    return addOutputLoopEdge(definition.sourceOutput, loopEdges_.back().get());
+    return addLoopEdge(std::move(edge), definition.sourceOutput);
 }
 
 // Remove edge between nodes
@@ -189,4 +195,33 @@ NodeConstants::ProcessResult IterableGraph::process()
     }
 
     return NodeConstants::ProcessResult::Success;
+}
+
+/*
+ * Serialisation
+ */
+
+// Express as a serialisable value
+void IterableGraph::serialise(std::string tag, SerialisedValue &target) const
+{
+    Graph::serialise(tag, target);
+    auto &result = target[tag];
+    fromVector(loopEdges_, "loopEdges", result);
+}
+
+// Read values from a serialisable value
+void IterableGraph::deserialise(const SerialisedValue &node)
+{
+    Graph::deserialise(node);
+    toVector(node, "loopEdges",
+             [this](const auto &value)
+             {
+                 auto definition = toml::get<EdgeDefinition>(value);
+                 auto edge = Edge::create(
+                     this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
+                 if (!edge)
+                     return false;
+
+                 return addLoopEdge(std::move(edge), definition.sourceOutput);
+             });
 }

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -213,8 +213,8 @@ void IterableGraph::deserialise(const SerialisedValue &node)
              [this](const auto &value)
              {
                  auto definition = toml::get<EdgeDefinition>(value);
-                 auto edge =
-                     Edge::create(this, {definition.sourceNode, definition.sourceOutput, "LoopBacks", definition.targetInput});
+                 auto edge = Edge::create(
+                     this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
                  if (!edge)
                      return false;
 

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -88,9 +88,7 @@ LoopEdge *IterableGraph::findLoopEdge(const EdgeDefinition &definition) const
 // Add edge between nodes
 bool IterableGraph::addLoopEdge(std::unique_ptr<Edge> edge, std::string_view source)
 {
-    loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs()));
-
-    return addOutputLoopEdge(source, loopEdges_.back().get());
+    return addOutputLoopEdge(source, loopEdges_.emplace_back(LoopEdge::makeLoopEdge(edge.release(), proxyInputs())).get());
 }
 
 // Add edge to node map

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -45,8 +45,6 @@ void IterableGraph::setLoopBacks()
 
     for (const auto &[name, param] : sources)
         loopBacks_->inputs().insert_or_assign(name, param);
-
-    auto res = true;
 }
 
 // Release loopback by name

--- a/src/nodes/iterableGraph.cpp
+++ b/src/nodes/iterableGraph.cpp
@@ -215,8 +215,8 @@ void IterableGraph::deserialise(const SerialisedValue &node)
              [this](const auto &value)
              {
                  auto definition = toml::get<EdgeDefinition>(value);
-                 auto edge = Edge::create(
-                     this, {definition.sourceNode, definition.sourceOutput, definition.targetNode, definition.targetInput});
+                 auto edge =
+                     Edge::create(this, {definition.sourceNode, definition.sourceOutput, "LoopBacks", definition.targetInput});
                  if (!edge)
                      return false;
 

--- a/src/nodes/iterableGraph.h
+++ b/src/nodes/iterableGraph.h
@@ -46,6 +46,8 @@ class IterableGraph : public Graph
     void releaseLoopBack(const std::string &name);
 
     private:
+    // Add edge between nodes
+    bool addLoopEdge(std::unique_ptr<Edge> edge, std::string_view source);
     // Add edge to node map
     Edge *addOutputLoopEdge(std::string_view sourceOutput, Edge *edge);
     // Remove edge from node map
@@ -80,4 +82,13 @@ class IterableGraph : public Graph
     protected:
     // Perform processing
     NodeConstants::ProcessResult process() override;
+
+    /*
+     * Serialisation
+     */
+    public:
+    // Express as a serialisable value
+    void serialise(std::string tag, SerialisedValue &target) const override;
+    // Read values from a serialisable value
+    void deserialise(const SerialisedValue &node) override;
 };

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -7,6 +7,7 @@
 #include "nodes/numberNode.h"
 #include "nodes/outputs.h"
 #include "nodes/registry.h"
+#include "tests/testGraphFixture.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -37,39 +38,52 @@ class IterableGraphTest : public ::testing::Test
 
         // Create nodes
         i_ = dynamic_cast<NumberNode *>(root_.createNode("Number", "i"));
-        loop_ = dynamic_cast<IterableGraph *>(root_.createNode("Iterator", "Iterator"));
-        x_ = dynamic_cast<AddNode *>(loop_->createNode("Add", "x"));
+        loopGraph_ = dynamic_cast<IterableGraph *>(root_.createNode("Iterator", "Iterator"));
+        x_ = dynamic_cast<AddNode *>(loopGraph_->createNode("Add", "x"));
         y_ = dynamic_cast<AddNode *>(root_.createNode("Add", "y"));
 
         ASSERT_TRUE(i_);
         ASSERT_TRUE(x_);
         ASSERT_TRUE(y_);
-        ASSERT_TRUE(loop_);
+        ASSERT_TRUE(loopGraph_);
 
         ASSERT_EQ(i_->name(), "i");
         ASSERT_EQ(x_->name(), "x");
         ASSERT_EQ(y_->name(), "y");
-        ASSERT_EQ(loop_->name(), "Iterator");
+        ASSERT_EQ(loopGraph_->name(), "Iterator");
 
         // Create edge connections
         // - Number 'i' is a dynamic input to the IterableGraph - we'll call the input "I"
         EXPECT_TRUE(root_.addEdge({"i", "X", "Iterator", "I"}));
         // - Add 'x' takes the IterableGraph input "I" as its parameter "X"
-        EXPECT_TRUE(loop_->addEdge({"Inputs", "I", "x", "X"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"Inputs", "I", "x", "X"}));
         // - Result from Add 'x' goes to graph output (which we will call "C") as well as loopback to "I"
-        EXPECT_TRUE(loop_->addEdge({"x", "Result", "Outputs", "C"}));
-        EXPECT_TRUE(loop_->addEdge({"x", "Result", "LoopBacks", "I"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"x", "Result", "Outputs", "C"}));
+        EXPECT_TRUE(loopGraph_->addEdge({"x", "Result", "LoopBacks", "I"}));
         // - The output "C" of the loop graph then goes to input "X" of Add 'y'
         EXPECT_TRUE(root_.addEdge({"Iterator", "C", "y", "X"}));
     }
 
     protected:
     // We need a CoreData and Dissolve definition to properly instantiate DissolveGraph at present.
-    DissolveGraph root_;
+    TestGraph root_;
     NumberNode *i_{nullptr};
     AddNode *x_{nullptr}, *y_{nullptr};
-    IterableGraph *loop_{nullptr};
+    IterableGraph *loopGraph_{nullptr};
 };
+
+TEST_F(IterableGraphTest, RoundTrip)
+{
+    createGraph();
+
+    // Serialised graph TOML
+    SerialisedValue graphTOML_;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML_));
+
+    // Deserialise from the stored TOML
+    auto deserialisedGraph = std::make_unique<DissolveGraph>();
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML_["graph"]));
+}
 
 TEST_F(IterableGraphTest, BasicNonLoopingSeries)
 {
@@ -184,7 +198,7 @@ TEST_F(IterableGraphTest, NoRun)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     nLoops->set<Number>(0);
@@ -194,13 +208,13 @@ TEST_F(IterableGraphTest, NoRun)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(x_->versionIndex(), NodeConstants::InvalidVersion);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), NodeConstants::InvalidVersion);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
 }
 
 TEST_F(IterableGraphTest, NoFeedback)
@@ -219,7 +233,7 @@ TEST_F(IterableGraphTest, NoFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     // Zero iterations: We expect 1 + (xB = 1) = 1 + 1 = 2
@@ -230,13 +244,13 @@ TEST_F(IterableGraphTest, NoFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 0);
     EXPECT_EQ(x_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 0);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), NodeConstants::InvalidVersion);
 }
 
 TEST_F(IterableGraphTest, SingleFeedback)
@@ -255,7 +269,7 @@ TEST_F(IterableGraphTest, SingleFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     // One iteration: We expect (LB = 2) + (xB = 1) = 2 + 1 = 3
@@ -266,13 +280,13 @@ TEST_F(IterableGraphTest, SingleFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 1);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 1);
     EXPECT_EQ(x_->versionIndex(), 1);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 1);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 1);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 0
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 0);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 0);
 }
 
 TEST_F(IterableGraphTest, ExtendedFeedback)
@@ -291,7 +305,7 @@ TEST_F(IterableGraphTest, ExtendedFeedback)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     /*
@@ -318,27 +332,27 @@ TEST_F(IterableGraphTest, ExtendedFeedback)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 9);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 9);
     EXPECT_EQ(x_->versionIndex(), 9);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 9);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 9);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration i > 1
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 8);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 8);
 }
 
 TEST_F(IterableGraphTest, ReleaseLoopBack)
 {
     createGraph();
 
-    const auto nEdges = loop_->edges().size();
+    const auto nEdges = loopGraph_->edges().size();
 
-    auto flagged = loop_->proxyInputs().findOutput("I");
+    auto flagged = loopGraph_->proxyInputs().findOutput("I");
 
-    loop_->removeEdge({"x", "Result", "LoopBacks", "I"});
+    loopGraph_->removeEdge({"x", "Result", "LoopBacks", "I"});
 
-    ASSERT_EQ(loop_->loopEdges().size(), 0);
-    ASSERT_EQ(loop_->edges().size(), nEdges);
+    ASSERT_EQ(loopGraph_->loopEdges().size(), 0);
+    ASSERT_EQ(loopGraph_->edges().size(), nEdges);
 }
 
 TEST_F(IterableGraphTest, UpstreamChange)
@@ -357,7 +371,7 @@ TEST_F(IterableGraphTest, UpstreamChange)
     EXPECT_TRUE(iA);
     iA->set<Number>(1);
 
-    auto nLoops = loop_->findOption("N");
+    auto nLoops = loopGraph_->findOption("N");
     EXPECT_TRUE(nLoops);
 
     /*
@@ -373,14 +387,14 @@ TEST_F(IterableGraphTest, UpstreamChange)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 0);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 99);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 99);
     EXPECT_EQ(x_->versionIndex(), 99);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 99);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 99);
     EXPECT_EQ(y_->versionIndex(), 0);
 
     // Loopbacks node only runs on iteration 0 < i <= nLoops
     // (in 100 runs, loop backs up version 99 times, starting from -1)
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 98);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 98);
 
     /*
      * Alter upstream number node and run for another 100 iterations
@@ -395,14 +409,14 @@ TEST_F(IterableGraphTest, UpstreamChange)
 
     // Check node versioning
     EXPECT_EQ(i_->versionIndex(), 1);
-    EXPECT_EQ(loop_->proxyInputs().versionIndex(), 199);
+    EXPECT_EQ(loopGraph_->proxyInputs().versionIndex(), 199);
     EXPECT_EQ(x_->versionIndex(), 199);
-    EXPECT_EQ(loop_->proxyOutputs().versionIndex(), 199);
+    EXPECT_EQ(loopGraph_->proxyOutputs().versionIndex(), 199);
     EXPECT_EQ(y_->versionIndex(), 1);
 
     // Loopbacks node only runs on iteration 0 < i <= nLoops
     // (after another 100 runs, loop backs up version a further 99 times, starting from 98)
-    EXPECT_EQ(loop_->loopBacks()->versionIndex(), 197);
+    EXPECT_EQ(loopGraph_->loopBacks()->versionIndex(), 197);
 }
 
 } // namespace UnitTest

--- a/tests/nodes/loop.cpp
+++ b/tests/nodes/loop.cpp
@@ -77,12 +77,17 @@ TEST_F(IterableGraphTest, RoundTrip)
     createGraph();
 
     // Serialised graph TOML
-    SerialisedValue graphTOML_;
-    ASSERT_NO_THROW(root_.serialise("graph", graphTOML_));
+    SerialisedValue graphTOML;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
 
     // Deserialise from the stored TOML
     auto deserialisedGraph = std::make_unique<DissolveGraph>();
-    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML_["graph"]));
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
+
+    // Complete round trip - re-serialise the result and compare it to the original TOML
+    SerialisedValue compareTOML;
+    ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
+    ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
 }
 
 TEST_F(IterableGraphTest, BasicNonLoopingSeries)

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -83,6 +83,34 @@ class SubGraphTest : public ::testing::Test
     std::shared_ptr<ParameterBase> wB_{nullptr};
 };
 
+TEST_F(SubGraphTest, RoundTrip)
+{
+    createGraph();
+
+    // Create a mapped input on GraphA by creating an edge to it
+    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
+
+    // Connect the mapped input on GraphA internally to it's "z" node
+    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
+
+    // Connect y result to z
+    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
+
+    // Connect z result to graphA output, creating a mapped output
+    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
+
+    // Connect GraphA mapped output "D" to node "w"
+    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+
+    // Serialised graph TOML
+    SerialisedValue graphTOML_;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML_));
+
+    // Deserialise from the stored TOML
+    auto deserialisedGraph = std::make_unique<DissolveGraph>();
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML_["graph"]));
+}
+
 TEST_F(SubGraphTest, Serialisation){
     //    createGraph();
     //

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -72,6 +72,21 @@ class SubGraphTest : public ::testing::Test
         wB_ = w_->findInput("Y");
         ASSERT_TRUE(wB_);
         wB_->set(Number{5});
+
+        // Create a mapped input on GraphA by creating an edge to it
+        EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
+
+        // Connect the mapped input on GraphA internally to it's "z" node
+        EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
+
+        // Connect y result to z
+        EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
+
+        // Connect z result to graphA output, creating a mapped output
+        EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
+
+        // Connect GraphA mapped output "D" to node "w"
+        EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
     }
 
     protected:
@@ -106,8 +121,6 @@ class SubGraphTest : public ::testing::Test
 TEST_F(SubGraphTest, RoundTrip)
 {
     createGraph();
-
-    connect();
 
     // Serialised graph TOML
     SerialisedValue graphTOML;
@@ -144,15 +157,11 @@ TEST_F(SubGraphTest, Serialisation){
 TEST_F(SubGraphTest, Connections)
 {
     createGraph();
-
-    connect();
 }
 
 TEST_F(SubGraphTest, Flow)
 {
     createGraph();
-
-    connect();
 
     // Run w - all nodes should update
     EXPECT_EQ(w_->run(), NodeConstants::ProcessResult::Success);

--- a/tests/nodes/subGraph.cpp
+++ b/tests/nodes/subGraph.cpp
@@ -4,6 +4,7 @@
 #include "nodes/add.h"
 #include "nodes/dissolve.h"
 #include "nodes/number.h"
+#include "tests/testing.h"
 #include <gtest/gtest.h>
 
 namespace UnitTest
@@ -81,34 +82,45 @@ class SubGraphTest : public ::testing::Test
     std::shared_ptr<ParameterBase> xA_{nullptr}, xB_{nullptr};
     std::shared_ptr<ParameterBase> yA_{nullptr}, yB_{nullptr};
     std::shared_ptr<ParameterBase> wB_{nullptr};
+
+    // Basic sub-graph connection test
+    void connect()
+    {
+        // Create a mapped input on GraphA by creating an edge to it
+        EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
+
+        // Connect the mapped input on GraphA internally to it's "z" node
+        EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
+
+        // Connect y result to z
+        EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
+
+        // Connect z result to graphA output, creating a mapped output
+        EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
+
+        // Connect GraphA mapped output "D" to node "w"
+        EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+    }
 };
 
 TEST_F(SubGraphTest, RoundTrip)
 {
     createGraph();
 
-    // Create a mapped input on GraphA by creating an edge to it
-    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
-
-    // Connect the mapped input on GraphA internally to it's "z" node
-    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
-
-    // Connect y result to z
-    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
-
-    // Connect z result to graphA output, creating a mapped output
-    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
-
-    // Connect GraphA mapped output "D" to node "w"
-    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+    connect();
 
     // Serialised graph TOML
-    SerialisedValue graphTOML_;
-    ASSERT_NO_THROW(root_.serialise("graph", graphTOML_));
+    SerialisedValue graphTOML;
+    ASSERT_NO_THROW(root_.serialise("graph", graphTOML));
 
     // Deserialise from the stored TOML
     auto deserialisedGraph = std::make_unique<DissolveGraph>();
-    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML_["graph"]));
+    ASSERT_NO_THROW(deserialisedGraph->deserialise(graphTOML["graph"]));
+
+    // Complete round trip - re-serialise the result and compare it to the original TOML
+    SerialisedValue compareTOML;
+    ASSERT_NO_THROW(deserialisedGraph->serialise("graph", compareTOML));
+    ASSERT_NO_THROW(UnitTest::compareToml("", graphTOML, compareTOML));
 }
 
 TEST_F(SubGraphTest, Serialisation){
@@ -133,40 +145,14 @@ TEST_F(SubGraphTest, Connections)
 {
     createGraph();
 
-    // Create a mapped input on GraphA by creating an edge to it
-    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
-
-    // Connect the mapped input on GraphA internally to it's "z" node
-    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
-
-    // Connect y result to z
-    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
-
-    // Connect z result to graphA output, creating a mapped output
-    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
-
-    // Connect GraphA mapped output "D" to node "w"
-    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+    connect();
 }
 
 TEST_F(SubGraphTest, Flow)
 {
     createGraph();
 
-    // Create a mapped input on GraphA by creating an edge to it
-    EXPECT_TRUE(root_.addEdge({"x", "Result", "GraphA", "C"}));
-
-    // Connect the mapped input on GraphA internally to it's "z" node
-    EXPECT_TRUE(graphA_->addEdge({"Inputs", "C", "z", "X"}));
-
-    // Connect y result to z
-    EXPECT_TRUE(graphA_->addEdge({"y", "Result", "z", "Y"}));
-
-    // Connect z result to graphA output, creating a mapped output
-    EXPECT_TRUE(graphA_->addEdge({"z", "Result", "Outputs", "D"}));
-
-    // Connect GraphA mapped output "D" to node "w"
-    EXPECT_TRUE(root_.addEdge({"GraphA", "D", "w", "X"}));
+    connect();
 
     // Run w - all nodes should update
     EXPECT_EQ(w_->run(), NodeConstants::ProcessResult::Success);

--- a/tests/testing.cpp
+++ b/tests/testing.cpp
@@ -427,9 +427,12 @@ void compareToml(std::string location, SerialisedValue toml, SerialisedValue tom
     if (toml.is_table())
     {
         ASSERT_TRUE(toml2.is_table()) << location;
+        auto tab1 = toml.as_table();
+        auto tab2 = toml2.as_table();
         for (auto &[k, v] : toml.as_table())
         {
-            ASSERT_TRUE(toml2.contains(k)) << location << "." << k << std::endl << "Expected:" << std::endl << toml[k];
+            auto result = toml2.contains(k);
+            ASSERT_TRUE(result) << location << "." << k << std::endl << "Expected:" << std::endl << toml[k];
             compareToml(std::format("{}.{}", location, k), v, toml2.at(k));
         }
     }


### PR DESCRIPTION
There's a couple of things going on in this PR, all with the purpose of fixing deserialisation of `IterableGraph` from TOML:

- The problem was in the first instance that deserialisation builds out the graph in the 'opposite' direction to how we typically construct them manually*, such that when it comes to parsing a 'sub'-graph (such as any graph containing an instance of `IterableGraph`), the edges that depend on external nodes connected to the sub-`InputsNode` basically fail to materialise, since they have no awareness of any such data source. Upon closer analysis it was found that this was a problem occuring for deserialisation of _any_ `Graph` node, iterable or otherwise. This issue has been fixed in this PR, so a TOML roundtrip is possible for the `SubGraph` test. This exact problem would have been the root cause of the `IterableGraph` loop edges not being parsed, however...
- ...it turns out that no specialised de/serialisation code had ever been written for `IterableGraph` and `LoopEdge` classes, so the `loopEdges_` were never parsed anyway. This has also been fixed, and there are new tests for this.

*it should be noted that after implementing these changes, it should in theory be possible for a user to manually construct a nested graph from the inside-out without having yet emplaced the relevant external nodes! It may however require some further GUI work where, for instance, hovering an edge over a graph's `InputsNode` triggers the edge creation, whether or not any (proxy) inputs exist or not.