### PR TITLE
refactor: Simplify box creation

### DIFF
--- a/benchmark/classes/box.cpp
+++ b/benchmark/classes/box.cpp
@@ -11,29 +11,19 @@ namespace Benchmarks
 {
 Box createTestBox(Box::BoxType boxType)
 {
-    if (boxType == Box::BoxType::Cubic)
+    switch (boxType)
     {
-        double lengths = 1.00;
-        return Box::cubic(lengths);
+        case (Box::BoxType::Cubic):
+            return Box({1.0, 1.0, 1.0});
+        case (Box::BoxType::Orthorhombic):
+            return Box({1.0, 2.0, 3.0});
+        case (Box::BoxType::MonoclinicAlpha):
+            return Box({1.0, 1.0, 1.0}, {45.0, 90.0, 90.0});
+        case (Box::BoxType::Triclinic):
+            return Box({1.0, 1.0, 1.0}, {45.0, 60.0, 80.0});
+        default:
+            throw std::runtime_error("Invalid box type");
     }
-    else if (boxType == Box::BoxType::Orthorhombic)
-    {
-        Vector3 lengths(1.00, 1.00, 1.00);
-        return Box::orthorhombic(lengths);
-    }
-    else if (boxType == Box::BoxType::MonoclinicAlpha)
-    {
-        Vector3 lengths(1.00, 1.00, 1.00);
-        return Box::monoclinicAlpha(lengths, 45);
-    }
-    else if (boxType == Box::BoxType::Triclinic)
-    {
-        Vector3 lengths(1.00, 1.00, 1.00);
-        Vector3 angles(45, 45, 45);
-        return Box::triclinic(lengths, angles);
-    }
-    else
-        throw std::runtime_error("Invalid box type");
 }
 
 static void BM_Box_MinimumImage(benchmark::State &state, Box::BoxType t)

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -284,7 +284,7 @@ inline void Box::toReal(Vector3 &r) const
             r.z *= axesArray_[8];
             break;
         case BoxType::None:
-            break; // Single Image performs no conversion
+            break;
     }
 }
 
@@ -336,7 +336,7 @@ inline void Box::toFractional(Vector3 &r) const
             r.z *= inverseAxesArray_[8];
             break;
         case BoxType::None:
-            break; // Single Image performs no conversion
+            break;
     }
 }
 

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -397,14 +397,6 @@ Box Box::generate(Vector3 lengths, std::optional<Vector3> angles, bool nonPeriod
         angles = {90.0, 90.0, 90.0};
     return nonPeriodic ? Box(Box::BoxType::None, lengths, *angles) : Box::generate(lengths, *angles);
 }
-Box Box::generate(Vector3 lengths, Vector3 angles)
-{
-    auto boxType = type(lengths, angles);
-    if (!boxType)
-        Messenger::exception("Suitable box type couldn't be determined, so no Box can be generated.");
-
-    return Box(*boxType, lengths, angles);
-}
 
 // Generate Boxes of a given type
 Box Box::none() { return Box(Box::BoxType::None, Vector3{0, 0, 0}, Vector3{0.0, 0.0, 0.0}); }

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -44,7 +44,6 @@ Box::Box(const Box &other)
     inverseAxes_ = other.inverseAxes_;
     inverseAxesArray_ = other.inverseAxesArray_;
     reciprocalAxes_ = other.reciprocalAxes_;
-    periodic_ = other.periodic_;
     volume_ = other.volume_;
     reciprocalVolume_ = other.reciprocalVolume_;
 }
@@ -69,9 +68,6 @@ void Box::initialise(const Vector3 &lengths, const Vector3 &angles)
 
     // Determine box type
     type_ = type(lengths, angles);
-
-    // Set periodicity flags
-    periodic_ = {type_ != BoxType::None, type_ != BoxType::None, type_ != BoxType::None};
 
     // Construct axes matrix
     axes_.setIdentity();
@@ -570,5 +566,4 @@ void Box::serialise(std::string tag, SerialisedValue &target) const
     auto &box = target[tag];
     box["lengths"] = {a_, b_, c_};
     box["angles"] = {alpha_, beta_, gamma_};
-    box["nonPeriodic"] = {!std::get<0>(periodic_), !std::get<1>(periodic_), !std::get<2>(periodic_)};
 }

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -5,10 +5,71 @@
 #include "classes/cell.h"
 #include "math/mathFunc.h"
 
-Box::Box(Box::BoxType boxType, const Vector3 lengths, const Vector3 angles)
-    : type_(boxType), a_(lengths.x), b_(lengths.y), c_(lengths.z), ra_(1.0 / lengths.x), rb_(1.0 / lengths.y),
-      rc_(1.0 / lengths.z), alpha_(angles.x), beta_(angles.y), gamma_(angles.z)
+Box::Box(const Vector3 &lengths, const Vector3 &angles) { initialise(lengths, angles); }
+
+Box::Box(const Matrix3 &axes)
 {
+    // Calculate cell lengths
+    Vector3 lengths(axes.columnMagnitude(0), axes.columnMagnitude(1), axes.columnMagnitude(2));
+
+    // Calculate cell angles
+
+    auto vecx = axes.columnAsVec3(0);
+    auto vecy = axes.columnAsVec3(1);
+    auto vecz = axes.columnAsVec3(2);
+    vecx.normalise();
+    vecy.normalise();
+    vecz.normalise();
+
+    Vector3 angles(acos(vecy.dp(vecz)), acos(vecx.dp(vecz)), acos(vecx.dp(vecy)));
+    angles.toDegrees();
+
+    initialise(lengths, angles);
+}
+
+Box::Box(const Box &other)
+{
+    type_ = other.type_;
+    a_ = other.a_;
+    b_ = other.b_;
+    c_ = other.c_;
+    ra_ = other.ra_;
+    rb_ = other.rb_;
+    rc_ = other.rc_;
+    alpha_ = other.alpha_;
+    beta_ = other.beta_;
+    gamma_ = other.gamma_;
+    axes_ = other.axes_;
+    axesArray_ = other.axesArray_;
+    inverseAxes_ = other.inverseAxes_;
+    inverseAxesArray_ = other.inverseAxesArray_;
+    reciprocalAxes_ = other.reciprocalAxes_;
+    periodic_ = other.periodic_;
+    volume_ = other.volume_;
+    reciprocalVolume_ = other.reciprocalVolume_;
+}
+
+/*
+ * Basic Definition
+ */
+
+// Initialise the box with the supplied lengths and angles
+void Box::initialise(const Vector3 &lengths, const Vector3 &angles)
+{
+    // Set basic values
+    a_ = lengths.x;
+    b_ = lengths.y;
+    c_ = lengths.z;
+    ra_ = 1.0 / lengths.x;
+    rb_ = 1.0 / lengths.y;
+    rc_ = 1.0 / lengths.z;
+    alpha_ = angles.x;
+    beta_ = angles.y;
+    gamma_ = angles.z;
+
+    // Determine box type
+    type_ = type(lengths, angles);
+
     // Set periodicity flags
     periodic_ = {type_ != BoxType::None, type_ != BoxType::None, type_ != BoxType::None};
 
@@ -66,32 +127,6 @@ Box::Box(Box::BoxType boxType, const Vector3 lengths, const Vector3 angles)
     reciprocalVolume_ = (reciprocalAxes_.columnAsVec3(1) * reciprocalAxes_.columnAsVec3(2)).dp(reciprocalAxes_.columnAsVec3(0));
 }
 
-Box::Box(const Box &other)
-{
-    type_ = other.type_;
-    a_ = other.a_;
-    b_ = other.b_;
-    c_ = other.c_;
-    ra_ = other.ra_;
-    rb_ = other.rb_;
-    rc_ = other.rc_;
-    alpha_ = other.alpha_;
-    beta_ = other.beta_;
-    gamma_ = other.gamma_;
-    axes_ = other.axes_;
-    axesArray_ = other.axesArray_;
-    inverseAxes_ = other.inverseAxes_;
-    inverseAxesArray_ = other.inverseAxesArray_;
-    reciprocalAxes_ = other.reciprocalAxes_;
-    periodic_ = other.periodic_;
-    volume_ = other.volume_;
-    reciprocalVolume_ = other.reciprocalVolume_;
-}
-
-/*
- * Basic Definition
- */
-
 // Return enum options for BoxType
 EnumOptions<Box::BoxType> Box::boxTypes()
 {
@@ -108,11 +143,11 @@ EnumOptions<Box::BoxType> Box::boxTypes()
 Box::BoxType Box::type() const { return type_; }
 
 // Determine Box type
-std::optional<Box::BoxType> Box::type(Vector3 lengths, Vector3 angles)
+Box::BoxType Box::type(const Vector3 &lengths, const Vector3 &angles)
 {
     // Check lengths
     if (lengths.min() < 1.0e-5 || angles.min() < 1.0)
-        return {};
+        return BoxType::None;
 
     // Determine any right angles
     auto rightAlpha = (fabs(angles.x - 90.0) < 1.0e-5);
@@ -390,41 +425,12 @@ double Box::torsionInRadians(const Vector3 &i, const Vector3 &j, const Vector3 &
  * Utility Routines
  */
 
-// Generate a suitable Box given the supplied relative lengths, angles
-Box Box::generate(Vector3 lengths, std::optional<Vector3> angles, bool nonPeriodic)
-{
-    if (!angles)
-        angles = {90.0, 90.0, 90.0};
-    return nonPeriodic ? Box(Box::BoxType::None, lengths, *angles) : Box::generate(lengths, *angles);
-}
-
-// Generate Boxes of a given type
-Box Box::none() { return Box(Box::BoxType::None, Vector3{0, 0, 0}, Vector3{0.0, 0.0, 0.0}); }
-
-Box Box::cubic(double length) { return Box(Box::BoxType::Cubic, Vector3{length, length, length}, Vector3{90.0, 90.0, 90.0}); }
-
-Box Box::orthorhombic(const Vector3 &lengths) { return Box(Box::BoxType::Orthorhombic, lengths, Vector3{90.0, 90.0, 90.0}); }
-
-Box Box::monoclinicAlpha(const Vector3 &lengths, double alpha)
-{
-    return Box(Box::BoxType::MonoclinicAlpha, lengths, Vector3{alpha, 90.0, 90.0});
-}
-
-Box Box::monoclinicBeta(const Vector3 &lengths, double beta)
-{
-    return Box(Box::BoxType::MonoclinicBeta, lengths, Vector3{90.0, beta, 90.0});
-}
-
-Box Box::monoclinicGamma(const Vector3 &lengths, double gamma)
-{
-    return Box(Box::BoxType::MonoclinicGamma, lengths, Vector3{90.0, 90.0, gamma});
-}
-
-Box Box::triclinic(const Vector3 &lengths, const Vector3 &angles) { return Box(Box::BoxType::Triclinic, lengths, angles); }
-
 // Return radius of largest possible inscribed sphere for box
 double Box::inscribedSphereRadius() const
 {
+    if (type_ == BoxType::None)
+        return 0.0;
+
     // Radius of largest inscribed sphere is the smallest of the three calculated values....
     double mag, diameter, result = 0.0;
     Vector3 cross;

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -8,13 +8,6 @@
 #include "math/matrix3.h"
 #include "math/vector3.h"
 
-#include <map>
-#include <vector>
-
-// Forward Declarations
-class Cell;
-class Data1D;
-
 // Basic Box Definition
 class Box : public Serialisable
 {

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -145,7 +145,6 @@ class Box : public Serialisable
     public:
     // Generate a suitable Box given the supplied relative lengths, angles, and volume
     static Box generate(Vector3 lengths, std::optional<Vector3> angles = {}, bool nonPeriodic = false);
-    static Box generate(Vector3 lengths, Vector3 angles);
     // Generate Boxes of a given type
     static Box none();
     static Box cubic(double length);

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -32,7 +32,7 @@ class Box : public Serialisable
     };
     // Return enum options for BoxType
     static EnumOptions<BoxType> boxTypes();
-    Box(Box::BoxType boxType, const Vector3 lengths, const Vector3 angles);
+    Box(Box::BoxType boxType, Vector3 lengths, Vector3 angles);
     Box(const Box &other);
     ~Box() = default;
     Box &operator=(const Box &source) = default;

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -32,7 +32,9 @@ class Box : public Serialisable
     };
     // Return enum options for BoxType
     static EnumOptions<BoxType> boxTypes();
-    Box(Box::BoxType boxType, Vector3 lengths, Vector3 angles);
+    Box() = default;
+    Box(const Vector3 &lengths, const Vector3 &angles = {90.0, 90.0, 90.0});
+    Box(const Matrix3 &axes);
     Box(const Box &other);
     ~Box() = default;
     Box &operator=(const Box &source) = default;
@@ -42,7 +44,7 @@ class Box : public Serialisable
      */
     protected:
     // Box type
-    BoxType type_;
+    BoxType type_{BoxType::None};
     // Box lengths
     double a_, b_, c_;
     // Reciprocal Box lengths
@@ -62,15 +64,19 @@ class Box : public Serialisable
     // Reciprocal axes
     Matrix3 reciprocalAxes_;
     // Volume
-    double volume_;
+    double volume_{0.0};
     // Reciprocal volume
-    double reciprocalVolume_;
+    double reciprocalVolume_{0.0};
+
+    private:
+    // Initialise the box with the supplied lengths and angles
+    void initialise(const Vector3 &lengths, const Vector3 &angles);
 
     public:
     // Return Box type
     BoxType type() const;
     // Determine Box type
-    static std::optional<BoxType> type(Vector3 lengths, Vector3 angles);
+    static BoxType type(const Vector3 &lengths, const Vector3 &angles);
     // Return volume
     double volume() const;
     // Return axis lengths
@@ -143,16 +149,6 @@ class Box : public Serialisable
      * Utility Routines
      */
     public:
-    // Generate a suitable Box given the supplied relative lengths, angles, and volume
-    static Box generate(Vector3 lengths, std::optional<Vector3> angles = {}, bool nonPeriodic = false);
-    // Generate Boxes of a given type
-    static Box none();
-    static Box cubic(double length);
-    static Box orthorhombic(const Vector3 &lengths);
-    static Box monoclinicAlpha(const Vector3 &lengths, double alpha);
-    static Box monoclinicBeta(const Vector3 &lengths, double beta);
-    static Box monoclinicGamma(const Vector3 &lengths, double gamma);
-    static Box triclinic(const Vector3 &lengths, const Vector3 &angles);
     // Return radius of largest possible inscribed sphere for box
     double inscribedSphereRadius() const;
     // Return random coordinate inside Box

--- a/src/classes/box.h
+++ b/src/classes/box.h
@@ -51,8 +51,6 @@ class Box : public Serialisable
     double ra_, rb_, rc_;
     // Box angles
     double alpha_, beta_, gamma_;
-    // Flags stating periodicity along x, y, and z
-    std::array<bool, 3> periodic_;
     // Axes
     Matrix3 axes_;
     // Axes as simple array

--- a/src/classes/configuration.cpp
+++ b/src/classes/configuration.cpp
@@ -9,7 +9,7 @@
 #include "classes/species.h"
 #include "main/dissolve.h"
 
-Configuration::Configuration() : box_(Box::BoxType::Cubic, {1.0, 1.0, 1.0}, {90.0, 90.0, 90.0}) {}
+Configuration::Configuration() : box_({1.0, 1.0, 1.0}) {}
 
 Configuration::~Configuration() { clear(); }
 

--- a/src/classes/configuration.h
+++ b/src/classes/configuration.h
@@ -146,14 +146,8 @@ class Configuration : public Serialisable
     CellArray cells_;
 
     public:
-    // Create Box definition with specified lengths and angles
-    void createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic = false);
-    // Create Box definition from axes matrix
-    void createBox(const Matrix3 axes);
-    // Create Box definition with specified lengths and angles, and initialise cell array
-    void createBoxAndCells(const Vector3 lengths, const Vector3 angles, bool nonPeriodic);
-    // Create Box definition from axes matrix, and initialise cell array
-    void createBoxAndCells(const Matrix3 axes);
+    // Set new box definition and recalculate cells
+    void setBox(const Box &box);
     // Update cell array, and reassign atoms to cells
     void updateCells();
     // Return Box

--- a/src/classes/configuration_box.cpp
+++ b/src/classes/configuration_box.cpp
@@ -6,51 +6,10 @@
 #include "classes/configuration.h"
 #include "kernels/energy.h"
 
-// Create Box definition with specified lengths and angles
-void Configuration::createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic)
+// Set new box definition and recalculate cells
+void Configuration::setBox(const Box &box)
 {
-    box_ = Box::generate(lengths, angles, nonPeriodic);
-
-    cells_.clear();
-}
-
-// Create Box definition from axes matrix
-void Configuration::createBox(const Matrix3 axes)
-{
-    // Calculate cell lengths
-    Vector3 lengths(axes.columnMagnitude(0), axes.columnMagnitude(1), axes.columnMagnitude(2));
-
-    // Calculate cell angles
-    Vector3 vecx, vecy, vecz;
-    vecx = axes.columnAsVec3(0);
-    vecy = axes.columnAsVec3(1);
-    vecz = axes.columnAsVec3(2);
-    vecx.normalise();
-    vecy.normalise();
-    vecz.normalise();
-
-    Vector3 angles(acos(vecy.dp(vecz)), acos(vecx.dp(vecz)), acos(vecx.dp(vecy)));
-    angles.toDegrees();
-
-    box_ = Box::generate(lengths, angles);
-
-    cells_.clear();
-}
-
-// Create Box definition with specified lengths and angles, and initialise cell array
-void Configuration::createBoxAndCells(const Vector3 lengths, const Vector3 angles, bool nonPeriodic)
-{
-    createBox(lengths, angles, nonPeriodic);
-    cells_.generate(box_, requestedCellDivisionLength_);
-}
-
-// Create Box definition from axes matrix, and initialise cell array
-void Configuration::createBoxAndCells(const Matrix3 axes)
-{
-    // Forcibly clear the cell array so we ensure that it is regenerated following the box change
-    cells_.clear();
-
-    createBox(axes);
+    box_ = box;
     cells_.generate(box_, requestedCellDivisionLength_);
 }
 

--- a/src/classes/species.cpp
+++ b/src/classes/species.cpp
@@ -6,11 +6,7 @@
 #include "data/ff/ff.h"
 #include "data/isotopes.h"
 
-Species::Species(std::string name)
-    : name_(name), naturalIsotopologue_(this, "Natural"), attachedAtomListsGenerated_(false), box_(Box::none())
-{
-    box_ = Box::none();
-}
+Species::Species(std::string name) : name_(name), naturalIsotopologue_(this, "Natural"), attachedAtomListsGenerated_(false) {}
 
 // Clear Data
 void Species::clear()

--- a/src/classes/species.h
+++ b/src/classes/species.h
@@ -210,11 +210,10 @@ class Species : public Serialisable
 
     public:
     // Return periodic box
+    Box &box();
     const Box &box() const;
     // Remove Box definition and revert to single image
     void removeBox();
-    // Create Box definition with specified lengths and angles
-    void createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic = false);
 
     /*
      * Isotopologues

--- a/src/classes/species_intra.cpp
+++ b/src/classes/species_intra.cpp
@@ -136,13 +136,8 @@ void Species::clearIntramolecularForcefieldTerms()
 }
 
 // Return periodic box
+Box &Species::box() { return box_; }
 const Box &Species::box() const { return box_; }
 
-// Remove Box definition and revert to single image
-void Species::removeBox() { box_ = Box::none(); }
-
-// Create Box definition with specified lengths and angles
-void Species::createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic)
-{
-    box_ = Box::generate(lengths, angles, nonPeriodic);
-}
+// Remove Box definition and revert to nonperiodic
+void Species::removeBox() { box_ = Box(); }

--- a/src/classes/structure.cpp
+++ b/src/classes/structure.cpp
@@ -6,9 +6,7 @@
 #include "classes/species.h"
 #include "templates/algorithms.h"
 
-Structure::Structure() : box_(Box::none()) {}
-
-Structure::Structure(const Structure &source) : box_(source.box_) { *this = source; }
+Structure::Structure(const Structure &source) { *this = source; }
 
 Structure &Structure::operator=(const Structure &source)
 {
@@ -29,7 +27,7 @@ Structure &Structure::operator=(const Structure &source)
     instances_ = source.instances_;
 
     // Copy source box
-    createBox(source.box_.axisLengths(), source.box_.axisAngles(), source.box_.type() == Box::BoxType::None);
+    box_ = source.box_;
 
     return *this;
 }
@@ -39,7 +37,7 @@ void Structure::clear()
 {
     bonds_.clear();
     atoms_.clear();
-    box_ = Box::none();
+    box_ = Box();
 }
 
 /*
@@ -223,37 +221,8 @@ void Structure::clearBonds()
  */
 
 // Return periodic box
+Box &Structure::box() { return box_; }
 const Box &Structure::box() const { return box_; }
-
-// Remove box definition and revert to single image
-void Structure::removeBox() { box_ = Box::none(); }
-
-// Create box definition with specified lengths and angles
-void Structure::createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic)
-{
-    box_ = Box::generate(lengths, angles, nonPeriodic);
-}
-
-// Create Box definition from axes matrix
-void Structure::createBox(const Matrix3 &axes)
-{
-    // Calculate cell lengths
-    Vector3 lengths(axes.columnMagnitude(0), axes.columnMagnitude(1), axes.columnMagnitude(2));
-
-    // Calculate cell angles
-    Vector3 vecx, vecy, vecz;
-    vecx = axes.columnAsVec3(0);
-    vecy = axes.columnAsVec3(1);
-    vecz = axes.columnAsVec3(2);
-    vecx.normalise();
-    vecy.normalise();
-    vecz.normalise();
-
-    Vector3 angles(acos(vecy.dp(vecz)), acos(vecx.dp(vecz)), acos(vecx.dp(vecy)));
-    angles.toDegrees();
-
-    box_ = Box::generate(lengths, angles);
-}
 
 /*
  * Manipulations

--- a/src/classes/structure.h
+++ b/src/classes/structure.h
@@ -39,7 +39,7 @@ class StructureAtom : public Atom<Bond<StructureAtom>>
 class Structure : public Serialisable
 {
     public:
-    Structure();
+    Structure() = default;
     virtual ~Structure() = default;
     Structure(const Structure &source);
     Structure &operator=(const Structure &source);
@@ -114,13 +114,8 @@ class Structure : public Serialisable
 
     public:
     // Return periodic box
+    Box &box();
     const Box &box() const;
-    // Remove Box definition and revert to single image
-    void removeBox();
-    // Create Box definition with specified lengths and angles
-    void createBox(const Vector3 lengths, const Vector3 angles, bool nonPeriodic = false);
-    // Create Box definition from axes matrix
-    void createBox(const Matrix3 &axes);
 
     /*
      * Manipulations

--- a/src/nodes/cif/importCIFStructure.cpp
+++ b/src/nodes/cif/importCIFStructure.cpp
@@ -430,7 +430,7 @@ bool ImportCIFStructureNode::createStructure()
         return false;
 
     // Configuration
-    structure_.createBox(cellLengths.value(), cellAngles.value(), false);
+    structure_.box() = Box(cellLengths.value(), cellAngles.value());
 
     const auto &box = structure_.box();
 

--- a/src/nodes/detectMolecules.cpp
+++ b/src/nodes/detectMolecules.cpp
@@ -206,7 +206,7 @@ NodeConstants::ProcessResult DetectMoleculesNode::process()
 
             // Create a provisional structure for the current fragment, using indices in the order matched by NETA
             auto detectedStructure = copyAtomsAndBonds(netaOrdering);
-            detectedStructure.createBox(inputStructure_.box().axes());
+            detectedStructure.box() = Box(inputStructure_.box().axes());
 
             // Find, copy as instances, and then erase all fragments that match the current NETA
             fragments.erase(std::remove_if(fragments.begin(), fragments.end(),

--- a/src/nodes/importDLPOLYStructure.cpp
+++ b/src/nodes/importDLPOLYStructure.cpp
@@ -80,7 +80,7 @@ NodeConstants::ProcessResult ImportDLPOLYStructureNode::read(std::istream &input
         auto mat = matrix3().parse(input);
         if (!mat)
             return NodeConstants::ProcessResult::Failed;
-        structure.createBox(std::get<0>(*mat));
+        structure.box() = Box(std::get<0>(*mat));
     }
 
     auto atomType = graphs() << inlineSpaces() & natural() << inlineSpaces() &

--- a/src/nodes/importEPSRAtoStructure.cpp
+++ b/src/nodes/importEPSRAtoStructure.cpp
@@ -53,7 +53,7 @@ NodeConstants::ProcessResult ImportEPSRAtoStructureNode::process()
     auto &[nMols, boxSize, temperature] = std::get<0>(*head);
     if (boxSize != -1.0)
     {
-        structure_.createBox({boxSize, boxSize, boxSize}, {90.0, 90.0, 90.0});
+        structure_.box() = Box({boxSize, boxSize, boxSize}, {90.0, 90.0, 90.0});
     }
     else
     {
@@ -66,7 +66,7 @@ NodeConstants::ProcessResult ImportEPSRAtoStructureNode::process()
         if (!a)
             return NodeConstants::ProcessResult::Failed;
         auto angles = std::get<0>(*a);
-        structure_.createBox(lengths, angles);
+        structure_.box() = Box(lengths, angles);
     }
 
     // 2 : step sizes etc. **IGNORED**

--- a/src/nodes/importMoscitoStructure.cpp
+++ b/src/nodes/importMoscitoStructure.cpp
@@ -72,7 +72,7 @@ NodeConstants::ProcessResult ImportMoscitoStructureNode::process()
     structure_.clear();
     forces_.clear();
 
-    structure_.createBox(box, {90.0, 90.0, 90.0});
+    structure_.box() = Box(box, {90.0, 90.0, 90.0});
     assert(nmolecules == molecules.size());
     for (auto molecule : molecules)
     {

--- a/src/nodes/setBox.cpp
+++ b/src/nodes/setBox.cpp
@@ -44,9 +44,9 @@ NodeConstants::ProcessResult SetBoxNode::process()
             if constexpr (std::is_same_v<T, std::monostate>)
                 return NodeConstants::ProcessResult::Failed;
             else if constexpr (std::is_same_v<T, Configuration *>)
-                arg->createBoxAndCells(lengths_, angles_, nonPeriodic_);
+                arg->setBox(Box(lengths_, angles_));
             else if constexpr (std::is_same_v<T, Structure>)
-                arg.createBox(lengths_, angles_, nonPeriodic_);
+                arg.box() = Box(lengths_, angles_);
             else
                 static_assert(false, "Visitor doesn't cater for all possible types.");
 

--- a/src/nodes/supercellConfiguration.cpp
+++ b/src/nodes/supercellConfiguration.cpp
@@ -41,7 +41,7 @@ NodeConstants::ProcessResult SupercellConfigurationNode::process()
     // Set up configuration
     auto supercellLengths = box.axisLengths();
     supercellLengths.multiply(supercellRepeat_.x, supercellRepeat_.y, supercellRepeat_.z);
-    supercellConfiguration_.createBoxAndCells(supercellLengths, box.axisAngles(), false);
+    supercellConfiguration_.setBox(Box(supercellLengths, box.axisAngles()));
 
     // Create images of all molecular unit cell species
     for (auto &mol : targetConfiguration_->molecules())

--- a/tests/classes/box.cpp
+++ b/tests/classes/box.cpp
@@ -137,7 +137,8 @@ void testPBC(const Box &box, const Vector3 origin, int nPoints = 100)
 
 TEST(BoxTest, Cubic)
 {
-    auto box = Box::cubic(10.0);
+    auto box = Box({10.0, 10.0, 10.0});
+    ASSERT_EQ(box.type(), Box::BoxType::Cubic);
     testBasicOperations(box);
     testPBC(box, {1.0, 2.4, 5.2131});
     testScaling(box);
@@ -145,12 +146,12 @@ TEST(BoxTest, Cubic)
 
 TEST(BoxTest, Orthorhombic)
 {
-    auto box1 = Box::orthorhombic({10.0, 20.0, 30.0});
+    auto box1 = Box({10.0, 20.0, 30.0});
     ASSERT_EQ(box1.type(), Box::BoxType::Orthorhombic);
     testBasicOperations(box1);
     testPBC(box1, {9.4, 13.0491, 1.325});
     testScaling(box1);
-    auto box2 = Box::orthorhombic({15.0, 2.0, 88.0});
+    auto box2 = Box({15.0, 2.0, 88.0});
     ASSERT_EQ(box2.type(), Box::BoxType::Orthorhombic);
     testBasicOperations(box2);
     testPBC(box2, {9.4, 13.0491, 1.325});
@@ -159,27 +160,33 @@ TEST(BoxTest, Orthorhombic)
 
 TEST(BoxTest, Monoclinic)
 {
-    auto box1 = Box::monoclinicAlpha({30.0, 30.0, 30.0}, 66.0);
+    auto box1 = Box({30.0, 30.0, 30.0}, {66.0, 90.0, 90.0});
+    ASSERT_EQ(box1.type(), Box::BoxType::MonoclinicAlpha);
     testBasicOperations(box1);
     testPBC(box1, {3.4, 4.902, 15.875});
     testScaling(box1);
-    auto box2 = Box::monoclinicAlpha({10.0, 20.0, 30.0}, 120.0);
+    auto box2 = Box({10.0, 20.0, 30.0}, {120.0, 90.0, 90.0});
+    ASSERT_EQ(box2.type(), Box::BoxType::MonoclinicAlpha);
     testBasicOperations(box2);
     testPBC(box2, {3.4, 4.902, 15.875});
     testScaling(box2);
-    auto box3 = Box::monoclinicBeta({30.0, 30.0, 30.0}, 66.0);
+    auto box3 = Box({30.0, 30.0, 30.0}, {90.0, 66.0, 90.0});
+    ASSERT_EQ(box3.type(), Box::BoxType::MonoclinicBeta);
     testBasicOperations(box3);
     testPBC(box3, {3.4, 4.902, 15.875});
     testScaling(box3);
-    auto box4 = Box::monoclinicBeta({10.0, 20.0, 30.0}, 120.0);
+    auto box4 = Box({10.0, 20.0, 30.0}, {90.0, 120.0, 90.0});
+    ASSERT_EQ(box4.type(), Box::BoxType::MonoclinicBeta);
     testBasicOperations(box4);
     testPBC(box4, {3.4, 4.902, 15.875});
     testScaling(box4);
-    auto box5 = Box::monoclinicGamma({30.0, 30.0, 30.0}, 66.0);
+    auto box5 = Box({30.0, 30.0, 30.0}, {90.0, 90.0, 66.0});
+    ASSERT_EQ(box5.type(), Box::BoxType::MonoclinicGamma);
     testBasicOperations(box5);
     testPBC(box5, {3.4, 4.902, 15.875});
     testScaling(box5);
-    auto box6 = Box::monoclinicGamma({10.0, 20.0, 30.0}, 120.0);
+    auto box6 = Box({10.0, 20.0, 30.0}, {90.0, 90.0, 120.0});
+    ASSERT_EQ(box6.type(), Box::BoxType::MonoclinicGamma);
     testBasicOperations(box6);
     testPBC(box6, {3.4, 4.902, 15.875});
     testScaling(box6);
@@ -187,15 +194,18 @@ TEST(BoxTest, Monoclinic)
 
 TEST(BoxTest, Triclinic)
 {
-    auto box1 = Box::triclinic({30.0, 30.0, 30.0}, {66.0, 33.0, 77.0});
+    auto box1 = Box({30.0, 30.0, 30.0}, {66.0, 33.0, 77.0});
+    ASSERT_EQ(box1.type(), Box::BoxType::Triclinic);
     testBasicOperations(box1);
     testPBC(box1, {14.8, 8.77, 0.01});
     testScaling(box1);
-    auto box2 = Box::triclinic({10.0, 20.0, 30.0}, {85.0, 80.0, 90.0});
+    auto box2 = Box({10.0, 20.0, 30.0}, {85.0, 80.0, 90.0});
+    ASSERT_EQ(box2.type(), Box::BoxType::Triclinic);
     testBasicOperations(box2);
     testPBC(box2, {14.8, 8.77, 0.01});
     testScaling(box2);
-    auto box3 = Box::triclinic({27.0, 25.5, 31.2311}, {89.0, 120.0, 70.0});
+    auto box3 = Box({27.0, 25.5, 31.2311}, {89.0, 120.0, 70.0});
+    ASSERT_EQ(box2.type(), Box::BoxType::Triclinic);
     testBasicOperations(box3);
     testPBC(box3, {14.8, 8.77, 0.01});
     testScaling(box3);

--- a/tests/classes/cells2.cpp
+++ b/tests/classes/cells2.cpp
@@ -31,7 +31,7 @@ class CellsPBCTest : public ::testing::Test
     void createConfiguration(const Vector3 &lengths, const Vector3 &angles, const Vector3 &origin, int nMolecules = 1000)
     {
         // Setup Configuration
-        configuration_.createBoxAndCells(lengths, angles, false);
+        configuration_.setBox(Box(lengths, angles));
 
         // Add a molecule at the origin
         auto central = configuration_.addMolecule(&probe_);


### PR DESCRIPTION
This PR simplifies the creation of `Box` objects for two principal reasons:
1) Previously we would request the type of box and provide the lengths / angles in the same function call, which is somewhat prone to abuse / error as the lengths angles may not reflect the type as no checks were made. Here we revert to three constructors: the default which creates a `BoxType::None`, and two overloaded ones taking `Vector3`s of lengths/angles or a `Matrix3`.
2) Classes using `Box` (`Configuration`, `Species`, and `Structure`) all had their own setter functions for creating the box which contained duplicate code. For the most part we now just expose the `Box` as a mutable member variable so we can do, e.g., `structure.box_ = Box({10.0,10.0,10.0});`. The exception to this is `Configuration` which still has a `setBox` method as the `CellArray` also needs to be constructed in tandem. However, this would disappear as well if #2397 is implemented.