### PR TITLE
fix: Check parameter validity by type name

### DIFF
--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -126,7 +126,11 @@ class ParameterBase
     // Get the parameter's value
     template <typename DataClass> DataClass get()
     {
-        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
+        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type.
+        // Note: We check by name() here rather than comparing type_index objects since, on OSX, it is possible for the same
+        // type to obtain different hash values within type_index (thus breaking comparison) if the object is only forward-
+        // declared rather than being fully in scope. There is no easy way around this, and it doesn't affect other platforms,
+        // so here we just revert to the name comparison.
         if (std::type_index(typeid(DataClass)).name() != storedDataType_.name())
             throw(std::runtime_error(std::format("ParameterBase::get() called with wrong type ({} vs {}), name = {}\n",
                                                  std::type_index(typeid(DataClass)).name(), storedDataType_.name(), name_)));
@@ -140,7 +144,8 @@ class ParameterBase
     // Set the parameter's value
     template <typename DataClass> void set(const DataClass &data)
     {
-        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
+        // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type.
+        // See note in ParameterBase::get() regarding choice of name() comparison.
         if (std::type_index(typeid(DataClass)).name() != storedDataType_.name())
             throw(std::runtime_error(std::format("ParameterBase::set() called with wrong type ({} vs {}), name = {}\n",
                                                  std::type_index(typeid(DataClass)).name(), storedDataType_.name(), name_)));

--- a/src/nodes/parameter.h
+++ b/src/nodes/parameter.h
@@ -127,7 +127,7 @@ class ParameterBase
     template <typename DataClass> DataClass get()
     {
         // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
-        if (std::type_index(typeid(DataClass)) != storedDataType_)
+        if (std::type_index(typeid(DataClass)).name() != storedDataType_.name())
             throw(std::runtime_error(std::format("ParameterBase::get() called with wrong type ({} vs {}), name = {}\n",
                                                  std::type_index(typeid(DataClass)).name(), storedDataType_.name(), name_)));
 
@@ -141,7 +141,7 @@ class ParameterBase
     template <typename DataClass> void set(const DataClass &data)
     {
         // Requested DataClass must always match the storedDataType_, regardless of the underlying parameter type
-        if (std::type_index(typeid(DataClass)) != storedDataType_)
+        if (std::type_index(typeid(DataClass)).name() != storedDataType_.name())
             throw(std::runtime_error(std::format("ParameterBase::set() called with wrong type ({} vs {}), name = {}\n",
                                                  std::type_index(typeid(DataClass)).name(), storedDataType_.name(), name_)));
 


### PR DESCRIPTION
A quick PR to change the checks made in `ParameterBase::get` and `ParameterBase::set` to explicitly match the names of `type_id`s rather than just comparing `std::type_index` objects. The latter would cause unit tests to fail on OSX due to different hash_codes for the same type being generated (presumably due to some scope / forward declaration issue on that platform).