### PR TITLE
fix: Scattering matrix data was not correctly updated

### DIFF
--- a/src/classes/scatteringMatrix.cpp
+++ b/src/classes/scatteringMatrix.cpp
@@ -366,11 +366,16 @@ void ScatteringMatrix::initialise(const AtomTypeMix &typeMix, Array2D<Data1D> &e
 }
 
 // Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
-bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor)
+bool ScatteringMatrix::addReferenceData(std::string_view dataTag, const Data1D &weightedData, const NeutronWeights &dataWeights,
+                                        double factor)
 {
+    // Sanity check that we don't already have data by this tag
+    if (std::find_if(data_.begin(), data_.end(), [dataTag](auto &data) { return dataTag == data.tag(); }) != data_.end())
+        return Messenger::error("Data with name '{}' already exists in the scattering matrix.\n", dataTag);
+
     // Make sure that the scattering weights are valid
     if (!dataWeights.isValid())
-        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.tag());
+        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", dataTag);
 
     // Extend the scattering matrix by one row
     A_.addRow(typePairs_.size());
@@ -395,7 +400,9 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const Neutro
     }
 
     // Add reference data and apply the associated factor
-    data_.emplace_back(weightedData) *= factor;
+    auto &data = data_.emplace_back(weightedData);
+    data *= factor;
+    data.setTag(dataTag);
 
     // Neutron data, so store dummy XRay form factor data indicator
     xRayData_.emplace_back(false, std::nullopt, StructureFactors::NoNormalisation);
@@ -404,11 +411,16 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const Neutro
 }
 
 // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself
-bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWeights &dataWeights, double factor)
+bool ScatteringMatrix::addReferenceData(std::string_view dataTag, const Data1D &weightedData, const XRayWeights &dataWeights,
+                                        double factor)
 {
+    // Sanity check that we don't already have data by this tag
+    if (std::find_if(data_.begin(), data_.end(), [dataTag](auto &data) { return dataTag == data.tag(); }) != data_.end())
+        return Messenger::error("Data with name '{}' already exists in the scattering matrix.\n", dataTag);
+
     // Make sure that the scattering weights are valid
     if (!dataWeights.isValid())
-        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", weightedData.tag());
+        return Messenger::error("Reference data '{}' does not have valid scattering weights.\n", dataTag);
 
     // Extend the scattering matrix by one row
     A_.addRow(typePairs_.size());
@@ -434,7 +446,9 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
     }
 
     // Add reference data and apply the associated factor
-    data_.emplace_back(weightedData) *= factor;
+    auto &data = data_.emplace_back(weightedData);
+    data *= factor;
+    data.setTag(dataTag);
 
     // Store XRay form factor data indicator
     xRayData_.emplace_back(true, dataWeights, StructureFactors::AverageOfSquaresNormalisation);
@@ -443,22 +457,28 @@ bool ScatteringMatrix::addReferenceData(const Data1D &weightedData, const XRayWe
 }
 
 // Update reference data)
-bool ScatteringMatrix::updateReferenceData(const Data1D &weightedData, double factor)
+bool ScatteringMatrix::updateReferenceData(std::string_view dataTag, const Data1D &weightedData, double factor)
 {
-    auto it = std::find_if(data_.begin(), data_.end(), [weightedData](auto &data) { return weightedData.tag() == data.tag(); });
+    auto it = std::find_if(data_.begin(), data_.end(), [dataTag](auto &data) { return dataTag == data.tag(); });
     if (it == data_.end())
         return false;
 
     *it = weightedData;
+    it->setTag(dataTag);
     *it *= factor;
 
     return true;
 }
 
 // Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
-bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::shared_ptr<AtomType> &at1,
-                                               const std::shared_ptr<AtomType> &at2, double dataWeight, double factor)
+bool ScatteringMatrix::addPartialReferenceData(std::string_view dataTag, const Data1D &weightedData,
+                                               const std::shared_ptr<AtomType> &at1, const std::shared_ptr<AtomType> &at2,
+                                               double dataWeight, double factor)
 {
+    // Sanity check that we don't already have data by this tag
+    if (std::find_if(data_.begin(), data_.end(), [dataTag](auto &data) { return dataTag == data.tag(); }) != data_.end())
+        return Messenger::error("Data with name '{}' already exists in the scattering matrix.\n", dataTag);
+
     // Extend the scattering matrix by one row
     A_.addRow(typePairs_.size());
     const auto rowIndex = A_.nRows() - 1;
@@ -473,8 +493,10 @@ bool ScatteringMatrix::addPartialReferenceData(Data1D &weightedData, const std::
     A_.setRow(rowIndex, 0.0);
     A_[{rowIndex, colIndex}] = dataWeight * factor;
 
-    // Add reference data and its associated factor
-    data_.emplace_back(weightedData) *= factor;
+    // Add reference data and apply the associated factor
+    auto &data = data_.emplace_back(weightedData);
+    data *= factor;
+    data.setTag(dataTag);
 
     // Simulated partial data, so store dummy XRay form factor data indicator
     xRayData_.emplace_back(false, std::nullopt, StructureFactors::NoNormalisation);

--- a/src/classes/scatteringMatrix.h
+++ b/src/classes/scatteringMatrix.h
@@ -85,13 +85,15 @@ class ScatteringMatrix
     // Initialise from supplied list of AtomTypes
     void initialise(const AtomTypeMix &typeMix, Array2D<Data1D> &estimatedSQ);
     // Add reference data with its associated NeutronWeights, applying optional factor to those weights and the data itself
-    bool addReferenceData(const Data1D &weightedData, const NeutronWeights &dataWeights, double factor = 1.0);
+    bool addReferenceData(std::string_view dataTag, const Data1D &weightedData, const NeutronWeights &dataWeights,
+                          double factor = 1.0);
     // Add reference data with its associated XRayWeights, applying optional factor to those weights and the data itself
-    bool addReferenceData(const Data1D &weightedData, const XRayWeights &dataWeights, double factor = 1.0);
-    // Update reference data)
-    bool updateReferenceData(const Data1D &weightedData, double factor = 1.0);
+    bool addReferenceData(std::string_view dataTag, const Data1D &weightedData, const XRayWeights &dataWeights,
+                          double factor = 1.0);
+    // Update reference data
+    bool updateReferenceData(std::string_view dataTag, const Data1D &weightedData, double factor = 1.0);
     // Add reference partial data between specified AtomTypes, applying optional factor to the weight and the data itself
-    bool addPartialReferenceData(Data1D &weightedData, const std::shared_ptr<AtomType> &at1,
+    bool addPartialReferenceData(std::string_view dataTag, const Data1D &weightedData, const std::shared_ptr<AtomType> &at1,
                                  const std::shared_ptr<AtomType> &at2, double dataWeight, double factor = 1.0);
     // Return number of currently-defined reference data sets (== matrix rows)
     int nReferenceData() const;

--- a/src/modules/epsr/process.cpp
+++ b/src/modules/epsr/process.cpp
@@ -436,8 +436,8 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             for (auto &&[x, y] : zip(refMinusIntra.xAxis(), refMinusIntra.values()))
                 zeroed.addPoint(x, y);
 
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(zeroed, dataSetWeight)
-                                      : !scatteringMatrix_.addReferenceData(zeroed, weights, dataSetWeight))
+            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(module->name(), zeroed, dataSetWeight)
+                                      : !scatteringMatrix_.addReferenceData(module->name(), zeroed, weights, dataSetWeight))
             {
                 Messenger::error("Failed to add target data '{}' to weights matrix.\n", module->name());
                 return ExecutionResult::Failed;
@@ -475,8 +475,8 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
             for (auto &&[x, y] : zip(refMinusIntra.xAxis(), refMinusIntra.values()))
                 zeroed.addPoint(x, y);
 
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(zeroed, dataSetWeight)
-                                      : !scatteringMatrix_.addReferenceData(zeroed, weights, dataSetWeight))
+            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(module->name(), zeroed, dataSetWeight)
+                                      : !scatteringMatrix_.addReferenceData(module->name(), zeroed, weights, dataSetWeight))
             {
                 Messenger::error("Failed to add target data '{}' to weights matrix.\n", module->name());
                 return ExecutionResult::Failed;
@@ -571,13 +571,14 @@ Module::ExecutionResult EPSRModule::process(ModuleContext &moduleContext)
         atomTypes.begin(), atomTypes.end(),
         [&](int i, auto at1, int j, auto at2) -> EarlyReturn<bool>
         {
-            // Copy and rename the data for clarity
-            auto data = calculatedUnweightedSQ[{i, j}];
-            data.setTag(std::format("Simulated {}-{}", at1->name(), at2->name()));
+            // Generate data tag
+            auto dataTag = std::format("Simulated {}-{}", at1->name(), at2->name());
 
             // Add this partial data to the scattering matrix - its factored weight will be (1.0 - feedback)
-            if (scatteringMatrixSetUp ? !scatteringMatrix_.updateReferenceData(data, 1.0 - feedback_)
-                                      : !scatteringMatrix_.addPartialReferenceData(data, at1, at2, 1.0, (1.0 - feedback_)))
+            if (scatteringMatrixSetUp
+                    ? !scatteringMatrix_.updateReferenceData(dataTag, calculatedUnweightedSQ[{i, j}], 1.0 - feedback_)
+                    : !scatteringMatrix_.addPartialReferenceData(dataTag, calculatedUnweightedSQ[{i, j}], at1, at2, 1.0,
+                                                                 (1.0 - feedback_)))
             {
                 Messenger::error("EPSR: Failed to augment scattering matrix with partial {}-{}.\n", at1->name(), at2->name());
                 return false;


### PR DESCRIPTION
This PR fixes a _horrible_ bug introduced by me at the end of last year whereby the data in the scattering matrix was never updated correctly. It was set correctly on the first run of the EPSR module, but after that everything but the first dataset remained static.  Unfortunate bug, but good refinements still have been achievable by several people depending on their individual circumstances.