### PR TITLE
refactor: Toml11 4.4

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -7,6 +7,7 @@ class DissolveRecipe(ConanFile):
     name = "Dissolve"
     settings = "os", "compiler", "build_type", "arch"
     generators = "CMakeToolchain", "CMakeDeps"
+
     def configure(self):
         self.options["puxixml"].header_only = False
         self.options["antlr4-cppruntime"].shared = True
@@ -22,7 +23,7 @@ class DissolveRecipe(ConanFile):
         self.requires("pugixml/1.15")
         self.requires("onetbb/2021.10.0")
         self.requires("onedpl/2022.3.0")
-        self.requires("toml11/3.7.0")
+        self.requires("toml11/4.4.0")
         self.requires("antlr4-cppruntime/4.13.1")
         self.requires("gsl/2.7.1")
         self.requires("gtest/1.17.0")

--- a/flake.lock
+++ b/flake.lock
@@ -89,16 +89,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1755704039,
-        "narHash": "sha256-gKlP0LbyJ3qX0KObfIWcp5nbuHSb5EHwIvU6UcNBg2A=",
+        "lastModified": 1785386831,
+        "narHash": "sha256-sPS3CaXH8RAT3FZRuy4VcV47iuYIWMMfa0GbyJKC3o4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cb344e96d5b6918e94e1bca2d9f3ea1e9615545",
+        "rev": "21ea275a7c46aef9d4d6ddc962e6d562e9d94183",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
           cmake
           cli11
           freetype
+          gcc14
           gsl
           inetutils # for rsh
           ninja
@@ -89,7 +90,7 @@
             checks ? true,
             benchmarks ? false,
           }:
-          pkgs.stdenv.mkDerivation ({
+          pkgs.gcc14Stdenv.mkDerivation ({
             inherit version;
             pname = exe-name gui;
             src = pkgs.lib.fileset.toSource {
@@ -111,9 +112,8 @@
               ++ pkgs.lib.optionals gui (gui_libs system pkgs qt)
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optionals threading [
-                pkgs.tbb_2021_11
+                old.tbb_2021_11
                 (onedpl pkgs old)
-                (onedpl pkgs old).dev
               ];
             nativeBuildInputs = pkgs.lib.optionals gui [ pkgs.wrapGAppsHook ];
 
@@ -177,7 +177,7 @@
 
         defaultPackage = self.packages.${system}.dissolve;
 
-        devShells.default = pkgs.mkShell {
+        devShells.default = pkgs.mkShellNoCC {
           name = "dissolve-shell";
           buildInputs =
             base_libs pkgs
@@ -196,6 +196,7 @@
               conan
               cppcheck
               direnv
+              gcc14
               gdb
               gtk3
               nixGL.nixGLIntel

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   inputs = {
     self.submodules = true;
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     outdated.url = "github:NixOS/nixpkgs/nixos-24.05";
     bundlers.url = "github:nix-community/nix-bundle";
     bundlers.inputs.nixpkgs.follows = "outdated";
@@ -22,18 +22,17 @@
     let
 
       toml = pkgs: ((import ./nix/toml11.nix) { inherit pkgs; });
-      onedpl =
-        pkgs:
-        ((import ./nix/onedpl.nix) {
-          inherit (pkgs)
-            lib
-            stdenv
-            fetchFromGitHub
-            fetchpatch
-            cmake
-            ;
-          tbb = pkgs.tbb_2021_11;
-        });
+      onedpl = pkgs: old: pkgs.onedpl;
+      # ((import ./nix/onedpl.nix) {
+      #   inherit (pkgs)
+      #     lib
+      #     stdenv
+      #     fetchFromGitHub
+      #     fetchpatch
+      #     cmake
+      #     ;
+      #   tbb = old.tbb_2021_11;
+      # });
       exe-name = gui: if gui then "dissolve-gui" else "dissolve";
       cmake-bool = x: if x then "ON" else "OFF";
       version = "1.9.0";
@@ -113,8 +112,8 @@
               ++ pkgs.lib.optionals checks (check_libs pkgs)
               ++ pkgs.lib.optionals threading [
                 pkgs.tbb_2021_11
-                (onedpl pkgs)
-                (onedpl pkgs).dev
+                (onedpl pkgs old)
+                (onedpl pkgs old).dev
               ];
             nativeBuildInputs = pkgs.lib.optionals gui [ pkgs.wrapGAppsHook ];
 
@@ -187,7 +186,7 @@
             ++ (with pkgs; [
               llvmPackages_20.clang-tools
 
-                (onedpl pkgs)
+              (onedpl pkgs old)
 
               ccache
               ccls
@@ -201,7 +200,7 @@
               gtk3
               nixGL.nixGLIntel
               qt.qttools
-              tbb_2021_11
+              old.tbb_2021_11
               valgrind
               weggli
             ]);

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,7 @@
                 old.tbb_2021_11
                 (onedpl pkgs old)
               ];
-            nativeBuildInputs = pkgs.lib.optionals gui [ pkgs.wrapGAppsHook ];
+            nativeBuildInputs = pkgs.lib.optionals gui [ pkgs.wrapGAppsHook3 ];
 
             CTEST_OUTPUT_ON_FAILURE = "ON";
 

--- a/nix/toml11.nix
+++ b/nix/toml11.nix
@@ -1,15 +1,15 @@
 { pkgs }:
 
-pkgs.gcc9Stdenv.mkDerivation rec {
+pkgs.stdenv.mkDerivation rec {
   name = "toml11";
-  version = "v3.7.1";
+  version = "v4.4.0";
   cmake = true;
-  buildInputs = [pkgs.cmake];
+  buildInputs = [ pkgs.cmake ];
   src = pkgs.fetchFromGitHub {
     owner = "ToruNiina";
     repo = "toml11";
     rev = version;
-    sha256 = "HnhXBvIjo1JXhp+hUQvjs83t5IBVbNN6o3ZGhB4WESQ=";
+    sha256 = "sha256-sgWKYxNT22nw376ttGsTdg0AMzOwp8QH3E8mx0BZJTQ=";
     fetchSubmodules = true;
   };
   cmakeFlags = [

--- a/src/base/geometry.cpp
+++ b/src/base/geometry.cpp
@@ -32,7 +32,10 @@ double Geometry::value() const { return value_; }
 // Return index value
 int Geometry::indices(int i) const { return indices_[i]; }
 
-bool Geometry::operator==(const Geometry &rhs) const { return value_ == rhs.value_ && indices_ == rhs.indices_; }
+bool Geometry::operator==(const Geometry &rhs) const
+{
+    return value_ == rhs.value_ && std::equal(std::begin(indices_), std::end(indices_), std::begin(rhs.indices_));
+}
 bool Geometry::operator!=(const Geometry &rhs) const { return !(rhs == *this); }
 
 namespace Serialisable

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -5,13 +5,45 @@
 
 #include "templates/orderedMap.h"
 #include <toml11/toml.hpp>
+#include <toml11/toml11/error_info.hpp>
+#include <toml11/toml11/parser.hpp>
+#include <toml11/toml11/result.hpp>
+#include <toml11/toml11/source_location.hpp>
 #include <vector>
 
+struct wo_comment_config
+{
+    using comment_type = toml::discard_comments; // XXX
+
+    using boolean_type = bool;
+    using integer_type = std::int64_t;
+    using floating_type = double;
+    using string_type = std::string;
+
+    template <typename T> using array_type = std::vector<T>;
+    template <typename K, typename T> using table_type = dissolve::OrderedMap<K, T>;
+
+    static toml::result<integer_type, toml::error_info> parse_int(const std::string &str, const toml::source_location src,
+                                                                  const std::uint8_t base)
+    {
+        return toml::read_int<integer_type>(str, src, base);
+    }
+
+    static toml::result<floating_type, toml::error_info> parse_float(const std::string &str, const toml::source_location src,
+                                                                     const bool is_hex)
+    {
+        return toml::read_float<floating_type>(str, src, is_hex);
+    }
+};
+
 // The type we use for the nodes of our serialisation tree
-using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::OrderedMap, std::vector>;
+using SerialisedValue = toml::basic_value<wo_comment_config>;
 
 namespace Serialisable
 {
+
+using array = toml::array;
+using table = toml::table;
 
 void serialiseOnto(const int a, std::string tag, SerialisedValue &target);
 void serialiseOnto(const double a, std::string tag, SerialisedValue &target);

--- a/src/base/serialiser.h
+++ b/src/base/serialiser.h
@@ -13,7 +13,7 @@
 
 struct wo_comment_config
 {
-    using comment_type = toml::discard_comments; // XXX
+    using comment_type = toml::discard_comments;
 
     using boolean_type = bool;
     using integer_type = std::int64_t;

--- a/src/base/serialiserLibrary.h
+++ b/src/base/serialiserLibrary.h
@@ -119,13 +119,7 @@ template <typename T> void vector(const std::vector<std::shared_ptr<T>> &vec, st
 // A helper function to add the elements of a vector to a node under a name
 template <typename T> void vector(const std::vector<T> &vec, std::string name, SerialisedValue &node)
 {
-    vector(vec, name, node,
-           [](const auto &item)
-           {
-               SerialisedValue outer;
-               item.serialise("inner", outer);
-               return outer["inner"];
-           });
+    vector(vec, name, node, [](const auto &item) { return ser(item); });
 }
 // A helper function to add the elements of a vector to a node under a name
 template <typename T, typename Lambda>
@@ -213,7 +207,7 @@ template <typename Lambda> bool optionalOn(const SerialisedValue &node, std::str
     if (node.contains(name))
     {
         auto child = toml::find(node, name);
-        if (!node.is_uninitialized())
+        if (!child.is_empty())
             action(child);
         return true;
     }

--- a/src/classes/atom.cpp
+++ b/src/classes/atom.cpp
@@ -140,7 +140,7 @@ bool AtomBase::isGeometry(AtomGeometry geom) const { return geometry() == geom; 
 // Express as a serialisable value
 void AtomBase::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
+    target[tag] = Serialisable::table{{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
 }
 // Read values from a serialisable value
 void AtomBase::deserialise(const SerialisedValue &node)

--- a/src/classes/atomType.cpp
+++ b/src/classes/atomType.cpp
@@ -69,7 +69,7 @@ void AtomType::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &atomType = target[tag];
 
-    atomType["z"] = Z_;
+    atomType["z"] = Serialisable::ser(Z_);
     atomType["charge"] = charge_;
     atomType["form"] = ShortRangeFunctions::forms().keyword(interactionPotential_.form());
     atomType["exchangeable"] = exchangeable_;

--- a/src/classes/bond.h
+++ b/src/classes/bond.h
@@ -32,5 +32,8 @@ template <class AtomClass> class Bond
      */
     public:
     // Express as a serialisable value
-    void serialise(std::string tag, SerialisedValue &target) const { target[tag] = {{"i", i_->index()}, {"j", j_->index()}}; }
+    void serialise(std::string tag, SerialisedValue &target) const
+    {
+        target[tag] = Serialisable::table{{"i", i_->index()}, {"j", j_->index()}};
+    }
 };

--- a/src/classes/box.cpp
+++ b/src/classes/box.cpp
@@ -565,6 +565,6 @@ double Box::minimumDistanceSquared(const Vector3 &r1, const Vector3 &r2) const {
 void Box::serialise(std::string tag, SerialisedValue &target) const
 {
     auto &box = target[tag];
-    box["lengths"] = {a_, b_, c_};
-    box["angles"] = {alpha_, beta_, gamma_};
+    box["lengths"] = SerialisedValue::array_type{a_, b_, c_};
+    box["angles"] = SerialisedValue::array_type{alpha_, beta_, gamma_};
 }

--- a/src/classes/speciesAtom.cpp
+++ b/src/classes/speciesAtom.cpp
@@ -168,7 +168,7 @@ SpeciesAtom::ScaledInteractionDefinition SpeciesAtom::scaling(const SpeciesAtom 
 // Express as a serialisable value
 void SpeciesAtom::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
+    target[tag] = Serialisable::table{{"index", index_}, {"z", Serialisable::ser(Z_)}, {"r", Serialisable::ser(r_)}, {"q", q_}};
     if (atomType_)
         target[tag]["type"] = atomType_->name().data();
 }

--- a/src/classes/speciesSite.cpp
+++ b/src/classes/speciesSite.cpp
@@ -514,7 +514,7 @@ void SpeciesSite::serialise(std::string tag, SerialisedValue &target) const
     switch (type_)
     {
         case SiteType::Dynamic:
-            site["element"] = dynamicElements_;
+            Serialisable::vector(dynamicElements_, "element", site);
             break;
         case SiteType::Fragment:
             site["description"] = fragment_.definitionString();

--- a/src/expression/variable.cpp
+++ b/src/expression/variable.cpp
@@ -62,7 +62,7 @@ ExpressionValue *ExpressionVariable::valuePointer() { return &value_; }
 // Express as a serialisable value
 void ExpressionVariable::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"name", Serialisable::ser(baseName_)}, {"value", Serialisable::ser(value_)}};
+    target[tag] = Serialisable::table{{"name", Serialisable::ser(baseName_)}, {"value", Serialisable::ser(value_)}};
 }
 
 // Read values from a serialisable value

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,6 @@
 #include <format>
 #include <fstream>
 #include <iostream>
-#include <toml11/toml/exception.hpp>
 
 int main(int args, char **argv)
 {

--- a/src/main/io.cpp
+++ b/src/main/io.cpp
@@ -15,7 +15,7 @@
 // Serialise pair potential
 SerialisedValue Dissolve::serialisePairPotentials() const
 {
-    SerialisedValue pairPotentials = {
+    SerialisedValue pairPotentials = Serialisable::table{
         {"range", PairPotential::range()},
         {"delta", PairPotential::delta()},
         {"chargeSource", PairPotential::chargeSources().serialise(PairPotential::chargeSource())},

--- a/src/math/data1D.cpp
+++ b/src/math/data1D.cpp
@@ -419,7 +419,7 @@ void Data1D::operator/=(const double factor)
 // Express as a serialisable value
 void Data1D::serialise(std::string tag, SerialisedValue &target) const
 {
-    SerialisedValue result = {{"tag", tag_}, {"x", x_}, {"y", values_}};
+    SerialisedValue result = Serialisable::table{{"tag", tag_}, {"x", x_}, {"y", values_}};
     if (hasError_)
         result["errors"] = errors_;
     target[tag] = result;

--- a/src/math/data2D.cpp
+++ b/src/math/data2D.cpp
@@ -323,7 +323,7 @@ void Data2D::operator/=(const double factor)
 // Express as a serialisable value
 void Data2D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"tag", tag_}, {"x", x_}, {"y", y_}, {"values", values_.linearArray()}};
+    target[tag] = Serialisable::table{{"tag", tag_}, {"x", x_}, {"y", y_}, {"values", values_.linearArray()}};
     if (hasError_)
         target[tag]["errors"] = errors_.linearArray();
 }

--- a/src/math/data3D.cpp
+++ b/src/math/data3D.cpp
@@ -332,7 +332,7 @@ void Data3D::operator/=(const double factor)
 // Express as a serialisable value
 void Data3D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"tag", tag_}, {"x", x_}, {"y", y_}, {"z", z_}, {"values", values_.linearArray()}};
+    target[tag] = Serialisable::table{{"tag", tag_}, {"x", x_}, {"y", y_}, {"z", z_}, {"values", values_.linearArray()}};
     if (hasError_)
         target[tag]["errors"] = errors_.linearArray();
 }

--- a/src/math/histogram1D.cpp
+++ b/src/math/histogram1D.cpp
@@ -215,7 +215,7 @@ Histogram1D Histogram1D::operator+(const Histogram1D &other) const
 // Express as a serialisable value
 void Histogram1D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {
+    target[tag] = Serialisable::table{
         {"minimum", minimum_}, {"maximum", maximum_}, {"binWidth", binWidth_}, {"nBinned", nBinned_}, {"nMissed", nMissed_}};
     Serialisable::vector(averages_, "averages", target[tag]);
 }

--- a/src/math/histogram2D.cpp
+++ b/src/math/histogram2D.cpp
@@ -223,8 +223,9 @@ void Histogram2D::operator=(const Histogram2D &source)
 // Express as a serialisable value
 void Histogram2D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"xMinimum", xMinimum_}, {"xMaximum", xMaximum_},   {"xBinWidth", xBinWidth_}, {"yMinimum", yMinimum_},
-                   {"yMaximum", yMaximum_}, {"yBinWidth", yBinWidth_}, {"nBinned", nBinned_},     {"nMissed", nMissed_}};
+    target[tag] = Serialisable::table{{"xMinimum", xMinimum_}, {"xMaximum", xMaximum_}, {"xBinWidth", xBinWidth_},
+                                      {"yMinimum", yMinimum_}, {"yMaximum", yMaximum_}, {"yBinWidth", yBinWidth_},
+                                      {"nBinned", nBinned_},   {"nMissed", nMissed_}};
     Serialisable::vector(averages_.linearArray(), "averages", target[tag]);
 }
 

--- a/src/math/histogram3D.cpp
+++ b/src/math/histogram3D.cpp
@@ -245,9 +245,10 @@ void Histogram3D::operator=(const Histogram3D &source)
 // Express as a serialisable value
 void Histogram3D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"xMinimum", xMinimum_},   {"xMaximum", xMaximum_},   {"xBinWidth", xBinWidth_}, {"yMinimum", yMinimum_},
-                   {"yMaximum", yMaximum_},   {"yBinWidth", yBinWidth_}, {"zMinimum", zMinimum_},   {"zMaximum", zMaximum_},
-                   {"zBinWidth", zBinWidth_}, {"nBinned", nBinned_},     {"nMissed", nMissed_}};
+    target[tag] = Serialisable::table{{"xMinimum", xMinimum_}, {"xMaximum", xMaximum_}, {"xBinWidth", xBinWidth_},
+                                      {"yMinimum", yMinimum_}, {"yMaximum", yMaximum_}, {"yBinWidth", yBinWidth_},
+                                      {"zMinimum", zMinimum_}, {"zMaximum", zMaximum_}, {"zBinWidth", zBinWidth_},
+                                      {"nBinned", nBinned_},   {"nMissed", nMissed_}};
     Serialisable::vector(averages_.linearArray(), "averages", target[tag]);
 }
 

--- a/src/math/integerHistogram1D.cpp
+++ b/src/math/integerHistogram1D.cpp
@@ -156,7 +156,8 @@ const Data1D &IntegerHistogram1D::accumulatedData() const { return accumulatedDa
 // Express as a serialisable value
 void IntegerHistogram1D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"zeroCounter", Serialisable::ser(zeroCounter_)}, {"nBinned", nBinned_}, {"nMissed", nMissed_}};
+    target[tag] =
+        Serialisable::table{{"zeroCounter", Serialisable::ser(zeroCounter_)}, {"nBinned", nBinned_}, {"nMissed", nMissed_}};
 
     if (minimum_)
         target[tag]["minimum"] = *minimum_;

--- a/src/math/range.cpp
+++ b/src/math/range.cpp
@@ -52,7 +52,7 @@ bool Range::isDefined() const { return (minimum_ && maximum_); }
 // Express as a serialisable value
 void Range::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"min", minimum()}, {"max", maximum()}};
+    target[tag] = Serialisable::table{{"min", minimum()}, {"max", maximum()}};
 }
 
 // Read values from a serialisable value

--- a/src/math/sampledData1D.cpp
+++ b/src/math/sampledData1D.cpp
@@ -151,7 +151,7 @@ void SampledData1D::operator+=(const std::vector<double> &source)
 // Express as a serialisable value
 void SampledData1D::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"x", x_}};
+    target[tag] = Serialisable::table{{"x", x_}};
     values_.serialise("values", target[tag]);
 }
 

--- a/src/math/sampledDouble.cpp
+++ b/src/math/sampledDouble.cpp
@@ -144,7 +144,7 @@ void SampledDouble::operator/=(double x)
 // Express as a serialisable value
 void SampledDouble::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"mean", mean_}, {"count", count_}, {"m2", m2_}};
+    target[tag] = Serialisable::table{{"mean", mean_}, {"count", count_}, {"m2", m2_}};
 }
 
 // Read values from a serialisable value

--- a/src/math/sampledVector.cpp
+++ b/src/math/sampledVector.cpp
@@ -178,7 +178,7 @@ void SampledVector::operator/=(double x)
 // Express as a serialisable value
 void SampledVector::serialise(std::string tag, SerialisedValue &target) const
 {
-    target[tag] = {{"count", count_}, {"mean", mean_}, {"stDev", stDev_}, {"m2", m2_}};
+    target[tag] = Serialisable::table{{"count", count_}, {"mean", mean_}, {"stDev", stDev_}, {"m2", m2_}};
 }
 
 // Read values from a serialisable value

--- a/src/nodes/dissolve.cpp
+++ b/src/nodes/dissolve.cpp
@@ -35,7 +35,8 @@ std::optional<std::string> DissolveGraph::loadFile(std::filesystem::path name)
     }
     catch (toml::type_error err)
     {
-        return std::format("{} at {} on line ", err.what(), err.location().file_name(), err.location().line_str());
+        return std::format("{} in {} at {} through {} ", err.what(), err.location().file_name(), err.location().first_line(),
+                           err.location().last_line());
     }
     return {};
 }

--- a/src/nodes/number.cpp
+++ b/src/nodes/number.cpp
@@ -172,18 +172,8 @@ void Number::serialise(std::string tag, SerialisedValue &target) const
 // Read values from a serialisable value
 void Number::deserialise(const SerialisedValue &node)
 {
-    toml::visit(
-        [this](auto &arg)
-        {
-            using T = std::decay_t<decltype(arg)>;
-            if constexpr (std::is_same_v<T, toml::integer>)
-            {
-                set((int)arg);
-            }
-            else if constexpr (std::is_same_v<T, toml::floating>)
-            {
-                set((double)arg);
-            }
-        },
-        node);
+    if (node.is_floating())
+        set(node.as_floating());
+    else
+        set((int)node.as_integer());
 }

--- a/src/nodes/species.cpp
+++ b/src/nodes/species.cpp
@@ -3,8 +3,6 @@
 
 #include "species.h"
 #include "nodes/constants.h"
-#include <toml11/toml.hpp>
-#include <toml11/toml/parser.hpp>
 
 SpeciesNode::SpeciesNode(Graph *parentGraph) : Node(parentGraph)
 {

--- a/src/templates/orderedMap.h
+++ b/src/templates/orderedMap.h
@@ -76,6 +76,20 @@ template <typename Key, typename Value> class OrderedMap
     }
     Value &operator[](const Key &key) { return insistKey(key).second; }
     Value &operator[](Key &&key) { return insistKey(key).second; }
+
+    std::vector<std::pair<Key, Value>>::iterator find(const Key &key)
+    {
+        if (index_.contains(key))
+            return values_.begin() + index_[key];
+        return end();
+    }
+    std::vector<std::pair<Key, Value>>::const_iterator find(const Key &key) const
+    {
+        if (index_.contains(key))
+            return values_.begin() + index_.at(key);
+        return end();
+    }
+    bool empty() const { return index_.empty(); }
 };
 
 } // namespace dissolve

--- a/tests/algorithms/orderedMap.cpp
+++ b/tests/algorithms/orderedMap.cpp
@@ -2,13 +2,13 @@
 // Copyright (c) 2026 Team Dissolve and contributors
 
 #include "templates/orderedMap.h"
+#include "base/serialiser.h"
 #include <gtest/gtest.h>
 #include <toml11/toml.hpp>
 
 namespace UnitTest
 {
 
-using SerialisedValue = toml::basic_value<toml::discard_comments, dissolve::OrderedMap, std::vector>;
 TEST(OrderedMapTest, BasicOrderedMap)
 {
     SerialisedValue example;


### PR DESCRIPTION
Merge after #2560

This PR upgrades our toml11 dependency from 3.7.0 to 4.4.0.  This allows us to switch to cmake version 4.  I also upgrade to the latest nixpkgs release (we were over a year out of date).  Additionally, I have fixed us on GCC 14 on Linux, since GCC 15 has a known bug with compiling Qt at this time.
